### PR TITLE
feat(mass-notifications): WebApp restyle to Landing design system

### DIFF
--- a/mass-notifications/src/webapp/Index.html
+++ b/mass-notifications/src/webapp/Index.html
@@ -4,33 +4,170 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Mass Notifications</title>
+
+  <!-- Landing design system fonts. Match AI-Scoring frontend (serif + monospace). -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:wght@300;400;500;600;700&family=DM+Mono:wght@300;400;500&display=swap">
+
   <style>
-    body {
-      font-family: Arial, Helvetica, sans-serif;
-      background: #f5f7fa;
-      color: #15192D;
-      margin: 0;
-      padding: 32px;
+    /* ── Landing design tokens ──────────────────────────────────────────
+       Mirrors qa-automation/AI-Scoring/frontend/index.html :root vars so
+       both internal tools share one visual language. */
+    :root {
+      --bg:           #E7EFFB;
+      --surface:      #ffffff;
+      --text:         #15192D;
+      --accent:       #1A61D9;
+      --accent-hover: #1550b5;
+      --navy:         #15192D;
+      --muted:        #5a6478;
+      --border:       #c9d5e8;
+
+      --success:      #2d6a4f;
+      --success-bg:   #d1fae5;
+      --warning:      #b45309;
+      --warning-bg:   #fef3c7;
+      --error:        #991b1b;
+      --error-bg:     #fee2e2;
+
+      --amber:        #E8A317;
+      --red:          #D9534F;
+      --green:        #28A745;
+
+      --radius-card:  12px;
+      --radius-ctrl:  4px;
+      --radius-pill:  20px;
+
+      --font-serif:   'Fraunces', Georgia, serif;
+      --font-mono:    'DM Mono', ui-monospace, 'SF Mono', Menlo, monospace;
     }
-    h1 { font-size: 22px; margin: 0 0 8px; }
-    p  { color: #4A4A4A; }
+
+    /* ── Base ───────────────────────────────────────────────────────────── */
+    html, body {
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }
+    h1, h2, h3, h4 {
+      font-family: var(--font-serif);
+      font-weight: 400;
+      letter-spacing: -0.01em;
+    }
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.9em;
+      background: rgba(21, 25, 45, 0.06);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+    a { color: var(--accent); }
+    a:hover { color: var(--accent-hover); }
+
+    /* ── App header bar ────────────────────────────────────────────────── */
+    .app-header {
+      background: var(--navy);
+      color: #ffffff;
+      padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
+    }
+    .app-header-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    .app-header h1 {
+      font-family: var(--font-serif);
+      font-weight: 300;
+      font-size: 2rem;
+      margin: 0;
+      letter-spacing: -0.02em;
+    }
+    .app-header p {
+      color: rgba(255, 255, 255, 0.7);
+      font-size: 0.78rem;
+      margin: 0.25rem 0 0;
+      letter-spacing: 0.02em;
+    }
+
+    /* ── Main column wrap ──────────────────────────────────────────────── */
+    .app-main {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 2rem 3rem;
+    }
+
+    /* ── Section card scaffolding (shared by all four section partials) ──
+       Each partial keeps its own #section-* selector; this provides the
+       outer surface + navy h2 strip. Inner content stays inside the
+       section via the negative-margin h2 bleed (no HTML structure change
+       required in the partials). */
+    #section-recipients,
+    #section-config,
+    #section-preview,
+    #section-send {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-card);
+      padding: 1.5rem 1.75rem;
+      margin-bottom: 1.5rem;
+      overflow: hidden;
+    }
+    #section-recipients > h2,
+    #section-config > h2,
+    #section-send > h2,
+    #section-preview #preview-header h2 {
+      background: var(--navy);
+      color: #ffffff;
+      font-family: var(--font-serif);
+      font-size: 1.1rem;
+      font-weight: 400;
+      letter-spacing: 0.005em;
+      margin: -1.5rem -1.75rem 1.25rem;
+      padding: 0.75rem 1.25rem;
+    }
+    /* Preview's h2 sits inside a flex header row; let its container wrap
+       the navy strip instead of bleeding to section edges. */
+    #section-preview #preview-header {
+      background: var(--navy);
+      margin: -1.5rem -1.75rem 1.25rem;
+      padding: 0.5rem 1.25rem;
+    }
+    #section-preview #preview-header h2 {
+      background: transparent;
+      margin: 0;
+      padding: 0;
+    }
   </style>
 </head>
 <body>
 
-  <h1>Mass Notifications</h1>
+  <header class="app-header">
+    <div class="app-header-inner">
+      <h1>Mass Notifications</h1>
+      <p>Landing — resident &amp; property communications</p>
+    </div>
+  </header>
 
