### PR TITLE
fix(push): rewrite rootDir for staged builds; polish QA email scorecard

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -232,6 +232,19 @@ if [[ -n "$BUILD_DIR" ]]; then
   mkdir -p "$BUILD_DIR"
   cp -R "$BASE_DIR/." "$BUILD_DIR/"
   cp -R "$CLASP_DIR/." "$BUILD_DIR/"
+
+  # Files land flat at the build-dir root after overlay, so rootDir must be
+  # "." here. The team's source .clasp.json deliberately keeps a different
+  # rootDir (e.g. "./src") as a foot-gun guard: a stray `clasp push` from
+  # teams/<team>/ then resolves to a non-existent dir and no-ops safely
+  # instead of partially deploying only Config.js. We rewrite rootDir for
+  # the build dir specifically so clasp finds the staged files here.
+  cat > "$BUILD_DIR/.clasp.json" <<EOF
+{
+  "scriptId": "$SCRIPT_ID",
+  "rootDir": "."
+}
+EOF
 fi
 
 (cd "$PUSH_FROM" && clasp push)

--- a/qa-automation/src/ScoreCard.js
+++ b/qa-automation/src/ScoreCard.js
@@ -42,33 +42,30 @@ class ScoreCard {
       var color = QAEntry.colorForScore(score);
       var pct   = (score / 5 * 100).toFixed(0);
       var isLast = i === categories.length - 1;
-      var reasoning  = (this.entry.aiReasoning  && this.entry.aiReasoning[cat.key])  || '';
-      var confidence = (this.entry.aiConfidence && this.entry.aiConfidence[cat.key]) || '';
+      var reasoning = (this.entry.aiReasoning && this.entry.aiReasoning[cat.key]) || '';
       var hasReasoning = !!reasoning;
 
-      // Bottom border lives on whichever row is the LAST visual row for this category
+      // Score row gets a bottom separator only when this is the FINAL visual
+      // row for the section (no reasoning box below) AND it isn't the very
+      // last section in the card.
       var scoreRowBorder = (isLast || hasReasoning) ? '' : 'border-bottom:1px solid #F0F0F0;';
 
       html += '<tr>'
-            // Label + confidence chip
             + '<td style="padding:6px 8px 6px 0;font-size:13px;color:' + CONFIG.COLORS.TEXT_GRAY
             + ';width:45%;' + scoreRowBorder + '">'
-            + this._esc(cat.label) + this._renderConfidenceChip(confidence) + '</td>'
-            // Bar
+            + this._esc(cat.label) + '</td>'
             + '<td style="padding:6px 8px;width:40%;' + scoreRowBorder + '">'
             + this._renderBar(pct, color)
             + '</td>'
-            // Value
             + '<td style="padding:6px 0 6px 8px;font-size:14px;font-weight:bold;color:' + color
             + ';text-align:right;width:15%;' + scoreRowBorder + '">'
-            + score.toFixed(1) + '/5</td>'
+            + this._formatScore(score) + '/5</td>'
             + '</tr>';
 
       if (hasReasoning) {
-        var reasoningBorder = isLast ? '' : 'border-bottom:1px solid #F0F0F0;';
-        html += '<tr><td colspan="3" style="padding:0 0 8px 0;font-size:12px;color:'
-              + CONFIG.COLORS.TEXT_GRAY + ';font-style:italic;line-height:1.4;'
-              + reasoningBorder + '">' + this._esc(reasoning) + '</td></tr>';
+        html += '<tr><td colspan="3" style="padding:2px 0 ' + (isLast ? '0' : '12px') + ' 0;">'
+              + this._renderReasoningBox(reasoning)
+              + '</td></tr>';
       }
     }
 
