### PR TITLE
feat: email-based Dialpad lookup (team-scoped, supersedes feature/loo…

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -15,6 +15,7 @@ from backend.routes.scoring import router as scoring_router
 from backend.routes.dashboard import router as dashboard_router
 from backend.routes.team import router as team_router
 from backend.routes.datapoints import router as datapoints_router
+from backend.routes.lookup import router as lookup_router
 from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
 from backend.middleware.audit import AuditLogMiddleware
 
@@ -39,11 +40,11 @@ app.add_middleware(
 app.add_middleware(AuditLogMiddleware)
 
 # Team-aware routes (primary). API key's team_id must match the URL team_id.
-for r in (scoring_router, dashboard_router, team_router, datapoints_router):
+for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router):
     app.include_router(r, prefix="/api/{team_id}", dependencies=TEAM_AUTH_DEPENDENCY)
 
 # Legacy single-team shim (30-day transition). team_id defaults to 'member_support'.
-for r in (scoring_router, dashboard_router, team_router, datapoints_router):
+for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router):
     app.include_router(r, prefix="/api", dependencies=AUTH_DEPENDENCY)
 
 
@@ -75,6 +76,11 @@ async def serve_datapoint_page(team_id: str, call_id: str):
 @app.get("/dashboard/{team_id}", include_in_schema=False)
 async def serve_team_dashboard(team_id: str):
     return FileResponse(_frontend_dir / "team_dashboard.html")
+
+
+@app.get("/lookup/{team_id}", include_in_schema=False)
+async def serve_lookup_page(team_id: str):
+    return FileResponse(_frontend_dir / "lookup.html")
 
 
 # --- Legacy page redirects (30-day transition) ---

