### PR TITLE
refactor: multi-team support for QA automation (Apps Script + stats engine)

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +78,25 @@ class ScoringPromptConfig(BaseModel):
     sop_sections: list[int]                  # section_numbers that need SOP context
 
 
+class StatsConfig(BaseModel):
+    """Per-team statistical thresholds.
+
+    Today every team uses the same defaults — these became magic numbers
+    when the engine was MS-only.  Lifted to config so a low-volume team
+    (e.g. Sales during ramp) can loosen sensitivity without forking code.
+
+    When 100% Local AI scoring goes live, these defaults will need to
+    change again (much higher N → tighter thresholds, longer EWMA spans).
+    Kept here so that change is one config edit, not a code release.
+    """
+    min_evals_for_outlier: int = 5
+    outlier_z_threshold: float = 3.5      # Modified-Z cutoff (MAD-based)
+    ewma_span: int = 5
+    ewma_min_evals: int = 3
+    ewma_trend_delta: float = 3.0          # |Δ| to trigger improving/declining
+    spc_sigma_multiplier: float = 2.0      # Shewhart control limits
+
+
 class SectionDef(BaseModel):
     """Definition of a single rubric section."""
     id: str                                  # canonical scoring ID
@@ -103,10 +122,16 @@ class TeamConfig(BaseModel):
     team_id: str
     display_name: str
     company: str
+    rubric_version: str = "1.0"  # bump when sections / score_descriptions / SOP refs change
+    excluded_test_agents: list[str] = Field(
+        default_factory=list,
+        description="Canonical agent names to exclude from analytics (e.g. dev/test users).",
+    )
     gemini: GeminiConfig
     sheets: SheetsConfig
     sections: list[SectionDef]
     scoring_prompt: ScoringPromptConfig
+    stats: StatsConfig = Field(default_factory=StatsConfig)
 
     # --- Computed properties ------------------------------------------------
 
@@ -124,6 +149,20 @@ class TeamConfig(BaseModel):
     def yn_sections(self) -> list[SectionDef]:
         """Binary Y/N sections."""
         return [s for s in self.sections if s.score_type == "yn"]
+
+    @property
+    def yn_history_ids(self) -> list[str]:
+        """history_id list for Y/N sections — used as DataFrame column names."""
+        return [s.history_id for s in self.yn_sections]
+
+    @property
+    def yn_section_labels(self) -> dict[str, str]:
+        """history_id -> display name for Y/N sections.
+
+        Used by the dashboard to title binary-stats KPI cards and
+        roster-table columns.
+        """
+        return {s.history_id: s.name for s in self.yn_sections}
 
     @property
     def numeric_history_ids(self) -> list[str]:

--- a/qa-automation/AI-Scoring/backend/config/teams/member_support.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/member_support.json
@@ -2,6 +2,18 @@
   "team_id": "member_support",
   "display_name": "Member Support",
   "company": "Landing Living LLC",
+  "rubric_version": "1.0",
+
+  "excluded_test_agents": ["Maximiliano Perez"],
+
+  "stats": {
+    "min_evals_for_outlier": 5,
+    "outlier_z_threshold": 3.5,
+    "ewma_span": 5,
+    "ewma_min_evals": 3,
+    "ewma_trend_delta": 3.0,
+    "spc_sigma_multiplier": 2.0
+  },
 
   "gemini": {
     "scoring_model": "gemini-2.5-flash",
@@ -271,7 +283,7 @@
   ],
 
   "scoring_prompt": {
-    "system_prompt_template": "You are a QA evaluator for a call center at {company}.\nYou will listen to a full call recording and score it using the rubric provided.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the agent in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone.",
+    "system_prompt_template": "You are a QA evaluator for a call center at {company}.\nYou will listen to a full call recording and score it using the rubric provided.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the agent in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone, DO NOT use the Third person (\"they/them\") anywhere in your outputs.",
     "confidence_levels_note": "- \"high\": Clear evidence in audio, no ambiguity\n- \"medium\": Reasonable inference, some ambiguity or audio-dependent nuance\n- \"low\": Insufficient signal, heavy guessing required",
     "sop_sections": [5, 6]
   }

--- a/qa-automation/AI-Scoring/backend/config/teams/sales.json.example
+++ b/qa-automation/AI-Scoring/backend/config/teams/sales.json.example
@@ -1,0 +1,290 @@
+{
+  "team_id": "sales",
+  "display_name": "Sales",
+  "company": "Landing Living LLC",
+  "rubric_version": "1.0",
+
+  "excluded_test_agents": [],
+
+  "stats": {
+    "min_evals_for_outlier": 5,
+    "outlier_z_threshold": 3.5,
+    "ewma_span": 5,
+    "ewma_min_evals": 3,
+    "ewma_trend_delta": 3.0,
+    "spc_sigma_multiplier": 2.0
+  },
+
+  "gemini": {
+    "scoring_model": "gemini-2.5-flash",
+    "scoring_temperature": 0.2,
+    "scoring_max_output_tokens": 65536,
+    "progression_model": "gemini-2.5-flash",
+    "progression_temperature": 0.3,
+    "progression_max_output_tokens": 16384
+  },
+
+  "sheets": {
+    "form_responses_ai": {
+      "tab_name_default": "QA Scores",
+      "column_map": {
+        "A": "timestamp",
+        "B": "manager_email",
+        "C": "agent_name",
+        "D": "greeting",
+        "E": "contact_verification",
+        "F": "discovery",
+        "G": "tone_alignment",
+        "H": "process_adherence",
+        "I": "objection_handling",
+        "J": "communication",
+        "K": "closing",
+        "L": "crm_documentation",
+        "M": "next_step_commitment",
+        "N": "key_strengths",
+        "O": "opportunities",
+        "P": "dialpad_link"
+      },
+      "scored_section_columns": {
+        "D": "greeting",
+        "E": "contact_verification",
+        "F": "discovery",
+        "G": "tone_alignment",
+        "H": "process_adherence",
+        "I": "objection_handling",
+        "J": "communication",
+        "K": "closing",
+        "M": "next_step_commitment"
+      },
+      "reasoning_start_col": "Q",
+      "caller_metadata_cols": {
+        "call_summary": "AJ",
+        "caller_name": "AK",
+        "caller_phone": "AL"
+      },
+      "doc_reasoning_col": "AM"
+    },
+    "analyst_history": {
+      "tab_name_default": "Analyst_History",
+      "col_agent_name": 0,
+      "col_agent_email": 1,
+      "col_timestamp": 2,
+      "col_overall_score": 3,
+      "section_columns": {
+        "greeting": 4,
+        "discovery": 5,
+        "tone_alignment": 6,
+        "process_adherence": 7,
+        "objection_handling": 8,
+        "communication": 9,
+        "closing": 10,
+        "crm_documentation": 11
+      },
+      "yn_columns": {
+        "contact_verification": 12,
+        "next_step_commitment": 13
+      },
+      "col_manager_email": 14,
+      "col_dialpad_link": 15,
+      "col_key_strengths": 16,
+      "col_improvements": 17,
+      "col_source": 18,
+      "extended_columns": {
+        "greeting": [19, 20],
+        "contact_verification": [21, 22],
+        "discovery": [23, 24],
+        "tone_alignment": [25, 26],
+        "process_adherence": [27, 28],
+        "objection_handling": [29, 30],
+        "communication": [31, 32],
+        "closing": [33, 34],
+        "next_step_commitment": [35, 36],
+        "crm_documentation": [40, 41]
+      },
+      "col_call_summary": 37,
+      "col_caller_name": 38,
+      "col_caller_phone": 39
+    },
+    "form_responses_1_tab": "Form Responses 1",
+    "mails_tab": "Mails"
+  },
+
+  "sections": [
+    {
+      "id": "greeting",
+      "history_id": "greeting",
+      "name": "Greeting & Rapport",
+      "section_number": 1,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": "Did the rep open with a professional greeting and establish rapport quickly?",
+      "score_descriptions": {
+        "1": "Cold open, no name introduction, abrupt tone",
+        "2": "Introduced self but rushed, no attempt at connection",
+        "3": "Standard greeting, professional but transactional",
+        "4": "Warm greeting plus light rapport (acknowledged timing, role, or context)",
+        "5": "Authentic warmth, used prospect's name, set a positive tone for the call"
+      },
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "contact_verification",
+      "history_id": "contact_verification",
+      "name": "Contact Verification",
+      "section_number": 2,
+      "score_type": "yn",
+      "audio_dependent": false,
+      "rubric_question": "Did the rep confirm they were speaking with the intended decision-maker or qualified contact?",
+      "na_applicable": true,
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "discovery",
+      "history_id": "discovery",
+      "name": "Discovery & Needs Analysis",
+      "section_number": 3,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": "Did the rep ask open-ended discovery questions and uncover prospect needs?",
+      "score_descriptions": {
+        "1": "Pitched immediately, no discovery questions",
+        "2": "Surface-level questions, accepted first answer without probing",
+        "3": "Asked basic discovery questions, missed root cause",
+        "4": "Multiple probing questions, surfaced specific pain points",
+        "5": "Layered discovery — uncovered budget, timeline, decision criteria, and emotional drivers"
+      },
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "tone_alignment",
+      "history_id": "tone_alignment",
+      "name": "Tone Alignment",
+      "section_number": 4,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": true,
+      "rubric_question": "Did the rep match the prospect's energy, pace, and communication style appropriately?",
+      "score_descriptions": {
+        "1": "Tone clash — pushy when prospect was hesitant, or flat when prospect was excited",
+        "2": "Inconsistent tone, talked over prospect or left long awkward gaps",
+        "3": "Adequate tone, no major mismatches",
+        "4": "Good adaptation to prospect's mood",
+        "5": "Mirrored pace and emotion expertly — prospect noticeably opened up"
+      },
+      "confidence_cap": "medium",
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "process_adherence",
+      "history_id": "process_adherence",
+      "name": "Process Adherence",
+      "section_number": 5,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": "Did the rep follow the documented Sales SOP (qualification framework, pricing rules, compliance disclosures)?",
+      "score_descriptions": {
+        "1": "Skipped multiple SOP steps, made off-script claims",
+        "2": "Followed parts of SOP but missed compliance items",
+        "3": "Followed SOP with minor deviations",
+        "4": "Followed SOP, included required disclosures",
+        "5": "Fully adhered to SOP plus best-practice extras (pricing caveats, ROI framing)"
+      },
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "objection_handling",
+      "history_id": "objection_handling",
+      "name": "Objection Handling",
+      "section_number": 6,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": "When the prospect raised concerns, did the rep acknowledge, understand, and respond effectively?",
+      "score_descriptions": {
+        "1": "Ignored objections or argued back",
+        "2": "Addressed objection with a generic scripted answer",
+        "3": "Acknowledged objection and provided a reasonable response",
+        "4": "Acknowledged plus clarified the underlying concern, then addressed it directly",
+        "5": "Reframed the objection as a benefit, validated prospect, secured agreement to move forward"
+      },
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "communication",
+      "history_id": "communication",
+      "name": "Communication",
+      "section_number": 7,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": "Was the rep clear, concise, and professional?",
+      "score_descriptions": {
+        "1": "Confusing, jargon-heavy, frequent fillers",
+        "2": "Some clarity, lots of internal lingo or rambling",
+        "3": "Clear basic communication",
+        "4": "Polished and professional, appropriate vocabulary for the prospect",
+        "5": "Crisp, persuasive, built credibility through language"
+      },
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "closing",
+      "history_id": "closing",
+      "name": "Closing & Call Control",
+      "section_number": 8,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "audio_dependent": true,
+      "rubric_question": "Did the rep drive the call toward a clear next step and manage the timing well?",
+      "score_descriptions": {
+        "1": "Lost control of the call, no defined next step, drifted to a vague follow-up",
+        "2": "Suggested next step but didn't confirm prospect commitment",
+        "3": "Set a next step but did not secure it on the calendar",
+        "4": "Secured a next step with a date/time committed",
+        "5": "Calendar invite sent live on call, mutual close-plan agreed"
+      },
+      "confidence_cap": "medium",
+      "special_reasoning_instructions": "ALWAYS include timestamps if the prospect explicitly committed to a meeting or signed up live during the call"
+    },
+    {
+      "id": "crm_documentation",
+      "history_id": "crm_documentation",
+      "name": "CRM Documentation",
+      "section_number": 9,
+      "score_type": "manual",
+      "score_range": [1, 5],
+      "audio_dependent": false,
+      "rubric_question": null,
+      "score_descriptions": null,
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "next_step_commitment",
+      "history_id": "next_step_commitment",
+      "name": "Next Step Commitment",
+      "section_number": 10,
+      "score_type": "yn",
+      "audio_dependent": false,
+      "rubric_question": "Did the prospect verbally commit to a specific next step (meeting, demo, decision call, signed agreement)?",
+      "na_applicable": true,
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    }
+  ],
+
+  "scoring_prompt": {
+    "system_prompt_template": "You are a QA evaluator for the Sales team at {company}.\nYou will listen to a full sales call recording and score it using the rubric provided.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the rep in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone, DO NOT use the Third person (\"they/them\") anywhere in your outputs.",
+    "confidence_levels_note": "- \"high\": Clear evidence in audio, no ambiguity\n- \"medium\": Reasonable inference, some ambiguity or audio-dependent nuance\n- \"low\": Insufficient signal, heavy guessing required",
+    "sop_sections": [5]
+  }
+}

