### PR TITLE
chore: push.sh — pre-push manifest preview + zero-file abort

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -190,6 +190,43 @@ if [[ -n "$DIRTY" ]]; then
 fi
 echo ""
 
+# ── Pre-push manifest preview ─────────────────────────────────────────────────
+# Ask clasp (or count staging inputs) what this push will actually deploy.
+# Catches the rootDir silent-no-op failure mode: a misconfigured .clasp.json
+# pointing at a non-existent dir lets `clasp push` exit 0 with zero files
+# transferred, so .push-log records "success" while nothing reaches GAS.
+echo "  Files clasp will push:"
+if [[ -n "$BUILD_DIR" ]]; then
+  # Multi-team: BUILD_DIR is created post-confirmation (staging step), so
+  # clasp status can't be queried here. Fall back to staging-input counts.
+  _count_pushable() {
+    find "$1" -type f \
+      \( -name '*.gs' -o -name '*.js' -o -name '*.html' -o -name '*.json' \) \
+      2>/dev/null | wc -l | tr -d ' '
+  }
+  BASE_FILES=$(_count_pushable "$REPO_ROOT/$BASE_DIR")
+  OVERLAY_FILES=$(_count_pushable "$REPO_ROOT/$CLASP_DIR")
+  echo "    (multi-team — exact manifest available only after staging)"
+  echo "    Base files     : $BASE_FILES  (from $BASE_DIR)"
+  echo "    Overlay files  : $OVERLAY_FILES  (from $CLASP_DIR)"
+else
+  TRACKED=$(cd "$REPO_ROOT/$CLASP_DIR" && clasp status 2>/dev/null \
+            | awk '/^Tracked files:/{f=1; next} /^Untracked files:/{f=0} f && NF{print}')
+  TRACKED_COUNT=$(echo "$TRACKED" | awk 'NF{c++} END{print c+0}')
+  if (( TRACKED_COUNT == 0 )); then
+    echo ""
+    echo "  ❌ clasp sees zero tracked files in $CLASP_DIR."
+    echo "     Check rootDir in $CLASP_DIR/.clasp.json — a misconfigured"
+    echo "     rootDir makes clasp push silently no-op."
+    echo ""
+    exit 1
+  fi
+  echo "$TRACKED" | sed 's/^/    /'
+  echo "    ──"
+  echo "    Total: $TRACKED_COUNT file(s)"
+fi
+echo ""
+
 if [[ "$LIVE" == "yes" ]]; then
   echo "  ┌───────────────────────────────────────────────┐"
   echo "  │  ⚠️  $TARGET is LIVE                          "


### PR DESCRIPTION
## Summary
- Adds a manifest-preview block between the dirty-tree warning and the confirmation prompt in `push.sh`, so the operator sees what `clasp push` will actually deploy **before** typing `yes`.
- **Aborts with a clear error if clasp sees zero tracked files** — the exact failure mode that bit the mass-notifications deploy when its `.clasp.json` rootDir resolved to a non-existent directory and every push silently no-op'd to `.push-log` for weeks.
- For single-dir projects (mass-notifications): renders the full file list with a totals row via `clasp status`.
- For multi-team projects (qa-member-support, qa-sales): falls back to base + overlay file counts, because the staged build dir doesn't exist until after confirmation. The exact list still appears in clasp's own post-push output.

## Test plan
- [x] `./push.sh mass-notifications --dry-run` — renders the 24-file manifest with totals row.
- [x] `./push.sh qa-sales --dry-run` — renders the base/overlay counts.
- [x] Manually break `mass-notifications/src/.clasp.json` (`"rootDir": "./does-not-exist"`) and confirm the script aborts pre-confirmation with the rootDir hint instead of silently succeeding. Restore after.
- [x] Sanity run a real push against `mass-notifications` to confirm the live (non-dry-run) path still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)