### PR TITLE
feat: add Power Outage and WiFi Outage templates and notification cards

### DIFF
--- a/mass-notifications/Cards.gs
+++ b/mass-notifications/Cards.gs
@@ -6,6 +6,7 @@
  *
  * USAGE IN CONFIG SHEET:
  *   notification_card = FIRE_INSPECTION | WATER_OUTAGE | MAINTENANCE | WEATHER_ALERT
+ *                     | POWER_OUTAGE | WIFI_OUTAGE
  *   Leave blank to include no card.
  *
  * ADDING A NEW CARD TYPE:
@@ -31,6 +32,7 @@ const LANDING = {
   LIGHT_BLUE:  '#E7EFFB',
   WHITE:       '#FFFFFF',
   AMBER:       '#E8A317',
+  ORANGE:      '#D4600A', // Power outage — urgent but distinct from RED
   RED:         '#D9534F',
   GREEN:       '#28A745',
   TEXT_GRAY:   '#4A4A4A',
@@ -160,6 +162,41 @@ class WeatherAlertCard extends NotificationCard {
   }
 }
 
+class PowerOutageCard extends NotificationCard {
+  render() {
+    const body = [
+      this._row('Property', '{{property_name}}'),
+      this._row('Reported', '{{today}}', LANDING.ORANGE),
+      this._row('Status',
+        '<strong>Active</strong> — Landing is engaged with the property ' +
+        'and working toward the fastest possible resolution.'),
+      this._row('Immediate steps',
+        'Unplug sensitive electronics &nbsp;·&nbsp; ' +
+        'Keep fridge &amp; freezer closed &nbsp;·&nbsp; ' +
+        'Use flashlights, not candles'),
+    ].join('');
+
+    return this._shell(LANDING.ORANGE, '⚡', 'Power Outage — Active', body);
+  }
+}
+
+class WiFiOutageCard extends NotificationCard {
+  render() {
+    const body = [
+      this._row('Property', '{{property_name}}'),
+      this._row('Reported', '{{today}}', LANDING.AMBER),
+      this._row('Status',
+        '<strong>Active</strong> — Landing is coordinating with the property ' +
+        'and the internet service provider on a resolution.'),
+      this._row('In the meantime',
+        'Mobile data is available as a backup &nbsp;·&nbsp; ' +
+        'Disable WiFi on your device to switch automatically'),
+    ].join('');
+
+    return this._shell(LANDING.AMBER, '📶', 'WiFi Service Disruption — Active', body);
+  }
+}
+
 // ── Registry & factory ────────────────────────────────────────────────────────
 
 /**
@@ -171,6 +208,8 @@ const CARD_REGISTRY = {
   WATER_OUTAGE:    WaterOutageCard,
   MAINTENANCE:     MaintenanceCard,
   WEATHER_ALERT:   WeatherAlertCard,
+  POWER_OUTAGE:    PowerOutageCard,
+  WIFI_OUTAGE:     WiFiOutageCard,
 };
 
 /**

--- a/mass-notifications/Templates.gs
+++ b/mass-notifications/Templates.gs
@@ -89,6 +89,85 @@ const EMAIL_TEMPLATES = {
     send_mode:         'BCC',
   },
 
+  'Power Outage': {
+    event_name:        'Power Outage',
+    // Uses {{today}} instead of {{date_range}} — this is a live incident, not a scheduled window.
+    subject_template:  'Urgent: Power Outage at {{property_name}} — {{today}}',
+    greeting_template: '<p>Dear {{first_name | Resident}},</p>',
+    include_disclaimer: 'YES',
+    disclaimer_html:   '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is an urgent notification to all active residents at {{property_name}}. Please see the message below:</div>',
+    notification_card: 'POWER_OUTAGE',
+    body_intro_html:
+      '<p>We are reaching out because <strong>{{property_name}}</strong> is currently ' +
+      'experiencing an <strong>unexpected power outage</strong> affecting your unit. ' +
+      'We understand how disruptive this is — Landing is actively engaged with the ' +
+      'property management team and working toward the fastest possible resolution.</p>' +
+      '<p>While service is being restored, please take the following precautions:</p>' +
+      '<ul>' +
+      '<li><strong>Unplug sensitive electronics</strong> (laptops, TVs, gaming consoles) ' +
+      'to protect them from potential power surges when electricity is restored.</li>' +
+      '<li><strong>Keep your refrigerator and freezer doors closed</strong> — a closed ' +
+      'refrigerator will maintain safe temperatures for approximately 4 hours.</li>' +
+      '<li>Use <strong>flashlights instead of candles</strong> for your safety.</li>' +
+      '<li>If you rely on <strong>powered medical equipment</strong>, please contact us ' +
+      'immediately so we can assist you.</li>' +
+      '</ul>',
+    include_unit_line: 'NO',
+    closing_html:
+      '<p>For the latest updates or if you need immediate assistance, please reach out to ' +
+      'your General Manager <strong>{{manager_name}}</strong> directly, or contact our ' +
+      '<strong>24/7 Member Support</strong> team at ' +
+      '<a href="tel:+12058528798">(205) 852-8798</a> — we are standing by to help.</p>' +
+      '<p>We sincerely apologize for the inconvenience and thank you for your patience.<br>' +
+      'The Landing Team</p>',
+    send_mode: 'BCC',
+    _hint:
+      'Power Outage template loaded.\n\n' +
+      'Please fill in:\n  • property_name\n  • manager_email\n\n' +
+      'Dates are optional for live outages — {{today}} in the subject will\n' +
+      'automatically reflect the send date.\n\n' +
+      'Run Dry Run → Preview to verify before sending.',
+  },
+
+  'WiFi Outage': {
+    event_name:        'WiFi Service Disruption',
+    subject_template:  'Service Notice: WiFi Outage at {{property_name}} — {{today}}',
+    greeting_template: '<p>Dear {{first_name | Resident}},</p>',
+    include_disclaimer: 'YES',
+    disclaimer_html:   '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is a notification to all active residents at {{property_name}}. Please see the message below:</div>',
+    notification_card: 'WIFI_OUTAGE',
+    body_intro_html:
+      '<p>We are writing to let you know that <strong>{{property_name}}</strong> is ' +
+      'currently experiencing a <strong>WiFi service disruption</strong> affecting your unit. ' +
+      'Our team is actively coordinating with the property and the internet service provider ' +
+      'to identify the cause and restore service as quickly as possible.</p>' +
+      '<p>In the meantime, here are a few things that may help:</p>' +
+      '<ul>' +
+      '<li>Your <strong>mobile data plan</strong> can serve as a reliable backup for ' +
+      'essential connectivity while service is restored.</li>' +
+      '<li>If your device connects automatically to the property WiFi, consider ' +
+      '<strong>disabling WiFi on your device temporarily</strong> so it falls back to ' +
+      'mobile data without interruption.</li>' +
+      '<li>Once service is restored, <strong>restarting your devices or toggling WiFi ' +
+      'off and back on</strong> should reconnect you automatically.</li>' +
+      '</ul>',
+    include_unit_line: 'NO',
+    closing_html:
+      '<p>For updates on the status of this outage or if you need any assistance, please ' +
+      'reach out to your General Manager <strong>{{manager_name}}</strong>, or contact our ' +
+      '<strong>24/7 Member Support</strong> team at ' +
+      '<a href="tel:+12058528798">(205) 852-8798</a>.</p>' +
+      '<p>We appreciate your patience and apologize for any inconvenience this causes.<br>' +
+      'The Landing Team</p>',
+    send_mode: 'BCC',
+    _hint:
+      'WiFi Outage template loaded.\n\n' +
+      'Please fill in:\n  • property_name\n  • manager_email\n\n' +
+      'Dates are optional for live outages — {{today}} in the subject will\n' +
+      'automatically reflect the send date.\n\n' +
+      'Run Dry Run → Preview to verify before sending.',
+  },
+
 };
 
 // ── Template loader ───────────────────────────────────────────────────────────
@@ -108,15 +187,18 @@ function loadTemplate_(templateName) {
     return;
   }
 
-  // Apply template-defined values
-  Object.entries(template).forEach(([key, value]) => setConfigValue_(key, value));
+  // Apply template-defined values, skipping the internal _hint key
+  Object.entries(template).forEach(([key, value]) => {
+    if (!key.startsWith('_')) setConfigValue_(key, value);
+  });
 
   // Clear run-specific fields that the operator must fill in
   TEMPLATE_BLANK_KEYS.forEach(key => {
     if (!(key in template)) setConfigValue_(key, '');
   });
 
-  safeAlert_(
+  // Use the template's custom hint if provided, otherwise show the generic one
+  safeAlert_(template._hint ||
     `Template "${templateName}" loaded.\n\n` +
     'Please fill in:\n  • property_name\n  • manager_email\n  • window_start / window_end\n\n' +
     'Then run Dry Run → Preview to verify before sending.'

--- a/mass-notifications/UI.gs
+++ b/mass-notifications/UI.gs
@@ -79,6 +79,8 @@ function _loadTemplate_Annual_Fire_Inspection()  { loadTemplate_('Annual Fire In
 function _loadTemplate_Water_Outage()            { loadTemplate_('Water Outage');            }
 function _loadTemplate_General_Maintenance()     { loadTemplate_('General Maintenance');     }
 function _loadTemplate_Weather_Alert()           { loadTemplate_('Weather Alert');           }
+function _loadTemplate_Power_Outage()            { loadTemplate_('Power Outage');            }
+function _loadTemplate_WiFi_Outage()             { loadTemplate_('WiFi Outage');             }
 
 // ── About ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Cards.gs:
- Add ORANGE (#D4600A) to LANDING palette for power outage urgency
- Add PowerOutageCard — orange shell, shows property, reported date ({{today}}), live status, and immediate safety steps (unplug electronics, keep fridge closed, etc.)
- Add WiFiOutageCard — amber shell, shows property, reported date, live status, and mobile data fallback tip
- Register both in CARD_REGISTRY as POWER_OUTAGE and WIFI_OUTAGE

Templates.gs:
- Add 'Power Outage' template — uses {{today}} in subject (live incident, not scheduled), full body with safety precautions list, GM + Member Support CTA
- Add 'WiFi Outage' template — uses {{today}} in subject, connectivity tips list, same CTA pattern
- Both templates include a custom _hint that tells operator dates are optional
- loadTemplate_() now skips internal _hint key when writing to Config sheet

UI.gs:
- Add _loadTemplate_Power_Outage() and _loadTemplate_WiFi_Outage() shims

https://claude.ai/code/session_01CssSHJrsSN5oASVT6P26f9