--- a/qa-automation/AI-Scoring/backend/models/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/models/team_stats.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AgentRosterEntry(BaseModel):
@@ -10,8 +11,10 @@ class AgentRosterEntry(BaseModel):
     std: float
     ewma: Optional[float] = None
     trend: str  # "improving", "declining", "flat"
-    id_val_pct: float
-    cust_res_pct: float
+    binary_pcts: dict[str, float] = Field(
+        default_factory=dict,
+        description="section_id -> Y%. Keys map to team_config.yn_history_ids.",
+    )
     status: str  # "excellent", "good", "watch", "at_risk"
     weak_sections: list[str]
     is_active: bool
@@ -73,13 +76,10 @@ class BinaryAgentBreakdown(BaseModel):
 
 
 class BinarySectionStats(BaseModel):
+    section_id: str
+    label: str
     team_pct: float
     agents: list[BinaryAgentBreakdown]
-
-
-class BinaryStats(BaseModel):
-    identity_validation: BinarySectionStats
-    customer_resolution: BinarySectionStats
 
 
 class EWMAEntry(BaseModel):
@@ -102,13 +102,59 @@ class MailsEntry(BaseModel):
 
 
 class TeamStatsResponse(BaseModel):
-    kpis: dict  # total_evals, avg_score, std_score, analyst_count
+    """Envelope for /api/{team_id}/team/stats.
+
+    Top-level metadata fields are load-bearing for the predictive era —
+    they let downstream consumers (forecasters, drift detectors, parquet
+    exporters) reason about whether two responses are comparable.
+
+    schema_version: bump on any breaking shape change to this envelope.
+    rubric_version: from team_config; bump when the rubric itself changes.
+    coverage_regime: 'manager_sample' today (curated subset of calls);
+                     'full_coverage' once Local AI scores 100% of calls.
+                     Mixing the two regimes in one analysis will skew
+                     statistics — consumers must check this field.
+    """
+    schema_version: str = "1.1"
+    team_id: str
+    rubric_version: str
+    generated_at: datetime
+    coverage_regime: str  # "manager_sample" | "full_coverage"
+
+    kpis: dict
     roster: list[AgentRosterEntry]
     outliers: list[OutlierRecord]
     spc: SPCData
     section_analysis: SectionStats
-    binary_stats: BinaryStats
+    binary_stats: list[BinarySectionStats]
     supervisor_stats: list[SupervisorStats]
     ewma: list[EWMAEntry]
     distribution: list[DistributionBin]
     filters_applied: dict  # days, active_only, supervisor
+
+
+class LongFormRow(BaseModel):
+    """One row of the canonical long-form analytical shape.
+
+    Long form is what every predictive / ML / cohort analysis will start
+    from. Returned by GET /api/{team_id}/team/long_form.
+    """
+    agent: str
+    eval_id: str
+    timestamp: datetime
+    supervisor: str = ""
+    manager_email: str = ""
+    section_id: str
+    section_name: str
+    score_type: str  # "numeric" | "yn" | "manual"
+    score: object    # float for numeric/manual, str for yn
+
+
+class LongFormResponse(BaseModel):
+    schema_version: str = "1.1"
+    team_id: str
+    rubric_version: str
+    generated_at: datetime
+    coverage_regime: str
+    rows: list[LongFormRow]
+    filters_applied: dict

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Query, Request
 
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
 from backend.models.team_stats import (
+    LongFormResponse,
+    LongFormRow,
     MailsEntry,
     TeamStatsResponse,
 )
