### PR TITLE
feat: pipe-delimited Vehicle and Pet info parsing in Move-In Flow

### DIFF
--- a/mass-notifications/src/Cards.gs
+++ b/mass-notifications/src/Cards.gs
@@ -220,13 +220,46 @@ class MoveInCard extends NotificationCard {
   <strong>Contact Email:</strong> ${this._mailtoLink(t.member_email)}
 </div>`.trim();
 
-    const vehicle = `
-<p style="margin:0 0 4px 0;"><strong>Vehicle Information</strong></p>
-<p style="margin:0 0 14px 0;">${escapeHtml_(t.vehicle_info || 'N/A')}</p>`.trim();
+    // Vehicles render structured (labeled per field) when the cell is
+    // pipe-delimited "Year|Make|Model|Color|License Plate|State". Multiple
+    // vehicles can be ';'-separated. Falls back to the raw cell value (or
+    // "N/A") for legacy rows that were entered as free text.
+    const vehiclesList = (t._vehicles || []).map(v => {
+      const rows = [];
+      if (v.year)  rows.push(`<strong>Year:</strong> ${escapeHtml_(v.year)}`);
+      if (v.make)  rows.push(`<strong>Make:</strong> ${escapeHtml_(v.make)}`);
+      if (v.model) rows.push(`<strong>Model:</strong> ${escapeHtml_(v.model)}`);
+      if (v.color) rows.push(`<strong>Color:</strong> ${escapeHtml_(v.color)}`);
+      if (v.plate) rows.push(`<strong>License Plate:</strong> ${escapeHtml_(v.plate)}`);
+      if (v.state) rows.push(`<strong>State:</strong> ${escapeHtml_(v.state)}`);
+      if (!rows.length) return '';
+      return `<div style="margin:0 0 10px 0;font-size:14px;color:${LANDING.DARK_NAVY};line-height:1.5;">${rows.join('<br>')}</div>`;
+    }).filter(Boolean).join('');
 
-    const pet = `
-<p style="margin:0 0 4px 0;"><strong>Pet Information</strong></p>
-<p style="margin:0 0 14px 0;">${escapeHtml_(t.pet_info || 'N/A')}</p>`.trim();
+    const vehicleHeader = `<p style="margin:0 0 4px 0;"><strong>Vehicle Information</strong></p>`;
+    const vehicle = vehiclesList
+      ? `${vehicleHeader}<div style="margin:0 0 14px 0;">${vehiclesList}</div>`
+      : `${vehicleHeader}<p style="margin:0 0 14px 0;">${escapeHtml_(t.vehicle_info || 'N/A')}</p>`;
+
+    // Pets render structured (labeled per field) when the cell is
+    // pipe-delimited "Animal|Breed|Weight|ESA?|Name". Multiple pets can be
+    // ';'-separated. Falls back to the raw cell value (or "N/A") for legacy
+    // rows entered as free text.
+    const petsList = (t._pets || []).map(p => {
+      const rows = [];
+      if (p.animal) rows.push(`<strong>Animal:</strong> ${escapeHtml_(p.animal)}`);
+      if (p.breed)  rows.push(`<strong>Breed:</strong> ${escapeHtml_(p.breed)}`);
+      if (p.weight) rows.push(`<strong>Weight:</strong> ${escapeHtml_(p.weight)}`);
+      if (p.esa)    rows.push(`<strong>ESA:</strong> ${escapeHtml_(p.esa)}`);
+      if (p.name)   rows.push(`<strong>Name:</strong> ${escapeHtml_(p.name)}`);
+      if (!rows.length) return '';
+      return `<div style="margin:0 0 10px 0;font-size:14px;color:${LANDING.DARK_NAVY};line-height:1.5;">${rows.join('<br>')}</div>`;
+    }).filter(Boolean).join('');
+
+    const petHeader = `<p style="margin:0 0 4px 0;"><strong>Pet Information</strong></p>`;
+    const pet = petsList
+      ? `${petHeader}<div style="margin:0 0 14px 0;">${petsList}</div>`
+      : `${petHeader}<p style="margin:0 0 14px 0;">${escapeHtml_(t.pet_info || 'N/A')}</p>`;
 
     const occupantsList = (t._occupants || []).map(o => `
 <div style="margin:0 0 10px 0;font-size:14px;color:${LANDING.DARK_NAVY};line-height:1.5;">

--- a/mass-notifications/src/Constants.gs
+++ b/mass-notifications/src/Constants.gs
@@ -6,7 +6,7 @@
  * here is available project-wide without imports.
  */
 
-const VERSION                    = 'v3.3.0';
+const VERSION                    = 'v3.3.1';
 const LANDING_IVR_PHONE          = '+14152311701';
 const LANDING_IVR_PHONE_DISPLAY  = '(415) 231-1701';
 const CONFIG_SHEET               = 'Config';

--- a/mass-notifications/src/Recipients.gs
+++ b/mass-notifications/src/Recipients.gs
@@ -154,6 +154,80 @@ function parseOccupants_(raw) {
 }
 
 /**
+ * Parses the Vehicle Info cell, formatted as pipe-delimited records separated
+ * by ';' or newline. Field order matches the operator-facing template hint:
+ *
+ *   "Year|Make|Model|Color|License Plate|State"
+ *
+ *   "2018|Toyota|4Runner|Black|LCS3767|TX; 2021|Honda|Civic|White||"
+ *
+ * Returns an empty array when no '|' is present anywhere — the caller falls
+ * back to rendering the raw cell value, preserving backward compatibility
+ * with rows that were entered as free-text before this format existed.
+ *
+ * @param {*} raw
+ * @return {Array<{year:string, make:string, model:string, color:string,
+ *                 plate:string, state:string}>}
+ */
+function parseVehicles_(raw) {
+  if (raw == null) return [];
+  const text = String(raw);
+  if (!text.trim() || text.indexOf('|') === -1) return [];
+  return text
+    .split(/[;\n]+/)
+    .map(chunk => chunk.trim())
+    .filter(Boolean)
+    .map(chunk => {
+      const parts = chunk.split('|').map(p => p.trim());
+      return {
+        year:  parts[0] || '',
+        make:  parts[1] || '',
+        model: parts[2] || '',
+        color: parts[3] || '',
+        plate: parts[4] || '',
+        state: parts[5] || '',
+      };
+    })
+    .filter(v => v.year || v.make || v.model || v.color || v.plate || v.state);
+}
+
+/**
+ * Parses the Pet/ESA Info cell, formatted as pipe-delimited records separated
+ * by ';' or newline. Field order matches the operator-facing template hint:
+ *
+ *   "Animal|Breed|Weight|ESA?|Name"
+ *
+ *   "Dog|Golden Retriever|65 lbs|Yes|Buddy; Cat|Tabby|10 lbs|No|Whiskers"
+ *
+ * Returns [] when no '|' is present (caller falls back to raw rendering),
+ * matching parseVehicles_ semantics for backward compatibility.
+ *
+ * @param {*} raw
+ * @return {Array<{animal:string, breed:string, weight:string,
+ *                 esa:string, name:string}>}
+ */
+function parsePets_(raw) {
+  if (raw == null) return [];
+  const text = String(raw);
+  if (!text.trim() || text.indexOf('|') === -1) return [];
+  return text
+    .split(/[;\n]+/)
+    .map(chunk => chunk.trim())
+    .filter(Boolean)
+    .map(chunk => {
+      const parts = chunk.split('|').map(p => p.trim());
+      return {
+        animal: parts[0] || '',
+        breed:  parts[1] || '',
+        weight: parts[2] || '',
+        esa:    parts[3] || '',
+        name:   parts[4] || '',
+      };
+    })
+    .filter(p => p.animal || p.breed || p.weight || p.esa || p.name);
+}
+
+/**
  * Parses the Property Email cell into an array of valid email addresses.
  * Accepts comma, semicolon, whitespace, or newline as separators.
  */
@@ -202,7 +276,9 @@ function getMoveInTargetRows_(sh, limit) {
       moveInDate:     r[MOVEIN_COL.MOVE_IN_DATE  - 1],   // raw — formatter handles Date or string
       moveOutDate:    r[MOVEIN_COL.MOVE_OUT_DATE - 1],
       vehicleInfo:    String(r[MOVEIN_COL.VEHICLE_INFO  - 1] || '').trim(),
+      vehicles:       parseVehicles_(r[MOVEIN_COL.VEHICLE_INFO - 1]),
       petInfo:        String(r[MOVEIN_COL.PET_INFO      - 1] || '').trim(),
+      pets:           parsePets_(r[MOVEIN_COL.PET_INFO - 1]),
       occupants:      parseOccupants_(r[MOVEIN_COL.OCCUPANTS - 1]),
       areaMgrName:    String(r[MOVEIN_COL.AREA_MGR_NAME  - 1] || '').trim(),
       areaMgrPhone:   String(r[MOVEIN_COL.AREA_MGR_PHONE - 1] || '').trim(),

--- a/mass-notifications/src/Templates.gs
+++ b/mass-notifications/src/Templates.gs
@@ -193,9 +193,17 @@ const EMAIL_TEMPLATES = {
       '  - A single Drive FOLDER ID — every file in that folder is attached.\n' +
       'Folder mode is the recommended workflow: drop all per-reservation\n' +
       'documents into a Google Drive folder and paste the folder ID once.\n\n' +
-      'Optional: Vehicle Info, Pet/ESA Info (blank renders as "N/A"),\n' +
-      'Move-Out Date, Occupants (pipe-delimited:\n' +
-      '  "Name|Phone|Email; Name|Phone|Email").\n\n' +
+      'Optional: Move-Out Date.\n\n' +
+      'Vehicle Info (optional) is pipe-delimited:\n' +
+      '  "Year|Make|Model|Color|License Plate|State"\n' +
+      '  e.g. "2018|Toyota|4Runner|Black|LCS3767|TX"\n' +
+      'Multiple vehicles separated by ";". Blank cell renders as "N/A".\n\n' +
+      'Pet/ESA Info (optional) is pipe-delimited:\n' +
+      '  "Animal|Breed|Weight|ESA?|Name"\n' +
+      '  e.g. "Dog|Golden Retriever|65 lbs|Yes|Buddy"\n' +
+      'Multiple pets separated by ";". Blank cell renders as "N/A".\n\n' +
+      'Occupants (optional) is pipe-delimited similarly:\n' +
+      '  "Name|Phone|Email; Name|Phone|Email"\n\n' +
       'Branded wrapper: cream background is on by default. To add the LANDING\n' +
       'wordmark, paste a public PNG URL into the Config sheet field\n' +
       '"email_header_image_url".\n\n' +

--- a/mass-notifications/src/Tokenizer.gs
+++ b/mass-notifications/src/Tokenizer.gs
@@ -117,6 +117,8 @@ function buildMoveInTokens_(cfg, rec) {
     area_mgr_email:   rec.areaMgrEmail    || '',
     reservation_id:   rec.reservationId   || '',
     _occupants:       rec.occupants       || [],
+    _vehicles:        rec.vehicles        || [],
+    _pets:            rec.pets            || [],
   };
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -210,7 +210,13 @@ SENDING MODES
                     in the dedicated "Move_In_Flow" tab, sent to that row's
                     Property Email contacts (not to the member). Each email
                     carries the approved member's apartment, contact info,
-                    move-in date, vehicle/pet info (optional → renders as N/A),
+                    move-in date, vehicle info (pipe-delimited
+                    "Year|Make|Model|Color|License Plate|State"; multi-vehicle
+                    rows separated by ";"; blank renders as N/A; legacy free
+                    text falls through unchanged), pet/ESA info (pipe-delimited
+                    "Animal|Breed|Weight|ESA?|Name"; multi-pet rows separated
+                    by ";"; blank renders as N/A; legacy free text falls
+                    through unchanged),
                     additional occupants (pipe-delimited "Name|Phone|Email"),
                     and a per-row Landing area-manager sign-off block.
                     Background-check + ID-scan PDFs travel as attachments.


### PR DESCRIPTION
## Summary
- Vehicle Information and Pet/ESA Information now render as **labeled fields** when the cell is pipe-delimited, mirroring how Occupants are parsed.
- Schemas:
  - **Vehicle:** `Year|Make|Model|Color|License Plate|State` (e.g. `2018|Toyota|4Runner|Black|LCS3767|TX`)
  - **Pet:** `Animal|Breed|Weight|ESA?|Name` (e.g. `Dog|Golden Retriever|65 lbs|Yes|Buddy`)
- Multi-record rows: `;`-separated.
- Backward-compatible: rows with no `|` fall through to the previous raw-string render. Empty cells still render as `N/A`.
- Bumps `mass-notifications` v3.3.0 → v3.3.1. Pure card-rendering change — no schema, attachment, or send-time changes.

## Test plan
- [ ] `./push.sh mass-notifications` and hard-reload sheet.
- [ ] **Load Template → Move-In Notification** updates the on-screen hint to document both Vehicle and Pet pipe-delimited formats.
- [ ] Row with `Vehicle Info = "2018|Toyota|4Runner|Black|LCS3767|TX"` renders six labeled lines (Year/Make/Model/Color/License Plate/State).
- [ ] Row with `Pet/ESA Info = "Dog|Golden Retriever|65 lbs|Yes|Buddy"` renders five labeled lines (Animal/Breed/Weight/ESA/Name).
- [ ] Multi-record: `"Dog|Lab|70|No|Rex; Cat|Tabby|10|No|Whiskers"` renders as two stacked blocks.
- [ ] Partial fields: `"|Toyota|Camry||LCS|"` shows only the populated rows (Make and License Plate); empty fields are skipped.
- [ ] Legacy free-text row (no `|`): cell value renders verbatim, same as before — confirm against an existing pre-migration row.
- [ ] Blank cell still shows `N/A` for both sections.
- [ ] Regression: Occupants rendering unchanged; INDIVIDUAL/BCC sends unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)