@@ -83,21 +80,20 @@ class ScoreCard {
     for (var j = 0; j < binaries.length; j++) {
       var bcat   = binaries[j];
       var passed = this.entry.binaryChecks[bcat.key];
-      var bReasoning  = (this.entry.aiReasoning  && this.entry.aiReasoning[bcat.key])  || '';
-      var bConfidence = (this.entry.aiConfidence && this.entry.aiConfidence[bcat.key]) || '';
+      var bReasoning = (this.entry.aiReasoning && this.entry.aiReasoning[bcat.key]) || '';
 
       html += '<tr>'
             + '<td style="padding:6px 8px 6px 0;font-size:13px;color:' + CONFIG.COLORS.TEXT_GRAY + ';">'
-            + this._esc(bcat.label) + this._renderConfidenceChip(bConfidence) + '</td>'
+            + this._esc(bcat.label) + '</td>'
             + '<td style="padding:6px 0;text-align:right;font-size:14px;font-weight:bold;color:'
             + (passed ? CONFIG.COLORS.GREEN : CONFIG.COLORS.RED) + ';">'
             + (passed ? '&#10003; Yes' : '&#10007; No') + '</td>'
             + '</tr>';
 
       if (bReasoning) {
-        html += '<tr><td colspan="2" style="padding:0 0 8px 0;font-size:12px;color:'
-              + CONFIG.COLORS.TEXT_GRAY + ';font-style:italic;line-height:1.4;">'
-              + this._esc(bReasoning) + '</td></tr>';
+        html += '<tr><td colspan="2" style="padding:2px 0 8px 0;">'
+              + this._renderReasoningBox(bReasoning)
+              + '</td></tr>';
       }
     }
 
@@ -112,7 +108,7 @@ class ScoreCard {
           + '<span style="font-size:13px;color:' + CONFIG.COLORS.TEXT_GRAY + ';">Overall Score</span>'
           + '<br>'
           + '<span style="font-size:28px;font-weight:bold;color:' + overallColor + ';">'
-          + overall.toFixed(1) + '</span>'
+          + this._formatScore(overall) + '</span>'
           + '</td></tr>';
 
     html += '</table>';
@@ -140,28 +136,28 @@ class ScoreCard {
   }
 
   /**
-   * Renders a small bordered pill showing AI confidence ("high" / "medium" /
-   * "low" / "manual"). Returns an empty string for empty / unrecognized values.
+   * Renders the AI reasoning text wrapped in a subtle bordered box.
    * @private
-   * @param  {string} confidence
+   * @param  {string} reasoning
    * @return {string}
    */
-  _renderConfidenceChip(confidence) {
-    var c = (confidence || '').toString().toLowerCase().trim();
-    if (!c) return '';
+  _renderReasoningBox(reasoning) {
+    return '<div style="border:1px solid #EEEEEE;border-radius:4px;'
+         + 'background:#FAFAFA;padding:8px 12px;font-size:12px;color:'
+         + CONFIG.COLORS.TEXT_GRAY + ';font-style:italic;line-height:1.5;">'
+         + this._esc(reasoning) + '</div>';
+  }
 
-    var color;
-    switch (c) {
-      case 'high':   color = CONFIG.COLORS.GREEN;     break;
-      case 'medium': color = CONFIG.COLORS.AMBER;     break;
-      case 'low':    color = CONFIG.COLORS.RED;       break;
-      case 'manual': color = CONFIG.COLORS.TEXT_GRAY; break;
-      default: return '';
-    }
-    return ' <span style="display:inline-block;border:1px solid ' + color
-         + ';color:' + color + ';font-size:9px;padding:1px 6px;border-radius:8px;'
-         + 'text-transform:uppercase;letter-spacing:0.5px;font-weight:bold;'
-         + 'vertical-align:middle;margin-left:4px;">' + this._esc(c) + '</span>';
+  /**
+   * Formats a 1–5 score for display. Drops the trailing ".0" when the score
+   * is a whole number ("5" instead of "5.0") but preserves one decimal for
+   * fractional scores ("4.5").
+   * @private
+   * @param  {number} score
+   * @return {string}
+   */
+  _formatScore(score) {
+    return score % 1 === 0 ? String(score) : score.toFixed(1);
   }
 
   /** @private — HTML-escape a string. */

--- a/qa-automation/teams/sales/README.md
+++ b/qa-automation/teams/sales/README.md
@@ -5,11 +5,16 @@ Placeholder until Sales' Apps Script is bound to their QA spreadsheet.
 ## Onboarding
 
 1. Create a new Apps Script project bound to the Sales QA Google Sheet.
-2. Drop `.clasp.json` here with the new scriptId:
+2. Drop `.clasp.json` here with the new scriptId. Use `rootDir: "./src"`
+   (NOT `"."`) — `push.sh` rewrites it to `"."` automatically in the build
+   dir. Keeping `"./src"` here is a deliberate foot-gun guard: if anyone
+   runs `clasp push` directly from this directory, clasp resolves into a
+   non-existent `src/` and no-ops safely instead of half-deploying only
+   `Config.js`.
    ```json
    {
      "scriptId": "<sales-script-id>",
-     "rootDir": "."
+     "rootDir": "./src"
    }
    ```
 3. Drop `Config.js` here — copy from `../member_support/Config.js` and edit


### PR DESCRIPTION
The rootDir bug: push.sh's overlay produced a flat build dir, but the staged .clasp.json still declared rootDir: "./src" (carried over from the legacy single-team layout). Clasp resolved into a non-existent src/ subdir, found no files to push, and silently no-op'd with "Script is already up to date" — masking failed deployments. push.sh now rewrites rootDir to "." after the overlay copy. The team source .clasp.json keeps "./src" deliberately as a foot-gun guard: a stray `clasp push` from teams/<team>/ now resolves into a non-existent dir and no-ops safely instead of half-deploying only Config.js. The Sales onboarding README is updated to recommend the same pattern.

Scorecard polish (driven by agent-facing UX concerns):
- removed AI confidence chips from per-section labels — the data still flows to Analyst_History for internal use, just not surfaced to agents
- dropped the trailing ".0" on whole-number scores (5/5, 100, not 5.0/5)
- wrapped per-section reasoning text in a subtle 1px bordered box on a light background, instead of loose italic text