-  <!-- Section 1: Recipients grid -->
-  <?!= include('webapp/WebApp_Recipients') ?>
+  <main class="app-main">
+    <!-- Section 1: Recipients grid -->
+    <?!= include('webapp/WebApp_Recipients') ?>
 
-  <!-- Section 2: Email configuration -->
-  <?!= include('webapp/WebApp_Config') ?>
+    <!-- Section 2: Email configuration -->
+    <?!= include('webapp/WebApp_Config') ?>
 
-  <!-- Section 3: Live preview -->
-  <?!= include('webapp/WebApp_Preview') ?>
+    <!-- Section 3: Live preview -->
+    <?!= include('webapp/WebApp_Preview') ?>
 
-  <!-- Section 4: Send -->
-  <?!= include('webapp/WebApp_Send') ?>
+    <!-- Section 4: Send -->
+    <?!= include('webapp/WebApp_Send') ?>
+  </main>
 
   <script>
     // Capture the Web App URL before any GAS internal redirects alter it.

--- a/mass-notifications/src/webapp/WebApp_Config.html
+++ b/mass-notifications/src/webapp/WebApp_Config.html
@@ -22,33 +22,22 @@
 -->
 
 <style>
-  /* ── Section card ─────────────────────────────────────────────────────── */
-  #section-config {
-    background: #ffffff;
-    border: 1px solid #dce3f0;
-    border-radius: 10px;
-    padding: 24px 28px;
-    margin-bottom: 28px;
-  }
-  #section-config h2 {
-    font-size: 17px;
-    font-weight: 700;
-    color: #15192D;
-    margin: 0 0 20px;
-  }
+  /* Section card scaffolding lives in Index.html. Below: inner controls. */
 
   /* ── Form groups ────────────────────────────────────────────────────── */
   .cfg-group {
-    border-top: 1px solid #f0f2f7;
+    border-top: 1px solid var(--border);
     padding: 18px 0 4px;
     margin-bottom: 6px;
   }
+  .cfg-group:first-of-type { border-top: none; padding-top: 0; }
   .cfg-group-label {
-    font-size: 11px;
-    font-weight: 700;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: .6px;
-    color: #1A61D9;
+    letter-spacing: .1em;
+    color: var(--accent);
     margin-bottom: 14px;
   }
 
@@ -60,14 +49,19 @@
     margin-bottom: 14px;
   }
   .cfg-field label {
-    font-size: 12px;
-    font-weight: 600;
-    color: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--text);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
   .cfg-token-hint {
     font-weight: 400;
-    color: #888;
-    font-size: 11px;
+    color: var(--muted);
+    font-size: 0.7rem;
+    text-transform: none;
+    letter-spacing: 0;
   }
   .cfg-row-2 { display: grid; grid-template-columns: 1fr 1fr;     gap: 14px; }
   .cfg-row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
@@ -77,12 +71,12 @@
 
   /* ── Inputs & textareas ─────────────────────────────────────────────── */
   .cfg-input, .cfg-textarea {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 13px;
-    color: #15192D;
-    background: #fafbfd;
-    border: 1px solid #dce3f0;
-    border-radius: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-ctrl);
     padding: 7px 10px;
     outline: none;
     transition: border-color .15s, background .15s;
@@ -90,12 +84,12 @@
     box-sizing: border-box;
   }
   .cfg-input:focus, .cfg-textarea:focus {
-    border-color: #1A61D9;
-    background: #fff;
+    border-color: var(--accent);
+    background: var(--surface);
   }
   .cfg-input:disabled, .cfg-textarea:disabled {
     background: #eef0f4;
-    color: #6B7280;
+    color: var(--muted);
     cursor: not-allowed;
   }
   .cfg-textarea { resize: vertical; min-height: 80px; }
