### PR TITLE
feat: team routing + multi-team support (Step 4)

### DIFF
--- a/qa-automation/AI-Scoring/.env.example
+++ b/qa-automation/AI-Scoring/.env.example
@@ -1,18 +1,35 @@
 # --- Required ---
 GEMINI_API_KEY=
 DIALPAD_API_KEY=
-GOOGLE_SHEETS_ID=
-GOOGLE_SHEETS_TAB=Form Responses AI
-GOOGLE_HISTORY_TAB=Analyst_History
 
-# Google Service Account credentials.
+# Google Service Account credentials (shared across teams).
 # Local dev: file path to the JSON key file.
 # Production (Railway): paste the entire JSON content of the key file as a single line.
 GOOGLE_SERVICE_ACCOUNT_JSON=
 
-# API key for the member_support team.
-# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# --- Per-team configuration ---
+# For each team served by the platform, set three env vars:
+#   API_KEY_{TEAM}            — auth token; generate with
+#                                python -c "import secrets; print(secrets.token_urlsafe(32))"
+#   GOOGLE_SHEETS_ID_{TEAM}   — that team's QA Google Sheet ID
+#   APPS_SCRIPT_WEBAPP_URL_{TEAM} — Apps Script web app URL deployed from the
+#                                   team's copy of qa-automation/src/Main.js
+
+# member_support (the default team). Legacy flat names (GOOGLE_SHEETS_ID,
+# APPS_SCRIPT_WEBAPP_URL) are still honored as a fallback ONLY for this team.
 API_KEY_MEMBER_SUPPORT=
+GOOGLE_SHEETS_ID=
+APPS_SCRIPT_WEBAPP_URL=
+
+# Optional sheet-tab overrides for member_support (defaults come from
+# backend/config/teams/member_support.json).
+GOOGLE_SHEETS_TAB=Form Responses AI
+GOOGLE_HISTORY_TAB=Analyst_History
+
+# Additional teams (example). Uncomment + fill in when onboarding Sales.
+# API_KEY_SALES=
+# GOOGLE_SHEETS_ID_SALES=
+# APPS_SCRIPT_WEBAPP_URL_SALES=
 
 # --- Optional ---
 # Comma-separated list of allowed CORS origins. Defaults to http://localhost:8000.
@@ -20,11 +37,6 @@ ALLOWED_ORIGINS=http://localhost:8000
 
 # Path to the audit log file. Defaults to audit.log in the working directory.
 AUDIT_LOG_PATH=audit.log
-
-# Apps Script Web App URL (deployed from qa-automation/src/Main.js)
-# Required for the Approve & Send workflow to trigger email pipeline.
-# Deploy Main.js as a web app in the Apps Script editor, copy the URL here.
-APPS_SCRIPT_WEBAPP_URL=
 
 # Notion (not yet active)
 NOTION_API_KEY=