--- a/qa-automation/AI-Scoring/backend/routes/lookup.py
+++ b/qa-automation/AI-Scoring/backend/routes/lookup.py
@@ -1,0 +1,72 @@
+"""Dialpad user lookup routes."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from backend.services.dialpad_client import (
+    get_recording_share_link,
+    get_user_by_email,
+    list_calls_for_user,
+)
+
+router = APIRouter(prefix="/lookup", tags=["lookup"])
+
+
+@router.get("")
+async def lookup_user(email: str = Query(..., description="Dialpad user email")):
+    """Look up a Dialpad user by email. Returns parsed user profile."""
+    user = await get_user_by_email(email)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"No Dialpad user found for '{email}'")
+    return user
+
+
+@router.get("/calls")
+async def lookup_calls(
+    user_id: str = Query(..., description="Dialpad user ID"),
+    date_start: Optional[str] = Query(None, description="Start date ISO (YYYY-MM-DDTHH:MM)"),
+    date_end: Optional[str] = Query(None, description="End date ISO (YYYY-MM-DDTHH:MM)"),
+    cursor: Optional[str] = Query(None, description="Pagination cursor from previous response"),
+    limit: int = Query(10, ge=1, le=100),
+):
+    """Fetch calls for a Dialpad user. Dates are local ISO strings, converted to epoch ms."""
+    started_after_ms = None
+    started_before_ms = None
+
+    if date_start:
+        try:
+            dt = datetime.fromisoformat(date_start)
+            started_after_ms = int(dt.timestamp() * 1000)
+        except ValueError:
+            raise HTTPException(400, "date_start must be ISO format (YYYY-MM-DDTHH:MM)")
+
+    if date_end:
+        try:
+            dt = datetime.fromisoformat(date_end)
+            started_before_ms = int(dt.timestamp() * 1000)
+        except ValueError:
+            raise HTTPException(400, "date_end must be ISO format (YYYY-MM-DDTHH:MM)")
+
+    calls, next_cursor = await list_calls_for_user(
+        user_id, started_after_ms, started_before_ms, limit, cursor
+    )
+    return {
+        "user_id": user_id,
+        "call_count": len(calls),
+        "calls": calls,
+        "cursor": next_cursor,
+    }
+
+
+@router.post("/recording-link")
+async def generate_recording_link(
+    recording_id: str = Query(..., description="Dialpad recording ID"),
+    recording_type: str = Query("admincallrecording", description="Recording type"),
+):
+    """Generate a shareable recording link via Dialpad API."""
+    link = await get_recording_share_link(recording_id, recording_type)
+    if not link:
+        raise HTTPException(404, "Could not generate recording link")
+    return {"link": link}

--- a/qa-automation/AI-Scoring/backend/services/dialpad_client.py
+++ b/qa-automation/AI-Scoring/backend/services/dialpad_client.py
@@ -28,16 +28,75 @@ FILTERED_MOMENT_TYPES = {
 def _headers() -> Optional[dict]:
     token = os.getenv("DIALPAD_API_KEY")
     if not token:
-        return None  # caller checks for None and skips
-    # DEBUG: remove after confirming auth works
-    print(f"[dialpad_client] Token length: {len(token)}, starts: {token[:20]}..., ends: ...{token[-10:]}")
-    print(f"[dialpad_client] Token repr (check for quotes/whitespace): {repr(token[:30])}")
+        print("No API token")
+        return None
     return {"Authorization": f"Bearer {token}"}
 
 
 # ---------------------------------------------------------------------------
 # User / agent lookup
 # ---------------------------------------------------------------------------
+
+async def get_user_by_email(email: str) -> Optional[dict]:
+    """
+    Look up a Dialpad user by email via GET /users?email=.
+    Returns a parsed dict with the fields the frontend needs, or None.
+    """
+    hdrs = _headers()
+    if not hdrs:
+        return None
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{BASE_URL}/users",
+                headers=hdrs,
+                params={"email": email},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            items = resp.json().get("items", [])
+    except httpx.HTTPStatusError as e:
+        print(f"[dialpad_client] user lookup by email failed ({e.response.status_code}): {e}")
+        return None
+    except httpx.RequestError as e:
+        print(f"[dialpad_client] user lookup request error: {e}")
+        return None
+
+    if not items:
+        return None
+
+    u = items[0]
+    return {
+        "id": str(u.get("id", "")),
+        "display_name": u.get("display_name", ""),
+        "first_name": u.get("first_name", ""),
+        "last_name": u.get("last_name", ""),
+        "emails": u.get("emails", []),
+        "extension": u.get("extension", ""),
+        "phone_numbers": u.get("phone_numbers", []),
+        "job_title": u.get("job_title", ""),
+        "state": u.get("state", ""),
+        "license": u.get("license", ""),
+        "is_admin": u.get("is_admin", False),
+        "is_online": u.get("is_online", False),
+        "is_available": u.get("is_available", False),
+        "is_on_duty": u.get("is_on_duty", False),
+        "on_duty_status": u.get("on_duty_status", ""),
+        "timezone": u.get("timezone", ""),
+        "office_id": str(u.get("office_id", "")),
+        "date_added": u.get("date_added", ""),
+        "duty_status_started": u.get("duty_status_started", ""),
+        "groups": [
+            {
+                "group_id": str(g.get("group_id", "")),
+                "group_type": g.get("group_type", ""),
+                "role": g.get("role", ""),
+            }
+            for g in u.get("group_details", [])
+        ],
+    }
+
 
 async def get_user_id_by_name(agent_name: str) -> Optional[str]:
     """
@@ -66,8 +125,92 @@ async def get_user_id_by_name(agent_name: str) -> Optional[str]:
     return None
 
 