@@ -103,25 +97,27 @@
   /* ── Segmented controls ─────────────────────────────────────────────── */
   .cfg-segmented {
     display: inline-flex;
-    border: 1px solid #dce3f0;
-    border-radius: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-ctrl);
     overflow: hidden;
     width: fit-content;
   }
   .cfg-segmented button {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
-    font-weight: 600;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
     padding: 6px 18px;
     border: none;
-    background: #f5f7fa;
-    color: #4A4A4A;
+    background: var(--surface);
+    color: var(--muted);
     cursor: pointer;
     transition: background .15s, color .15s;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
-  .cfg-segmented button + button { border-left: 1px solid #dce3f0; }
+  .cfg-segmented button + button { border-left: 1px solid var(--border); }
   .cfg-segmented button.cfg-active {
-    background: #1A61D9;
+    background: var(--accent);
     color: #fff;
   }
 
@@ -133,79 +129,97 @@
     min-height: 28px;
   }
   .cfg-chip {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
     padding: 5px 13px;
-    border: 1px solid #c3d4ef;
-    border-radius: 20px;
-    background: #E7EFFB;
-    color: #15192D;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg);
+    color: var(--text);
     cursor: pointer;
     transition: background .15s, border-color .15s, color .15s;
   }
-  .cfg-chip:hover { background: #d0e2f7; }
-  .cfg-chip.cfg-active { background: #1A61D9; color: #fff; border-color: #1A61D9; }
+  .cfg-chip:hover { background: #d0ddf0; }
+  .cfg-chip.cfg-active { background: var(--accent); color: #fff; border-color: var(--accent); }
 
   /* ── Card picker ────────────────────────────────────────────────────── */
   #cfg-cards { display: flex; flex-wrap: wrap; gap: 8px; min-height: 28px; }
   .cfg-card-btn {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
     padding: 6px 14px;
-    border: 1px solid #dce3f0;
-    border-radius: 6px;
-    background: #f5f7fa;
-    color: #15192D;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-ctrl);
+    background: var(--surface);
+    color: var(--text);
     cursor: pointer;
     transition: background .15s, border-color .15s, color .15s;
   }
-  .cfg-card-btn:hover { background: #E7EFFB; border-color: #c3d4ef; }
-  .cfg-card-btn.cfg-active { background: #15192D; color: #fff; border-color: #15192D; }
+  .cfg-card-btn:hover { background: var(--bg); border-color: var(--accent); }
+  .cfg-card-btn.cfg-active { background: var(--navy); color: #fff; border-color: var(--navy); }
 
   /* ── Body editor (Quill or textarea fallback) ───────────────────────── */
   #cfg-body-wrap {
-    border: 1px solid #dce3f0;
-    border-radius: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-ctrl);
     overflow: hidden;
-    background: #fafbfd;
+    background: var(--bg);
   }
-  #cfg-body-wrap:focus-within { border-color: #1A61D9; }
+  #cfg-body-wrap:focus-within { border-color: var(--accent); }
   /* Quill-specific overrides when loaded successfully */
   #cfg-body-wrap .ql-toolbar.ql-snow {
     border: none;
-    border-bottom: 1px solid #dce3f0;
-    background: #f5f7fa;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
   }
   #cfg-body-wrap .ql-container.ql-snow { border: none; }
-  #cfg-body-wrap .ql-editor { min-height: 140px; font-size: 13px; }
+  #cfg-body-wrap .ql-editor {
+    min-height: 140px;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    background: var(--surface);
+  }
   /* Textarea fallback */
   #cfg-body-textarea {
     width: 100%; box-sizing: border-box;
     min-height: 160px; resize: vertical;
     border: none; outline: none;
     padding: 10px 12px;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 13px; color: #15192D;
-    background: #fafbfd;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text);
+    background: var(--surface);
   }
 
   /* ── Token list ─────────────────────────────────────────────────────── */
   .cfg-token-list {
-    font-size: 11px; color: #888;
-    margin-top: 8px; line-height: 2;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--muted);
+    margin-top: 8px;
+    line-height: 2;
   }
   .cfg-token-list code {
-    background: #f0f2f7; border-radius: 3px;
-    padding: 1px 5px; font-size: 11px; color: #1A61D9;
+    background: var(--bg);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 0.7rem;
+    color: var(--accent);
   }
 
   /* ── Template hint toast ────────────────────────────────────────────── */
   #cfg-hint-toast {
     display: none;
-    background: #E7EFFB; border: 1px solid #c3d4ef;
-    border-radius: 6px; padding: 10px 14px;
-    font-size: 12px; color: #15192D;
-    white-space: pre-line; margin-bottom: 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
+    border-radius: var(--radius-ctrl);
+    padding: 10px 14px;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text);
+    white-space: pre-line;
+    margin-bottom: 14px;
   }
 </style>
 

--- a/mass-notifications/src/webapp/WebApp_Preview.html
+++ b/mass-notifications/src/webapp/WebApp_Preview.html
@@ -1,62 +1,57 @@
 <style>
   /* ── Section card ────────────────────────────────────────────────────────── */
-  #section-preview {
-    background: #ffffff;
-    border: 1px solid #dce3f0;
-    border-radius: 10px;
-    padding: 24px 28px;
-    margin-bottom: 28px;
-  }
+  /* Section card scaffolding lives in Index.html. */
 
   /* ── Header row ──────────────────────────────────────────────────────────── */
   #preview-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 18px;
     flex-wrap: wrap;
     gap: 10px;
   }
-  #section-preview h2 {
-    font-size: 17px;
-    font-weight: 700;
-    color: #15192D;
-    margin: 0;
-  }
+  #section-preview h2 { color: #fff; }
   #preview-recipient-tag {