@@ -18,6 +20,7 @@ from backend.services.team_stats import (
     compute_binary_stats,
     compute_distribution,
     compute_ewma,
+    compute_long_form,
     compute_monthly_spc,
     compute_outliers,
     compute_section_analysis,
@@ -26,6 +29,13 @@ from backend.services.team_stats import (
 )
 
 router = APIRouter(prefix="/team", tags=["team"])
+
+
+# Coverage regime is hardcoded until Local AI scores 100% of calls
+# (~1-2 months out per current roadmap). When that lands, this becomes
+# either an env-var lookup or a per-row metadata tag, and consumers will
+# need to filter long_form by regime to keep statistics comparable.
+_COVERAGE_REGIME = "manager_sample"
 
 
 @router.get("/stats", response_model=TeamStatsResponse)
@@ -43,23 +53,28 @@ async def team_stats(
     raw_history = provider._ws.get_all_values()
     raw_mails = provider._get_mails_sheet()
 
-    df = load_and_clean(raw_history, raw_mails, config.sheets.analyst_history)
+    df = load_and_clean(raw_history, raw_mails, config)
+    filters = {"days": days, "active_only": active_only, "supervisor": supervisor}
 
     if df.empty:
         return TeamStatsResponse(
+            team_id=team_id,
+            rubric_version=config.rubric_version,
+            generated_at=datetime.now(timezone.utc),
+            coverage_regime=_COVERAGE_REGIME,
             kpis={"total_evals": 0, "avg_score": 0, "std_score": 0, "analyst_count": 0},
             roster=[],
             outliers=[],
             spc={"months": [], "ucl": 0, "lcl": 0, "center": 0},
             section_analysis={"team_means": {}, "team_stds": {}, "training_opportunities": []},
-            binary_stats={
-                "identity_validation": {"team_pct": 0, "agents": []},
-                "customer_resolution": {"team_pct": 0, "agents": []},
-            },
+            binary_stats=[
+                {"section_id": sid, "label": label, "team_pct": 0.0, "agents": []}
+                for sid, label in config.yn_section_labels.items()
+            ],
             supervisor_stats=[],
             ewma=[],
             distribution=[],
-            filters_applied={"days": days, "active_only": active_only, "supervisor": supervisor},
+            filters_applied=filters,
         )
 
     # Apply time filter (days=0 means all time)
@@ -75,7 +90,6 @@ async def team_stats(
     if supervisor:
         df = df[df["supervisor"].str.lower() == supervisor.strip().lower()]
 
-    # Compute KPIs
     kpis = {
         "total_evals": len(df),
         "avg_score": round(float(df["overall_score"].mean()), 1) if len(df) > 0 else 0,
@@ -83,20 +97,90 @@ async def team_stats(
         "analyst_count": df["agent"].nunique(),
     }
 
-    numeric_sections = config.numeric_history_ids
-    section_labels = config.section_labels
-
     return TeamStatsResponse(
+        team_id=team_id,
+        rubric_version=config.rubric_version,
+        generated_at=datetime.now(timezone.utc),
+        coverage_regime=_COVERAGE_REGIME,
         kpis=kpis,
-        roster=compute_agent_roster(df, numeric_sections, section_labels),
-        outliers=compute_outliers(df),
-        spc=compute_monthly_spc(df),
-        section_analysis=compute_section_analysis(df, numeric_sections, section_labels),
-        binary_stats=compute_binary_stats(df),
+        roster=compute_agent_roster(
+            df,
+            config.numeric_history_ids,
+            config.section_labels,
+            config.yn_history_ids,
+            config.stats,
+        ),
+        outliers=compute_outliers(df, config.stats),
+        spc=compute_monthly_spc(df, config.stats),
+        section_analysis=compute_section_analysis(
+            df, config.numeric_history_ids, config.section_labels
+        ),
+        binary_stats=compute_binary_stats(df, config.yn_section_labels),
         supervisor_stats=compute_supervisor_stats(df),
-        ewma=compute_ewma(df),
+        ewma=compute_ewma(df, config.stats),
         distribution=compute_distribution(df),
-        filters_applied={"days": days, "active_only": active_only, "supervisor": supervisor},
+        filters_applied=filters,
+    )
+
+
+@router.get("/long_form", response_model=LongFormResponse)
+async def team_long_form(
+    request: Request,
+    days: int = Query(default=90, ge=0, le=730),
+    active_only: bool = Query(default=True),
+    supervisor: str = Query(default=""),
+):
+    """Return the canonical long-form analytical shape.
+
+    One row per (evaluation, section). This is what every downstream
+    predictive / ML / cohort analysis should start from. Today's
+    dashboards still use /stats (wide-form rollups); long form exists
+    so future feature stores and forecasters can consume a stable
+    contract without re-deriving from raw history.
+    """
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    provider = await get_provider(team_id)
+
+    raw_history = provider._ws.get_all_values()
+    raw_mails = provider._get_mails_sheet()
+
+    df = load_and_clean(raw_history, raw_mails, config)
+    filters = {"days": days, "active_only": active_only, "supervisor": supervisor}
+
+    if not df.empty:
+        if days > 0:
+            cutoff = datetime.now() - timedelta(days=days)
+            df = df[df["timestamp"] >= cutoff]
+        if active_only:
+            df = df[df["is_active"]]
+        if supervisor:
+            df = df[df["supervisor"].str.lower() == supervisor.strip().lower()]
+
+    long_df = compute_long_form(df, config)
+
+    rows = [
+        LongFormRow(
+            agent=r["agent"],
+            eval_id=r["eval_id"],
+            timestamp=r["timestamp"],
+            supervisor=r.get("supervisor", "") or "",
+            manager_email=r.get("manager_email", "") or "",
+            section_id=r["section_id"],
+            section_name=r["section_name"],
+            score_type=r["score_type"],
+            score=r["score"],
+        )
+        for r in long_df.to_dict(orient="records")
+    ]
+
+    return LongFormResponse(
+        team_id=team_id,
+        rubric_version=config.rubric_version,
+        generated_at=datetime.now(timezone.utc),
+        coverage_regime=_COVERAGE_REGIME,
+        rows=rows,
+        filters_applied=filters,
     )
 
 

--- a/qa-automation/AI-Scoring/backend/services/data_normalization.py
+++ b/qa-automation/AI-Scoring/backend/services/data_normalization.py
@@ -1,0 +1,70 @@
+"""Shared data-normalization helpers for analytics + future predictive ETL.
+
+Pulled out of team_stats.py so the same rules apply when (a) the live
+dashboard reads from Sheets today and (b) the predictive pipeline reads
+from Postgres after Step 9 / Local AI cutover. Keeping accent stripping,
+timestamp parsing, and test-row filtering in one place is the cheapest
+way to avoid drift between the two paths.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from datetime import datetime
+from typing import Iterable, Optional
+
+
+# Timestamp formats encountered in Analyst_History. Order matters: the
+# parser tries each in turn and returns the first match.
+_TS_FORMATS = (
+    "%m/%d/%Y %H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%m/%d/%Y %H:%M",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def strip_accents(s: str) -> str:
+    """Remove combining marks for case-insensitive comparison.
+
+    'León' → 'Leon'.  Used for agent-name canonicalization where
+    typists, form auto-fill, and Dialpad sometimes disagree.
+    """
+    nfkd = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
+def parse_timestamp(val: object) -> Optional[datetime]:
+    """Parse a Sheets timestamp string into a datetime, or None if unparseable."""
+    text = str(val).strip()
+    for fmt in _TS_FORMATS:
+        try:
+            return datetime.strptime(text, fmt)
+        except (ValueError, AttributeError):
+            continue
+    return None
+
+
+def is_excluded_test_row(
+    agent_name: str,
+    overall_score: float,
+    excluded_agents: Iterable[str],
+) -> bool:
+    """Return True if this row is a test entry that should be filtered.
+
+    Convention: a row is filtered iff the (accent-stripped, lower-cased)
+    agent name matches an entry in ``excluded_agents`` AND the overall
+    score is exactly 0.  The score-0 sentinel preserves the original
+    behavior — a real evaluation of a person whose name happens to
+    appear in the exclusion list still flows through analytics.
+
+    When 100% Local AI scoring lands the score-0 sentinel may be
+    revisited; for now we keep semantics identical to the legacy filter.
+    """
+    if overall_score != 0:
+        return False
+    needle = strip_accents(agent_name).lower()
+    for excluded in excluded_agents:
+        if needle.startswith(strip_accents(excluded).lower()):
+            return True
+    return False

--- a/qa-automation/AI-Scoring/backend/services/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/services/team_stats.py
@@ -1,46 +1,42 @@
 """Team-level statistical computations for the TeamStatsBoard.
 
 All functions are pure computation — they take raw data (lists or DataFrames)
-and return plain dicts/lists. No I/O, no Sheets API calls.
+plus a TeamConfig / StatsConfig and return plain dicts/lists. No I/O, no
+Sheets API calls.
 
-Section lists and column indices are passed as parameters (from TeamConfig)
-rather than read from module-level constants.
+Section keys, Y/N section IDs, and statistical thresholds are all driven
+by config — no rubric strings hardcoded here. The DataFrame schema is
+the contract between load_and_clean() and the compute_* functions.
+
+DataFrame schema (wide form, one row per evaluation):
+    agent              str             canonicalized agent name
+    timestamp          datetime
+    overall_score      float           0-100
+    <numeric_history_id>  float, …    one column per numeric section
+    <yn_history_id>       str, …      one column per Y/N section ('Y'|'N'|'NA'|'')
+    manager_email      str
+    is_active          bool            agent appears in active Mails roster
+    supervisor         str             from Mails sheet
+    eval_id            str             call_id parsed from Dialpad link
+
+For long form, see compute_long_form(): one row per (agent, eval_id, section).
 """
 
 from __future__ import annotations
 
-import unicodedata
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
+from backend.services.data_normalization import (
+    is_excluded_test_row,
+    parse_timestamp,
+    strip_accents,
+)
+
 if TYPE_CHECKING:
-    from backend.config.team_config import AnalystHistoryConfig
-
-# Timestamp formats
-_TS_FORMATS = [
-    "%m/%d/%Y %H:%M:%S",
-    "%Y-%m-%d %H:%M:%S",
-    "%m/%d/%Y %H:%M",
-    "%Y-%m-%dT%H:%M:%S",
-]
-
-
-def _strip_accents(s: str) -> str:
-    """Remove accent marks for comparison (e.g. Leon -> Leon)."""
-    nfkd = unicodedata.normalize("NFKD", s)
-    return "".join(c for c in nfkd if not unicodedata.combining(c))
-
-
-def _parse_ts(val: str) -> datetime | None:
-    for fmt in _TS_FORMATS:
-        try:
-            return datetime.strptime(str(val).strip(), fmt)
-        except (ValueError, AttributeError):
-            continue
-    return None
+    from backend.config.team_config import StatsConfig, TeamConfig
 
 
 # ---------------------------------------------------------------------------
@@ -50,25 +46,29 @@ def _parse_ts(val: str) -> datetime | None:
 def load_and_clean(
     history_rows: list[list[str]],
     mails_rows: list[list[str]],
-    ah_config: AnalystHistoryConfig,
+    team_config: TeamConfig,
 ) -> pd.DataFrame:
-    """Convert raw sheet rows into a cleaned DataFrame.
+    """Convert raw sheet rows into a cleaned wide-form DataFrame.
 
     Args:
         history_rows: Raw rows from Analyst_History (including header).
         mails_rows: Raw rows from Mails sheet (including header).
             Col A = Agent Name, B = Email, C = Supervisor, D = Canonical Name.
-        ah_config: Column layout config for the Analyst_History tab.
+        team_config: Active team config (drives column layout, Y/N section
+            ids, and the test-agent exclusion list).
 
     Returns:
-        DataFrame with columns: agent, timestamp, overall_score,
-        per-section scores, identity_validation, customer_resolution,
-        manager_email, is_active, supervisor.
+        DataFrame with the schema documented at the top of this module.
+        Empty DataFrame if no valid rows.
     """
+    ah_config = team_config.sheets.analyst_history
+    yn_section_ids = team_config.yn_history_ids
+    excluded_agents = team_config.excluded_test_agents
+
     # Build maps from Mails sheet
-    canonical_map: dict[str, str] = {}  # raw_name_lower -> canonical
-    supervisor_map: dict[str, str] = {}  # canonical_lower -> supervisor
-    active_set: set[str] = set()  # canonical_lower names
+    canonical_map: dict[str, str] = {}    # raw_name_lower -> canonical
+    supervisor_map: dict[str, str] = {}   # canonical_lower -> supervisor
+    active_set: set[str] = set()          # canonical_lower names
 
     for row in mails_rows[1:]:  # skip header
         if len(row) < 2 or not row[0].strip():
@@ -78,22 +78,23 @@ def load_and_clean(
         canonical = row[3].strip() if len(row) > 3 and row[3].strip() else raw_name
 
         canonical_map[raw_name.lower()] = canonical
-        canonical_map[_strip_accents(raw_name).lower()] = canonical
+        canonical_map[strip_accents(raw_name).lower()] = canonical
         supervisor_map[canonical.lower()] = supervisor
         active_set.add(canonical.lower())
 
-    # Parse history rows
-    numeric_sections = list(ah_config.section_columns.keys())
+    # Minimum row length to be parseable: must reach manager_email column.
+    min_cols = ah_config.col_manager_email + 1
+
     records = []
     for row in history_rows[1:]:  # skip header
-        if len(row) < 15:
+        if len(row) < min_cols:
             continue
 
         agent_raw = str(row[ah_config.col_agent_name]).strip()
         if not agent_raw:
             continue
 
-        ts = _parse_ts(row[ah_config.col_timestamp])
+        ts = parse_timestamp(row[ah_config.col_timestamp])
         if ts is None or ts.year < 2020:
             continue
 
@@ -102,17 +103,16 @@ def load_and_clean(
         except (ValueError, TypeError):
             continue
 
-        # Normalize agent name
+        # Normalize agent name via Mails canonical map
         agent = canonical_map.get(
             agent_raw.lower(),
-            canonical_map.get(_strip_accents(agent_raw).lower(), agent_raw),
+            canonical_map.get(strip_accents(agent_raw).lower(), agent_raw),
         )
 
-        # Exclude test rows (Maximiliano Perez with score 0)
-        if _strip_accents(agent).lower().startswith("maximiliano") and overall == 0:
+        if is_excluded_test_row(agent, overall, excluded_agents):
             continue
 
-        # Parse numeric section scores
+        # Numeric section scores — keyed by history_id
         section_scores = {}
         for sec_name, col_idx in ah_config.section_columns.items():
             try:
@@ -120,22 +120,24 @@ def load_and_clean(
             except (ValueError, TypeError, IndexError):
                 section_scores[sec_name] = np.nan
 
-        # Parse Y/N columns.
-        # The DataFrame uses fixed column names that downstream compute_*
-        # functions and the API response depend on. Config provides the
-        # column indices; the DataFrame column names are the internal contract.
-        _YN_DF_NAMES = {
-            "identity_validation": "identity_validation",
-            "customer_resolution_indicator": "customer_resolution",
-        }
+        # Y/N section values — keyed by history_id (no rename layer).
+        # Downstream consumers must reference these by team_config.yn_history_ids.
         yn_scores = {}
-        for yn_name, yn_idx in ah_config.yn_columns.items():
-            val = str(row[yn_idx]).strip().upper()[:1] if len(row) > yn_idx else ""
-            df_col = _YN_DF_NAMES.get(yn_name, yn_name)
-            yn_scores[df_col] = val
+        for yn_name in yn_section_ids:
+            yn_idx = ah_config.yn_columns.get(yn_name)
+            if yn_idx is None or len(row) <= yn_idx:
+                yn_scores[yn_name] = ""
+                continue
+            yn_scores[yn_name] = str(row[yn_idx]).strip().upper()[:1]
 
-        manager = str(row[ah_config.col_manager_email]).strip().lower() if len(row) > ah_config.col_manager_email else ""
-        dialpad_link = str(row[ah_config.col_dialpad_link]).strip() if len(row) > ah_config.col_dialpad_link else ""
+        manager = (
+            str(row[ah_config.col_manager_email]).strip().lower()
+            if len(row) > ah_config.col_manager_email else ""
+        )
+        dialpad_link = (
+            str(row[ah_config.col_dialpad_link]).strip()
+            if len(row) > ah_config.col_dialpad_link else ""
+        )
 
         # Extract eval_id from dialpad link (strip query params + [LONG CALL] suffix)
         eval_id = ""
@@ -164,24 +166,85 @@ def load_and_clean(
 
 
 # ---------------------------------------------------------------------------
+# compute_long_form
+# ---------------------------------------------------------------------------
+
+def compute_long_form(df: pd.DataFrame, team_config: TeamConfig) -> pd.DataFrame:
+    """Pivot the wide-form analytics DataFrame into long form.
+
+    Returns one row per (evaluation, section) — the canonical analytical
+    shape for downstream work (per-section trajectories, change-point
+    detection, parquet export, ML feature stores).
+
+    Columns: agent, eval_id, timestamp, supervisor, manager_email,
+             section_id, section_name, score_type, score
+        score is float for numeric sections, str ('Y'/'N'/'NA'/'') for yn.
+
+    Numeric and Y/N rows are concatenated; downstream consumers should
+    filter on score_type. Manual-only sections (e.g. Documentation) are
+    included if and only if they appear in section_columns — i.e. are
+    persisted to the history sheet as numeric values.
+    """
+    if df.empty:
+        return pd.DataFrame(columns=[
+            "agent", "eval_id", "timestamp", "supervisor", "manager_email",
+            "section_id", "section_name", "score_type", "score",
+        ])
+
+    section_lookup = team_config.history_id_to_section
+    base_cols = ["agent", "eval_id", "timestamp", "supervisor", "manager_email"]
+
+    pieces = []
+
+    # Numeric section_columns appear in load_and_clean's output as float cols.
+    for sec_id in team_config.sheets.analyst_history.section_columns.keys():
+        if sec_id not in df.columns:
+            continue
+        sec = section_lookup.get(sec_id)
+        piece = df[base_cols].copy()
+        piece["score"] = df[sec_id]
+        piece["section_id"] = sec_id
+        piece["section_name"] = sec.name if sec else sec_id
+        piece["score_type"] = sec.score_type if sec else "numeric"
+        pieces.append(piece)
+
+    # Y/N sections
+    for sec_id in team_config.yn_history_ids:
+        if sec_id not in df.columns:
+            continue
+        sec = section_lookup.get(sec_id)
+        piece = df[base_cols].copy()
+        piece["score"] = df[sec_id]
+        piece["section_id"] = sec_id
+        piece["section_name"] = sec.name if sec else sec_id
+        piece["score_type"] = "yn"
+        pieces.append(piece)
+
+    if not pieces:
+        return pd.DataFrame(columns=[*base_cols, "section_id", "section_name", "score_type", "score"])
+
+    long_df = pd.concat(pieces, ignore_index=True)
+    return long_df[
+        [*base_cols, "section_id", "section_name", "score_type", "score"]
+    ]
+
+
+# ---------------------------------------------------------------------------
 # compute_outliers
 # ---------------------------------------------------------------------------
 
-def compute_outliers(
-    df: pd.DataFrame,
-    min_evals: int = 5,
-    threshold: float = 3.5,
-) -> list[dict]:
+def compute_outliers(df: pd.DataFrame, stats_config: StatsConfig) -> list[dict]:
     """Modified Z-score outlier detection per agent.
 
     Uses MAD (Median Absolute Deviation) which is robust to skewed distributions.
+    Thresholds (min_evals, z-cutoff) come from the team's StatsConfig.
     """
     if df.empty:
         return []
 
     results = []
     for agent, group in df.groupby("agent"):
-        if len(group) < min_evals:
+        if len(group) < stats_config.min_evals_for_outlier:
             continue
 
         scores = group["overall_score"].values
@@ -193,7 +256,7 @@ def compute_outliers(
 
         for _, row in group.iterrows():
             z = 0.6745 * (row["overall_score"] - median) / mad
-            if abs(z) > threshold:
+            if abs(z) > stats_config.outlier_z_threshold:
                 results.append({
                     "agent": agent,
                     "date": row["timestamp"].strftime("%Y-%m-%d"),
@@ -212,14 +275,18 @@ def compute_outliers(
 # compute_ewma
 # ---------------------------------------------------------------------------
 
-def compute_ewma(
-    df: pd.DataFrame,
-    span: int = 5,
-    min_evals: int = 3,
-) -> list[dict]:
-    """Per-agent EWMA with trend detection."""
+def compute_ewma(df: pd.DataFrame, stats_config: StatsConfig) -> list[dict]:
+    """Per-agent EWMA on overall_score with trend detection.
+
+    Trend is improving / declining / flat based on |Δ| > ewma_trend_delta
+    between current EWMA and the value `span` evaluations ago.
+    """
     if df.empty:
         return []
+
+    span = stats_config.ewma_span
+    min_evals = stats_config.ewma_min_evals
+    trend_delta = stats_config.ewma_trend_delta
 
     results = []
     for agent, group in df.groupby("agent"):
@@ -231,14 +298,13 @@ def compute_ewma(
         ewma_series = scores.ewm(span=span).mean()
         current = float(ewma_series.iloc[-1])
 
-        # Trend: compare current to value 5 evals ago (or first if < 5)
         lookback_idx = max(0, len(ewma_series) - span - 1)
         past = float(ewma_series.iloc[lookback_idx])
         diff = current - past
 
-        if diff > 3:
+        if diff > trend_delta:
             trend = "improving"
-        elif diff < -3:
+        elif diff < -trend_delta:
             trend = "declining"
         else:
             trend = "flat"
@@ -258,8 +324,8 @@ def compute_ewma(
 # compute_monthly_spc
 # ---------------------------------------------------------------------------
 
-def compute_monthly_spc(df: pd.DataFrame) -> dict:
-    """Monthly team average with Shewhart-style +/-2sigma control limits."""
+def compute_monthly_spc(df: pd.DataFrame, stats_config: StatsConfig) -> dict:
+    """Monthly team average with Shewhart-style ±k·sigma control limits."""
     if df.empty:
         return {"months": [], "ucl": 0, "lcl": 0, "center": 0}
 
@@ -276,6 +342,7 @@ def compute_monthly_spc(df: pd.DataFrame) -> dict:
     means = monthly["mean"].values
     center = float(np.mean(means))
     sigma = float(np.std(means, ddof=1)) if len(means) > 1 else 0
+    k = stats_config.spc_sigma_multiplier
 
     return {
         "months": [
@@ -286,8 +353,8 @@ def compute_monthly_spc(df: pd.DataFrame) -> dict:
             }
             for _, row in monthly.iterrows()
         ],
-        "ucl": round(center + 2 * sigma, 1),
-        "lcl": round(center - 2 * sigma, 1),
+        "ucl": round(center + k * sigma, 1),
+        "lcl": round(center - k * sigma, 1),
         "center": round(center, 1),
     }
 
@@ -355,43 +422,51 @@ def compute_section_analysis(
 # compute_binary_stats
 # ---------------------------------------------------------------------------
 
-def compute_binary_stats(df: pd.DataFrame) -> dict:
-    """Team-wide binary section stats (Identity Validation, Customer Resolution).
+def compute_binary_stats(
+    df: pd.DataFrame,
+    yn_section_labels: dict[str, str],
+) -> list[dict]:
+    """Per-section Y/N stats, returned as an ordered list.
 
-    Returns per-section: team Y%, per-agent breakdown sorted by % ascending.
+    Each entry: {section_id, label, team_pct, agents: [{agent, pct, yes, total}]}.
+    Frontend iterates this list — no hardcoded section keys.
+
+    Empty DataFrame still returns one entry per configured Y/N section
+    (with team_pct=0, agents=[]) so the dashboard renders a placeholder
+    rather than collapsing the panel.
     """
-    if df.empty:
-        return {"identity_validation": {}, "customer_resolution": {}}
-
-    result = {}
-    for col, label in [
-        ("identity_validation", "identity_validation"),
-        ("customer_resolution", "customer_resolution"),
-    ]:
-        if col not in df.columns:
-            result[label] = {"team_pct": 0, "agents": []}
+    result = []
+    for section_id, label in yn_section_labels.items():
+        if df.empty or section_id not in df.columns:
+            result.append({
+                "section_id": section_id,
+                "label": label,
+                "team_pct": 0.0,
+                "agents": [],
+            })
             continue
 
-        team_pct = _compute_binary_pct(df[col])
+        team_pct = _compute_binary_pct(df[section_id])
 
         agents = []
         for agent, group in df.groupby("agent"):
-            pct = _compute_binary_pct(group[col])
-            total = ((group[col] == "Y") | (group[col] == "N")).sum()
+            pct = _compute_binary_pct(group[section_id])
+            total = ((group[section_id] == "Y") | (group[section_id] == "N")).sum()
             if total > 0:
                 agents.append({
                     "agent": agent,
                     "pct": pct,
-                    "yes": int((group[col] == "Y").sum()),
+                    "yes": int((group[section_id] == "Y").sum()),
                     "total": int(total),
                 })
 
         agents.sort(key=lambda x: x["pct"])
-
-        result[label] = {
+        result.append({
+            "section_id": section_id,
+            "label": label,
             "team_pct": team_pct,
             "agents": agents,
-        }
+        })
 
     return result
 
@@ -429,9 +504,9 @@ def compute_supervisor_stats(df: pd.DataFrame) -> list[dict]:
 
 def _compute_binary_pct(series: pd.Series) -> float:
     """Compute percentage of 'Y' out of valid Y/N responses."""
-    yes = (series == "Y").sum()
-    total = ((series == "Y") | (series == "N")).sum()
-    return round(100 * yes / total, 1) if total > 0 else 0
+    yes = int((series == "Y").sum())
+    total = int(((series == "Y") | (series == "N")).sum())
+    return round(100.0 * yes / total, 1) if total > 0 else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -442,8 +517,15 @@ def compute_agent_roster(
     df: pd.DataFrame,
     numeric_sections: list[str],
     section_labels: dict[str, str],
+    yn_section_ids: list[str],
+    stats_config: StatsConfig,
 ) -> list[dict]:
-    """Summary row per agent for the roster table."""
+    """Summary row per agent for the roster table.
+
+    binary_pcts is a dict {section_id: pct} — one entry per configured
+    Y/N section. The frontend renders these dynamically; old keys
+    (id_val_pct / cust_res_pct) no longer exist.
+    """
     if df.empty:
         return []
 
@@ -455,9 +537,7 @@ def compute_agent_roster(
             team_means[sec] = float(vals.mean()) if len(vals) > 0 else 0
 
     # Pre-compute EWMA for all agents
-    ewma_lookup = {}
-    for entry in compute_ewma(df):
-        ewma_lookup[entry["agent"]] = entry
+    ewma_lookup = {entry["agent"]: entry for entry in compute_ewma(df, stats_config)}
 
     results = []
     for agent, group in df.groupby("agent"):
@@ -465,7 +545,6 @@ def compute_agent_roster(
         mean_score = float(scores.mean())
         std_score = float(scores.std(ddof=1)) if len(scores) > 1 else 0
 
-        # EWMA and trend
         ewma_data = ewma_lookup.get(agent)
         ewma_val = ewma_data["current_ewma"] if ewma_data else None
         trend = ewma_data["trend"] if ewma_data else "flat"
@@ -481,9 +560,13 @@ def compute_agent_roster(
         else:
             status = "at_risk"
 
-        # Binary check percentages
-        id_pct = _compute_binary_pct(group["identity_validation"])
-        cust_pct = _compute_binary_pct(group["customer_resolution"])
+        # Per-section Y/N percentages, keyed by section_id
+        binary_pcts = {}
+        for yn_id in yn_section_ids:
+            if yn_id in group.columns:
+                binary_pcts[yn_id] = _compute_binary_pct(group[yn_id])
+            else:
+                binary_pcts[yn_id] = 0.0
 
         # Weak sections
         weak = []
@@ -507,8 +590,7 @@ def compute_agent_roster(
             "std": round(std_score, 1),
             "ewma": ewma_val,
             "trend": trend,
-            "id_val_pct": id_pct,
-            "cust_res_pct": cust_pct,
+            "binary_pcts": binary_pcts,
             "status": status,
             "weak_sections": weak,
             "is_active": is_active,

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -160,11 +160,11 @@
   <div class="tab-panel" id="panel-roster">
     <div class="card">
       <h3>Agent Roster</h3>
-      <div style="overflow-x:auto"><table id="rosterTable"><thead><tr>
+      <div style="overflow-x:auto"><table id="rosterTable"><thead><tr id="rosterHeaderRow">
         <th data-col="agent">Agent</th><th data-col="n">Evals</th>
         <th data-col="mean">Mean</th><th data-col="std">Std</th>
         <th data-col="ewma">EWMA</th><th data-col="trend">Trend</th>
-        <th data-col="id_val_pct">ID Val %</th><th data-col="cust_res_pct">Cust Res %</th>
+        <!-- One <th> per Y/N section is injected here at render time, between Trend and Status. -->
         <th data-col="status">Status</th><th>Weak Sections</th>
       </tr></thead><tbody></tbody></table></div>
     </div>
@@ -346,6 +346,12 @@ function priorityBadge(p) {
 }
 
 // --- Sort ---
+// data-col supports dot-paths (e.g. "binary_pcts.contact_verification")
+// so dynamically-injected nested columns (Y/N percentages per section)
+// sort the same way as flat fields.
+function _readPath(obj, path) {
+  return path.split('.').reduce((o, k) => (o == null ? null : o[k]), obj);
+}
 function attachSort(tableId, data, renderFn) {
   const table = document.getElementById(tableId);
   if (!table) return;
@@ -356,7 +362,7 @@ function attachSort(tableId, data, renderFn) {
       const asc = sortState[key] === 'asc' ? 'desc' : 'asc';
       sortState[key] = asc;
       data.sort((a, b) => {
-        let va = a[col], vb = b[col];
+        let va = _readPath(a, col), vb = _readPath(b, col);
         if (va == null) return 1; if (vb == null) return -1;
         if (typeof va === 'string') return asc === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
         return asc === 'asc' ? va - vb : vb - va;
@@ -535,20 +541,54 @@ function renderEwmaChart() {
 }
 
 // --- Roster ---
+// Roster columns are partially dynamic: every Y/N section configured for
+// the team gets its own column between Trend and Status. The (section_id,
+// label) pairs come from teamData.binary_stats so the table adapts to
+// whichever rubric is loaded.
+function rosterBinaryColumns() {
+  return (teamData?.binary_stats || []).map(b => ({
+    sectionId: b.section_id,
+    label: b.label,
+  }));
+}
+
+function rebuildRosterHeader() {
+  const headerRow = document.getElementById('rosterHeaderRow');
+  if (!headerRow) return;
+  // Strip any previously-injected binary headers (data-binary marker)
+  Array.from(headerRow.querySelectorAll('th[data-binary]')).forEach(th => th.remove());
+  const statusTh = headerRow.querySelector('th[data-col="status"]');
+  if (!statusTh) return;
+  for (const col of rosterBinaryColumns()) {
+    const th = document.createElement('th');
+    th.dataset.col = `binary_pcts.${col.sectionId}`;
+    th.dataset.binary = '1';
+    th.textContent = `${col.label} %`;
+    headerRow.insertBefore(th, statusTh);
+  }
+}
+
 function renderRoster() {
   const roster = teamData.roster || [];
+  rebuildRosterHeader();
   attachSort('rosterTable', roster, fillRoster);
   fillRoster(roster);
 }
 
 function fillRoster(data) {
-  document.querySelector('#rosterTable tbody').innerHTML = data.map(r => `<tr>
-    <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(r.agent)}">${escapeHtml(r.agent)}</a></td>
-    <td>${r.n ?? ''}</td><td style="color:${scoreColor(r.mean)}">${fmt(r.mean)}</td><td>${fmt(r.std)}</td>
-    <td style="color:${scoreColor(r.ewma)}">${fmt(r.ewma)}</td><td>${trendHtml(r.trend)}</td>
-    <td>${pctFmt(r.id_val_pct)}</td><td>${pctFmt(r.cust_res_pct)}</td>
-    <td>${statusBadge(r.status)}</td><td>${(r.weak_sections || []).join(', ')}</td>
-  </tr>`).join('');
+  const binCols = rosterBinaryColumns();
+  document.querySelector('#rosterTable tbody').innerHTML = data.map(r => {
+    const binCells = binCols
+      .map(c => `<td>${pctFmt((r.binary_pcts || {})[c.sectionId])}</td>`)
+      .join('');
+    return `<tr>
+      <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(r.agent)}">${escapeHtml(r.agent)}</a></td>
+      <td>${r.n ?? ''}</td><td style="color:${scoreColor(r.mean)}">${fmt(r.mean)}</td><td>${fmt(r.std)}</td>
+      <td style="color:${scoreColor(r.ewma)}">${fmt(r.ewma)}</td><td>${trendHtml(r.trend)}</td>
+      ${binCells}
+      <td>${statusBadge(r.status)}</td><td>${(r.weak_sections || []).join(', ')}</td>
+    </tr>`;
+  }).join('');
 }
 
 // --- Outliers ---
@@ -604,16 +644,20 @@ function renderSectionVarChart() {
 }
 
 function renderBinaryStats() {
-  const bs = teamData.binary_stats || {};
-  const idPct = bs.identity_validation ? bs.identity_validation.team_pct : null;
-  const crPct = bs.customer_resolution ? bs.customer_resolution.team_pct : null;
-  document.getElementById('binaryStats').innerHTML = [
-    { label: 'Identity Validation %', value: pctFmt(idPct), color: scoreColor(idPct || 0) },
-    { label: 'Customer Resolution %', value: pctFmt(crPct), color: scoreColor(crPct || 0) }
-  ].map(kpi => `<div class="kpi-box">
-    <div class="label">${kpi.label}</div>
-    <div class="value" style="color:${kpi.color}">${kpi.value}</div>
-  </div>`).join('');
+  const bs = teamData.binary_stats || [];
+  const container = document.getElementById('binaryStats');
+  if (!bs.length) {
+    container.innerHTML = '';
+    return;
+  }
+  container.style.gridTemplateColumns = `repeat(${bs.length}, 1fr)`;
+  container.innerHTML = bs.map(section => {
+    const pct = section.team_pct;
+    return `<div class="kpi-box">
+      <div class="label">${escapeHtml(section.label)} %</div>
+      <div class="value" style="color:${scoreColor(pct || 0)}">${pctFmt(pct)}</div>
+    </div>`;
+  }).join('');
 }
 
 function renderTraining() {

--- a/qa-automation/src/AnalystHistory.js
+++ b/qa-automation/src/AnalystHistory.js
@@ -64,45 +64,60 @@ class AnalystHistory {
    * Returns the most recent N QAEntry-like objects for a given agent,
    * sorted newest-first.
    *
+   * The numeric/binary score columns are walked dynamically from
+   * CONFIG.NUMERIC_CATEGORIES + BINARY_CATEGORIES (in toHistoryRow order),
+   * so each team's rubric drives its own history shape — no per-section
+   * keys are hardcoded here.
+   *
    * @param  {string} agentName  — value to match against column A
    * @param  {number} [limit]    — max records to return (default CONFIG.EMAIL.MAX_HISTORY)
-   * @return {Object[]} array of plain objects with keys matching HISTORY_COL
+   * @return {Object[]} plain objects with overallScore + per-category fields
    */
   getHistory(agentName, limit) {
     limit = limit || CONFIG.EMAIL.MAX_HISTORY;
     var data = this.sheet.getDataRange().getValues();
     var HC   = CONFIG.HISTORY_COL;
 
-    // Skip header row (index 0), filter by agent name
     var matches = [];
     for (var i = 1; i < data.length; i++) {
       var row = data[i];
-      if ((row[HC.AGENT_NAME] || '').toString().trim() === agentName) {
-        matches.push({
-          agentName:          row[HC.AGENT_NAME],
-          agentEmail:         row[HC.AGENT_EMAIL],
-          timestamp:          new Date(row[HC.TIMESTAMP]),
-          overallScore:       parseFloat(row[HC.OVERALL_SCORE]) || 0,
-          greeting:           parseFloat(row[HC.GREETING])      || 0,
-          callPurpose:        parseFloat(row[HC.CALL_PURPOSE])  || 0,
-          matchMoment:        parseFloat(row[HC.MATCH_MOMENT])  || 0,
-          processAdherence:   parseFloat(row[HC.PROCESS])       || 0,
-          callResolution:     parseFloat(row[HC.RESOLUTION])    || 0,
-          communication:      parseFloat(row[HC.COMMUNICATION]) || 0,
-          efficiency:         parseFloat(row[HC.EFFICIENCY])     || 0,
-          documentation:      parseFloat(row[HC.DOCUMENTATION]) || 0,
-          identityValidation: (row[HC.IDENTITY_VAL]  || '').toString().trim().toUpperCase().charAt(0) === 'Y',
-          customerResolution: (row[HC.CUSTOMER_RES]  || '').toString().trim().toUpperCase().charAt(0) === 'Y',
-          managerEmail:       row[HC.MANAGER_EMAIL],
-          dialpadLink:        (row[HC.DIALPAD_LINK]  || '').toString().trim(),
-          keyStrengths:       (row[HC.KEY_STRENGTHS]  || '').toString().trim(),
-          improvements:       (row[HC.IMPROVEMENTS]   || '').toString().trim(),
-          source:             (row[HC.SOURCE]          || '').toString().trim(),
-        });
-      }
+      if ((row[HC.AGENT_NAME] || '').toString().trim() !== agentName) continue;
+
+      var entry = {
+        agentName:    row[HC.AGENT_NAME],
+        agentEmail:   row[HC.AGENT_EMAIL],
+        timestamp:    new Date(row[HC.TIMESTAMP]),
+        overallScore: parseFloat(row[HC.OVERALL_SCORE]) || 0,
+        numericScores: {},
+        binaryChecks:  {},
+      };
+
+      // Score columns begin right after Overall Score (col E onwards),
+      // emitted in NUMERIC_CATEGORIES then BINARY_CATEGORIES order
+      // (must mirror QAEntry.toHistoryRow()).
+      var col = HC.OVERALL_SCORE + 1;
+      CONFIG.NUMERIC_CATEGORIES.forEach(function(cat) {
+        var val = parseFloat(row[col]) || 0;
+        entry.numericScores[cat.key] = val;
+        entry[cat.key] = val;  // top-level alias, kept for legacy callers
+        col++;
+      });
+      CONFIG.BINARY_CATEGORIES.forEach(function(cat) {
+        var passed = (row[col] || '').toString().trim().toUpperCase().charAt(0) === 'Y';
+        entry.binaryChecks[cat.key] = passed;
+        entry[cat.key] = passed;
+        col++;
+      });
+
+      entry.managerEmail = row[col];                                       col++;
+      entry.dialpadLink  = (row[col] || '').toString().trim();             col++;
+      entry.keyStrengths = (row[col] || '').toString().trim();             col++;
+      entry.improvements = (row[col] || '').toString().trim();             col++;
+      entry.source       = (row[col] || '').toString().trim();             col++;
+
+      matches.push(entry);
     }
 
-    // Sort newest first, then trim
     matches.sort(function(a, b) { return b.timestamp - a.timestamp; });
     return matches.slice(0, limit);
   }
@@ -111,56 +126,41 @@ class AnalystHistory {
   // Private helpers
   // ────────────────────────────────────────────────────────────────
 
-  /** @private — returns the Analyst_History sheet, creating it with headers if absent. */
+  /**
+   * @private — returns the Analyst_History sheet, creating it with headers
+   * if absent. Headers are derived from CONFIG so a new team's first run
+   * lays out its sheet to match its rubric automatically.
+   */
   _getOrCreateSheet() {
     var sheet = this.spreadsheet.getSheetByName(this.sheetName);
     if (sheet) return sheet;
 
     sheet = this.spreadsheet.insertSheet(this.sheetName);
-    var headers = [
-      'Agent Name',
-      'Agent Email',
-      'Timestamp',
-      'Overall Score',
-      'Greeting',
-      'Purpose of the Call',
-      'Matching the Moment',
-      'Process Adherence',
-      'Call Resolution',
-      'Communication',
-      'Efficiency & Call Handling',
-      'Documentation',
-      'Identity Validation',
-      'Customer Resolution',
-      'Manager Email',
-      'Dialpad Link',                    // P
-      'Key Strengths',                   // Q
-      'Opportunities for Improvement',   // R
-      'Source',                          // S
-      'Greeting Confidence',             // T
-      'Greeting Reasoning',              // U
-      'Identity Validation Confidence',  // V
-      'Identity Validation Reasoning',   // W
-      'Purpose of Call Confidence',      // X
-      'Purpose of Call Reasoning',       // Y
-      'Matching the Moment Confidence',  // Z
-      'Matching the Moment Reasoning',   // AA
-      'Process Adherence Confidence',    // AB
-      'Process Adherence Reasoning',     // AC
-      'Call Resolution Confidence',      // AD
-      'Call Resolution Reasoning',       // AE
-      'Communication Confidence',        // AF
-      'Communication Reasoning',         // AG
-      'Efficiency Confidence',           // AH
-      'Efficiency Reasoning',            // AI
-      'Customer Resolution Confidence',  // AJ
-      'Customer Resolution Reasoning',   // AK
-      'Call Summary',                    // AL
-      'Caller Name',                     // AM
-      'Caller Phone',                    // AN
-      'Documentation Confidence',        // AO
-      'Documentation Reasoning',         // AP
-    ];
+
+    var headers = ['Agent Name', 'Agent Email', 'Timestamp', 'Overall Score'];
+
+    // Numeric + binary score column headers, in toHistoryRow() order
+    CONFIG.NUMERIC_CATEGORIES.forEach(function(cat) { headers.push(cat.label); });
+    CONFIG.BINARY_CATEGORIES.forEach(function(cat) { headers.push(cat.label); });
+
+    // Trailing fixed metadata columns (always present across teams)
+    headers.push('Manager Email');                  // O
+    headers.push('Dialpad Link');                   // P
+    headers.push('Key Strengths');                  // Q
+    headers.push('Opportunities for Improvement'); // R
+    headers.push('Source');                         // S
+
+    // Per-section reasoning + caller meta block, ordered by HISTORY_EXTENDED_LAYOUT
+    CONFIG.HISTORY_EXTENDED_LAYOUT.forEach(function(slot) {
+      if (slot.type === 'meta') {
+        headers.push(slot.label);
+      } else {
+        // 'reasoning' and 'manual' both occupy a Conf+Reason pair on Analyst_History
+        headers.push(slot.label + ' Confidence');
+        headers.push(slot.label + ' Reasoning');
+      }
+    });
+
     sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
     sheet.getRange(1, 1, 1, headers.length)
       .setFontWeight('bold')
@@ -173,6 +173,13 @@ class AnalystHistory {
   /**
    * Looks up the matching row in Form Responses AI by Dialpad link and
    * returns a structured enrichment object. Pure read — no side effects.
+   *
+   * The per-section confidence/reasoning columns are walked dynamically
+   * from CONFIG.HISTORY_EXTENDED_LAYOUT, starting at the column after
+   * FORM_AI_COL.SOURCE. Slot semantics on Form Responses AI:
+   *   - 'reasoning' → 2 cols (Confidence, Reasoning)
+   *   - 'meta'      → 1 col, stored under enrichment[slot.key]
+   *   - 'manual'    → 1 col (Reasoning only); confidence synthesized as 'manual'
    *
    * @private
    * @param  {string} dialpadLink
@@ -203,38 +210,35 @@ class AnalystHistory {
 
       var s = function(v) { return (v || '').toString(); };
 
-      return {
+      var enrichment = {
         keyStrengths: s(matchedRow[C.STRENGTHS]),
         improvements: s(matchedRow[C.IMPROVEMENTS]),
         source:       s(matchedRow[FAC.SOURCE]),
-        callSummary:  s(matchedRow[FAC.CALL_SUMMARY]),
-        callerName:   s(matchedRow[FAC.CALLER_NAME]),
-        callerPhone:  s(matchedRow[FAC.CALLER_PHONE]),
-        confidence: {
-          greeting:           s(matchedRow[FAC.GREETING_CONF]),
-          identityValidation: s(matchedRow[FAC.IDENTITY_CONF]),
-          callPurpose:        s(matchedRow[FAC.PURPOSE_CONF]),
-          matchMoment:        s(matchedRow[FAC.MATCHING_CONF]),
-          processAdherence:   s(matchedRow[FAC.PROCESS_CONF]),
-          callResolution:     s(matchedRow[FAC.RESOLUTION_CONF]),
-          communication:      s(matchedRow[FAC.COMMUNICATION_CONF]),
-          efficiency:         s(matchedRow[FAC.EFFICIENCY_CONF]),
-          customerResolution: s(matchedRow[FAC.CUSTOMER_RES_CONF]),
-          documentation:      'manual',
-        },
-        reasoning: {
-          greeting:           s(matchedRow[FAC.GREETING_REASON]),
-          identityValidation: s(matchedRow[FAC.IDENTITY_REASON]),
-          callPurpose:        s(matchedRow[FAC.PURPOSE_REASON]),
-          matchMoment:        s(matchedRow[FAC.MATCHING_REASON]),
-          processAdherence:   s(matchedRow[FAC.PROCESS_REASON]),
-          callResolution:     s(matchedRow[FAC.RESOLUTION_REASON]),
-          communication:      s(matchedRow[FAC.COMMUNICATION_REASON]),
-          efficiency:         s(matchedRow[FAC.EFFICIENCY_REASON]),
-          customerResolution: s(matchedRow[FAC.CUSTOMER_RES_REASON]),
-          documentation:      s(matchedRow[FAC.DOC_REASONING]),
-        },
+        callSummary:  '',
+        callerName:   '',
+        callerPhone:  '',
+        confidence:   {},
+        reasoning:    {},
       };
+
+      // Walk the layout. Form AI extended block begins at SOURCE+1 (col R for MS).
+      var col = FAC.SOURCE + 1;
+      CONFIG.HISTORY_EXTENDED_LAYOUT.forEach(function(slot) {
+        if (slot.type === 'reasoning') {
+          enrichment.confidence[slot.key] = s(matchedRow[col]);
+          enrichment.reasoning[slot.key]  = s(matchedRow[col + 1]);
+          col += 2;
+        } else if (slot.type === 'meta') {
+          enrichment[slot.key] = s(matchedRow[col]);
+          col += 1;
+        } else if (slot.type === 'manual') {
+          enrichment.confidence[slot.key] = 'manual';
+          enrichment.reasoning[slot.key]  = s(matchedRow[col]);
+          col += 1;
+        }
+      });
+
+      return enrichment;
     } catch (err) {
       Logger.log('[AnalystHistory] _lookupEnrichment failed: ' + err.message);
       return null;
@@ -243,7 +247,12 @@ class AnalystHistory {
 
   /**
    * Writes a previously-fetched enrichment object to the given row's
-   * extended columns (Q–AP). Non-fatal on failure.
+   * extended columns. Non-fatal on failure.
+   *
+   * Column order is driven by CONFIG.HISTORY_EXTENDED_LAYOUT, starting at
+   * KEY_STRENGTHS. On Analyst_History both 'reasoning' and 'manual' slots
+   * occupy a Conf+Reason pair (the 'manual' confidence is the literal
+   * string 'manual' set by _lookupEnrichment).
    *
    * @private
    * @param {number} historyRowNum
@@ -252,40 +261,24 @@ class AnalystHistory {
   _writeEnrichment(historyRowNum, enrichment) {
     try {
       var HC = CONFIG.HISTORY_COL;
-      var r  = enrichment.reasoning;
-      var c  = enrichment.confidence;
 
-      var extendedValues = [
+      var values = [
         enrichment.keyStrengths,    // Q
         enrichment.improvements,    // R
         enrichment.source,          // S
-        c.greeting,                 // T
-        r.greeting,                 // U
-        c.identityValidation,       // V
-        r.identityValidation,       // W
-        c.callPurpose,              // X
-        r.callPurpose,              // Y
-        c.matchMoment,              // Z
-        r.matchMoment,              // AA
-        c.processAdherence,         // AB
-        r.processAdherence,         // AC
-        c.callResolution,           // AD
-        r.callResolution,           // AE
-        c.communication,            // AF
-        r.communication,            // AG
-        c.efficiency,               // AH
-        r.efficiency,               // AI
-        c.customerResolution,       // AJ
-        r.customerResolution,       // AK
-        enrichment.callSummary,     // AL
-        enrichment.callerName,      // AM
-        enrichment.callerPhone,     // AN
-        c.documentation,            // AO ('manual')
-        r.documentation,            // AP
       ];
 
-      this.sheet.getRange(historyRowNum, HC.KEY_STRENGTHS + 1, 1, extendedValues.length)
-        .setValues([extendedValues]);
+      CONFIG.HISTORY_EXTENDED_LAYOUT.forEach(function(slot) {
+        if (slot.type === 'reasoning' || slot.type === 'manual') {
+          values.push(enrichment.confidence[slot.key] || '');
+          values.push(enrichment.reasoning[slot.key]  || '');
+        } else if (slot.type === 'meta') {
+          values.push(enrichment[slot.key] || '');
+        }
+      });
+
+      this.sheet.getRange(historyRowNum, HC.KEY_STRENGTHS + 1, 1, values.length)
+        .setValues([values]);
     } catch (err) {
       Logger.log('[AnalystHistory] _writeEnrichment failed: ' + err.message);
     }

--- a/qa-automation/src/QAEntry.js
+++ b/qa-automation/src/QAEntry.js
@@ -60,26 +60,33 @@ class QAEntry {
     );
   }
 
-  /** Returns a flat object suitable for writing to the Analyst_History sheet. */
+  /**
+   * Returns a flat object suitable for writing to the Analyst_History sheet.
+   * Numeric and binary slots are emitted in CONFIG.NUMERIC_CATEGORIES /
+   * BINARY_CATEGORIES order so each team's rubric drives the column layout.
+   */
   toHistoryRow() {
-    return [
-      this.agentName,
-      this.agentEmail,
-      this.timestamp,
-      this.overallScore,
-      this.numericScores.greeting,
-      this.numericScores.callPurpose,
-      this.numericScores.matchMoment,
-      this.numericScores.processAdherence,
-      this.numericScores.callResolution,
-      this.numericScores.communication,
-      this.numericScores.efficiency,
-      this.numericScores.documentation,
-      this.binaryChecks.identityValidation  ? 'Y' : 'N',
-      this.binaryChecks.customerResolution  ? 'Y' : 'N',
-      this.managerEmail,
-      this.dialpadLink,     // P  (Dialpad link — used as lookup key for AI reasoning)
+    var row = [
+      this.agentName,        // A
+      this.agentEmail,       // B
+      this.timestamp,        // C
+      this.overallScore,     // D
     ];
+
+    // Numeric scores (1–5) in rubric order
+    CONFIG.NUMERIC_CATEGORIES.forEach(function(cat) {
+      row.push(this.numericScores[cat.key]);
+    }, this);
+
+    // Binary checks (Y/N) in rubric order
+    CONFIG.BINARY_CATEGORIES.forEach(function(cat) {
+      row.push(this.binaryChecks[cat.key] ? 'Y' : 'N');
+    }, this);
+
+    row.push(this.managerEmail);  // O
+    row.push(this.dialpadLink);   // P  (Dialpad link — used as lookup key for AI reasoning)
+
+    return row;
   }
 
   /**

--- a/qa-automation/teams/member_support/Config.js
+++ b/qa-automation/teams/member_support/Config.js
@@ -163,4 +163,32 @@ const CONFIG = {
     CALLER_PHONE:       37,  // AL
     DOC_REASONING:      38,  // AM
   },
+
+  // ── Extended-block layout (drives AnalystHistory header + enrichment) ──
+  // Single ordered descriptor for the per-section reasoning/meta block that
+  // appears after Source on Analyst_History (col T+) and after Source on
+  // Form Responses AI (col R+). New teams override this list to declare
+  // their rubric ordering instead of forking AnalystHistory.js.
+  //
+  // Slot types:
+  //   'reasoning' — AI-scored category. Two cols on both tabs (Conf + Reason).
+  //   'meta'      — single-column metadata (caller details). Same on both tabs.
+  //   'manual'    — manual-scored category (e.g. Documentation). Two cols on
+  //                 Analyst_History (Conf set to 'manual' + Reason); one col
+  //                 on Form AI (Reason only — the manager types it in).
+  HISTORY_EXTENDED_LAYOUT: [
+    { type: 'reasoning', key: 'greeting',           label: 'Greeting' },
+    { type: 'reasoning', key: 'identityValidation', label: 'Identity Validation' },
+    { type: 'reasoning', key: 'callPurpose',        label: 'Purpose of Call' },
+    { type: 'reasoning', key: 'matchMoment',        label: 'Matching the Moment' },
+    { type: 'reasoning', key: 'processAdherence',   label: 'Process Adherence' },
+    { type: 'reasoning', key: 'callResolution',     label: 'Call Resolution' },
+    { type: 'reasoning', key: 'communication',      label: 'Communication' },
+    { type: 'reasoning', key: 'efficiency',         label: 'Efficiency' },
+    { type: 'reasoning', key: 'customerResolution', label: 'Customer Resolution' },
+    { type: 'meta',      key: 'callSummary',        label: 'Call Summary' },
+    { type: 'meta',      key: 'callerName',         label: 'Caller Name' },
+    { type: 'meta',      key: 'callerPhone',        label: 'Caller Phone' },
+    { type: 'manual',    key: 'documentation',      label: 'Documentation' },
+  ],
 };


### PR DESCRIPTION
## Summary

Two refactors that together unblock Sales onboarding (Step 5 of the Phase 1 roadmap) and lay structural groundwork for the predictive-analytics era when Local AI scores 100% of calls.

- **Apps Script side** — drops the last hardcoded references to the Member Support rubric in the shared base (`QAEntry.js`, `AnalystHistory.js`). Rubric structure now lives in each team's `Config.js` via a single `HISTORY_EXTENDED_LAYOUT` descriptor. New teams onboard by copy-and-edit instead of forking shared logic. Ships `sales.json.example` as a starter template.
- **Stats engine side** — `team_stats.py` no longer keys binary stats on MS-specific section names. `compute_binary_stats` and `compute_agent_roster` iterate `team_config.yn_history_ids` and emit generic shapes (`binary_stats` list of `{section_id, label, …}`; `roster.binary_pcts` dict). Sales no longer KeyErrors on the dashboard. Magic-number thresholds (outlier z, EWMA span, SPC sigma) lifted into a per-team `StatsConfig`.
- **Predictive groundwork** — adds `compute_long_form()` and `GET /api/{team_id}/team/long_form`: the canonical analytical shape (one row per `(agent, eval_id, section)`) for future feature stores, change-point detectors, and ML pipelines. Wraps `/team/stats` in a versioned envelope with `rubric_version` and `coverage_regime` (`manager_sample` until Local AI cutover) so future consumers can reason about comparability.
- **Frontend** — roster table and Section Analysis cards render Y/N sections dynamically from `binary_stats`; `attachSort` supports dot-path keys for nested columns.
- **Shared normalization** — `data_normalization.py` extracts accent stripping, timestamp parsing, and the test-row filter so the future predictive ETL reuses the same rules.
- **Test-agent filter** — moved from a hardcoded `maximiliano` check into `TeamConfig.excluded_test_agents`. Score-zero sentinel preserved.

## Behavioral parity

- MS Apps Script `toHistoryRow` / `_writeEnrichment` / `_lookupEnrichment` outputs verified byte-identical to pre-refactor against MS's existing layout (Node parity script).
- New `/team/stats` envelope verified end-to-end with live MS data: `binary_stats` list shape, `roster.binary_pcts` dict, `coverage_regime: manager_sample`.
- Sales config validates cleanly through the production `TeamConfig` pydantic model and produces non-empty `binary_stats` / `binary_pcts` from synthetic data — no KeyError.

## Schema notes

- `TeamStatsResponse.schema_version` bumped to `1.1`.
- `BinaryStats` (fixed-field model) replaced with `list[BinarySectionStats]`.
- `AgentRosterEntry.id_val_pct` / `cust_res_pct` removed; replaced with `binary_pcts: dict[str, float]`.
- New: `LongFormResponse` + `LongFormRow` for `/team/long_form`.
- `coverage_regime` is process-wide for now; will need per-row tagging when Local AI lands and old/new data coexists (callout in `routes/team.py`).

## Test plan

- [x] `./push.sh qa-member-support --dry-run` succeeds; staging path unchanged.
- [x] Score one MS call through the live pipeline; confirm Form Responses AI + Analyst_History land identical to pre-refactor.
- [x] Open `/dashboard/member_support` after a hard refresh; confirm roster columns labeled `Caller Identity Validation %` / `Customer Resolution Indicator %` render real percentages.
- [x] Section Analysis tab shows two binary KPI cards with 81.2% / 66.8% (or current values).
- [x] Hit `/api/member_support/team/long_form?days=90` with the MS API key and confirm it returns rows with `score_type ∈ {numeric, yn, manual}`.
- [x] Smoke-test that an MS API key cannot read `/api/sales/...` (returns 403). (Sales endpoints will return `FileNotFoundError` until `sales.json` is dropped in — by design.)

## Out of scope (deliberately deferred)

- Distribution bins still hardcoded in `compute_distribution`; promote to `StatsConfig` when needed.
- No UI consumer of `/team/long_form` yet — exists as the contract for the predictive era.
- `coverage_regime` is process-wide today; per-row tagging deferred until Local AI cutover (~1-2 months out).
- Sales' actual `sales.json`, Apps Script binding, and env vars: still TODO per `qa-automation/teams/sales/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)