+async def list_calls_for_user(
+    user_id: str,
+    started_after_ms: Optional[int] = None,
+    started_before_ms: Optional[int] = None,
+    limit: int = 10,
+    cursor: Optional[str] = None,
+) -> tuple[list[dict], Optional[str]]:
+    """
+    Fetch recent calls for a user via GET /call?target_id=&target_type=user.
+    Timestamps are epoch milliseconds (UTC). Returns (parsed call dicts, next_cursor).
+    """
+    hdrs = _headers()
+    if not hdrs:
+        return [], None
+
+    params: dict = {
+        "target_id": user_id,
+        "target_type": "user",
+        "limit": limit,
+    }
+    if started_after_ms is not None:
+        params["started_after"] = started_after_ms
+    if started_before_ms is not None:
+        params["started_before"] = started_before_ms
+    if cursor:
+        params["cursor"] = cursor
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{BASE_URL}/call",
+                headers=hdrs,
+                params=params,
+                timeout=20,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            items = data.get("items", [])
+            next_cursor = data.get("cursor") or None
+    except httpx.HTTPStatusError as e:
+        print(f"[dialpad_client] list_calls_for_user failed ({e.response.status_code}): {e}")
+        return [], None
+    except httpx.RequestError as e:
+        print(f"[dialpad_client] list_calls_for_user request error: {e}")
+        return [], None
+
+    calls = []
+    for c in items:
+        duration = c.get("total_duration", 0) or c.get("duration", 0) or 0
+        calls.append({
+            "call_id": str(c.get("call_id", "")),
+            "date_started": _epoch_to_iso(c.get("date_started")),
+            "date_connected": _epoch_to_iso(c.get("date_connected")),
+            "date_ended": _epoch_to_iso(c.get("date_ended")),
+            "duration": duration,
+            "direction": c.get("direction", ""),
+            "was_recorded": bool(c.get("recording_details")),
+            "recording_id": str(c.get("recording_details", [{}])[0].get("id", "")) if c.get("recording_details") else "",
+            "recording_url": c.get("recording_details", [{}])[0].get("url", "") if c.get("recording_details") else "",
+            "recording_duration": int(c.get("recording_details", [{}])[0].get("duration", 0)) if c.get("recording_details") else 0,
+            "recording_type": c.get("recording_details", [{}])[0].get("recording_type", "") if c.get("recording_details") else "",
+            "is_transferred": c.get("is_transferred", False),
+            "external_number": c.get("external_number", ""),
+            "internal_number": c.get("internal_number", ""),
+            "contact_name": (c.get("contact") or {}).get("name", ""),
+            "contact_phone": (c.get("contact") or {}).get("phone", ""),
+            "mos_score": c.get("mos_score"),
+            "entry_point_call_id": str(c.get("entry_point_call_id", "")),
+            "_flagged_long_call": duration > CALL_DURATION_FLAG_MS,
+        })
+    return calls, next_cursor
+
+
+def _epoch_to_iso(val) -> str:
+    """Convert an epoch-ms timestamp (int or numeric string) to ISO string."""
+    if val is None:
+        return ""
+    try:
+        ts = int(val) / 1000
+        return datetime.fromtimestamp(ts).isoformat()
+    except (ValueError, TypeError, OSError):
+        return str(val)
+
+
 # ---------------------------------------------------------------------------