-    font-size: 11px;
-    color: #888;
-    background: #f0f2f7;
-    border-radius: 20px;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: var(--radius-pill);
     padding: 3px 10px;
     display: none;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 
   /* ── Refresh button ──────────────────────────────────────────────────────── */
   #btn-preview-refresh {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
-    font-weight: 600;
-    padding: 7px 16px;
-    border: 1px solid #dce3f0;
-    border-radius: 6px;
-    background: #f5f7fa;
-    color: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
+    padding: 6px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: var(--radius-ctrl);
+    background: transparent;
+    color: #fff;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    transition: background .15s;
+    transition: background .15s, border-color .15s;
   }
-  #btn-preview-refresh:hover:not(:disabled) { background: #E7EFFB; border-color: #c3d4ef; }
+  #btn-preview-refresh:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.5);
+  }
   #btn-preview-refresh:disabled { opacity: .5; cursor: default; }
 
   /* ── Spinner (reuse animation from Send section) ─────────────────────────── */
   .preview-spinner {
     display: inline-block;
     width: 12px; height: 12px;
-    border: 2px solid rgba(26,97,217,.3);
-    border-top-color: #1A61D9;
+    border: 2px solid rgba(255,255,255,.3);
+    border-top-color: #fff;
     border-radius: 50%;
     animation: spin .7s linear infinite;
     vertical-align: middle;
@@ -69,32 +64,37 @@
     align-items: center;
     justify-content: center;
     min-height: 180px;
-    color: #aaa;
-    font-size: 13px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
     gap: 10px;
-    border: 1px dashed #dce3f0;
+    border: 1px dashed var(--border);
     border-radius: 8px;
   }
   #preview-placeholder svg { opacity: .35; }
 
-  /* ── Error banner ────────────────────────────────────────────────────────── */
+  /* Error banner */
   #preview-error {
     display: none;
-    background: #FEF2F2;
-    border: 1px solid #FCA5A5;
-    color: #991B1B;
-    border-radius: 8px;
+    background: var(--error-bg);
+    border: 1px solid var(--red);
+    border-left: 4px solid var(--red);
+    color: var(--error);
+    border-radius: var(--radius-ctrl);
     padding: 12px 16px;
-    font-size: 13px;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
   }
 
-  /* ── iframe wrapper ──────────────────────────────────────────────────────── */
+  /* iframe wrapper: navy top/bottom borders mirror AI-Scoring scorecard panels */
   #preview-frame-wrap {
     display: none;
-    border: 1px solid #dce3f0;
-    border-radius: 8px;
+    border: 1px solid var(--border);
+    border-top: 4px solid var(--navy);
+    border-bottom: 4px solid var(--navy);
+    border-radius: 0;
     overflow: hidden;
-    background: #fff;
+    background: var(--surface);
   }
   #preview-frame {
     width: 100%;
@@ -103,21 +103,23 @@
     display: block;
   }
 
-  /* ── Attachment list ─────────────────────────────────────────────────────── */
+  /* Attachment list */
   #preview-attachments {
     display: none;
-    border-top: 1px solid #f0f2f7;
+    border-top: 1px solid var(--border);
     padding: 10px 14px;
-    font-size: 12px;
-    color: #4A4A4A;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--text);
     line-height: 1.9;
-    background: #fafbfd;
+    background: var(--bg);
   }
   #preview-attachments strong {
-    color: #15192D;
-    font-size: 11px;
+    color: var(--text);
+    font-size: 0.65rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: .5px;
+    letter-spacing: .08em;
     display: block;
     margin-bottom: 4px;
   }

--- a/mass-notifications/src/webapp/WebApp_Recipients.html
+++ b/mass-notifications/src/webapp/WebApp_Recipients.html
@@ -14,191 +14,48 @@
 -->
 
 <style>
-  /* ── Section card ─────────────────────────────────────────────────────── */
-  #section-recipients {
-    background: #ffffff;
-    border: 1px solid #dce3f0;
-    border-radius: 10px;
-    padding: 24px 28px;
-    margin-bottom: 28px;
-  }
-
-  /* ── Header row ─────────────────────────────────────────────────────── */
-  .rec-header {
+  /* ── Subtitle / counter row ──────────────────────────────────────────── */
+  .rec-subtitle-row {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 16px;
-  }
-  .rec-header h2 {
-    font-size: 17px;
-    font-weight: 700;
-    color: #15192D;
-    margin: 0 0 4px;
+    gap: 12px;
+    margin-bottom: 1.25rem;
   }
   .rec-subtitle {
-    font-size: 12px;
-    color: #4A4A4A;
+    font-size: 0.78rem;
+    color: var(--muted);
     margin: 0;
+    line-height: 1.6;
   }
 
-  /* ── Row counter badge ──────────────────────────────────────────────── */
+  /* ── Row counter pill ────────────────────────────────────────────────── */
   #rec-counter {
-    font-size: 13px;
-    font-weight: 600;
-    background: #E7EFFB;
-    color: #1A61D9;
-    border-radius: 20px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
+    background: var(--bg);
+    color: var(--accent);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
     padding: 4px 12px;
     white-space: nowrap;
+    letter-spacing: 0.02em;
   }
   #rec-counter.rec-over-limit {