--- a/qa-automation/AI-Scoring/backend/config/env.py
+++ b/qa-automation/AI-Scoring/backend/config/env.py
@@ -1,0 +1,27 @@
+"""Team-scoped environment variable lookup.
+
+Convention: per-team overrides take the form ``{BASE}_{TEAM_ID_UPPER}``
+(e.g. ``GOOGLE_SHEETS_ID_SALES``).  For ``member_support``, callers can
+opt into a legacy fallback to the flat ``{BASE}`` name so the existing
+single-tenant ``.env`` continues to work unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def env_for_team(base: str, team_id: str, legacy_ok: bool = False, default: str = "") -> str:
+    """Return the env var value for *base* scoped to *team_id*.
+
+    Lookup order:
+      1. ``{base}_{team_id.upper()}``
+      2. If ``legacy_ok`` and team_id == 'member_support': bare ``{base}``
+      3. ``default``
+    """
+    val = os.getenv(f"{base}_{team_id.upper()}", "")
+    if val:
+        return val
+    if legacy_ok and team_id == "member_support":
+        return os.getenv(base, default)
+    return default

--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -2,8 +2,7 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from pathlib import Path
 from dotenv import load_dotenv
 import os
@@ -12,17 +11,17 @@ import os
 _env_path = Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(_env_path)
 
-from backend.routes.scoring import router
+from backend.routes.scoring import router as scoring_router
 from backend.routes.dashboard import router as dashboard_router
 from backend.routes.team import router as team_router
 from backend.routes.datapoints import router as datapoints_router
-from backend.middleware.auth import AUTH_DEPENDENCY
+from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
 from backend.middleware.audit import AuditLogMiddleware
 
 app = FastAPI(
     title="Landing QA Scoring API",
     description="AI-powered call center QA scoring pipeline",
-    version="1.1.0",
+    version="1.2.0",
 )
 
 _allowed_origins = [
@@ -39,10 +38,13 @@ app.add_middleware(
 )
 app.add_middleware(AuditLogMiddleware)
 
-app.include_router(router, dependencies=AUTH_DEPENDENCY)
-app.include_router(dashboard_router, dependencies=AUTH_DEPENDENCY)
-app.include_router(team_router, dependencies=AUTH_DEPENDENCY)
-app.include_router(datapoints_router, dependencies=AUTH_DEPENDENCY)
+# Team-aware routes (primary). API key's team_id must match the URL team_id.
+for r in (scoring_router, dashboard_router, team_router, datapoints_router):
+    app.include_router(r, prefix="/api/{team_id}", dependencies=TEAM_AUTH_DEPENDENCY)
+
+# Legacy single-team shim (30-day transition). team_id defaults to 'member_support'.
+for r in (scoring_router, dashboard_router, team_router, datapoints_router):
+    app.include_router(r, prefix="/api", dependencies=AUTH_DEPENDENCY)
 
 
 @app.get("/api/health")
@@ -52,25 +54,49 @@ async def health():
 # Serve the frontend HTML at the root
 _frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
 
-@app.get("/", include_in_schema=False)
-async def serve_frontend():
+
+# --- Team-aware page routes ---
+
+@app.get("/score/{team_id}", include_in_schema=False)
+async def serve_scoring_ui(team_id: str):
     return FileResponse(_frontend_dir / "index.html")
 
 
-# Agent drill-down — must be registered before /dashboard to avoid path conflicts
-@app.get("/dashboard/agent/{name:path}", include_in_schema=False)
-async def serve_agent_dashboard(name: str):
+@app.get("/dashboard/{team_id}/agent/{name:path}", include_in_schema=False)
+async def serve_agent_dashboard(team_id: str, name: str):
     return FileResponse(_frontend_dir / "dashboard.html")
 
 
-@app.get("/datapoint/{call_id}", include_in_schema=False)
-async def serve_datapoint_page(call_id: str):
+@app.get("/datapoint/{team_id}/{call_id}", include_in_schema=False)
+async def serve_datapoint_page(team_id: str, call_id: str):
     return FileResponse(_frontend_dir / "datapoint.html")
 
 
-@app.get("/dashboard", include_in_schema=False)
-async def serve_team_dashboard():
+@app.get("/dashboard/{team_id}", include_in_schema=False)
+async def serve_team_dashboard(team_id: str):
     return FileResponse(_frontend_dir / "team_dashboard.html")
+
+
+# --- Legacy page redirects (30-day transition) ---
+
+@app.get("/", include_in_schema=False)
+async def serve_frontend():
+    return RedirectResponse(url="/score/member_support", status_code=307)
+
+
+@app.get("/dashboard", include_in_schema=False)
+async def legacy_team_dashboard():
+    return RedirectResponse(url="/dashboard/member_support", status_code=307)
+
+
+@app.get("/dashboard/agent/{name:path}", include_in_schema=False)
+async def legacy_agent_dashboard(name: str):
+    return RedirectResponse(url=f"/dashboard/member_support/agent/{name}", status_code=307)
+
+
+@app.get("/datapoint/{call_id}", include_in_schema=False)
+async def legacy_datapoint(call_id: str):
+    return RedirectResponse(url=f"/datapoint/member_support/{call_id}", status_code=307)
 
 
 if __name__ == "__main__":

--- a/qa-automation/AI-Scoring/backend/middleware/auth.py
+++ b/qa-automation/AI-Scoring/backend/middleware/auth.py
@@ -3,7 +3,7 @@
 import os
 import secrets
 
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, Header, HTTPException, Request
 
 
 def _build_key_map() -> dict[str, str]:
@@ -50,4 +50,31 @@ async def require_api_key(authorization: str = Header(None)) -> str:
     raise HTTPException(status_code=401, detail="Invalid API key")
 
 
+async def require_team_access(team_id: str, authorization: str = Header(None)) -> str:
+    """Validate the key *and* enforce it matches the team_id in the URL.
+
+    Binds ``team_id`` automatically from the path param of the route it
+    protects, so a Sales key cannot reach Member Support data (and vice
+    versa).  Returns the resolved team_id.
+    """
+    key_team = await require_api_key(authorization)
+    if key_team != team_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"API key not authorized for team '{team_id}'",
+        )
+    return team_id
+
+
 AUTH_DEPENDENCY = [Depends(require_api_key)]
+TEAM_AUTH_DEPENDENCY = [Depends(require_team_access)]
+
+
+def team_id_from_path(request: Request) -> str:
+    """Return team_id from the URL path.
+
+    For team-prefixed routes this resolves to the path param.  For legacy
+    routes (no ``{team_id}`` in the path) it defaults to ``member_support``
+    so the single-tenant form keeps working during the 30-day transition.
+    """
+    return request.path_params.get("team_id", "member_support")

--- a/qa-automation/AI-Scoring/backend/routes/dashboard.py
+++ b/qa-automation/AI-Scoring/backend/routes/dashboard.py
@@ -1,25 +1,33 @@
-"""Dashboard API endpoints for agent progression."""
+"""Dashboard API endpoints for agent progression.
 