-# Call listing
+# Call listing (stats — used by scoring pipeline)
 # ---------------------------------------------------------------------------
 
 async def get_calls_for_agent(
@@ -110,8 +253,44 @@ async def get_calls_for_agent(
 
 
 def build_dialpad_link(call_id: str) -> str:
-    """Construct the Dialpad web link for a call."""
+    """Construct the Dialpad web link for a call (used by scoring pipeline)."""
     return f"https://dialpad.com/callhistory/callreview/{call_id}"
+
+
+async def get_recording_share_link(
+    recording_id: str,
+    recording_type: str = "admincallrecording",
+) -> Optional[str]:
+    """
+    Generate a shareable recording link via POST /recordingsharelink.
+    Returns the share URL, or None on failure.
+    """
+    hdrs = _headers()
+    if not hdrs or not recording_id:
+        return None
+
+    hdrs["Content-Type"] = "application/json"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{BASE_URL}/recordingsharelink",
+                headers=hdrs,
+                json={
+                    "privacy": "company",
+                    "recording_type": recording_type,
+                    "recording_id": recording_id,
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("access_link") or None
+    except httpx.HTTPStatusError as e:
+        print(f"[dialpad_client] recording share link failed ({e.response.status_code}): {e}")
+        return None
+    except httpx.RequestError as e:
+        print(f"[dialpad_client] recording share link request error: {e}")
+        return None
 
 
 async def get_call_details(call_id: str) -> dict:

--- a/qa-automation/AI-Scoring/frontend/lookup.html
+++ b/qa-automation/AI-Scoring/frontend/lookup.html
@@ -1,0 +1,502 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dialpad User Lookup</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --navy: #15192D; --accent: #1A61D9; --bg: #E7EFFB; --surface: #ffffff;
+      --border: #c9d5e8; --text: #15192D; --muted: #5a6478;
+      --green: #28A745; --amber: #E8A317; --red: #D9534F;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    /* Header */
+    .header {
+      background: var(--navy); color: #fff; padding: 16px 24px;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    .header h1 { font-size: 1.25rem; font-weight: 600; }
+    .nav-links { display: flex; gap: 8px; }
+    .nav-links a {
+      color: rgba(255,255,255,0.7); text-decoration: none; font-size: 0.8rem;
+      border: 1px solid rgba(255,255,255,0.3); padding: 4px 12px; border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .nav-links a:hover { background: rgba(255,255,255,0.1); }
+
+    /* Layout */
+    .container { max-width: 800px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+
+    /* Search bar */
+    .search-bar {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+      padding: 20px; display: flex; gap: 12px; align-items: end;
+    }
+    .search-bar .field { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+    .search-bar label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .search-bar input {
+      font-family: 'DM Mono', monospace; font-size: 0.9rem; padding: 8px 12px;
+      border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+    }
+    .search-bar input:focus { outline: none; border-color: var(--accent); }
+    .search-bar button {
+      font-family: 'DM Mono', monospace; font-size: 0.85rem; padding: 8px 20px;
+      background: var(--accent); color: #fff; border: none; border-radius: 6px;
+      cursor: pointer; white-space: nowrap; transition: opacity 0.2s;
+    }
+    .search-bar button:hover { opacity: 0.9; }
+    .search-bar button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* Result card */
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+    .card h2 { font-size: 1.1rem; margin-bottom: 16px; }
+
+    /* Profile header */
+    .profile-header { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
+    .profile-avatar {
+      width: 56px; height: 56px; border-radius: 50%; background: var(--accent);
+      color: #fff; display: flex; align-items: center; justify-content: center;
+      font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 700; flex-shrink: 0;
+    }
+    .profile-name { font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 600; }
+    .profile-title { font-size: 0.8rem; color: var(--muted); margin-top: 2px; }
+
+    /* Status badges */
+    .badges { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .badge {
+      font-size: 0.7rem; padding: 3px 10px; border-radius: 20px; font-weight: 500;
+      text-transform: uppercase; letter-spacing: 0.03em;
+    }
+    .badge.green { background: #e6f4ea; color: #137333; }
+    .badge.amber { background: #fef7e0; color: #9a6700; }
+    .badge.red { background: #fce8e6; color: #c5221f; }
+    .badge.blue { background: #e8f0fe; color: #1a61d9; }
+    .badge.gray { background: #f1f3f5; color: #5a6478; }
+
+    /* Info grid */
+    .info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; }
+    .info-item label { display: block; font-size: 0.65rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px; }
+    .info-item .val { font-size: 0.85rem; word-break: break-all; }
+
+    /* Groups table */
+    .groups-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 8px; }
+    .groups-table th, .groups-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    .groups-table th { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+
+    /* Calls section */
+    .calls-controls {
+      display: flex; gap: 12px; align-items: end; flex-wrap: wrap; margin-bottom: 16px;
+    }
+    .calls-controls .field { display: flex; flex-direction: column; gap: 4px; }
+    .calls-controls label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .calls-controls input[type="datetime-local"] {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 10px;
+      border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+    }
+    .calls-controls input:focus { outline: none; border-color: var(--accent); }
+    .calls-controls button {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 16px;
+      background: var(--accent); color: #fff; border: none; border-radius: 6px;
+      cursor: pointer; transition: opacity 0.2s;
+    }
+    .calls-controls button:hover { opacity: 0.9; }
+    .calls-controls button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .calls-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    .calls-table th, .calls-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    .calls-table th {
+      font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+      position: sticky; top: 0; background: var(--surface);
+    }
+    .calls-table tr.flagged { background: #fef7e0; }
+    .calls-table a { color: var(--accent); text-decoration: none; }
+    .calls-table a:hover { text-decoration: underline; }
+    .calls-count { font-size: 0.75rem; color: var(--muted); margin-bottom: 8px; }
+    .direction-badge {
+      font-size: 0.65rem; padding: 2px 8px; border-radius: 10px; font-weight: 500;
+    }
+    .direction-badge.inbound { background: #e8f0fe; color: #1a61d9; }
+    .direction-badge.outbound { background: #e6f4ea; color: #137333; }
+
+    /* Error / empty states */
+    .msg { padding: 16px; border-radius: 8px; font-size: 0.85rem; text-align: center; }
+    .msg.error { background: #fce8e6; color: #c5221f; }
+    .msg.empty { background: var(--surface); color: var(--muted); border: 1px solid var(--border); }
+
+    .hidden { display: none; }
+
+    @media (max-width: 600px) {
+      .info-grid { grid-template-columns: 1fr; }
+      .search-bar { flex-direction: column; align-items: stretch; }
+      .calls-controls { flex-direction: column; align-items: stretch; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Dialpad User Lookup</h1>
+    <div class="nav-links">
+      <a href="/">Scoring</a>
+      <a href="/dashboard">Dashboard</a>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="search-bar">
+      <div class="field">
+        <label for="email">Email address</label>
+        <input type="email" id="email" placeholder="agent@hellolanding.com" />
+      </div>
+      <button id="searchBtn" onclick="doSearch()">Look up</button>
+    </div>
+
+    <div id="errorMsg" class="msg error hidden"></div>
+    <div id="emptyMsg" class="msg empty hidden">No user found for that email.</div>
+
+    <div id="resultCard" class="card hidden">
+      <div class="profile-header">
+        <div class="profile-avatar" id="avatar"></div>
+        <div>
+          <div class="profile-name" id="displayName"></div>
+          <div class="profile-title" id="jobTitle"></div>
+        </div>
+      </div>
+
+      <div class="badges" id="badges"></div>
+
+      <h3 style="font-size:0.85rem; margin-bottom:12px;">Details</h3>
+      <div class="info-grid" id="infoGrid"></div>
+
+      <div id="groupsSection" class="hidden" style="margin-top:20px;">
+        <h3 style="font-size:0.85rem; margin-bottom:8px;">Groups</h3>
+        <table class="groups-table">
+          <thead><tr><th>Group ID</th><th>Type</th><th>Role</th></tr></thead>
+          <tbody id="groupsBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Calls section — appears after successful user lookup -->
+    <div id="callsCard" class="card hidden">
+      <h3 style="font-size:0.95rem; margin-bottom:16px;">Call History</h3>
+      <div class="calls-controls">
+        <div class="field">
+          <label for="dateStart">From</label>
+          <input type="datetime-local" id="dateStart" />
+        </div>
+        <div class="field">
+          <label for="dateEnd">To</label>
+          <input type="datetime-local" id="dateEnd" />
+        </div>
+        <button id="fetchCallsBtn" onclick="fetchCalls()">Fetch calls</button>
+      </div>
+      <div id="callsError" class="msg error hidden"></div>
+      <div id="callsEmpty" class="msg empty hidden">No calls found in this range.</div>
+      <div id="callsCount" class="calls-count hidden"></div>
+      <div style="overflow-x:auto;">
+        <table class="calls-table hidden" id="callsTable">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Direction</th>
+              <th>Contact</th>
+              <th>Duration</th>
+              <th>Recorded</th>
+              <th>Link</th>
+            </tr>
+          </thead>
+          <tbody id="callsBody"></tbody>
+        </table>
+      </div>
+      <button id="loadMoreBtn" class="hidden" onclick="loadMore()" style="
+        font-family:'DM Mono',monospace; font-size:0.8rem; padding:8px 20px; margin-top:12px;
+        background:transparent; color:var(--accent); border:1px solid var(--accent); border-radius:6px;
+        cursor:pointer; align-self:center; transition:background 0.2s, color 0.2s;
+      ">Load next 10</button>
+    </div>
+  </div>
+
+<script>
+const TEAM_ID = (location.pathname.match(/^\/lookup\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `/api/${TEAM_ID}`;
+
+const $ = id => document.getElementById(id);
+
+function getApiKey() {
+  let key = sessionStorage.getItem('qa_api_key');
+  if (!key) {
+    key = prompt('Enter your QA API key:');
+    if (key) sessionStorage.setItem('qa_api_key', key);
+  }
+  return key;
+}
+function authHeaders() {
+  const key = getApiKey();
+  return key ? { 'Authorization': 'Bearer ' + key } : {};
+}
+
+let currentUserId = null;
+let nextCursor = null;
+let totalLoaded = 0;
+
+// Default date range: past 7 days
+function initDateDefaults() {
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  $('dateEnd').value = toLocalISO(now);
+  $('dateStart').value = toLocalISO(weekAgo);
+}
+function toLocalISO(d) {
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+initDateDefaults();
+
+// Allow Enter key to trigger search
+$('email').addEventListener('keydown', e => { if (e.key === 'Enter') doSearch(); });
+
+async function doSearch() {
+  const email = $('email').value.trim();
+  if (!email) return;
+
+  const btn = $('searchBtn');
+  btn.disabled = true;
+  btn.textContent = 'Searching...';
+  $('resultCard').classList.add('hidden');
+  $('callsCard').classList.add('hidden');
+  $('errorMsg').classList.add('hidden');
+  $('emptyMsg').classList.add('hidden');
+  currentUserId = null;
+
+  try {
+    const resp = await fetch(`${API_BASE}/lookup?email=${encodeURIComponent(email)}`, { headers: authHeaders() });
+    if (resp.status === 404) {
+      $('emptyMsg').classList.remove('hidden');
+      return;
+    }
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const user = await resp.json();
+    currentUserId = user.id;
+    renderUser(user);
+    // Show calls section and auto-fetch
+    $('callsCard').classList.remove('hidden');
+    fetchCalls();
+  } catch (e) {
+    $('errorMsg').textContent = e.message;
+    $('errorMsg').classList.remove('hidden');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Look up';
+  }
+}
+
+async function fetchCalls(append = false) {
+  if (!currentUserId) return;
+
+  const btn = append ? $('loadMoreBtn') : $('fetchCallsBtn');
+  btn.disabled = true;
+  btn.textContent = 'Loading...';
+
+  if (!append) {
+    $('callsTable').classList.add('hidden');
+    $('callsCount').classList.add('hidden');
+    $('callsError').classList.add('hidden');
+    $('callsEmpty').classList.add('hidden');
+    $('loadMoreBtn').classList.add('hidden');
+    $('callsBody').innerHTML = '';
+    nextCursor = null;
+    totalLoaded = 0;
+  }
+
+  const params = new URLSearchParams({ user_id: currentUserId, limit: '10' });
+  const ds = $('dateStart').value;
+  const de = $('dateEnd').value;
+  if (ds) params.set('date_start', ds);
+  if (de) params.set('date_end', de);
+  if (append && nextCursor) params.set('cursor', nextCursor);
+
+  try {
+    const resp = await fetch(`${API_BASE}/lookup/calls?${params}`, { headers: authHeaders() });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const data = await resp.json();
+    nextCursor = data.cursor || null;
+    renderCalls(data.calls, append);
+  } catch (e) {
+    $('callsError').textContent = e.message;
+    $('callsError').classList.remove('hidden');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = append ? 'Load next 10' : 'Fetch calls';
+  }
+}
+
+function loadMore() {
+  fetchCalls(true);
+}
+
+async function generateLink(e, el) {
+  e.preventDefault();
+  const rid = el.dataset.rid;
+  const rtype = el.dataset.rtype || 'admincallrecording';
+  el.textContent = '...';
+  el.style.pointerEvents = 'none';
+  try {
+    const resp = await fetch(
+      `${API_BASE}/lookup/recording-link?recording_id=${encodeURIComponent(rid)}&recording_type=${encodeURIComponent(rtype)}`,
+      { method: 'POST', headers: authHeaders() }
+    );
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const data = await resp.json();
+    el.href = data.link;
+    el.target = '_blank';
+    el.textContent = 'Link';
+    el.style.pointerEvents = '';
+    el.onclick = null;
+  } catch (err) {
+    el.textContent = 'Failed';
+    el.style.color = 'var(--red)';
+    el.title = err.message;
+    el.style.pointerEvents = '';
+  }
+}
+
+function renderCalls(calls, append) {
+  if (!calls.length && !append) {
+    $('callsEmpty').classList.remove('hidden');
+    return;
+  }
+
+  totalLoaded += calls.length;
+  $('callsCount').textContent = `${totalLoaded} call${totalLoaded !== 1 ? 's' : ''} loaded`;
+  $('callsCount').classList.remove('hidden');
+
+  const rows = calls.map(c => {
+    const dir = c.direction || 'unknown';
+    const dirCls = dir === 'inbound' ? 'inbound' : 'outbound';
+    const flagCls = c._flagged_long_call ? ' flagged' : '';
+    const dur = fmtDuration(c.duration);
+    const contact = c.contact_name || c.external_number || c.contact_phone || '-';
+    const dateStr = fmtDateTime(c.date_started || c.date_connected);
+    const rec = c.was_recorded ? 'Yes' : 'No';
+    let linkCell = '-';
+    if (c.recording_id) {
+      linkCell = `<a href="#" class="gen-link" data-rid="${esc(c.recording_id)}" data-rtype="${esc(c.recording_type)}" onclick="generateLink(event, this)">Generate</a>`;
+    }
+    return `<tr class="${flagCls}">
+      <td>${esc(dateStr)}</td>
+      <td><span class="direction-badge ${dirCls}">${esc(dir)}</span></td>
+      <td>${esc(contact)}</td>
+      <td>${esc(dur)}</td>
+      <td>${rec}</td>
+      <td>${linkCell}</td>
+    </tr>`;
+  }).join('');
+
+  $('callsBody').insertAdjacentHTML('beforeend', rows);
+  $('callsTable').classList.remove('hidden');
+
+  // Show/hide Load More based on cursor
+  if (nextCursor) $('loadMoreBtn').classList.remove('hidden');
+  else $('loadMoreBtn').classList.add('hidden');
+}
+
+function renderUser(u) {
+  // Avatar initials
+  const initials = (u.first_name?.[0] || '') + (u.last_name?.[0] || '');
+  $('avatar').textContent = initials.toUpperCase();
+
+  $('displayName').textContent = u.display_name;
+  $('jobTitle').textContent = u.job_title || 'No title';
+
+  // Badges
+  const badges = [];
+  badges.push({ text: u.state, cls: u.state === 'active' ? 'green' : 'red' });
+  if (u.is_online) badges.push({ text: 'Online', cls: 'green' });
+  else badges.push({ text: 'Offline', cls: 'gray' });
+  if (u.is_on_duty) badges.push({ text: 'On duty', cls: 'blue' });
+  else if (u.is_available) badges.push({ text: 'Available', cls: 'green' });
+  else badges.push({ text: u.on_duty_status || 'Off duty', cls: 'gray' });
+  if (u.is_admin) badges.push({ text: 'Admin', cls: 'amber' });
+  badges.push({ text: u.license, cls: 'blue' });
+
+  $('badges').innerHTML = badges
+    .map(b => `<span class="badge ${b.cls}">${esc(b.text)}</span>`)
+    .join('');
+
+  // Info grid
+  const fields = [
+    ['User ID', u.id],
+    ['Email', (u.emails || []).join(', ')],
+    ['Extension', u.extension],
+    ['Phone', (u.phone_numbers || []).join(', ')],
+    ['Timezone', u.timezone],
+    ['Office ID', u.office_id],
+    ['Date Added', fmtDate(u.date_added)],
+    ['Last Active', fmtDate(u.duty_status_started)],
+  ];
+  $('infoGrid').innerHTML = fields
+    .map(([label, val]) => `<div class="info-item"><label>${esc(label)}</label><div class="val">${esc(val || '-')}</div></div>`)
+    .join('');
+
+  // Groups
+  const groups = u.groups || [];
+  if (groups.length) {
+    $('groupsBody').innerHTML = groups
+      .map(g => `<tr><td>${esc(g.group_id)}</td><td>${esc(g.group_type)}</td><td>${esc(g.role)}</td></tr>`)
+      .join('');
+    $('groupsSection').classList.remove('hidden');
+  } else {
+    $('groupsSection').classList.add('hidden');
+  }
+
+  $('resultCard').classList.remove('hidden');
+}
+
+function fmtDate(iso) {
+  if (!iso) return '-';
+  try { return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }); }
+  catch { return iso; }
+}
+
+function fmtDateTime(iso) {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true
+    });
+  } catch { return iso; }
+}
+
+function fmtDuration(ms) {
+  if (!ms) return '-';
+  const totalSec = Math.round(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
…kup)

Salvages the email→profile→calls→recording-link flow from the abandoned `feature/lookup` branch and re-wires it onto the post-Step-4 multi-team baseline. Routes mount under `/api/{team_id}/lookup` (with the legacy `/api/lookup` shim) so every request is attributed via the team-aware auth dependency and audit middleware.

The Dialpad data itself isn't team-partitioned — the lookup is intentionally cross-team for company-wide call visibility — but routing through the same team-scoped pipeline keeps audit attribution consistent with the rest of the API.