-    background: #fde8e8;
-    color: #D9534F;
-  }
-
-  /* ── Toolbar ────────────────────────────────────────────────────────── */
-  .rec-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 14px;
-    flex-wrap: wrap;
-  }
-  .rec-btn {
-    font-size: 13px;
-    font-family: Arial, Helvetica, sans-serif;
-    border-radius: 6px;
-    padding: 6px 14px;
-    cursor: pointer;
-    border: none;
-    transition: opacity .15s;
-  }
-  .rec-btn:hover { opacity: .85; }
-  .rec-btn-primary {
-    background: #1A61D9;
-    color: #fff;
-  }
-  .rec-btn-secondary {
-    background: #E7EFFB;
-    color: #15192D;
-    border: 1px solid #c3d4ef;
-  }
-  .rec-toolbar-hint {
-    font-size: 12px;
-    color: #888;
-    margin-left: 4px;
-  }
-  /* Drag-over visual feedback on the toolbar drop zone */
-  .rec-toolbar.rec-drag-over {
-    background: #E7EFFB;
-    border: 2px dashed #1A61D9;
-    border-radius: 8px;
-    padding: 8px 10px;
-  }
-
-  /* ── Table ──────────────────────────────────────────────────────────── */
-  .rec-table-wrap {
-    overflow-x: auto;
-    border: 1px solid #dce3f0;
-    border-radius: 8px;
-  }
-  #rec-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 13px;
-  }
-  #rec-table thead tr {
-    background: #f5f7fa;
-  }
-  #rec-table th {
-    text-align: left;
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: .5px;
-    color: #4A4A4A;
-    padding: 9px 10px;
-    border-bottom: 1px solid #dce3f0;
-  }
-  #rec-table td {
-    padding: 4px 6px;
-    border-bottom: 1px solid #f0f2f7;
-    vertical-align: middle;
-  }
-  #rec-table tbody tr:last-child td { border-bottom: none; }
-  #rec-table tbody tr:hover { background: #fafbfd; }
-
-  /* ── Column widths ──────────────────────────────────────────────────── */
-  .rec-col-num  { width: 36px; text-align: center; color: #aaa; font-size: 12px; }
-  .rec-col-email{ min-width: 220px; }
-  .rec-col-name { min-width: 160px; }
-  .rec-col-unit { min-width: 90px;  }
-  .rec-col-del  { width: 36px; text-align: center; }
-
-  /* ── Inputs inside table cells ──────────────────────────────────────── */
-  .rec-input {
-    width: 100%;
-    box-sizing: border-box;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    padding: 5px 8px;
-    font-size: 13px;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #15192D;
-    background: transparent;
-    outline: none;
-    transition: border-color .15s, background .15s;
-  }
-  .rec-input:focus {
-    border-color: #1A61D9;
-    background: #fff;
-  }
-  /* Email states set by JS on blur */
-  .rec-input.rec-invalid {
-    border-color: #D9534F;
-    background: #fff5f5;
-  }
-  .rec-input.rec-valid {
-    border-color: #28A745;
-  }
-
-  /* ── Delete button ──────────────────────────────────────────────────── */
-  .rec-del-btn {
-    background: none;
-    border: none;
-    color: #ccc;
-    cursor: pointer;
-    font-size: 14px;
-    line-height: 1;
-    padding: 4px 6px;
-    border-radius: 4px;
-    transition: color .15s, background .15s;
-  }
-  .rec-del-btn:hover {
-    color: #D9534F;
-    background: #fde8e8;
-  }
-
-  /* ── Required asterisk ──────────────────────────────────────────────── */
-  .rec-req { color: #D9534F; margin-left: 2px; }
-
-  /* ── Empty state ────────────────────────────────────────────────────── */
-  #rec-empty {
-    text-align: center;
-    padding: 32px 16px;
-    color: #aaa;
-    font-size: 13px;
-    display: none;
+    background: var(--error-bg);
+    color: var(--error);
+    border-color: var(--error-bg);
   }
 
   /* ── Looker fetch panel ──────────────────────────────────────────────── */
   .looker-panel {
-    background: #F5F7FA;
-    border: 1px solid #dce3f0;
-    border-radius: 8px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
+    border-radius: var(--radius-ctrl);
     padding: 14px 16px;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
   }
   .looker-panel-row {
     display: flex;
@@ -207,72 +64,229 @@
     flex-wrap: wrap;
   }
   .looker-panel-label {
-    font-size: 13px;
-    font-weight: 600;
-    color: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text);
     white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
   .looker-panel-label span {
     font-weight: 400;
-    font-size: 11px;
-    color: #888;
-    margin-left: 4px;
+    font-size: 0.68rem;
+    color: var(--muted);
+    margin-left: 6px;
+    text-transform: none;
+    letter-spacing: 0;
   }
   #looker-property-input {
     flex: 1;
     min-width: 180px;
     max-width: 320px;
     box-sizing: border-box;
-    border: 1px solid #c3d4ef;
-    border-radius: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-ctrl);
     padding: 7px 10px;