-from fastapi import APIRouter, HTTPException, Query
+Registered twice in main.py: team-aware (/api/{team_id}/...) and
+legacy (/api/...).  team_id is extracted from the path via
+``team_id_from_path``; legacy routes default to ``member_support``.
+"""
+
+from fastapi import APIRouter, HTTPException, Query, Request
 from backend.config.team_config import get_team_config
+from backend.middleware.auth import team_id_from_path
 from backend.models.dashboard import EvaluationRecord, ProgressionAssessment
 from backend.services.data_provider import get_provider
 from backend.services.progression_service import get_progression
 
-router = APIRouter(prefix="/api", tags=["dashboard"])
+router = APIRouter(tags=["dashboard"])
 
 
 @router.get("/agents", response_model=list[str])
-async def list_agents():
+async def list_agents(request: Request):
     """Return all unique agent names from evaluation history."""
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    provider = await get_provider(team_id)
     return await provider.list_agents()
 
 
 @router.get("/agents/{name}/history", response_model=list[EvaluationRecord])
-async def agent_history(name: str, days: int = Query(default=30, ge=1, le=365)):
+async def agent_history(request: Request, name: str, days: int = Query(default=30, ge=1, le=365)):
     """Return evaluation records for an agent within a time window."""
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    provider = await get_provider(team_id)
     records = await provider.get_agent_history(name, days)
     if not records:
         raise HTTPException(404, f"No evaluations found for '{name}' in the last {days} days")
@@ -27,8 +35,9 @@ async def agent_history(name: str, days: int = Query(default=30, ge=1, le=365)):
 
 
 @router.get("/agents/{name}/progression", response_model=ProgressionAssessment)
-async def agent_progression(name: str, days: int = Query(default=30, ge=1, le=365)):
+async def agent_progression(request: Request, name: str, days: int = Query(default=30, ge=1, le=365)):
     """Return Gemini-generated progression assessment for an agent."""
-    config = get_team_config()
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    provider = await get_provider(team_id)
     return await get_progression(provider, name, days, config=config)

--- a/qa-automation/AI-Scoring/backend/routes/datapoints.py
+++ b/qa-automation/AI-Scoring/backend/routes/datapoints.py
@@ -2,18 +2,20 @@
 
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
+from backend.middleware.auth import team_id_from_path
 from backend.models.dashboard import EvaluationRecord
 from backend.services.data_provider import get_provider
 
-router = APIRouter(prefix="/api", tags=["datapoints"])
+router = APIRouter(tags=["datapoints"])
 
 
 @router.get("/datapoints/{call_id}", response_model=EvaluationRecord)
-async def get_datapoint(call_id: str):
+async def get_datapoint(request: Request, call_id: str):
     """Return a single evaluation record by call_id (extracted from Dialpad link)."""
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    provider = await get_provider(team_id)
     all_records = await provider.get_all_history(days=365)
 
     for rec in all_records:
@@ -41,6 +43,7 @@ async def get_datapoint(call_id: str):
 
 @router.get("/datapoints", response_model=list[EvaluationRecord])
 async def list_datapoints(
+    request: Request,
     bin: Optional[str] = Query(default=None, description="Score range, e.g. '81-90'"),
     agent: Optional[str] = Query(default=None),
     days: int = Query(default=90, ge=1, le=365),
@@ -54,7 +57,8 @@ async def list_datapoints(
     if not bin and not agent:
         raise HTTPException(400, "Provide 'bin' (e.g. '81-90') or 'agent' query parameter")
 
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    provider = await get_provider(team_id)
 
     if agent:
         records = await provider.get_agent_history(agent, days)

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -1,14 +1,19 @@
-"""FastAPI routes for the QA scoring pipeline."""
+"""FastAPI routes for the QA scoring pipeline.
+
+Registered twice in main.py:
+  - /api/{team_id}/...  (team-aware, TEAM_AUTH_DEPENDENCY)
+  - /api/...            (legacy shim, resolves team_id='member_support')
+"""
 
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from datetime import datetime
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, UploadFile, File, Form
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, UploadFile, File, Form
 
 from backend.config.team_config import get_team_config
+from backend.middleware.auth import team_id_from_path
 from backend.models.scorecard import ApprovalRequest
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
@@ -18,12 +23,20 @@ from backend.services.sheets_service import (
     trigger_apps_script,
 )
 from backend.services.dialpad_client import get_user_id_by_name, get_calls_for_agent
-from datetime import datetime
 
-router = APIRouter(prefix="/api", tags=["scoring"])
+router = APIRouter(tags=["scoring"])
 
-# In-memory job store (replace with DB in Phase 2)
+# In-memory job store. Keyed by f"{team_id}:{job_id}" so jobs from one team
+# cannot be read by another.
 _jobs: dict[str, dict] = {}
+
+
+def _job_key(team_id: str, job_id: str) -> str:
+    return f"{team_id}:{job_id}"
+
+
+def _make_job_id(call_id: str, agent_name: str) -> str:
+    return f"{call_id}_{agent_name}".replace(" ", "_")
 
 
 @router.get("/calls")
@@ -66,6 +79,7 @@ async def list_calls(agent_name: str, date_start: str, date_end: str):
 
 @router.post("/score")
 async def score_single_call(
+    request: Request,
     background_tasks: BackgroundTasks,
     audio_file: UploadFile = File(...),
     call_id: str = Form(...),
@@ -79,14 +93,16 @@ async def score_single_call(
     Runs scoring in background and writes result to Google Sheets.
     Returns a job_id to poll for status.
     """
+    team_id = team_id_from_path(request)
     audio_bytes = await audio_file.read()
-    job_id = f"{call_id}_{agent_name}".replace(" ", "_")
-    _jobs[job_id] = {"status": "pending", "call_id": call_id}
-    config = get_team_config()
+    job_id = _make_job_id(call_id, agent_name)
+    key = _job_key(team_id, job_id)
+    _jobs[key] = {"status": "pending", "call_id": call_id}
+    config = get_team_config(team_id)
 
     async def run():
         try:
-            _jobs[job_id]["status"] = "scoring"
+            _jobs[key]["status"] = "scoring"
             scorecard = await score_call(
                 audio_bytes=audio_bytes,
                 filename=audio_file.filename,
@@ -97,21 +113,22 @@ async def score_single_call(
                 duration_ms=duration_ms,
             )
             row_num = append_scorecard_row(scorecard, config)
-            _jobs[job_id]["status"] = "complete"
-            _jobs[job_id]["sheets_row"] = row_num
-            _jobs[job_id]["scorecard"] = scorecard.model_dump()
+            _jobs[key]["status"] = "complete"
+            _jobs[key]["sheets_row"] = row_num
+            _jobs[key]["scorecard"] = scorecard.model_dump()
         except Exception as e:
-            _jobs[job_id]["status"] = "error"
-            _jobs[job_id]["error"] = str(e)
+            _jobs[key]["status"] = "error"
+            _jobs[key]["error"] = str(e)
 
     background_tasks.add_task(run)
     return {"job_id": job_id, "status": "pending"}
 
 
 @router.get("/score/{job_id}")
-async def get_score_result(job_id: str):
+async def get_score_result(request: Request, job_id: str):
     """Poll for the result of a scoring job."""
-    job = _jobs.get(job_id)
+    team_id = team_id_from_path(request)
+    job = _jobs.get(_job_key(team_id, job_id))
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -119,6 +136,7 @@ async def get_score_result(job_id: str):
 
 @router.post("/score/batch")
 async def score_batch(
+    request: Request,
     background_tasks: BackgroundTasks,
     audio_files: list[UploadFile] = File(...),
     call_ids: str = Form(...),        # comma-separated, matching order of audio_files
@@ -130,6 +148,7 @@ async def score_batch(
     Score multiple calls in one submission.
     audio_files and call_ids must be in the same order.
     """
+    team_id = team_id_from_path(request)
     id_list = [cid.strip() for cid in call_ids.split(",")]
     dur_list = [float(d.strip()) if d.strip() else 0 for d in durations_ms.split(",")] if durations_ms else []
 
@@ -139,18 +158,19 @@ async def score_batch(
             detail=f"Mismatch: {len(audio_files)} files vs {len(id_list)} call IDs"
         )
 
-    config = get_team_config()
+    config = get_team_config(team_id)
     job_ids = []
     for i, (audio_file, call_id) in enumerate(zip(audio_files, id_list)):
         audio_bytes = await audio_file.read()
         duration = dur_list[i] if i < len(dur_list) else 0
-        job_id = f"{call_id}_{agent_name}".replace(" ", "_")
-        _jobs[job_id] = {"status": "pending", "call_id": call_id}
+        job_id = _make_job_id(call_id, agent_name)
+        key = _job_key(team_id, job_id)
+        _jobs[key] = {"status": "pending", "call_id": call_id}
         job_ids.append(job_id)
 
-        async def run(ab=audio_bytes, fn=audio_file.filename, cid=call_id, jid=job_id, dur=duration):
+        async def run(ab=audio_bytes, fn=audio_file.filename, cid=call_id, k=key, dur=duration):
             try:
-                _jobs[jid]["status"] = "scoring"
+                _jobs[k]["status"] = "scoring"
                 scorecard = await score_call(
                     audio_bytes=ab,
                     filename=fn,
@@ -161,12 +181,12 @@ async def score_batch(
                     duration_ms=dur,
                 )
                 row_num = append_scorecard_row(scorecard, config)
-                _jobs[jid]["status"] = "complete"
-                _jobs[jid]["sheets_row"] = row_num
-                _jobs[jid]["scorecard"] = scorecard.model_dump()
+                _jobs[k]["status"] = "complete"
+                _jobs[k]["sheets_row"] = row_num
+                _jobs[k]["scorecard"] = scorecard.model_dump()
             except Exception as e:
-                _jobs[jid]["status"] = "error"
-                _jobs[jid]["error"] = str(e)
+                _jobs[k]["status"] = "error"
+                _jobs[k]["error"] = str(e)
 
         background_tasks.add_task(run)
 
@@ -174,13 +194,15 @@ async def score_batch(
 
 
 @router.post("/score/{job_id}/approve")
-async def approve_scorecard(job_id: str, approval: ApprovalRequest):
+async def approve_scorecard(request: Request, job_id: str, approval: ApprovalRequest):
     """
     Manager approves a scored call (optionally with edits).
     Updates Form Responses AI, copies to Form Responses 1,
     waits for ARRAYFORMULA, then triggers Apps Script email pipeline.
     """
-    job = _jobs.get(job_id)
+    team_id = team_id_from_path(request)
+    key = _job_key(team_id, job_id)
+    job = _jobs.get(key)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     if job["status"] == "approved":
@@ -199,7 +221,7 @@ async def approve_scorecard(job_id: str, approval: ApprovalRequest):
         )
 
     job["status"] = "approving"
-    config = get_team_config()
+    config = get_team_config(team_id)
 
     try:
         sections_dicts = [s.model_dump() for s in approval.sections]
@@ -238,7 +260,7 @@ async def approve_scorecard(job_id: str, approval: ApprovalRequest):
 
         # 4. Trigger Apps Script email pipeline
         print(f"[approve] Step 4: triggering Apps Script doPost for row {form_1_row}...")
-        script_response = trigger_apps_script(form_1_row)
+        script_response = trigger_apps_script(form_1_row, config.team_id)
         print(f"[approve] Step 4 complete: {script_response}")
 
         # 5. Mark as approved

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 
 from backend.config.team_config import get_team_config
+from backend.middleware.auth import team_id_from_path
 from backend.models.team_stats import (
     MailsEntry,
     TeamStatsResponse,
@@ -24,18 +25,20 @@ from backend.services.team_stats import (
     load_and_clean,
 )
 
-router = APIRouter(prefix="/api/team", tags=["team"])
+router = APIRouter(prefix="/team", tags=["team"])
 
 
 @router.get("/stats", response_model=TeamStatsResponse)
 async def team_stats(
+    request: Request,
     days: int = Query(default=90, ge=0, le=730),
     active_only: bool = Query(default=True),
     supervisor: str = Query(default=""),
 ):
     """Return all team-level statistical computations in one response."""
-    config = get_team_config()
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    provider = await get_provider(team_id)
 
     raw_history = provider._ws.get_all_values()
     raw_mails = provider._get_mails_sheet()
@@ -98,9 +101,10 @@ async def team_stats(
 
 
 @router.get("/mails", response_model=list[MailsEntry])
-async def team_mails():
+async def team_mails(request: Request):
     """Return active analyst roster from Mails sheet."""
-    provider = await get_provider()
+    team_id = team_id_from_path(request)
+    provider = await get_provider(team_id)
     raw_mails = provider._get_mails_sheet()
 
     entries = []

--- a/qa-automation/AI-Scoring/backend/services/history_service.py
+++ b/qa-automation/AI-Scoring/backend/services/history_service.py
@@ -14,6 +14,7 @@ import time as _time
 import gspread
 from google.oauth2.service_account import Credentials
 
+from backend.config.env import env_for_team
 from backend.models.dashboard import EvaluationRecord, SectionScore
 from backend.services.data_provider import DataProvider
 
@@ -124,8 +125,16 @@ class SheetsProvider(DataProvider):
             creds = Credentials.from_service_account_file(creds_env, scopes=_SCOPES)
 
         self._gc = gspread.authorize(creds)
-        sheet_id = os.environ["GOOGLE_SHEETS_ID"]
-        tab_name = os.environ.get("GOOGLE_HISTORY_TAB", self._ah.tab_name_default)
+        sheet_id = env_for_team("GOOGLE_SHEETS_ID", config.team_id, legacy_ok=True)
+        if not sheet_id:
+            raise RuntimeError(
+                f"GOOGLE_SHEETS_ID (or GOOGLE_SHEETS_ID_{config.team_id.upper()}) not set"
+            )
+        self._sheet_id = sheet_id
+        tab_name = (
+            env_for_team("GOOGLE_HISTORY_TAB", config.team_id, legacy_ok=True)
+            or self._ah.tab_name_default
+        )
         self._ws = self._gc.open_by_key(sheet_id).worksheet(tab_name)
 
     # ------------------------------------------------------------------
@@ -202,9 +211,17 @@ class SheetsProvider(DataProvider):
         )
 
     # ------------------------------------------------------------------
+    @property
+    def _history_cache_key(self) -> str:
+        return f"{self._config.team_id}:history"
+
+    @property
+    def _mails_cache_key(self) -> str:
+        return f"{self._config.team_id}:mails"
+
     async def list_agents(self) -> list[str]:
         """Return sorted, deduplicated agent names from column A."""
-        cached = _get_cached_raw("history")
+        cached = _get_cached_raw(self._history_cache_key)
         if cached is not None:
             values = [row[0] if row else "" for row in cached]
         else:
@@ -219,12 +236,12 @@ class SheetsProvider(DataProvider):
     ) -> list[EvaluationRecord]:
         """Return evaluations for *agent_name* within the last *days* days."""
         cutoff = datetime.now() - timedelta(days=days)
-        cached = _get_cached_raw("history")
+        cached = _get_cached_raw(self._history_cache_key)
         if cached is not None:
             all_rows = cached
         else:
             all_rows = self._ws.get_all_values()
-            _set_cached_raw("history", all_rows)
+            _set_cached_raw(self._history_cache_key, all_rows)
 
         records: list[EvaluationRecord] = []
         for row in all_rows[1:]:  # skip header
@@ -246,25 +263,25 @@ class SheetsProvider(DataProvider):
     def _get_mails_sheet(self) -> list[list[str]]:
         """Read the Mails tab (agent roster with supervisors and canonical names).
         Returns raw rows including header. Cached for 5 minutes."""
-        cached = _get_cached_raw("mails")
+        cached = _get_cached_raw(self._mails_cache_key)
         if cached is not None:
             return cached
-        mails_ws = self._gc.open_by_key(
-            os.environ.get("GOOGLE_SHEETS_ID", "")
-        ).worksheet(self._config.sheets.mails_tab)
+        mails_ws = self._gc.open_by_key(self._sheet_id).worksheet(
+            self._config.sheets.mails_tab
+        )
         data = mails_ws.get_all_values()
-        _set_cached_raw("mails", data)
+        _set_cached_raw(self._mails_cache_key, data)
         return data
 
     # ------------------------------------------------------------------
     async def get_all_history(self, days: int = 90) -> list[EvaluationRecord]:
         """Return ALL evaluation records within the time window (no agent filter)."""
-        cached = _get_cached_raw("history")
+        cached = _get_cached_raw(self._history_cache_key)
         if cached is not None:
             all_rows = cached
         else:
             all_rows = self._ws.get_all_values()
-            _set_cached_raw("history", all_rows)
+            _set_cached_raw(self._history_cache_key, all_rows)
 
         cutoff = datetime.now() - timedelta(days=days)
         records: list[EvaluationRecord] = []

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 import gspread
 from google.oauth2.service_account import Credentials
 
+from backend.config.env import env_for_team
 from backend.models.scorecard import ScorecardWithMeta
 
 if TYPE_CHECKING:
@@ -32,14 +33,15 @@ if TYPE_CHECKING:
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
 
-def _get_spreadsheet():
-    """Return a fresh gspread Spreadsheet object."""
+def _get_spreadsheet(team_id: str):
+    """Return a fresh gspread Spreadsheet object for *team_id*."""
     creds_env = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON", "")
-    sheet_id = os.getenv("GOOGLE_SHEETS_ID")
+    sheet_id = env_for_team("GOOGLE_SHEETS_ID", team_id, legacy_ok=True)
 
     if not creds_env or not sheet_id:
         raise RuntimeError(
-            "GOOGLE_SERVICE_ACCOUNT_JSON and GOOGLE_SHEETS_ID must be set"
+            f"GOOGLE_SERVICE_ACCOUNT_JSON and GOOGLE_SHEETS_ID (or "
+            f"GOOGLE_SHEETS_ID_{team_id.upper()}) must be set"
         )
 
     if creds_env.strip().startswith("{"):
@@ -53,10 +55,21 @@ def _get_spreadsheet():
     return client.open_by_key(sheet_id)
 
 
-def _get_sheet(tab_name: str | None = None):
-    """Return a worksheet from the QA spreadsheet."""
-    tab = tab_name or os.getenv("GOOGLE_SHEETS_TAB", "QA Scores")
-    return _get_spreadsheet().worksheet(tab)
+def _get_sheet(config: TeamConfig, tab_name: str | None = None):
+    """Return the Form Responses AI worksheet for *config*'s team."""
+    tab = (
+        tab_name
+        or env_for_team("GOOGLE_SHEETS_TAB", config.team_id, legacy_ok=True)
+        or config.sheets.form_responses_ai.tab_name_default
+    )
+    return _get_spreadsheet(config.team_id).worksheet(tab)
+
+
+def _sheets_configured(team_id: str) -> bool:
+    """True if the env vars needed to reach *team_id*'s sheet are present."""
+    return bool(os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")) and bool(
+        env_for_team("GOOGLE_SHEETS_ID", team_id, legacy_ok=True)
+    )
 
 
 YN_DISPLAY = {
@@ -80,12 +93,12 @@ def append_scorecard_row(scorecard: ScorecardWithMeta, config: TeamConfig) -> in
     Append one draft row to the QA Google Sheet.
     Returns the row number written, or -1 if Sheets is not configured.
     """
-    if not os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON") or not os.getenv("GOOGLE_SHEETS_ID"):
-        print("[sheets_service] Sheets not configured — skipping write.")
+    if not _sheets_configured(config.team_id):
+        print(f"[sheets_service] Sheets not configured for team '{config.team_id}' — skipping write.")
         return -1
 
     fai = config.sheets.form_responses_ai
-    sheet = _get_sheet()
+    sheet = _get_sheet(config)
 
     # Build section lookup by id
     sections_by_id = {s.id: s.model_dump() for s in scorecard.sections}
@@ -167,7 +180,7 @@ def update_scorecard_reasoning(
     the original AI draft scores are preserved as an audit trail.
     """
     fai = config.sheets.form_responses_ai
-    sheet = _get_sheet()
+    sheet = _get_sheet(config)
     sections_by_id = {s["id"]: s for s in sections}
 
     # --- Feedback columns N-O (needed for Analyst_History enrichment) ---
@@ -226,7 +239,7 @@ def write_approved_to_form_responses_1(
     """
     fai = config.sheets.form_responses_ai
     print("[sheets] write_approved: opening Form Responses 1...")
-    spreadsheet = _get_spreadsheet()
+    spreadsheet = _get_spreadsheet(config.team_id)
     form_1 = spreadsheet.worksheet(config.sheets.form_responses_1_tab)
 
     sections_by_id = {s["id"]: s for s in sections}
@@ -262,15 +275,16 @@ def write_approved_to_form_responses_1(
     return form_1_row
 
 
-def trigger_apps_script(form_1_row_num: int) -> dict:
+def trigger_apps_script(form_1_row_num: int, team_id: str) -> dict:
     """POST to the Apps Script web app to trigger the email pipeline."""
     import httpx
 
-    url = os.getenv("APPS_SCRIPT_WEBAPP_URL", "")
+    url = env_for_team("APPS_SCRIPT_WEBAPP_URL", team_id, legacy_ok=True)
     if not url:
         raise RuntimeError(
-            "APPS_SCRIPT_WEBAPP_URL not set — deploy Main.js as a web app "
-            "and add the URL to .env"
+            f"APPS_SCRIPT_WEBAPP_URL not set for team '{team_id}' — deploy "
+            f"Main.js as a web app and set APPS_SCRIPT_WEBAPP_URL"
+            f"{'' if team_id == 'member_support' else '_' + team_id.upper()}"
         )
 
     response = httpx.post(

--- a/qa-automation/AI-Scoring/frontend/dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/dashboard.html
@@ -238,7 +238,7 @@
 <body>
   <div class="header">
     <div style="display:flex;align-items:center;gap:16px;">
-      <a href="/dashboard" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Team View</a>
+      <a id="team-view-link" href="/dashboard/member_support" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Team View</a>
       <h1 id="headerTitle">Agent Dashboard</h1>
     </div>
     <div class="header-controls">
@@ -320,7 +320,12 @@
       const key = getApiKey();
       return key ? { 'Authorization': 'Bearer ' + key } : {};
     }
-    const API_BASE = window.location.origin;
+    const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)\/agent\//) || [, 'member_support'])[1];
+    const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+    document.addEventListener('DOMContentLoaded', () => {
+      const teamLink = document.getElementById('team-view-link');
+      if (teamLink) teamLink.href = `/dashboard/${TEAM_ID}`;
+    });
     let selectedDays = 30;
     let trendChartInstance = null;
     let sectionChartInstance = null;
@@ -387,14 +392,10 @@
       }
     }
 
-    // Extract agent name from URL: /dashboard/agent/{name}
+    // Extract agent name from URL: /dashboard/{team_id}/agent/{name}
     function getAgentFromURL() {
-      const path = window.location.pathname;
-      const prefix = '/dashboard/agent/';
-      if (path.startsWith(prefix)) {
-        return decodeURIComponent(path.substring(prefix.length));
-      }
-      return null;
+      const m = window.location.pathname.match(/^\/dashboard\/[^\/]+\/agent\/(.+)$/);
+      return m ? decodeURIComponent(m[1]) : null;
     }
 
     const currentAgent = getAgentFromURL();
@@ -414,7 +415,7 @@
       document.getElementById('footer').textContent = '';
 
       const history = await fetchJSON(
-        `${API_BASE}/api/agents/${encodeURIComponent(agentName)}/history?days=${selectedDays}`
+        `${API_BASE}/agents/${encodeURIComponent(agentName)}/history?days=${selectedDays}`
       );
 
       if (!history) {
@@ -481,7 +482,7 @@
       btn.textContent = 'Generating...';
 
       const progression = await fetchJSON(
-        `${API_BASE}/api/agents/${encodeURIComponent(currentAgent)}/progression?days=${selectedDays}`
+        `${API_BASE}/agents/${encodeURIComponent(currentAgent)}/progression?days=${selectedDays}`
       );
 
       if (progression) {
@@ -551,7 +552,7 @@
             if (activeElements.length) {
               const idx = activeElements[0].index;
               const rec = history[idx];
-              if (rec.eval_id) window.location.href = `/datapoint/${rec.eval_id}`;
+              if (rec.eval_id) window.location.href = `/datapoint/${TEAM_ID}/${rec.eval_id}`;
             }
           },
           scales: {

--- a/qa-automation/AI-Scoring/frontend/datapoint.html
+++ b/qa-automation/AI-Scoring/frontend/datapoint.html
@@ -217,7 +217,7 @@
       <div class="header-meta" id="headerMeta"></div>
     </div>
     <div class="nav-links">
-      <a href="/dashboard">Team View</a>
+      <a id="teamLink" href="/dashboard/member_support">Team View</a>
       <a href="#" id="agentLink">Agent View</a>
     </div>
   </div>
@@ -306,17 +306,19 @@
       return 'score-red';
     }
 
-    // Extract call_id from URL: /datapoint/{call_id}
-    function getCallIdFromURL() {
-      const path = window.location.pathname;
-      const prefix = '/datapoint/';
-      if (path.startsWith(prefix)) {
-        return decodeURIComponent(path.substring(prefix.length));
-      }
-      return null;
+    // Extract team_id and call_id from URL: /datapoint/{team_id}/{call_id}
+    function parseURL() {
+      const m = window.location.pathname.match(/^\/datapoint\/([^\/]+)\/(.+)$/);
+      if (m) return { teamId: m[1], callId: decodeURIComponent(m[2]) };
+      return { teamId: 'member_support', callId: null };
     }
 
-    const callId = getCallIdFromURL();
+    const { teamId: TEAM_ID, callId } = parseURL();
+    const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+    document.addEventListener('DOMContentLoaded', () => {
+      const teamLink = document.getElementById('teamLink');
+      if (teamLink) teamLink.href = `/dashboard/${TEAM_ID}`;
+    });
 
     async function loadDataPoint() {
       if (!callId) {
@@ -324,8 +326,7 @@
         return;
       }
 
-      const API_BASE = window.location.origin;
-      const eval_ = await fetchJSON(`${API_BASE}/api/datapoints/${callId}`);
+      const eval_ = await fetchJSON(`${API_BASE}/datapoints/${callId}`);
 
       if (!eval_) {
         document.getElementById('placeholder').textContent = `No evaluation found for call ${callId}.`;
@@ -338,7 +339,7 @@
       document.getElementById('headerTitle').textContent = eval_.agent_name;
       document.getElementById('headerMeta').textContent =
         `Call ${callId}  |  ${new Date(eval_.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}  |  Evaluator: ${eval_.manager_email}`;
-      document.getElementById('agentLink').href = `/dashboard/agent/${encodeURIComponent(eval_.agent_name)}`;
+      document.getElementById('agentLink').href = `/dashboard/${TEAM_ID}/agent/${encodeURIComponent(eval_.agent_name)}`;
 
       // Info grid
       const infoCard = document.getElementById('infoCard');
@@ -414,7 +415,7 @@
       }
 
       // Mini progression history
-      const history = await fetchJSON(`${API_BASE}/api/agents/${encodeURIComponent(eval_.agent_name)}/history?days=90`);
+      const history = await fetchJSON(`${API_BASE}/agents/${encodeURIComponent(eval_.agent_name)}/history?days=90`);
       if (history && history.length > 0) {
         const last5 = history.slice(-5);
         let tbody = '';

--- a/qa-automation/AI-Scoring/frontend/index.html
+++ b/qa-automation/AI-Scoring/frontend/index.html
@@ -484,7 +484,7 @@
       <h1>Landing QA Scoring</h1>
       <p>AI-assisted call evaluation — Phase 1. Human review required before scores reach agents.</p>
     </div>
-    <a href="/dashboard" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Team Dashboard</a>
+    <a id="team-dashboard-link" href="/dashboard/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Team Dashboard</a>
   </div>
 </header>
 
@@ -531,7 +531,14 @@
 </div>
 
 <script>
-  // --- Auth ---
+  // --- Team + Auth ---
+  const TEAM_ID = (location.pathname.match(/^\/score\/([^\/]+)/) || [, 'member_support'])[1];
+  const API_BASE = `/api/${TEAM_ID}`;
+  document.addEventListener('DOMContentLoaded', () => {
+    const dashLink = document.getElementById('team-dashboard-link');
+    if (dashLink) dashLink.href = `/dashboard/${TEAM_ID}`;
+  });
+
   function getApiKey() {
     let key = sessionStorage.getItem('qa_api_key');
     if (!key) {
@@ -549,7 +556,7 @@
   async function loadAgentDropdown() {
     const select = document.getElementById('agent-name');
     try {
-      const res = await fetch('/api/team/mails', { headers: authHeaders() });
+      const res = await fetch(`${API_BASE}/team/mails`, { headers: authHeaders() });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const mails = await res.json();
       const names = mails.map(m => m.agent_name).sort();
@@ -644,7 +651,7 @@
       formData.append('agent_name', agentName);
       formData.append('manager_email', managerEmail);
 
-      const res = await fetch('/api/score', { method: 'POST', body: formData, headers: authHeaders() });
+      const res = await fetch(`${API_BASE}/score`, { method: 'POST', body: formData, headers: authHeaders() });
       if (res.status === 401) {
         sessionStorage.removeItem('qa_api_key');
         alert('Invalid API key. Please reload and try again.');
@@ -683,7 +690,7 @@
     const interval = setInterval(async () => {
       let allDone = true;
       for (const { jobId, filename, callId } of jobs) {
-        const res = await fetch(`/api/score/${jobId}`, { headers: authHeaders() });
+        const res = await fetch(`${API_BASE}/score/${jobId}`, { headers: authHeaders() });
         const data = await res.json();
         updateJobRow(jobId, filename, callId, data);
         if (!['complete', 'approved', 'error'].includes(data.status)) allDone = false;
@@ -942,7 +949,7 @@
     };
 
     try {
-      const res = await fetch(`/api/score/${jobId}/approve`, {
+      const res = await fetch(`${API_BASE}/score/${jobId}/approve`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(payload),

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -120,7 +120,7 @@
 
 <div class="header">
   <div style="display:flex;align-items:center;gap:16px;">
-    <a href="/" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Scoring</a>
+    <a id="scoring-link" href="/score/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Scoring</a>
     <h1>Team Analytics Dashboard</h1>
   </div>
   <div class="header-controls">
@@ -228,7 +228,12 @@ function authHeaders() {
   return key ? { 'Authorization': 'Bearer ' + key } : {};
 }
 
-const API_BASE = window.location.origin;
+const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+document.addEventListener('DOMContentLoaded', () => {
+  const scoringLink = document.getElementById('scoring-link');
+  if (scoringLink) scoringLink.href = `/score/${TEAM_ID}`;
+});
 let selectedDays = 90;
 let activeOnly = true;
 let selectedSupervisor = '';
@@ -245,7 +250,7 @@ async function fetchTeamStats() {
   const params = new URLSearchParams({ days: selectedDays, active_only: activeOnly });
   if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
   try {
-    const r = await fetch(`${API_BASE}/api/team/stats?${params}`, { headers: authHeaders() });
+    const r = await fetch(`${API_BASE}/team/stats?${params}`, { headers: authHeaders() });
     if (r.status === 401) {
       sessionStorage.removeItem('qa_api_key');
       alert('Invalid API key. Please reload and try again.');
@@ -261,7 +266,7 @@ async function fetchTeamStats() {
 
 async function fetchMails() {
   try {
-    const r = await fetch(`${API_BASE}/api/team/mails`, { headers: authHeaders() });
+    const r = await fetch(`${API_BASE}/team/mails`, { headers: authHeaders() });
     if (r.status === 401) {
       sessionStorage.removeItem('qa_api_key');
       alert('Invalid API key. Please reload and try again.');
@@ -483,10 +488,10 @@ function renderDistDrillTable() {
         <th style="${thStyle}">Call</th>
       </tr>
       ${sorted.map(e => `<tr style="border-bottom:1px solid var(--border);">
-        <td style="padding:6px;"><a href="/dashboard/agent/${encodeURIComponent(e.agent_name)}">${e.agent_name}</a></td>
+        <td style="padding:6px;"><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(e.agent_name)}">${e.agent_name}</a></td>
         <td style="padding:6px;text-align:center;">${new Date(e.timestamp).toLocaleDateString('en-US',{month:'short',day:'numeric'})}</td>
         <td style="padding:6px;text-align:center;color:${e.overall_score>=85?'var(--green)':e.overall_score>=70?'var(--amber)':'var(--red)'};font-weight:500;">${e.overall_score.toFixed(1)}</td>
-        <td style="padding:6px;text-align:center;">${e.eval_id ? `<a href="/datapoint/${e.eval_id}">View</a>` : ''}</td>
+        <td style="padding:6px;text-align:center;">${e.eval_id ? `<a href="/datapoint/${TEAM_ID}/${e.eval_id}">View</a>` : ''}</td>
       </tr>`).join('')}
     </table>`;
 }
@@ -507,7 +512,7 @@ async function loadDistDrillDown(bin) {
   drillEl.innerHTML = `<p style="color:var(--muted);font-size:0.8rem;padding:10px 6px;">Loading evaluations in ${bin}...</p>`;
 
   try {
-    const r = await fetch(`${API_BASE}/api/datapoints?bin=${bin}&days=${selectedDays}&active_only=${activeOnly}`, { headers: authHeaders() });
+    const r = await fetch(`${API_BASE}/datapoints?bin=${bin}&days=${selectedDays}&active_only=${activeOnly}`, { headers: authHeaders() });
     if (!r.ok) { drillEl.innerHTML = `<p style="color:var(--red);font-size:0.8rem;padding:8px;">Failed to load.</p>`; return; }
     _distDrillData = await r.json();
     if (!_distDrillData.length) { drillEl.innerHTML = `<p style="color:var(--muted);font-size:0.8rem;padding:10px 6px;">No evaluations in ${bin}.</p>`; return; }
@@ -538,7 +543,7 @@ function renderRoster() {
 
 function fillRoster(data) {
   document.querySelector('#rosterTable tbody').innerHTML = data.map(r => `<tr>
-    <td><a href="/dashboard/agent/${encodeURIComponent(r.agent)}">${escapeHtml(r.agent)}</a></td>
+    <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(r.agent)}">${escapeHtml(r.agent)}</a></td>
     <td>${r.n ?? ''}</td><td style="color:${scoreColor(r.mean)}">${fmt(r.mean)}</td><td>${fmt(r.std)}</td>
     <td style="color:${scoreColor(r.ewma)}">${fmt(r.ewma)}</td><td>${trendHtml(r.trend)}</td>
     <td>${pctFmt(r.id_val_pct)}</td><td>${pctFmt(r.cust_res_pct)}</td>
@@ -555,8 +560,8 @@ function renderOutliers() {
 
 function fillOutliers(data) {
   document.querySelector('#outliersTable tbody').innerHTML = data.map(o => `<tr>
-    <td><a href="/dashboard/agent/${encodeURIComponent(o.agent)}">${escapeHtml(o.agent)}</a></td>
-    <td>${o.date || ''}</td><td>${o.eval_id ? `<a href="/datapoint/${o.eval_id}" style="color:${scoreColor(o.score)};font-weight:500;">${fmt(o.score, 0)}</a>` : `<span style="color:${scoreColor(o.score)}">${fmt(o.score, 0)}</span>`}</td>
+    <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(o.agent)}">${escapeHtml(o.agent)}</a></td>
+    <td>${o.date || ''}</td><td>${o.eval_id ? `<a href="/datapoint/${TEAM_ID}/${o.eval_id}" style="color:${scoreColor(o.score)};font-weight:500;">${fmt(o.score, 0)}</a>` : `<span style="color:${scoreColor(o.score)}">${fmt(o.score, 0)}</span>`}</td>
     <td>${fmt(o.agent_median)}</td><td>${fmt(o.modified_z, 2)}</td>
     <td><span class="badge badge-${o.classification}">${o.classification}</span></td>
   </tr>`).join('');


### PR DESCRIPTION
URL-based team routing (/api/{team_id}/..., /score/{team_id}, /dashboard/{team_id}[/agent/{name}], /datapoint/{team_id}/{call_id}). API key auth now enforces that the URL's team matches the key's team — a Sales key returns 403 on any Member Support endpoint, and vice versa.

Legacy single-tenant URLs (/api/score, /dashboard, etc.) are preserved for 30 days via a shim router that hardcodes team_id='member_support', plus 307 redirects for the page routes.

Per-team env var convention: GOOGLE_SHEETS_ID_{TEAM}, APPS_SCRIPT_WEBAPP_URL_{TEAM}, API_KEY_{TEAM}. member_support keeps falling back to the flat names so the existing .env keeps working.

History-cache keys and the in-memory job store are now prefixed with team_id to prevent cross-team leakage.