-    font-size: 13px;
-    font-family: Arial, Helvetica, sans-serif;
-    color: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text);
+    background: var(--surface);
     outline: none;
     transition: border-color .15s;
   }
-  #looker-property-input:focus { border-color: #1A61D9; }
+  #looker-property-input:focus { border-color: var(--accent); }
   #looker-fetch-btn {
-    font-size: 13px;
-    font-family: Arial, Helvetica, sans-serif;
-    background: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    background: var(--accent);
     color: #fff;
-    border: none;
-    border-radius: 6px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-ctrl);
     padding: 7px 16px;
     cursor: pointer;
     white-space: nowrap;
-    transition: opacity .15s;
+    transition: background .15s;
   }
-  #looker-fetch-btn:hover    { opacity: .85; }
-  #looker-fetch-btn:disabled { opacity: .5; cursor: not-allowed; }
+  #looker-fetch-btn:hover    { background: var(--accent-hover); }
+  #looker-fetch-btn:disabled { background: var(--border); border-color: var(--border); cursor: not-allowed; }
   #looker-status-line {
     margin-top: 10px;
-    font-size: 12px;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
     min-height: 18px;
     display: none;
   }
-  .looker-status-ok    { color: #1A7F37; }
-  .looker-status-error { color: #D9534F; }
-  .looker-status-info  { color: #555; }
+  .looker-status-ok    { color: var(--success); }
+  .looker-status-error { color: var(--error); }
+  .looker-status-info  { color: var(--muted); }
+
+  /* ── Toolbar ─────────────────────────────────────────────────────────── */
+  .rec-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+  .rec-btn {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    border-radius: var(--radius-ctrl);
+    padding: 7px 14px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background .15s, color .15s, border-color .15s;
+  }
+  .rec-btn-primary {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  .rec-btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+  .rec-btn-secondary {
+    background: transparent;
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .rec-btn-secondary:hover { background: var(--bg); }
+  .rec-toolbar-hint {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--muted);
+    margin-left: 4px;
+  }
+  .rec-toolbar.rec-drag-over {
+    background: var(--bg);
+    border: 2px dashed var(--accent);
+    border-radius: 8px;
+    padding: 8px 10px;
+  }
+
+  /* ── Table ───────────────────────────────────────────────────────────── */
+  .rec-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  #rec-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+  }
+  #rec-table thead tr {
+    background: var(--navy);
+  }
+  #rec-table th {
+    text-align: left;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: rgba(255, 255, 255, 0.85);
+    padding: 9px 10px;
+    border-bottom: 1px solid var(--navy);
+  }
+  #rec-table td {
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+    background: var(--surface);
+  }
+  #rec-table tbody tr:last-child td { border-bottom: none; }
+  #rec-table tbody tr:hover td { background: var(--bg); }
+
+  /* ── Column widths ───────────────────────────────────────────────────── */
+  .rec-col-num    { width: 36px; text-align: center; color: var(--muted); font-size: 0.7rem; }
+  .rec-col-email  { min-width: 220px; }
+  .rec-col-name   { min-width: 160px; }
+  .rec-col-unit   { min-width: 90px;  }
+  .rec-col-status { width: 84px; text-align: center; }
+  .rec-col-del    { width: 36px; text-align: center; }
+
+  /* ── Inputs inside table cells ───────────────────────────────────────── */
+  .rec-input {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid transparent;
+    border-radius: var(--radius-ctrl);
+    padding: 5px 8px;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text);
+    background: transparent;
+    outline: none;
+    transition: border-color .15s, background .15s;
+  }
+  .rec-input:focus {
+    border-color: var(--accent);
+    background: var(--surface);
+  }
+  .rec-input.rec-invalid {
+    border-color: var(--red);
+    background: var(--error-bg);
+  }
+  .rec-input.rec-valid { border-color: var(--green); }
+
+  /* ── Delete button ───────────────────────────────────────────────────── */
+  .rec-del-btn {
+    background: none;
+    border: none;
+    color: var(--border);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 4px 6px;
+    border-radius: var(--radius-ctrl);
+    transition: color .15s, background .15s;
+  }
+  .rec-del-btn:hover {
+    color: var(--red);
+    background: var(--error-bg);
+  }
+
+  .rec-req { color: var(--red); margin-left: 2px; }
+
+  /* ── Empty state ─────────────────────────────────────────────────────── */
+  #rec-empty {
+    text-align: center;
+    padding: 32px 16px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    display: none;
+  }
 
   /* ── Status badges ───────────────────────────────────────────────────── */
-  .rec-col-status { width: 80px; text-align: center; }
   .rec-status-badge {
     display: inline-block;
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: .3px;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 500;
+    letter-spacing: .08em;
+    text-transform: uppercase;
     padding: 2px 8px;
-    border-radius: 10px;
+    border-radius: var(--radius-pill);
     white-space: nowrap;
   }
-  .rec-status-pending { background: #E7EFFB; color: #1A61D9; }
-  .rec-status-review  { background: #FDE8E8; color: #D9534F; }
+  .rec-status-pending { background: var(--bg);        color: var(--accent);  }
+  .rec-status-review  { background: var(--error-bg);  color: var(--error);   }
 </style>
 
 <section id="section-recipients">
+  <h2>Recipients</h2>
+
+  <div class="rec-subtitle-row">
+    <p class="rec-subtitle">
+      Maps to <code>Mass_Notification</code> sheet — col A (Email), B (Name), C (Unit).
+      Saving will overwrite the sheet.
+    </p>
+    <span id="rec-counter">0 / 500</span>
+  </div>
 
   <!-- ── Looker fetch panel ─────────────────────────────────────────── -->
   <div class="looker-panel">
@@ -290,17 +304,6 @@
       <button id="looker-fetch-btn">Fetch recipients</button>
     </div>
     <div id="looker-status-line"></div>
-  </div>
-
-  <div class="rec-header">
-    <div>
-      <h2>Recipients</h2>
-      <p class="rec-subtitle">
-        Maps to Mass_Notification sheet — col A (Email), B (Name), C (Unit).
-        Saving will overwrite the sheet.
-      </p>
-    </div>
-    <span id="rec-counter">0 / 500</span>
   </div>
 
   <div class="rec-toolbar">

--- a/mass-notifications/src/webapp/WebApp_Send.html
+++ b/mass-notifications/src/webapp/WebApp_Send.html
@@ -1,39 +1,33 @@
 <style>
   /* ── Section card ────────────────────────────────────────────────────────── */
-  #section-send {
-    background: #ffffff;
-    border: 1px solid #dce3f0;
-    border-radius: 10px;
-    padding: 24px 28px;
-    margin-bottom: 28px;
-  }
-  #section-send h2 {
-    font-size: 17px;
-    font-weight: 700;
-    color: #15192D;
-    margin: 0 0 20px;
-  }
+  /* Section card scaffolding lives in Index.html. */
 
   /* ── Send summary card ───────────────────────────────────────────────────── */
   #send-summary {
-    background: #f5f7fa;
-    border: 1px solid #dce3f0;
-    border-radius: 8px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
+    border-radius: var(--radius-ctrl);
     padding: 14px 18px;
     margin-bottom: 20px;
-    font-size: 13px;
-    color: #15192D;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text);
     line-height: 1.7;
     display: none; /* shown when summary loads */
   }
-  #send-summary strong { color: #1A61D9; }
+  #send-summary strong {
+    color: var(--accent);
+    font-weight: 500;
+  }
 
   /* ── Banners ─────────────────────────────────────────────────────────────── */
   .send-banner {
-    border-radius: 8px;
+    border-radius: var(--radius-ctrl);
     padding: 12px 16px;
     margin-bottom: 16px;
-    font-size: 13px;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
     line-height: 1.6;
     display: none;
   }
@@ -42,19 +36,22 @@
     padding-left: 18px;
   }
   #send-error-banner {
-    background: #FEF2F2;
-    border: 1px solid #FCA5A5;
-    color: #991B1B;
+    background: var(--error-bg);
+    border: 1px solid var(--red);
+    border-left: 4px solid var(--red);
+    color: var(--error);
   }
   #send-warning-banner {
-    background: #FFFBEB;
-    border: 1px solid #FCD34D;
-    color: #92400E;
+    background: var(--warning-bg);
+    border: 1px solid var(--amber);
+    border-left: 4px solid var(--amber);
+    color: var(--warning);
   }
   #send-success-banner {
-    background: #F0FDF4;
-    border: 1px solid #86EFAC;
-    color: #166534;
+    background: var(--success-bg);
+    border: 1px solid var(--green);
+    border-left: 4px solid var(--green);
+    color: var(--success);
   }
 
   /* ── Action row ──────────────────────────────────────────────────────────── */
@@ -70,19 +67,19 @@
   #send-reset-row {
     margin-top: 16px;
     padding-top: 14px;
-    border-top: 1px solid #f0f2f7;
+    border-top: 1px solid var(--border);
   }
 
   /* ── Buttons ─────────────────────────────────────────────────────────────── */
   .send-btn {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 13px;
-    font-weight: 600;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    font-weight: 500;
     padding: 9px 22px;
-    border-radius: 6px;
-    border: none;
+    border-radius: var(--radius-ctrl);
+    border: 1px solid transparent;
     cursor: pointer;
-    transition: background .15s, opacity .15s;
+    transition: background .15s, opacity .15s, color .15s, border-color .15s;
     display: inline-flex;
     align-items: center;
     gap: 7px;
@@ -90,32 +87,40 @@
   .send-btn:disabled { opacity: .5; cursor: default; }
 
   #btn-send-primary {
-    background: #15192D;
+    background: var(--accent);
     color: #fff;
+    border-color: var(--accent);
   }
-  #btn-send-primary:hover:not(:disabled) { background: #1e2540; }
+  #btn-send-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
 
   #btn-send-proceed {
-    background: #D97706;
+    background: var(--amber);
     color: #fff;
+    border-color: var(--amber);
     display: none;
   }
-  #btn-send-proceed:hover:not(:disabled) { background: #B45309; }
+  #btn-send-proceed:hover:not(:disabled) {
+    background: var(--warning);
+    border-color: var(--warning);
+  }
 
   #btn-send-cancel {
-    background: #f5f7fa;
-    color: #15192D;
-    border: 1px solid #dce3f0;
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border);
     display: none;
   }
-  #btn-send-cancel:hover:not(:disabled) { background: #e8ecf4; }
+  #btn-send-cancel:hover:not(:disabled) { background: var(--bg); }
 
   #btn-send-reset {
-    background: #f5f7fa;
-    color: #15192D;
-    border: 1px solid #dce3f0;
+    background: transparent;
+    color: var(--accent);
+    border-color: var(--accent);
   }
-  #btn-send-reset:hover:not(:disabled) { background: #e8ecf4; }
+  #btn-send-reset:hover:not(:disabled) { background: var(--bg); }
 
   /* ── Spinner ─────────────────────────────────────────────────────────────── */
   .send-spinner {


### PR DESCRIPTION
## Summary
- Adopts the AI-Scoring frontend's visual language across all five WebApp HTML files so both internal tools share one identity.
- New foundation in `Index.html`: CSS custom-property tokens mirroring AI-Scoring's `:root` vars, Google Fonts (Fraunces + DM Mono), navy header bar with Fraunces wordmark, light-blue page background (`#E7EFFB`), shared section-card scaffolding (white surface, 1px `#c9d5e8` border, 12px radius, **navy h2 strip via negative-margin bleed**).
- Per-section restyles in Recipients / Config / Preview / Send: all hex literals replaced by `var(--…)` references; buttons standardised on AI-Scoring's primary/secondary pair (filled `#1A61D9` vs transparent-with-accent-border, 4px radius); inputs use light-blue fill + `#c9d5e8` border + accent focus; banners adopt the **4px colored border-left accent stripe** for `send-summary`, error/warning/success, and the Looker fetch panel; preview iframe gets navy top/bottom borders (scorecard-panel motif).
- Recipients h2 promoted to direct child of `<section>` so the navy strip can bleed to section edges; subtitle/counter row now sits below it.
- **No behaviour or JS changes** — all module APIs (`Recipients.*`, `Config.*`, `Send.*`, `Preview.*`) preserved.

## Test plan
- [x] `./push.sh mass-notifications` and bump WebApp deployment version.
- [x] Open the WebApp and verify the new look:
  - [x] Navy header bar across the top with Fraunces wordmark, light-blue page bg.
  - [x] Each of the four sections has a navy h2 strip bleeding to the card edges.
  - [x] Recipients table headers render navy with uppercase monospace labels; row hover stays subtle.
  - [x] Config inputs/segmented-controls/template-chips/card-picker pick up the monospace + tokens.
  - [x] Preview's refresh button is the navy-bar outline style; placeholder + iframe wrapper styling correct.
  - [x] Send banners render with left accent stripes (error/warning/success); buttons monospace.
- [x] Functional smoke test: Looker fetch → grid populates → Property Name locks → Refresh Preview renders → Send (or its MOVE_IN guard).
- [x] Confirm Google Fonts loads (check Network tab); fallback to system serif/mono should be readable if blocked.
- [x] Mobile width: section cards stack, form rows collapse to single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)