### PR TITLE
feat(qa-automation): AI-Scoring — Lookup-to-Score (6/6 PRs in stack)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,57 @@ dirty. The wrapper will warn but not block.
 
 ---
 
+## AI-Scoring operator notes
+
+### API key tiers
+
+`qa-automation/AI-Scoring` has two key tiers, both Bearer tokens in env vars:
+
+| Env var | Role | Reach |
+|---|---|---|
+| `API_KEY_MEMBER_SUPPORT`, `API_KEY_SALES` | `team` | Locked to that team's `/api/{team_id}/...` routes; only that team's Mails roster can be scored. |
+| `API_KEY_PRIVILEGED` | `privileged` | Cross-team. Bypasses the path-team check and the roster check; the frontend's team-pick dialog supplies the target team when the agent isn't rostered anywhere. |
+
+Generate a new key with `python -c "import secrets; print(secrets.token_urlsafe(32))"`. Both `.env.example` and the Railway env are the source of truth — keep them in sync.
+
+### One-time setup
+
+The audit log lives in a single `Score_Audit` tab on the **member_support** Google Sheet (one row per `/score` POST and per `/score/{job_id}/approve`, regardless of `target_team`). Create it once per Sheets host:
+
+```bash
+cd qa-automation/AI-Scoring
+python3 scripts/init_score_audit_tab.py [--dry-run]
+```
+
+The script is idempotent — re-running it on an existing tab is a no-op.
+
+### End-to-end smoke
+
+`scripts/score_by_call_id.py` exercises the full Lookup-to-Score pipeline against a running backend: `/score` (Dialpad download → Gemini scoring → FR-AI write → audit row) → poll → `/score/{job_id}/approve` (Stage 1.5 → 2 → 3 → 4 → Apps Script email dispatch). **Real side effects** — writes to Sheets and sends a QA evaluation email.
+
+```bash
+AI_SCORING_API_KEY=$API_KEY_PRIVILEGED \
+  python3 scripts/score_by_call_id.py \
+    --team member_support \
+    --call-id <dialpad-call-id> \
+    --agent-email agent@hellolanding.com \
+    --manager-email you@hellolanding.com
+```
+
+Pass `--score-only` to stop after scoring (skips the approve step + email). `--yes` skips the approve confirmation prompt; reserve it for CI.
+
+### Pages
+
+| Path | Purpose |
+|---|---|
+| `/score/{team}` | Upload-driven scoring — drag a recording, fill in metadata, score, approve. |
+| `/lookup/{team}` | Search a Dialpad agent by email, list their calls, one-click **Score Call** per row (no upload — backend downloads via `download_recording`). |
+| `/scorecard/{team}/{job_id}` | Dedicated editor for a single in-progress or completed scoring job. Reached via the **Open editor** link from `/lookup` after scoring completes. |
+
+The API key + manager email are stored in `localStorage` (shared across tabs), so the typical flow is: enter once on first page load → reused everywhere until the browser closes or you clear storage.
+
+---
+
 ## Substantial refactors
 
 For any change estimated at **more than half a day** of work, write a design

--- a/qa-automation/AI-Scoring/.env.example
+++ b/qa-automation/AI-Scoring/.env.example
@@ -31,6 +31,14 @@ GOOGLE_HISTORY_TAB=Analyst_History
 # GOOGLE_SHEETS_ID_SALES=
 # APPS_SCRIPT_WEBAPP_URL_SALES=
 
+# --- Privileged role (cross-team) ---
+# Optional. Bearer-token key for leadership / HR / dev tooling that needs to
+# score or inspect calls across teams without being bound to one team's roster.
+# Bypasses team-scoping on /api/{team_id}/... routes. /score still requires
+# the caller to specify a real target team (the frontend's team-pick dialog
+# handles this when the agent isn't rostered anywhere).
+# API_KEY_PRIVILEGED=
+
 # --- Optional ---
 # Comma-separated list of allowed CORS origins. Defaults to http://localhost:8000.
 ALLOWED_ORIGINS=http://localhost:8000

--- a/qa-automation/AI-Scoring/backend/config/score_audit.py
+++ b/qa-automation/AI-Scoring/backend/config/score_audit.py
@@ -1,0 +1,46 @@
+"""Score_Audit tab constants — shared by the writer, init script, and tests.
+
+Per the LookupToScore.md design, there is a single Score_Audit tab on
+the member_support spreadsheet (revisit if Sales auditing needs to
+diverge). Every successful /score POST, every auth-rejected /score POST,
+and every Stage 4 approval append one row here so we can spot-check
+which API-key role scored which agent for which team.
+"""
+
+from __future__ import annotations
+
+
+# The audit lives on this team's spreadsheet only.
+HOST_TEAM_ID = "member_support"
+
+# Tab name on the host spreadsheet.
+TAB_NAME = "Score_Audit"
+
+# Column order — A..J. The init script writes this as the header row;
+# append_score_audit_row writes values in the same order.
+COLUMNS: list[str] = [
+    "timestamp",         # A — ISO 8601 UTC
+    "api_key_role",      # B — "team" / "privileged"
+    "evaluator_email",   # C — from manager_email form field
+    "agent_email",       # D — resolved or supplied
+    "agent_name",        # E — display name from Mails or form
+    "call_id",           # F — Dialpad call ID
+    "target_team",       # G — which team's pipeline ran
+    "action",            # H — "scored" / "denied" / "approved"
+    "result_row",        # I — FR-AI row number on success; empty on denial
+    "notes",             # J — e.g. "no_recording", "rate_limited"
+]
+
+# Allowed values for the `action` column. Centralized so call sites
+# can't drift; PR 3 will reference these constants directly.
+ACTION_SCORED = "scored"
+ACTION_DENIED = "denied"
+ACTION_APPROVED = "approved"
+
+ACTIONS: frozenset[str] = frozenset({ACTION_SCORED, ACTION_DENIED, ACTION_APPROVED})
+
+# Allowed roles — mirrors KeyIdentity.role in middleware/auth.py.
+ROLE_TEAM = "team"
+ROLE_PRIVILEGED = "privileged"
+
+ROLES: frozenset[str] = frozenset({ROLE_TEAM, ROLE_PRIVILEGED})

--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -332,3 +332,8 @@ def get_team_config(team_id: str = "member_support") -> TeamConfig:
         raise FileNotFoundError(f"No config for team '{team_id}': {path}")
     raw = json.loads(path.read_text(encoding="utf-8"))
     return TeamConfig(**raw)
+
+
+def get_all_team_ids() -> list[str]:
+    """Return sorted list of team_ids with a JSON config on disk."""
+    return sorted(p.stem for p in _CONFIG_DIR.glob("*.json"))

--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -90,6 +90,11 @@ async def serve_lookup_page(team_id: str):
     return FileResponse(_frontend_dir / "lookup.html", headers=_HTML_NO_CACHE)
 
 
+@app.get("/scorecard/{team_id}/{job_id}", include_in_schema=False)
+async def serve_scorecard_page(team_id: str, job_id: str):
+    return FileResponse(_frontend_dir / "scorecard.html", headers=_HTML_NO_CACHE)
+
+
 # --- Legacy page redirects (30-day transition) ---
 
 @app.get("/", include_in_schema=False)

--- a/qa-automation/AI-Scoring/backend/middleware/auth.py
+++ b/qa-automation/AI-Scoring/backend/middleware/auth.py
@@ -1,23 +1,57 @@
-"""API key authentication middleware."""
+"""API key authentication middleware.
+
+Two key tiers:
+
+* **Team keys** — env vars named ``API_KEY_{TEAM_ID}`` (e.g.
+  ``API_KEY_MEMBER_SUPPORT``, ``API_KEY_SALES``). The suffix becomes the
+  ``team_id`` the key is bound to; routes under ``/api/{team_id}/...``
+  enforce that the path matches.
+* **Privileged key** — env var ``API_KEY_PRIVILEGED``. Not bound to any
+  team. Used by leadership / HR / dev tooling that needs to score or
+  inspect calls across teams. Bypasses team-scoping on every route that
+  applies it.
+
+Adding more privileged tiers later (e.g. ``API_KEY_HR``) is a one-line
+change in ``_PRIVILEGED_SUFFIXES``.
+"""
+
+from __future__ import annotations
 
 import os
 import secrets
+from dataclasses import dataclass
+from typing import Literal, Optional
 
 from fastapi import Depends, Header, HTTPException, Request
 
 
-def _build_key_map() -> dict[str, str]:
-    """Build mapping of API key -> team_id from environment variables.
+_PRIVILEGED_SUFFIXES = {"privileged"}
 
-    Looks for env vars named API_KEY_{TEAM_ID} (e.g. API_KEY_MEMBER_SUPPORT).
-    Forward-compatible with multi-team: add more env vars, get more mappings.
+
+@dataclass(frozen=True)
+class KeyIdentity:
+    """Resolved identity attached to a validated API key."""
+    role: Literal["team", "privileged"]
+    team_id: Optional[str]  # None for privileged keys
+
+
+def _build_key_map() -> dict[str, KeyIdentity]:
+    """Build mapping of API key -> KeyIdentity from environment variables.
+
+    Looks for env vars named ``API_KEY_{SUFFIX}``. Suffix ``PRIVILEGED``
+    yields ``role="privileged"`` with no team binding; any other suffix
+    is treated as a team_id (lowercased).
     """
-    mapping = {}
+    mapping: dict[str, KeyIdentity] = {}
     prefix = "API_KEY_"
     for key, value in os.environ.items():
-        if key.startswith(prefix) and value:
-            team_id = key[len(prefix):].lower()
-            mapping[value] = team_id
+        if not key.startswith(prefix) or not value:
+            continue
+        suffix = key[len(prefix):].lower()
+        if suffix in _PRIVILEGED_SUFFIXES:
+            mapping[value] = KeyIdentity(role="privileged", team_id=None)
+        else:
+            mapping[value] = KeyIdentity(role="team", team_id=suffix)
     return mapping
 
 
@@ -32,38 +66,73 @@ if not _KEY_MAP:
     )
 
 
-async def require_api_key(authorization: str = Header(None)) -> str:
-    """FastAPI dependency that validates the Bearer token and returns team_id."""
+async def require_api_key(authorization: str = Header(None)) -> KeyIdentity:
+    """FastAPI dependency that validates the Bearer token and returns its identity."""
     if not authorization:
         raise HTTPException(status_code=401, detail="Missing Authorization header")
 
     token = authorization.removeprefix("Bearer ").strip()
     if token == authorization:
-        # No "Bearer " prefix found
         raise HTTPException(status_code=401, detail="Authorization header must use Bearer scheme")
 
-    # Timing-safe comparison against all known keys
-    for known_key, team_id in _KEY_MAP.items():
+    for known_key, identity in _KEY_MAP.items():
         if secrets.compare_digest(token, known_key):
-            return team_id
+            return identity
 
     raise HTTPException(status_code=401, detail="Invalid API key")
 
 
-async def require_team_access(team_id: str, authorization: str = Header(None)) -> str:
-    """Validate the key *and* enforce it matches the team_id in the URL.
+async def require_team_access(team_id: str, authorization: str = Header(None)) -> KeyIdentity:
+    """Validate the key and enforce team scoping unless the key is privileged.
 
-    Binds ``team_id`` automatically from the path param of the route it
-    protects, so a Sales key cannot reach Member Support data (and vice
-    versa).  Returns the resolved team_id.
+    Privileged keys bypass the team check on every team-prefixed route.
+    Returns the resolved KeyIdentity so downstream handlers can branch on
+    role (e.g. /score uses it to decide whether to enforce roster membership).
     """
-    key_team = await require_api_key(authorization)
-    if key_team != team_id:
+    identity = await require_api_key(authorization)
+    if identity.role == "privileged":
+        return identity
+    if identity.team_id != team_id:
         raise HTTPException(
             status_code=403,
             detail=f"API key not authorized for team '{team_id}'",
         )
-    return team_id
+    return identity
+
+
+def check_scoring_access(
+    identity: KeyIdentity,
+    team_id: str,
+    agent_email: Optional[str],
+    *,
+    email_in_team_mails,
+) -> None:
+    """Raise 403 unless ``identity`` is allowed to score ``agent_email`` for ``team_id``.
+
+    Called from ``/score`` after the multipart form has been parsed, so
+    it can't be a ``Depends``-style FastAPI dependency. The Mails-check
+    callable is injected to keep this module free of service imports
+    (avoids the auth -> services -> sheets dep cycle).
+
+    Rules:
+      * Team key: must match ``team_id`` AND ``agent_email`` must appear
+        in that team's Mails roster.
+      * Privileged key: any real ``team_id`` is fine; roster membership
+        is NOT required (the frontend confirms intent via the team-pick
+        dialog when the agent is unrostered).
+    """
+    if identity.role == "privileged":
+        return
+    if identity.team_id != team_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"API key not authorized for team '{team_id}'",
+        )
+    if not agent_email or not email_in_team_mails(agent_email, team_id):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{agent_email}' is not in team '{team_id}' roster",
+        )
 
 
 AUTH_DEPENDENCY = [Depends(require_api_key)]

--- a/qa-automation/AI-Scoring/backend/middleware/auth.py
+++ b/qa-automation/AI-Scoring/backend/middleware/auth.py
@@ -105,18 +105,18 @@ def check_scoring_access(
     team_id: str,
     agent_email: Optional[str],
     *,
-    email_in_team_mails,
+    is_in_roster: bool,
 ) -> None:
     """Raise 403 unless ``identity`` is allowed to score ``agent_email`` for ``team_id``.
 
     Called from ``/score`` after the multipart form has been parsed, so
-    it can't be a ``Depends``-style FastAPI dependency. The Mails-check
-    callable is injected to keep this module free of service imports
-    (avoids the auth -> services -> sheets dep cycle).
+    it can't be a ``Depends``-style FastAPI dependency. The roster
+    membership is supplied as a precomputed bool — the handler does the
+    async Mails fetch and passes the result here. This keeps auth.py
+    free of service imports while avoiding awkward sync/async bridging.
 
     Rules:
-      * Team key: must match ``team_id`` AND ``agent_email`` must appear
-        in that team's Mails roster.
+      * Team key: must match ``team_id`` AND ``is_in_roster`` must be True.
       * Privileged key: any real ``team_id`` is fine; roster membership
         is NOT required (the frontend confirms intent via the team-pick
         dialog when the agent is unrostered).
@@ -128,7 +128,7 @@ def check_scoring_access(
             status_code=403,
             detail=f"API key not authorized for team '{team_id}'",
         )
-    if not agent_email or not email_in_team_mails(agent_email, team_id):
+    if not agent_email or not is_in_roster:
         raise HTTPException(
             status_code=403,
             detail=f"Agent '{agent_email}' is not in team '{team_id}' roster",

--- a/qa-automation/AI-Scoring/backend/routes/lookup.py
+++ b/qa-automation/AI-Scoring/backend/routes/lookup.py
@@ -3,15 +3,26 @@
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 
+from backend.middleware.auth import KeyIdentity, require_api_key, team_id_from_path
 from backend.services.dialpad_client import (
     get_recording_share_link,
     get_user_by_email,
     list_calls_for_user,
 )
+from backend.services.history_service import resolve_team_for_agent
 
 router = APIRouter(prefix="/lookup", tags=["lookup"])
+
+
+class ScoringPermission(BaseModel):
+    """Response shape for /lookup/scoring-permission."""
+    agent_email: str
+    resolved_team: Optional[str]
+    can_score: bool
+    needs_team_pick: bool
 
 
 @router.get("")
@@ -70,3 +81,42 @@ async def generate_recording_link(
     if not link:
         raise HTTPException(404, "Could not generate recording link")
     return {"link": link}
+
+
+@router.get("/scoring-permission", response_model=ScoringPermission)
+async def scoring_permission(
+    request: Request,
+    email: str = Query(..., description="Agent email to probe"),
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """Lightweight permission probe used by the frontend Score Call button.
+
+    Returns enough info for the client to render each /lookup row's
+    button state without re-implementing the Mails membership rule:
+
+      * ``resolved_team`` — first team whose Mails roster contains
+        ``email``, or null if unrostered anywhere.
+      * ``can_score`` — whether the calling key may post /score for this
+        email + the requested team_id (path).
+        - Team key: must match the resolved team.
+        - Privileged key: always true; the operator confirms target via
+          the team-pick dialog when unrostered.
+      * ``needs_team_pick`` — true only for privileged callers on an
+        unrostered agent; signal for the frontend to open the modal.
+    """
+    team_id = team_id_from_path(request)
+    resolved_team = await resolve_team_for_agent(email)
+
+    if identity.role == "privileged":
+        can_score = True
+        needs_team_pick = resolved_team is None
+    else:
+        can_score = resolved_team == identity.team_id == team_id
+        needs_team_pick = False
+
+    return ScoringPermission(
+        agent_email=email,
+        resolved_team=resolved_team,
+        can_score=can_score,
+        needs_team_pick=needs_team_pick,
+    )

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -241,7 +241,15 @@ async def score_single_call(
             )
         filename = f"{call_id}.mp3"
 
-    _jobs[key] = {"status": "pending", "call_id": call_id}
+    _jobs[key] = {
+        "status": "pending",
+        "call_id": call_id,
+        # Persisted so /score/{job_id}/approve can write a complete
+        # Score_Audit row without re-deriving identity from the scorecard.
+        "agent_email": agent_email or "",
+        "agent_name": agent_name,
+        "manager_email": manager_email,
+    }
 
     # Pre-fetch Dialpad metadata in the handler (sequential per request) so
     # fan-out background tasks don't burst Dialpad and lose metadata to 429s.
@@ -365,11 +373,20 @@ async def score_batch(
 
 
 @router.post("/score/{job_id}/approve")
-async def approve_scorecard(request: Request, job_id: str, approval: ApprovalRequest):
+async def approve_scorecard(
+    request: Request,
+    job_id: str,
+    approval: ApprovalRequest,
+    identity: KeyIdentity = Depends(require_api_key),
+):
     """
     Manager approves a scored call (optionally with edits).
     Updates Form Responses AI, copies to Form Responses 1,
     waits for ARRAYFORMULA, then triggers Apps Script email pipeline.
+
+    Writes a Score_Audit row with action="approved" once Stage 4
+    succeeds — captured before the Apps Script email dispatch so an
+    Apps Script failure still leaves the audit trail intact.
     """
     team_id = team_id_from_path(request)
     key = _job_key(team_id, job_id)
@@ -438,6 +455,22 @@ async def approve_scorecard(request: Request, job_id: str, approval: ApprovalReq
             config=config,
         )
         print(f"[approve] Stage 4 complete. Analyst_History row: {history_row}")
+
+        # Audit the approval BEFORE Stage 5 so a downstream Apps Script
+        # failure doesn't lose the record. Identity comes from the API key
+        # used to hit /approve (may differ from the one that hit /score —
+        # e.g. a privileged operator approving on behalf of a team).
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=evaluator_email,
+            agent_email=job.get("agent_email", ""),
+            agent_name=job.get("agent_name") or sc.get("agent_name") or "",
+            call_id=job.get("call_id", ""),
+            target_team=team_id,
+            action=audit_cfg.ACTION_APPROVED,
+            result_row=history_row,
+            notes="",
+        )
 
         # Stage 5 — dispatch QA email via Apps Script (reads AH row).
         print(f"[approve] Triggering Apps Script doPost (history_row={history_row})...")

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -9,27 +9,38 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, UploadFile, File, Form
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, UploadFile, File, Form
 
+from backend.config import score_audit as audit_cfg
 from backend.config.team_config import get_team_config
-from backend.middleware.auth import team_id_from_path
+from backend.middleware.auth import (
+    KeyIdentity,
+    check_scoring_access,
+    require_api_key,
+    team_id_from_path,
+)
 from backend.models.scorecard import ApprovalRequest
+from backend.services.history_service import agent_name_for_email, email_in_team_mails
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
-    write_draft_to_fr_ai,
+    append_score_audit_row,
     apply_analyst_edits_to_fr_ai,
-    write_to_score_destination,
-    read_score_and_writeback,
     finalize_to_analyst_history,
+    read_score_and_writeback,
     trigger_apps_script,
+    write_draft_to_fr_ai,
+    write_to_score_destination,
 )
 from backend.services.dialpad_client import (
-    get_user_id_by_name,
-    get_calls_for_agent,
-    get_transcript,
-    get_call_details,
     DialpadRateLimited,
+    NoRecordingAvailable,
+    download_recording,
+    get_calls_for_agent,
+    get_call_details,
+    get_transcript,
+    get_user_id_by_name,
 )
 
 router = APIRouter(tags=["scoring"])
@@ -37,6 +48,22 @@ router = APIRouter(tags=["scoring"])
 # In-memory job store. Keyed by f"{team_id}:{job_id}" so jobs from one team
 # cannot be read by another.
 _jobs: dict[str, dict] = {}
+
+# Per-API-key concurrent-jobs semaphore. Keyed on KeyIdentity (frozen
+# dataclass, hashable) so two requests with the same key share a slot
+# pool. Acquired inside the background task — the HTTP response still
+# returns immediately, but the Gemini scoring call queues behind the
+# cap so a single privileged operator can't fan out 50 calls at once.
+_KEY_CONCURRENT_LIMIT = 5
+_key_semaphores: dict[KeyIdentity, asyncio.Semaphore] = {}
+
+
+def _semaphore_for_key(identity: KeyIdentity) -> asyncio.Semaphore:
+    sem = _key_semaphores.get(identity)
+    if sem is None:
+        sem = asyncio.Semaphore(_KEY_CONCURRENT_LIMIT)
+        _key_semaphores[identity] = sem
+    return sem
 
 
 def _job_key(team_id: str, job_id: str) -> str:
@@ -89,24 +116,132 @@ async def list_calls(agent_name: str, date_start: str, date_end: str):
 async def score_single_call(
     request: Request,
     background_tasks: BackgroundTasks,
-    audio_file: UploadFile = File(...),
+    identity: KeyIdentity = Depends(require_api_key),
+    audio_file: Optional[UploadFile] = File(default=None),
     call_id: str = Form(...),
-    agent_name: str = Form(...),
+    agent_email: Optional[str] = Form(default=None),
+    agent_name: Optional[str] = Form(default=None),
     manager_email: str = Form(...),
     duration_ms: float = Form(default=0),
 ):
-    """
-    Score a single call.
-    Accepts an audio file upload + form fields.
-    Runs scoring in background and writes result to Google Sheets.
-    Returns a job_id to poll for status.
+    """Score a single call.
+
+    Two input modes:
+      * **Manual upload** (legacy) — caller sends ``audio_file`` + ``agent_name``.
+      * **Lookup-driven** (new) — caller sends ``call_id`` + ``agent_email``;
+        the backend downloads the recording via ``download_recording`` and
+        resolves ``agent_name`` from the team's Mails roster.
+
+    Returns ``{job_id, status}``. Idempotent against double-clicks: a
+    second POST with the same ``(team_id, call_id, agent_name)`` while a
+    prior job is still ``pending``/``scoring`` returns that job's id
+    instead of starting a new run.
+
+    Auth notes:
+      * Team key: ``agent_email`` (or the email resolved from
+        ``agent_name``) must be in the team's Mails roster.
+      * Privileged key: any real ``team_id`` is allowed; roster
+        membership is NOT required (caller picks the target team via the
+        frontend's team-pick dialog when the agent is unrostered).
     """
     team_id = team_id_from_path(request)
-    audio_bytes = await audio_file.read()
+    config = get_team_config(team_id)
+
+    if not agent_email and not agent_name:
+        raise HTTPException(
+            status_code=400,
+            detail="Must supply agent_email or agent_name",
+        )
+
+    # Resolve agent_name from email if missing. For team keys we also
+    # resolve email→name when both are present so the audit row carries
+    # the canonical display name.
+    if agent_email:
+        resolved_name = await agent_name_for_email(agent_email, team_id)
+        if resolved_name and not agent_name:
+            agent_name = resolved_name
+
+    if not agent_name:
+        # Unrostered + privileged caller may legitimately have only an
+        # email — fall back to the local part so the job key stays stable.
+        agent_name = (agent_email or "").split("@", 1)[0] or "unknown"
+
+    # Auth: precompute roster membership (async I/O) then run the sync
+    # check. On denial, write a denied-audit row before raising.
+    is_in_roster = (
+        await email_in_team_mails(agent_email, team_id)
+        if agent_email else False
+    )
+    try:
+        check_scoring_access(
+            identity, team_id, agent_email, is_in_roster=is_in_roster,
+        )
+    except HTTPException as exc:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=manager_email,
+            agent_email=agent_email or "",
+            agent_name=agent_name,
+            call_id=call_id,
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes=f"http_{exc.status_code}",
+        )
+        raise
+
+    # Idempotency: return an existing in-flight job_id rather than
+    # launching a duplicate background run on double-click.
     job_id = _make_job_id(call_id, agent_name)
     key = _job_key(team_id, job_id)
+    existing = _jobs.get(key)
+    if existing and existing.get("status") in {"pending", "scoring"}:
+        return {"job_id": job_id, "status": existing["status"]}
+
+    # Resolve audio bytes — either uploaded or fetched from Dialpad.
+    audio_bytes: bytes
+    filename: str
+    if audio_file is not None:
+        audio_bytes = await audio_file.read()
+        filename = audio_file.filename or f"{call_id}.mp3"
+    else:
+        try:
+            audio_bytes = await download_recording(call_id)
+        except NoRecordingAvailable:
+            append_score_audit_row(
+                api_key_role=identity.role,
+                evaluator_email=manager_email,
+                agent_email=agent_email or "",
+                agent_name=agent_name,
+                call_id=call_id,
+                target_team=team_id,
+                action=audit_cfg.ACTION_DENIED,
+                result_row=None,
+                notes="no_recording",
+            )
+            raise HTTPException(
+                status_code=422,
+                detail="Call has no recording in Dialpad",
+            )
+        except DialpadRateLimited:
+            append_score_audit_row(
+                api_key_role=identity.role,
+                evaluator_email=manager_email,
+                agent_email=agent_email or "",
+                agent_name=agent_name,
+                call_id=call_id,
+                target_team=team_id,
+                action=audit_cfg.ACTION_DENIED,
+                result_row=None,
+                notes="rate_limited",
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Dialpad rate-limited; retry shortly",
+            )
+        filename = f"{call_id}.mp3"
+
     _jobs[key] = {"status": "pending", "call_id": call_id}
-    config = get_team_config(team_id)
 
     # Pre-fetch Dialpad metadata in the handler (sequential per request) so
     # fan-out background tasks don't burst Dialpad and lose metadata to 429s.
@@ -117,20 +252,37 @@ async def score_single_call(
         print(f"[score] Dialpad rate-limited fetching call_details for {call_id}; proceeding with blanks")
         call_details = None
 
+    # Audit row written before the background task is scheduled so the
+    # operator action is logged even if the worker crashes.
+    append_score_audit_row(
+        api_key_role=identity.role,
+        evaluator_email=manager_email,
+        agent_email=agent_email or "",
+        agent_name=agent_name,
+        call_id=call_id,
+        target_team=team_id,
+        action=audit_cfg.ACTION_SCORED,
+        result_row=None,
+        notes="",
+    )
+
+    semaphore = _semaphore_for_key(identity)
+
     async def run():
         try:
             _jobs[key]["status"] = "scoring"
-            scorecard = await score_call(
-                audio_bytes=audio_bytes,
-                filename=audio_file.filename,
-                call_id=call_id,
-                agent_name=agent_name,
-                manager_email=manager_email,
-                config=config,
-                duration_ms=duration_ms,
-                transcript_data=transcript_data,
-                call_details=call_details,
-            )
+            async with semaphore:
+                scorecard = await score_call(
+                    audio_bytes=audio_bytes,
+                    filename=filename,
+                    call_id=call_id,
+                    agent_name=agent_name,
+                    manager_email=manager_email,
+                    config=config,
+                    duration_ms=duration_ms,
+                    transcript_data=transcript_data,
+                    call_details=call_details,
+                )
             row_num = write_draft_to_fr_ai(scorecard, config)
             _jobs[key]["status"] = "complete"
             _jobs[key]["sheets_row"] = row_num

--- a/qa-automation/AI-Scoring/backend/services/history_service.py
+++ b/qa-automation/AI-Scoring/backend/services/history_service.py
@@ -308,12 +308,42 @@ def _email_in_mails_rows(email: str, mails_rows: list[list[str]]) -> bool:
     return False
 
 
+def _agent_name_for_email_in_rows(email: str, mails_rows: list[list[str]]) -> str | None:
+    """Return the agent_name (col A) for ``email`` (col B), or None.
+
+    Uses the canonical name (col D) if present, else the raw name.
+    Case-insensitive on email; preserves the original casing of the name.
+    """
+    if not email:
+        return None
+    needle = email.strip().lower()
+    if not needle:
+        return None
+    for row in mails_rows[1:]:  # skip header
+        if len(row) < 2:
+            continue
+        if row[1].strip().lower() != needle:
+            continue
+        canonical = row[3].strip() if len(row) > 3 and row[3].strip() else ""
+        name = row[0].strip()
+        return canonical or name or None
+    return None
+
+
 async def email_in_team_mails(email: str, team_id: str) -> bool:
     """Return True if ``email`` is in the active Mails roster for ``team_id``."""
     from backend.services.data_provider import get_provider
     provider = await get_provider(team_id)
     rows = provider._get_mails_sheet()
     return _email_in_mails_rows(email, rows)
+
+
+async def agent_name_for_email(email: str, team_id: str) -> str | None:
+    """Resolve ``email`` to an agent display name via ``team_id``'s Mails tab."""
+    from backend.services.data_provider import get_provider
+    provider = await get_provider(team_id)
+    rows = provider._get_mails_sheet()
+    return _agent_name_for_email_in_rows(email, rows)
 
 
 async def resolve_team_for_agent(email: str) -> str | None:

--- a/qa-automation/AI-Scoring/backend/services/history_service.py
+++ b/qa-automation/AI-Scoring/backend/services/history_service.py
@@ -284,3 +284,42 @@ class SheetsProvider(DataProvider):
             records.append(rec)
         records.sort(key=lambda r: r.timestamp)
         return records
+
+
+# ---------------------------------------------------------------------------
+# Mails-tab helpers (used by /score auth + /lookup/scoring-permission)
+# ---------------------------------------------------------------------------
+# Pure logic lives in `_email_in_mails_rows` so tests can drive it with
+# synthetic list[list[str]] fixtures (matches the load_and_clean pattern).
+# The async wrappers fetch the Mails tab via the cached SheetsProvider.
+
+def _email_in_mails_rows(email: str, mails_rows: list[list[str]]) -> bool:
+    """Return True if ``email`` appears in column B of Mails (case-insensitive)."""
+    if not email:
+        return False
+    needle = email.strip().lower()
+    if not needle:
+        return False
+    for row in mails_rows[1:]:  # skip header
+        if len(row) < 2:
+            continue
+        if row[1].strip().lower() == needle:
+            return True
+    return False
+
+
+async def email_in_team_mails(email: str, team_id: str) -> bool:
+    """Return True if ``email`` is in the active Mails roster for ``team_id``."""
+    from backend.services.data_provider import get_provider
+    provider = await get_provider(team_id)
+    rows = provider._get_mails_sheet()
+    return _email_in_mails_rows(email, rows)
+
+
+async def resolve_team_for_agent(email: str) -> str | None:
+    """Return the team_id whose Mails roster contains ``email``, or None."""
+    from backend.config.team_config import get_all_team_ids
+    for team_id in get_all_team_ids():
+        if await email_in_team_mails(email, team_id):
+            return team_id
+    return None

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -573,6 +573,96 @@ def finalize_to_analyst_history(
 # Phase C will switch to Analyst_History row)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Score_Audit append (LookupToScore.md design)
+# ---------------------------------------------------------------------------
+
+def _build_score_audit_row(
+    *,
+    timestamp: str,
+    api_key_role: str,
+    evaluator_email: str,
+    agent_email: str,
+    agent_name: str,
+    call_id: str,
+    target_team: str,
+    action: str,
+    result_row: int | None,
+    notes: str,
+) -> list[str]:
+    """Compose one Score_Audit row in COLUMNS order.
+
+    Kept pure (no gspread, no clock) so tests can drive it directly and
+    the live-Sheets append helper stays a thin wrapper.
+    """
+    from backend.config import score_audit as audit_cfg
+
+    if action not in audit_cfg.ACTIONS:
+        raise ValueError(f"unknown audit action '{action}'")
+    if api_key_role not in audit_cfg.ROLES:
+        raise ValueError(f"unknown api_key_role '{api_key_role}'")
+
+    return [
+        timestamp,
+        api_key_role,
+        evaluator_email,
+        agent_email,
+        agent_name,
+        call_id,
+        target_team,
+        action,
+        "" if result_row is None else str(result_row),
+        notes,
+    ]
+
+
+def append_score_audit_row(
+    *,
+    api_key_role: str,
+    evaluator_email: str,
+    agent_email: str,
+    agent_name: str,
+    call_id: str,
+    target_team: str,
+    action: str,
+    result_row: int | None = None,
+    notes: str = "",
+) -> int:
+    """Append one row to the Score_Audit tab on the host spreadsheet.
+
+    Writes timestamp as ISO 8601 UTC. Always targets the audit host
+    team's spreadsheet (member_support) regardless of ``target_team`` —
+    a privileged evaluator scoring a Sales call still appends to the
+    same audit log.
+
+    Returns the appended row number (1-indexed), or -1 if the gspread
+    response can't be parsed (matches the rest of this module).
+    """
+    from backend.config import score_audit as audit_cfg
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    row = _build_score_audit_row(
+        timestamp=timestamp,
+        api_key_role=api_key_role,
+        evaluator_email=evaluator_email,
+        agent_email=agent_email,
+        agent_name=agent_name,
+        call_id=call_id,
+        target_team=target_team,
+        action=action,
+        result_row=result_row,
+        notes=notes,
+    )
+
+    sheet = _get_spreadsheet(audit_cfg.HOST_TEAM_ID).worksheet(audit_cfg.TAB_NAME)
+    result = sheet.append_row(row, value_input_option="USER_ENTERED")
+    return _parse_appended_row_num(result)
+
+
+# ---------------------------------------------------------------------------
+# Apps Script trigger
+# ---------------------------------------------------------------------------
+
 def trigger_apps_script(history_row_num: int, team_id: str) -> dict:
     """POST to the team's Apps Script web app to dispatch the QA email.
 

--- a/qa-automation/AI-Scoring/frontend/index.html
+++ b/qa-automation/AI-Scoring/frontend/index.html
@@ -539,11 +539,13 @@
     if (dashLink) dashLink.href = `/dashboard/${TEAM_ID}`;
   });
 
+  // localStorage (not sessionStorage) so /lookup, /scorecard, and /score
+  // share one auth state across tabs. Previously each tab re-prompted.
   function getApiKey() {
-    let key = sessionStorage.getItem('qa_api_key');
+    let key = localStorage.getItem('qa_api_key');
     if (!key) {
       key = prompt('Enter your QA API key:');
-      if (key) sessionStorage.setItem('qa_api_key', key);
+      if (key) localStorage.setItem('qa_api_key', key);
     }
     return key;
   }
@@ -692,7 +694,7 @@
 
       const res = await fetch(`${API_BASE}/score`, { method: 'POST', body: formData, headers: authHeaders() });
       if (res.status === 401) {
-        sessionStorage.removeItem('qa_api_key');
+        localStorage.removeItem('qa_api_key');
         alert('Invalid API key. Please reload and try again.');
         submitBtn.textContent = 'Score Calls';
         return;
@@ -824,9 +826,9 @@
                <option value="4">4/5</option>
                <option value="5">5/5</option>`;
           return `
-            <div class="section-row" style="border-left:3px solid var(--amber);">
+            <div class="section-row" style="border-left:3px solid var(--warning);">
               <div>
-                <div class="section-name" style="color:var(--amber);">${ts.name} — Score Required</div>
+                <div class="section-name" style="color:var(--warning);">${ts.name} — Score Required</div>
                 <textarea class="section-reasoning" id="manual-reasoning-${ts.id}-${jobId}"
                   placeholder="Enter reasoning for ${ts.name} score (persisted for progression analysis)"
                   rows="2" style="width:100%; margin-top:0.4rem; font-family:'DM Mono',monospace; font-size:0.82rem; border:1px solid #d1d5db; border-radius:4px; padding:0.4rem; resize:vertical;"></textarea>
@@ -1035,7 +1037,7 @@
       });
 
       if (res.status === 401) {
-        sessionStorage.removeItem('qa_api_key');
+        localStorage.removeItem('qa_api_key');
         alert('Invalid API key. Please reload and try again.');
         btn.disabled = false;
         btn.textContent = 'Approve & Send';

--- a/qa-automation/AI-Scoring/frontend/lookup.html
+++ b/qa-automation/AI-Scoring/frontend/lookup.html
@@ -132,6 +132,57 @@
 
     .hidden { display: none; }
 
+    /* Action buttons in calls table */
+    .row-action {
+      display: inline-block; font-family: 'DM Mono', monospace; font-size: 0.7rem;
+      padding: 3px 10px; border-radius: 4px; border: 1px solid var(--accent);
+      color: var(--accent); background: transparent; cursor: pointer; margin-right: 4px;
+      white-space: nowrap;
+    }
+    .row-action:hover:not(:disabled) { background: var(--accent); color: #fff; }
+    .row-action:disabled,
+    .row-action.disabled {
+      opacity: 0.4; cursor: not-allowed; border-color: var(--muted); color: var(--muted);
+    }
+    .row-action.score { border-color: var(--green); color: #137333; }
+    .row-action.score:hover:not(:disabled):not(.disabled) { background: var(--green); color: #fff; }
+    .score-status {
+      font-size: 0.7rem; color: var(--muted); display: inline-block; margin-left: 6px;
+    }
+    .score-status.complete { color: #137333; }
+    .score-status.error { color: var(--red); }
+
+    /* Team-pick modal */
+    .modal-backdrop {
+      position: fixed; inset: 0; background: rgba(21,25,45,0.5);
+      display: flex; align-items: center; justify-content: center; z-index: 100;
+    }
+    /* Specificity bump — .hidden alone loses to .modal-backdrop's display:flex
+       because .modal-backdrop is declared later in this stylesheet. */
+    .modal-backdrop.hidden { display: none; }
+    .modal {
+      background: var(--surface); border-radius: 12px; padding: 24px; max-width: 360px;
+      width: calc(100% - 32px); box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+    }
+    .modal h3 { font-size: 1rem; margin-bottom: 8px; }
+    .modal p { font-size: 0.8rem; color: var(--muted); margin-bottom: 16px; }
+    .modal .options { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
+    .modal .option {
+      display: flex; align-items: center; gap: 8px; padding: 10px 12px;
+      border: 1px solid var(--border); border-radius: 6px; cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .modal .option:hover { background: var(--bg); }
+    .modal .option input { cursor: pointer; }
+    .modal .actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .modal .actions button {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 16px;
+      border-radius: 6px; cursor: pointer; border: 1px solid var(--border);
+    }
+    .modal .actions .primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .modal .actions .primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .modal .actions .secondary { background: transparent; color: var(--text); }
+
     @media (max-width: 600px) {
       .info-grid { grid-template-columns: 1fr; }
       .search-bar { flex-direction: column; align-items: stretch; }
@@ -209,7 +260,7 @@
               <th>Contact</th>
               <th>Duration</th>
               <th>Recorded</th>
-              <th>Link</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody id="callsBody"></tbody>
@@ -223,17 +274,33 @@
     </div>
   </div>
 
+  <!-- Team-pick modal (privileged + unrostered agent) -->
+  <div id="teamPickModal" class="modal-backdrop hidden">
+    <div class="modal">
+      <h3>Choose target team</h3>
+      <p>This agent isn't in any team's roster. Pick which team's scoring pipeline should evaluate this call.</p>
+      <div class="options" id="teamPickOptions"></div>
+      <div class="actions">
+        <button class="secondary" onclick="closeTeamPick()">Cancel</button>
+        <button class="primary" id="teamPickConfirm" onclick="confirmTeamPick()" disabled>Score</button>
+      </div>
+    </div>
+  </div>
+
 <script>
 const TEAM_ID = (location.pathname.match(/^\/lookup\/([^\/]+)/) || [, 'member_support'])[1];
 const API_BASE = `/api/${TEAM_ID}`;
 
 const $ = id => document.getElementById(id);
 
+// localStorage (not sessionStorage) so the new tab opened by "Open editor"
+// inherits the API key + manager email without re-prompting. Same browser,
+// same origin, but a new tab has its own sessionStorage.
 function getApiKey() {
-  let key = sessionStorage.getItem('qa_api_key');
+  let key = localStorage.getItem('qa_api_key');
   if (!key) {
     key = prompt('Enter your QA API key:');
-    if (key) sessionStorage.setItem('qa_api_key', key);
+    if (key) localStorage.setItem('qa_api_key', key);
   }
   return key;
 }
@@ -242,9 +309,24 @@ function authHeaders() {
   return key ? { 'Authorization': 'Bearer ' + key } : {};
 }
 
+function getManagerEmail() {
+  let email = localStorage.getItem('qa_manager_email');
+  if (!email) {
+    email = prompt('Enter your evaluator email (you, the manager scoring this call):');
+    if (email) localStorage.setItem('qa_manager_email', email.trim());
+  }
+  return email;
+}
+
 let currentUserId = null;
+let currentSearchEmail = null;
+let currentScoringPermission = null;
 let nextCursor = null;
 let totalLoaded = 0;
+
+// Configured team list — keep in sync with backend/config/teams/*.json.
+// Drives the team-pick modal options for privileged + unrostered cases.
+const TEAMS = ['member_support', 'sales'];
 
 // Default date range: past 7 days
 function initDateDefaults() {
@@ -288,7 +370,11 @@ async function doSearch() {
     }
     const user = await resp.json();
     currentUserId = user.id;
+    currentSearchEmail = email;
     renderUser(user);
+    // Fetch scoring permission once per agent (same for every row) so
+    // renderCalls can decide Score Call button state without a per-row probe.
+    currentScoringPermission = await fetchScoringPermission(email);
     // Show calls section and auto-fetch
     $('callsCard').classList.remove('hidden');
     fetchCalls();
@@ -387,6 +473,14 @@ function renderCalls(calls, append) {
   $('callsCount').textContent = `${totalLoaded} call${totalLoaded !== 1 ? 's' : ''} loaded`;
   $('callsCount').classList.remove('hidden');
 
+  const perm = currentScoringPermission;
+  const canScore = !!(perm && perm.can_score);
+  // Tooltip explaining why Score Call is disabled. Same reason for every
+  // row when the calling key has no scoring access for this agent.
+  let disabledReason = '';
+  if (!perm) disabledReason = 'Could not check scoring permission';
+  else if (!perm.can_score) disabledReason = 'API key not authorized to score this agent';
+
   const rows = calls.map(c => {
     const dir = c.direction || 'unknown';
     const dirCls = dir === 'inbound' ? 'inbound' : 'outbound';
@@ -395,17 +489,36 @@ function renderCalls(calls, append) {
     const contact = c.contact_name || c.external_number || c.contact_phone || '-';
     const dateStr = fmtDateTime(c.date_started || c.date_connected);
     const rec = c.was_recorded ? 'Yes' : 'No';
-    let linkCell = '-';
+
+    // Share Link (renamed Generate)
+    let shareCell = '';
     if (c.recording_id) {
-      linkCell = `<a href="#" class="gen-link" data-rid="${esc(c.recording_id)}" data-rtype="${esc(c.recording_type)}" onclick="generateLink(event, this)">Generate</a>`;
+      shareCell = `<a href="#" class="row-action gen-link" data-rid="${esc(c.recording_id)}" data-rtype="${esc(c.recording_type)}" onclick="generateLink(event, this)">Share Link</a>`;
     }
+
+    // Score Call — needs call_id + recording + permission
+    let scoreCell = '';
+    const hasCall = !!c.call_id;
+    const recOk = !!c.was_recorded;
+    if (hasCall) {
+      const blocked = !recOk || !canScore;
+      const reason = !recOk ? 'No recording on this call' : disabledReason;
+      const cls = blocked ? 'row-action score disabled' : 'row-action score';
+      const onclick = blocked ? '' : `onclick="scoreCall(this, '${esc(c.call_id)}')"`;
+      const titleAttr = blocked ? ` title="${esc(reason)}"` : '';
+      const disabledAttr = blocked ? ' disabled' : '';
+      scoreCell = `<button class="${cls}" data-call-id="${esc(c.call_id)}"${onclick}${titleAttr}${disabledAttr}>Score Call</button><span class="score-status" data-status></span>`;
+    }
+
+    const actionsCell = (shareCell || scoreCell) ? `${shareCell}${scoreCell}` : '-';
+
     return `<tr class="${flagCls}">
       <td>${esc(dateStr)}</td>
       <td><span class="direction-badge ${dirCls}">${esc(dir)}</span></td>
       <td>${esc(contact)}</td>
       <td>${esc(dur)}</td>
       <td>${rec}</td>
-      <td>${linkCell}</td>
+      <td>${actionsCell}</td>
     </tr>`;
   }).join('');
 
@@ -496,6 +609,144 @@ function esc(s) {
   const d = document.createElement('div');
   d.textContent = s;
   return d.innerHTML;
+}
+
+// ---------------------------------------------------------------------
+// Scoring-permission probe + Score Call flow (LookupToScore.md PR 5)
+// ---------------------------------------------------------------------
+
+async function fetchScoringPermission(email) {
+  try {
+    const resp = await fetch(
+      `${API_BASE}/lookup/scoring-permission?email=${encodeURIComponent(email)}`,
+      { headers: authHeaders() }
+    );
+    if (!resp.ok) {
+      console.warn(`scoring-permission ${resp.status}`);
+      return { agent_email: email, resolved_team: null, can_score: false, needs_team_pick: false };
+    }
+    return await resp.json();
+  } catch (e) {
+    console.warn('scoring-permission failed', e);
+    return { agent_email: email, resolved_team: null, can_score: false, needs_team_pick: false };
+  }
+}
+
+let _pendingTeamPick = null;  // { btn, callId, resolve }
+
+function openTeamPick(callId, btn) {
+  const opts = TEAMS.map(t => `
+    <label class="option">
+      <input type="radio" name="targetTeam" value="${esc(t)}" onchange="$('teamPickConfirm').disabled = false;">
+      <span>${esc(t)}</span>
+    </label>`).join('');
+  $('teamPickOptions').innerHTML = opts;
+  $('teamPickConfirm').disabled = true;
+  $('teamPickModal').classList.remove('hidden');
+  return new Promise(resolve => {
+    _pendingTeamPick = { btn, callId, resolve };
+  });
+}
+
+function closeTeamPick() {
+  $('teamPickModal').classList.add('hidden');
+  if (_pendingTeamPick) {
+    _pendingTeamPick.resolve(null);
+    _pendingTeamPick = null;
+  }
+}
+
+function confirmTeamPick() {
+  const picked = document.querySelector('input[name="targetTeam"]:checked');
+  if (!picked) return;
+  const team = picked.value;
+  $('teamPickModal').classList.add('hidden');
+  if (_pendingTeamPick) {
+    _pendingTeamPick.resolve(team);
+    _pendingTeamPick = null;
+  }
+}
+
+async function scoreCall(btn, callId) {
+  if (!currentSearchEmail || !currentScoringPermission) {
+    alert('Refresh: missing agent context.');
+    return;
+  }
+  const managerEmail = getManagerEmail();
+  if (!managerEmail) {
+    alert('Manager email is required to score a call.');
+    return;
+  }
+
+  // Resolve target team: needs_team_pick (privileged + unrostered) → modal.
+  // Otherwise use the resolved team (if present) or the path team for team keys.
+  let targetTeam;
+  if (currentScoringPermission.needs_team_pick) {
+    targetTeam = await openTeamPick(callId, btn);
+    if (!targetTeam) return;  // cancelled
+  } else {
+    targetTeam = currentScoringPermission.resolved_team || TEAM_ID;
+  }
+
+  const statusEl = btn.parentElement.querySelector('[data-status]');
+  btn.disabled = true;
+  btn.classList.add('disabled');
+  statusEl.textContent = 'Submitting...';
+  statusEl.className = 'score-status';
+
+  const form = new FormData();
+  form.append('call_id', callId);
+  form.append('agent_email', currentSearchEmail);
+  form.append('manager_email', managerEmail);
+
+  let jobId;
+  try {
+    const resp = await fetch(`/api/${targetTeam}/score`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: form,
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(data.detail || `HTTP ${resp.status}`);
+    }
+    jobId = data.job_id;
+    statusEl.textContent = `${data.status || 'pending'}...`;
+  } catch (e) {
+    statusEl.textContent = 'Failed';
+    statusEl.className = 'score-status error';
+    statusEl.title = e.message;
+    btn.disabled = false;
+    btn.classList.remove('disabled');
+    return;
+  }
+
+  // Poll until terminal.
+  pollScoreJob(targetTeam, jobId, statusEl, btn);
+}
+
+function pollScoreJob(targetTeam, jobId, statusEl, btn) {
+  const interval = setInterval(async () => {
+    try {
+      const r = await fetch(`/api/${targetTeam}/score/${jobId}`, { headers: authHeaders() });
+      const data = await r.json();
+      const status = data.status || '?';
+      statusEl.textContent = status;
+      if (['complete', 'approved'].includes(status)) {
+        statusEl.className = 'score-status complete';
+        statusEl.innerHTML = `complete · <a href="/scorecard/${esc(targetTeam)}/${esc(jobId)}" target="_blank">Open editor</a>`;
+        clearInterval(interval);
+      } else if (status === 'error') {
+        statusEl.className = 'score-status error';
+        statusEl.title = data.error || '';
+        btn.disabled = false;
+        btn.classList.remove('disabled');
+        clearInterval(interval);
+      }
+    } catch (e) {
+      // Transient — keep polling. A long outage will be visible as "pending..." stalling.
+    }
+  }, 3000);
 }
 </script>
 </body>

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scorecard — Landing QA</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #E7EFFB;
+      --surface: #ffffff;
+      --border: #c9d5e8;
+      --text: #15192D;
+      --muted: #5a6478;
+      --accent: #1A61D9;
+      --navy: #15192D;
+      --success: #2d6a4f;
+      --warning: #b45309;
+      --error: #991b1b;
+      --badge-high: #d1fae5;
+      --badge-medium: #fef3c7;
+      --badge-low: #fee2e2;
+    }
+
+    body {
+      font-family: 'DM Mono', monospace;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 0;
+    }
+
+    /* Navy banner header — matches index.html typography exactly so the
+       /score and /scorecard pages feel like one app. The flex layout +
+       header-nav are scorecard-only (back link + scoring link). */
+    header {
+      background: var(--navy);
+      color: #ffffff;
+      padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    header h1 {
+      font-family: 'Fraunces', serif;
+      font-weight: 300;
+      font-size: 2rem;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.25rem;
+      color: #ffffff;
+    }
+    header p { color: rgba(255, 255, 255, 0.7); font-size: 0.8rem; }
+    .header-nav { display: flex; gap: 8px; }
+    .header-nav a {
+      color: #ffffff; text-decoration: none; font-size: 0.82rem;
+      padding: 8px 16px; border: 1px solid rgba(255,255,255,0.3); border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .header-nav a:hover { background: rgba(255,255,255,0.1); }
+
+    /* Card wrapper — mirrors index.html so the panel sits inside a white
+       surface with a navy h2 header (same shape as /score's "Scoring Progress"
+       card). */
+    .card {
+      max-width: 720px;
+      margin: 0 auto 1.5rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .card h2 {
+      font-family: 'Fraunces', serif;
+      font-weight: 400;
+      font-size: 1.1rem;
+      padding: 0.75rem 1.25rem;
+      margin: 0;
+      background: var(--navy);
+      color: #ffffff;
+    }
+    .job-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 1rem 1.25rem;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+    .job-row .err-detail { color: var(--error); font-size: 0.78rem; }
+
+    /* --- Scorecard panel styles (mirrored from index.html so this page renders
+       a panel identical to the upload flow). Keep these in sync until the
+       shared-module extraction lands as a follow-up. --- */
+
+    .status-badge { padding: 0.2rem 0.6rem; border-radius: 20px; font-size: 0.7rem; font-weight: 500; }
+    .status-pending  { background: #e5e7eb; color: #374151; }
+    .status-scoring  { background: #dbeafe; color: #1e40af; }
+    .status-complete { background: var(--badge-high); color: var(--success); }
+    .status-error    { background: var(--badge-low); color: var(--error); }
+
+    .scorecard-panel {
+      margin-top: 0.5rem; margin-bottom: 3rem;
+      border: 1px solid var(--border); border-radius: 6px; overflow: hidden;
+      border-top: 4px solid var(--navy); border-bottom: 4px solid var(--navy);
+    }
+
+    .scorecard-header {
+      padding: 1rem 1.25rem; background: var(--navy); color: #ffffff;
+      display: flex; justify-content: space-between; align-items: center; font-size: 0.82rem;
+    }
+
+    .scorecard-header .header-meta {
+      font-size: 0.7rem; color: rgba(255,255,255,0.6); margin-top: 2px;
+      display: flex; gap: 0.75rem; align-items: center;
+    }
+
+    .scorecard-avg {
+      font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 300; color: #ffffff;
+    }
+
+    .long-call-flag {
+      font-size: 0.72rem; padding: 0.2rem 0.6rem; background: #fef3c7; color: #b45309;
+      border-radius: 20px;
+    }
+
+    .section-row {
+      display: grid; grid-template-columns: 1fr 60px 80px; gap: 0.5rem;
+      align-items: start; padding: 0.85rem 1rem; border-bottom: 1px solid var(--border);
+      font-size: 0.78rem;
+    }
+    .section-row:last-child { border-bottom: none; }
+    .section-name { font-weight: 500; }
+    .section-reasoning { color: var(--muted); font-size: 0.72rem; margin-top: 0.2rem; }
+    .section-flags { color: var(--warning); font-size: 0.68rem; margin-top: 0.15rem; }
+
+    .confidence-badge {
+      font-size: 0.65rem; padding: 0.15rem 0.4rem; border-radius: 3px;
+      text-transform: uppercase; letter-spacing: 0.05em; text-align: center;
+    }
+
+    .notes-section {
+      padding: 1rem 1.25rem; background: #f9fafe; border-top: 2px solid var(--border);
+      font-size: 0.78rem;
+    }
+    .notes-label {
+      font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--muted); margin-bottom: 0.35rem;
+    }
+
+    .transcript-panel { border-top: 2px solid var(--navy); margin-top: 0.5rem; }
+    .transcript-toggle {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.65rem 1rem; cursor: pointer; font-size: 0.78rem; font-weight: 500;
+      background: var(--navy); color: #ffffff; user-select: none;
+    }
+    .transcript-toggle:hover { background: #1e2340; }
+    .transcript-toggle .arrow {
+      transition: transform 0.2s; font-size: 0.7rem; color: rgba(255, 255, 255, 0.7);
+    }
+    .transcript-toggle.open .arrow { transform: rotate(90deg); }
+    .transcript-body {
+      display: none; max-height: 400px; overflow-y: auto; padding: 0.5rem 1rem;
+      font-size: 0.75rem; line-height: 1.6;
+    }
+    .transcript-body.open { display: block; }
+    .transcript-line {
+      display: grid; grid-template-columns: 48px 1fr; gap: 0.5rem;
+      padding: 0.3rem 0; border-bottom: 1px solid #edf2fa;
+    }
+    .transcript-line:last-child { border-bottom: none; }
+    .transcript-ts { color: var(--muted); font-size: 0.7rem; font-variant-numeric: tabular-nums; padding-top: 0.1rem; }
+    .transcript-speaker { font-weight: 500; margin-right: 0.3rem; }
+    .moments-list { padding: 0.5rem 1rem; border-top: 1px solid var(--border); }
+    .moment-item {
+      display: inline-flex; align-items: center; gap: 0.35rem;
+      padding: 0.2rem 0.55rem; margin: 0.2rem 0.2rem; background: #d0ddf0;
+      border-radius: 12px; font-size: 0.68rem; color: var(--text);
+    }
+    .moment-ts { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+    .score-select, .confidence-select {
+      font-family: 'DM Mono', monospace; padding: 0.2rem 0.3rem;
+      border: 1px solid var(--border); border-radius: 4px; background: var(--bg);
+      color: var(--text); text-align: center; width: 100%; cursor: pointer;
+    }
+    .score-select { font-size: 0.78rem; }
+    .confidence-select { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .score-select:focus, .confidence-select:focus { border-color: var(--accent); outline: none; }
+    .score-select:disabled, .confidence-select:disabled { opacity: 0.6; cursor: default; }
+
+    .reasoning-textarea, .notes-textarea {
+      font-family: 'DM Mono', monospace; width: 100%;
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 0.35rem 0.5rem; resize: vertical; background: var(--bg); line-height: 1.4;
+    }
+    .reasoning-textarea { font-size: 0.72rem; color: var(--muted); margin-top: 0.2rem; min-height: 2.5rem; }
+    .notes-textarea { font-size: 0.78rem; min-height: 3rem; background: #fff; line-height: 1.5; padding: 0.5rem; }
+    .reasoning-textarea:focus, .notes-textarea:focus { border-color: var(--accent); outline: none; }
+    .reasoning-textarea:disabled, .notes-textarea:disabled { opacity: 0.6; cursor: default; }
+
+    .approve-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1rem 1.25rem; background: var(--navy);
+    }
+    .btn-approve {
+      font-family: 'DM Mono', monospace; font-size: 0.82rem;
+      padding: 0.7rem 2rem; background: var(--success); color: white;
+      border: none; border-radius: 4px; cursor: pointer; font-weight: 500;
+      transition: background 0.15s;
+    }
+    .btn-approve:hover { background: #245a42; }
+    .btn-approve:disabled { background: var(--border); cursor: not-allowed; }
+    .approve-status { font-size: 0.78rem; color: rgba(255,255,255,0.7); }
+  </style>
+</head>
+<body>
+
+<header>
+  <div>
+    <h1>Scorecard</h1>
+    <p id="scHeaderMeta">Loading job…</p>
+  </div>
+  <div class="header-nav">
+    <a id="backLink" href="#">← Back to lookup</a>
+    <a href="/" target="_self">Scoring</a>
+  </div>
+</header>
+
+<div class="card">
+  <h2>Scoring Progress</h2>
+  <div id="job-list">
+    <div id="loadingRow" class="job-row">
+      <span>Loading scorecard…</span>
+      <span id="loadingPill" class="status-badge status-pending">pending</span>
+      <span id="loadingDetail" class="err-detail"></span>
+    </div>
+  </div>
+</div>
+
+<script>
+// Path: /scorecard/{team_id}/{job_id}
+const _pathParts = location.pathname.split('/').filter(Boolean);
+const TEAM_ID = _pathParts[1] || 'member_support';
+const JOB_ID  = _pathParts[2] || '';
+const API_BASE = `/api/${TEAM_ID}`;
+
+document.getElementById('backLink').href = `/lookup/${TEAM_ID}`;
+
+// --- Auth — localStorage so the API key carries across tabs (new tab from
+// /lookup must inherit auth without re-prompting). ---
+function getApiKey() {
+  let key = localStorage.getItem('qa_api_key');
+  if (!key) {
+    key = prompt('Enter your QA API key:');
+    if (key) localStorage.setItem('qa_api_key', key);
+  }
+  return key;
+}
+function authHeaders() {
+  const key = getApiKey();
+  return key ? { 'Authorization': 'Bearer ' + key } : {};
+}
+
+// --- Team-section cache (drives manual-section rows + approve-gate logic) ---
+let _teamSections = [];
+let _scorecardData = {};
+
+async function loadTeamSections() {
+  if (_teamSections.length > 0) return _teamSections;
+  const res = await fetch(`${API_BASE}/team/sections`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`team/sections HTTP ${res.status}`);
+  _teamSections = await res.json();
+  return _teamSections;
+}
+
+// --- Bootstrap ---
+(async function init() {
+  if (!JOB_ID) {
+    showLoadError('No job_id in URL.');
+    return;
+  }
+  try {
+    await loadTeamSections();
+  } catch (e) {
+    showLoadError(`Could not load team sections: ${e.message}`);
+    return;
+  }
+  pollAndRender();
+})();
+
+let _pollTimer = null;
+
+async function pollAndRender() {
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}`, { headers: authHeaders() });
+    if (res.status === 401) {
+      localStorage.removeItem('qa_api_key');
+      showLoadError('Invalid API key. Reload to re-enter.');
+      return;
+    }
+    if (res.status === 404) {
+      showLoadError('Job not found. It may have been started in a different browser session.');
+      return;
+    }
+    if (!res.ok) {
+      showLoadError(`HTTP ${res.status}`);
+      return;
+    }
+    const data = await res.json();
+    updateLoadingPill(data.status);
+
+    if (data.status === 'complete' || data.status === 'approved') {
+      renderPanel(data);
+      return;
+    }
+    if (data.status === 'error') {
+      showLoadError(`Scoring error: ${data.error || 'unknown'}`);
+      return;
+    }
+    // pending / scoring — keep polling
+    _pollTimer = setTimeout(pollAndRender, 3000);
+  } catch (e) {
+    showLoadError(e.message);
+  }
+}
+
+function updateLoadingPill(status) {
+  const pill = document.getElementById('loadingPill');
+  if (!pill) return;  // already removed once the panel rendered
+  pill.textContent = status || 'pending';
+  pill.className = `status-badge status-${status || 'pending'}`;
+  document.getElementById('scHeaderMeta').textContent =
+    `Job ${JOB_ID} — ${TEAM_ID} — ${status || 'pending'}`;
+}
+
+function showLoadError(msg) {
+  const detail = document.getElementById('loadingDetail');
+  const pill = document.getElementById('loadingPill');
+  if (detail) detail.textContent = msg;
+  if (pill) {
+    pill.className = 'status-badge status-error';
+    pill.textContent = 'error';
+  }
+}
+
+function renderPanel(data) {
+  const loadingRow = document.getElementById('loadingRow');
+  if (loadingRow) loadingRow.remove();
+  document.getElementById('scHeaderMeta').textContent =
+    `Job ${JOB_ID} — ${TEAM_ID} — ${data.status}`;
+  // Filename isn't stored server-side; synthesize from call_id for the header.
+  const callId = (data.scorecard && data.scorecard.call_id) || JOB_ID.split('_')[0];
+  const filename = `${callId}.mp3`;
+  const panel = buildScorecardPanel(JOB_ID, data.scorecard, filename, callId, data.sheets_row);
+  // Append into the card's job-list (mirrors index.html's DOM structure).
+  document.getElementById('job-list').appendChild(panel);
+
+  // If we arrived after approval, lock everything down.
+  if (data.status === 'approved') {
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+    const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+    if (btn) { btn.disabled = true; btn.textContent = 'Sent'; btn.style.background = '#065f46'; }
+    const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+    if (statusEl) statusEl.textContent = 'Approved — evaluation email already dispatched.';
+  }
+}
+
+// --------------------------------------------------------------------
+// Below: scorecard-panel rendering + edit + approve logic mirrored from
+// frontend/index.html. Kept in sync manually; see the panel-style block
+// at the top of this file for the matching CSS.
+// --------------------------------------------------------------------
+
+function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
+  _scorecardData[jobId] = sc;
+
+  const numericScores = sc.sections
+    .filter(s => s.score_type === 'numeric' && s.score !== null)
+    .map(s => s.score);
+  const avg = numericScores.length
+    ? (numericScores.reduce((a, b) => a + b, 0) / numericScores.length).toFixed(2)
+    : 'N/A';
+
+  const flagged = sc.flagged_long_call;
+  const panel = document.createElement('div');
+  panel.id = `scorecard-${jobId}`;
+  panel.className = 'scorecard-panel';
+
+  const sheetsNote = sheetsRow > 0 ? `<span>Sheets row ${sheetsRow}</span>` : '';
+
+  const header = `
+    <div class="scorecard-header">
+      <div>
+        <div>${filename}</div>
+        <div class="header-meta">
+          <span>Call ${callId || ''}</span>
+          <span class="status-badge status-complete">complete</span>
+          ${sheetsNote}
+        </div>
+      </div>
+      <div style="display:flex; gap:0.5rem; align-items:center;">
+        ${flagged ? '<span class="long-call-flag">Long call — manager review</span>' : ''}
+        <span class="scorecard-avg">${avg}<span style="font-family:'DM Mono'; font-size:0.75rem; color:rgba(255,255,255,0.7);">/5</span></span>
+      </div>
+    </div>
+  `;
+
+  const aiById = Object.fromEntries(sc.sections.map(s => [s.id, s]));
+
+  const sectionRows = _teamSections
+    .filter(ts => !ts.auto_value)
+    .map(ts => {
+      if (ts.score_type === 'manual' || ts.score_type === 'manual_yn') {
+        const options = ts.score_type === 'manual_yn'
+          ? `<option value="" selected>—</option>
+             <option value="Y">Y</option>
+             <option value="N">N</option>
+             <option value="NA">NA</option>`
+          : `<option value="" selected>—</option>
+             <option value="1">1/5</option>
+             <option value="2">2/5</option>
+             <option value="3">3/5</option>
+             <option value="4">4/5</option>
+             <option value="5">5/5</option>`;
+        return `
+          <div class="section-row" style="border-left:3px solid var(--warning);">
+            <div>
+              <div class="section-name" style="color:var(--warning);">${ts.name} — Score Required</div>
+              <textarea class="section-reasoning" id="manual-reasoning-${ts.id}-${jobId}"
+                placeholder="Enter reasoning for ${ts.name} score (persisted for progression analysis)"
+                rows="2" style="width:100%; margin-top:0.4rem; font-family:'DM Mono',monospace; font-size:0.82rem; border:1px solid #d1d5db; border-radius:4px; padding:0.4rem; resize:vertical;"></textarea>
+            </div>
+            <div>
+              <select class="score-select" id="manual-score-${ts.id}-${jobId}" onchange="checkManualScores('${jobId}')">
+                ${options}
+              </select>
+            </div>
+            <div><span class="confidence-badge" style="background:#e5e7eb; color:#6b7280;">MANUAL</span></div>
+          </div>
+        `;
+      }
+
+      const s = aiById[ts.id];
+      if (!s) {
+        console.warn(`No AI data for section "${ts.id}"`);
+        return '';
+      }
+      const flags = s.flags && s.flags.length
+        ? `<div class="section-flags">${s.flags.join(', ')}</div>` : '';
+      const audioTag = s.audio_dependent ? ' <span style="color:var(--muted); font-size:0.68rem;">[audio]</span>' : '';
+
+      let scoreControl;
+      if (s.score_type === 'yn') {
+        scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="yn_value">
+          <option value="Y" ${s.yn_value==='Y'?'selected':''}>Y</option>
+          <option value="N" ${s.yn_value==='N'?'selected':''}>N</option>
+          <option value="NA" ${s.yn_value==='NA'?'selected':''}>NA</option>
+        </select>`;
+      } else {
+        scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="score">
+          ${[1,2,3,4,5].map(v => `<option value="${v}" ${s.score===v?'selected':''}>${v}/5</option>`).join('')}
+        </select>`;
+      }
+
+      const confControl = `<select class="confidence-select" data-section-id="${s.id}" data-field="confidence">
+        <option value="high" ${s.confidence==='high'?'selected':''}>HIGH</option>
+        <option value="medium" ${s.confidence==='medium'?'selected':''}>MEDIUM</option>
+        <option value="low" ${s.confidence==='low'?'selected':''}>LOW</option>
+      </select>`;
+
+      return `
+        <div class="section-row">
+          <div>
+            <div class="section-name">${s.name}${audioTag}</div>
+            <textarea class="reasoning-textarea" data-section-id="${s.id}" data-field="reasoning" rows="2">${s.reasoning}</textarea>
+            ${flags}
+          </div>
+          <div>${scoreControl}</div>
+          <div>${confControl}</div>
+        </div>
+      `;
+    });
+
+  const notes = `
+    <div class="notes-section">
+      ${sc.call_summary ? `<div class="notes-label">Call Summary</div><div style="margin-bottom:0.75rem;">${sc.call_summary}</div>` : ''}
+      <div class="notes-label">Key Strengths</div>
+      <textarea class="notes-textarea" id="strengths-${jobId}" rows="3">${sc.key_strengths || ''}</textarea>
+      <div style="margin-top:0.75rem;">
+        <div class="notes-label">Opportunities for Improvement</div>
+        <textarea class="notes-textarea" id="opportunities-${jobId}" rows="3">${sc.opportunities || ''}</textarea>
+      </div>
+    </div>
+  `;
+
+  const manualSecs = _teamSections.filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn');
+  const initialDisabled = manualSecs.length > 0;
+  const initialStatus = initialDisabled
+    ? `Score ${manualSecs.map(s => s.name).join(' + ')} to enable Approve & Send.`
+    : 'Review scores and click to send evaluation email.';
+  const approveBar = `
+    <div class="approve-bar" id="approve-bar-${jobId}">
+      <span class="approve-status" id="approve-status-${jobId}">${initialStatus}</span>
+      <button class="btn-approve" id="approve-btn-${jobId}" onclick="approveScorecard('${jobId}')" ${initialDisabled ? 'disabled' : ''}>Approve & Send</button>
+    </div>
+  `;
+
+  const transcriptId = `transcript-${jobId}`;
+  let transcriptPanel = '';
+  if (sc.transcript_display && sc.transcript_display.length > 0) {
+    const transcriptLines = sc.transcript_display.map(line => `
+      <div class="transcript-line">
+        <div class="transcript-ts">${line.timestamp || ''}</div>
+        <div><span class="transcript-speaker">${line.speaker}:</span> ${line.text}</div>
+      </div>
+    `).join('');
+
+    const momentsHtml = sc.moments_display && sc.moments_display.length > 0
+      ? `<div class="moments-list">
+          <div class="notes-label" style="margin-bottom:0.4rem;">Signal Moments</div>
+          ${sc.moments_display.map(m => `
+            <span class="moment-item"><span class="moment-ts">${m.timestamp || ''}</span> ${m.type}</span>
+          `).join('')}
+        </div>`
+      : '';
+
+    transcriptPanel = `
+      <div class="transcript-panel">
+        <div class="transcript-toggle" onclick="
+          this.classList.toggle('open');
+          document.getElementById('${transcriptId}').classList.toggle('open');
+        ">
+          <span>Transcript (${sc.transcript_display.length} lines)</span>
+          <span class="arrow">&#9654;</span>
+        </div>
+        <div class="transcript-body" id="${transcriptId}">
+          ${transcriptLines}
+        </div>
+        ${momentsHtml}
+      </div>
+    `;
+  }
+
+  panel.innerHTML = header + sectionRows.join('') + approveBar + notes + transcriptPanel;
+  return panel;
+}
+
+function checkManualScores(jobId) {
+  const btn = document.getElementById(`approve-btn-${jobId}`);
+  const statusEl = document.getElementById(`approve-status-${jobId}`);
+  if (!btn || !statusEl) return;
+
+  const missing = _teamSections
+    .filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn')
+    .filter(s => {
+      const sel = document.getElementById(`manual-score-${s.id}-${jobId}`);
+      return !sel || !sel.value;
+    });
+  if (missing.length === 0) {
+    btn.disabled = false;
+    statusEl.textContent = 'Review scores and click to send evaluation email.';
+  } else {
+    btn.disabled = true;
+    statusEl.textContent = `Score ${missing.map(s => s.name).join(' + ')} to enable Approve & Send.`;
+  }
+}
+
+async function approveScorecard(jobId) {
+  const btn = document.getElementById(`approve-btn-${jobId}`);
+  const statusEl = document.getElementById(`approve-status-${jobId}`);
+  const panel = document.getElementById(`scorecard-${jobId}`);
+
+  btn.disabled = true;
+  btn.textContent = 'Sending...';
+  statusEl.textContent = 'Updating sheets and sending email...';
+
+  const sc = _scorecardData[jobId];
+
+  const sections = sc.sections.map(s => {
+    const scoreEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="score"]`);
+    const ynEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="yn_value"]`);
+    const confEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="confidence"]`);
+    const reasonEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="reasoning"]`);
+
+    return {
+      id: s.id,
+      name: s.name,
+      score: scoreEl ? parseInt(scoreEl.value) : null,
+      score_type: s.score_type,
+      yn_value: ynEl ? ynEl.value : null,
+      confidence: confEl ? confEl.value : s.confidence,
+      reasoning: reasonEl ? reasonEl.value : s.reasoning,
+      audio_dependent: s.audio_dependent,
+      flags: s.flags || [],
+    };
+  });
+
+  _teamSections
+    .filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn')
+    .forEach(ms => {
+      const scoreEl = document.getElementById(`manual-score-${ms.id}-${jobId}`);
+      const reasonEl = document.getElementById(`manual-reasoning-${ms.id}-${jobId}`);
+      const rawValue = scoreEl && scoreEl.value ? scoreEl.value : '';
+      const isYn = ms.score_type === 'manual_yn';
+      const reasoning = (reasonEl && reasonEl.value || '').trim();
+      sections.push({
+        id: ms.id,
+        name: ms.name,
+        score: !isYn && rawValue ? parseInt(rawValue) : null,
+        score_type: ms.score_type,
+        yn_value: isYn && rawValue ? rawValue : null,
+        confidence: 'manual',
+        reasoning: reasoning || 'Scored manually by manager.',
+        audio_dependent: false,
+        flags: [],
+      });
+    });
+
+  const payload = {
+    sections,
+    key_strengths: document.getElementById(`strengths-${jobId}`).value,
+    opportunities: document.getElementById(`opportunities-${jobId}`).value,
+  };
+
+  try {
+    const res = await fetch(`${API_BASE}/score/${jobId}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      localStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      btn.disabled = false;
+      btn.textContent = 'Approve & Send';
+      return;
+    }
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.detail || 'Unknown error');
+    }
+
+    const data = await res.json();
+
+    btn.textContent = 'Sent';
+    btn.style.background = '#065f46';
+    statusEl.textContent = `Approved — destination row ${data.destination_row}. Email dispatched.`;
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}. You can retry.`;
+    statusEl.style.color = '#fca5a5';
+    btn.disabled = false;
+    btn.textContent = 'Retry Approve & Send';
+  }
+}
+</script>
+
+</body>
+</html>

--- a/qa-automation/AI-Scoring/scripts/init_score_audit_tab.py
+++ b/qa-automation/AI-Scoring/scripts/init_score_audit_tab.py
@@ -1,0 +1,74 @@
+"""
+init_score_audit_tab.py — idempotently create the Score_Audit tab.
+
+Usage:
+    python3 scripts/init_score_audit_tab.py [--dry-run]
+
+Run this ONCE per environment (local dev + each Railway deploy that has its
+own spreadsheet). Reads ``GOOGLE_SERVICE_ACCOUNT_JSON`` + ``GOOGLE_SHEETS_ID``
+(or ``GOOGLE_SHEETS_ID_MEMBER_SUPPORT``) from the env and:
+
+  * No-op if the Score_Audit tab already exists (just reports the row count).
+  * Otherwise creates the tab and writes the canonical header row.
+
+Safe to re-run — checks for existing tabs by name before creating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Make backend imports resolve when running from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from backend.config import score_audit as audit_cfg  # noqa: E402
+from backend.services.sheets_service import _get_spreadsheet  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would happen, but don't create or write anything.",
+    )
+    args = parser.parse_args()
+
+    spreadsheet = _get_spreadsheet(audit_cfg.HOST_TEAM_ID)
+    existing = {ws.title for ws in spreadsheet.worksheets()}
+
+    if audit_cfg.TAB_NAME in existing:
+        ws = spreadsheet.worksheet(audit_cfg.TAB_NAME)
+        rows = ws.row_count
+        print(
+            f"Tab '{audit_cfg.TAB_NAME}' already exists on host '{audit_cfg.HOST_TEAM_ID}' "
+            f"({rows} rows). No-op."
+        )
+        return 0
+
+    print(
+        f"Tab '{audit_cfg.TAB_NAME}' missing on host '{audit_cfg.HOST_TEAM_ID}'. "
+        f"Will create with {len(audit_cfg.COLUMNS)} columns: {audit_cfg.COLUMNS}"
+    )
+    if args.dry_run:
+        print("Dry run — nothing written.")
+        return 0
+
+    ws = spreadsheet.add_worksheet(
+        title=audit_cfg.TAB_NAME,
+        rows=1000,
+        cols=len(audit_cfg.COLUMNS),
+    )
+    ws.update("A1", [audit_cfg.COLUMNS], value_input_option="USER_ENTERED")
+    print(f"Created '{audit_cfg.TAB_NAME}' and wrote header row.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa-automation/AI-Scoring/scripts/score_by_call_id.py
+++ b/qa-automation/AI-Scoring/scripts/score_by_call_id.py
@@ -1,0 +1,239 @@
+"""
+score_by_call_id.py — end-to-end smoke for the Lookup-to-Score pipeline.
+
+Hits the running backend with a real call_id, a real privileged API key,
+and a real agent_email, exercising every stage:
+
+  1. POST /api/{team}/score   (audio fetched via Dialpad download_recording)
+  2. Poll /api/{team}/score/{job_id} until complete
+  3. POST /api/{team}/score/{job_id}/approve (sections passed through
+     unchanged — no analyst edits; manual sections submitted as NA / 3)
+  4. Stage 5 dispatches a real QA evaluation email via Apps Script
+
+REAL SIDE EFFECTS: this writes to Google Sheets and DISPATCHES THE QA EMAIL
+to the configured recipients of the chosen team. The script asks for a "y"
+confirmation before the approve step so a typo doesn't accidentally send
+an email. Use --score-only to skip approval (handy for repeated dev runs).
+
+Usage:
+    python3 scripts/score_by_call_id.py \\
+        --team member_support \\
+        --call-id 4924792590901248 \\
+        --agent-email luis@hellolanding.com \\
+        --manager-email you@hellolanding.com \\
+        --api-key $API_KEY_PRIVILEGED
+
+    # Or via env (recommended — keeps the key out of shell history):
+    AI_SCORING_API_KEY=$API_KEY_PRIVILEGED \\
+      python3 scripts/score_by_call_id.py \\
+        --team member_support \\
+        --call-id 4924792590901248 \\
+        --agent-email luis@hellolanding.com \\
+        --manager-email you@hellolanding.com
+
+Exit codes:
+    0  success (scored, optionally approved)
+    1  HTTP / pipeline error
+    2  user aborted at the approve confirmation
+    3  bad arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+
+
+def _die(code: int, msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="End-to-end Lookup-to-Score smoke against a running backend.",
+    )
+    parser.add_argument("--team", required=True, help="Target team_id (e.g. member_support)")
+    parser.add_argument("--call-id", required=True, help="Dialpad call ID to score")
+    parser.add_argument("--agent-email", required=True, help="Agent's email (for auth + audit)")
+    parser.add_argument("--manager-email", required=True, help="Your email (evaluator)")
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("AI_SCORING_API_KEY", ""),
+        help="Bearer token. Defaults to $AI_SCORING_API_KEY.",
+    )
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL,
+                        help=f"Backend base URL (default: {DEFAULT_BASE_URL}).")
+    parser.add_argument("--poll-interval", type=float, default=3.0,
+                        help="Seconds between /score/{job_id} polls (default: 3).")
+    parser.add_argument("--timeout", type=float, default=300.0,
+                        help="Max seconds to wait for status=complete (default: 300).")
+    parser.add_argument("--score-only", action="store_true",
+                        help="Stop after scoring; skip /approve (no email dispatched).")
+    parser.add_argument("--yes", action="store_true",
+                        help="Skip the approve confirmation prompt (CI use).")
+    args = parser.parse_args()
+    if not args.api_key:
+        _die(3, "missing --api-key (or $AI_SCORING_API_KEY)")
+    return args
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def submit_score(args, client: httpx.Client) -> str:
+    """POST /score without audio_file → backend fetches via download_recording."""
+    url = f"{args.base_url}/api/{args.team}/score"
+    print(f"→ POST {url}")
+    resp = client.post(
+        url,
+        headers=_auth(args.api_key),
+        data={
+            "call_id": args.call_id,
+            "agent_email": args.agent_email,
+            "manager_email": args.manager_email,
+        },
+    )
+    if resp.status_code != 200:
+        _die(1, f"/score returned {resp.status_code}: {resp.text}")
+    body = resp.json()
+    job_id = body["job_id"]
+    print(f"  job_id = {job_id}  status = {body['status']}")
+    return job_id
+
+
+def poll_until_complete(args, client: httpx.Client, job_id: str) -> dict:
+    url = f"{args.base_url}/api/{args.team}/score/{job_id}"
+    deadline = time.monotonic() + args.timeout
+    last_status = ""
+    while time.monotonic() < deadline:
+        resp = client.get(url, headers=_auth(args.api_key))
+        if resp.status_code != 200:
+            _die(1, f"GET {url} returned {resp.status_code}: {resp.text}")
+        data = resp.json()
+        status = data.get("status", "?")
+        if status != last_status:
+            print(f"  status = {status}")
+            last_status = status
+        if status == "complete":
+            return data
+        if status == "error":
+            _die(1, f"scoring job errored: {data.get('error', '(no detail)')}")
+        time.sleep(args.poll_interval)
+    _die(1, f"job did not reach 'complete' within {args.timeout}s (last status: {last_status})")
+    return {}  # unreachable, makes the type checker happy
+
+
+def confirm_approve(scorecard: dict) -> bool:
+    """Print a summary + ask for confirmation. Returns True if the user types 'y'."""
+    avg_numeric = [s.get("score") for s in scorecard.get("sections", [])
+                   if s.get("score_type") == "numeric" and s.get("score") is not None]
+    avg = sum(avg_numeric) / len(avg_numeric) if avg_numeric else None
+
+    print()
+    print("=" * 64)
+    print("READY TO APPROVE — this will dispatch the QA evaluation email.")
+    print(f"  Agent:      {scorecard.get('agent_name')}")
+    print(f"  Call:       {scorecard.get('call_id')}")
+    print(f"  Avg score:  {avg:.2f}/5" if avg is not None else "  Avg score:  N/A")
+    print(f"  Sections:   {len(scorecard.get('sections', []))}")
+    print("=" * 64)
+    answer = input("Send the QA email now? [y/N] ").strip().lower()
+    return answer == "y"
+
+
+def build_approval_payload(scorecard: dict, team_sections: list[dict]) -> dict:
+    """Pass AI sections through unchanged; fill manual sections with placeholders."""
+    ai_by_id = {s["id"]: s for s in scorecard.get("sections", [])}
+    sections: list[dict] = []
+    for ts in team_sections:
+        if ts.get("auto_value"):
+            continue
+        if ts["score_type"] in ("manual", "manual_yn"):
+            is_yn = ts["score_type"] == "manual_yn"
+            sections.append({
+                "id": ts["id"],
+                "name": ts["name"],
+                "score": None if is_yn else 3,
+                "score_type": ts["score_type"],
+                "yn_value": "NA" if is_yn else None,
+                "confidence": "manual",
+                "reasoning": "Auto-filled by score_by_call_id.py smoke.",
+                "audio_dependent": False,
+                "flags": [],
+            })
+        else:
+            s = ai_by_id.get(ts["id"])
+            if not s:
+                continue
+            sections.append(s)
+    return {
+        "sections": sections,
+        "key_strengths": scorecard.get("key_strengths", ""),
+        "opportunities": scorecard.get("opportunities", ""),
+    }
+
+
+def fetch_team_sections(args, client: httpx.Client) -> list[dict]:
+    url = f"{args.base_url}/api/{args.team}/team/sections"
+    resp = client.get(url, headers=_auth(args.api_key))
+    if resp.status_code != 200:
+        _die(1, f"GET {url} returned {resp.status_code}: {resp.text}")
+    return resp.json()
+
+
+def approve(args, client: httpx.Client, job_id: str, payload: dict) -> dict:
+    url = f"{args.base_url}/api/{args.team}/score/{job_id}/approve"
+    print(f"→ POST {url}")
+    resp = client.post(
+        url,
+        headers={**_auth(args.api_key), "Content-Type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+        timeout=120.0,
+    )
+    if resp.status_code != 200:
+        _die(1, f"/approve returned {resp.status_code}: {resp.text}")
+    return resp.json()
+
+
+def main() -> int:
+    args = parse_args()
+
+    with httpx.Client(timeout=60.0) as client:
+        job_id = submit_score(args, client)
+        complete = poll_until_complete(args, client, job_id)
+        sheets_row = complete.get("sheets_row")
+        print(f"  scored. FR-AI row = {sheets_row}")
+
+        if args.score_only:
+            print()
+            print(f"score-only: stopping before /approve. Job {job_id} parked at 'complete'.")
+            return 0
+
+        if not args.yes and not confirm_approve(complete.get("scorecard", {})):
+            print("aborted by user.")
+            return 2
+
+        team_sections = fetch_team_sections(args, client)
+        payload = build_approval_payload(complete.get("scorecard", {}), team_sections)
+        result = approve(args, client, job_id, payload)
+
+        print()
+        print("APPROVED:")
+        for k in ("fr_ai_row", "destination_row", "history_row", "overall_score"):
+            if k in result:
+                print(f"  {k} = {result[k]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/tests/test_auth.py
+++ b/qa-automation/AI-Scoring/tests/test_auth.py
@@ -1,0 +1,169 @@
+"""Auth middleware unit tests — API key tiers, team scoping, scoring access.
+
+``_build_key_map`` reads ``os.environ`` at import time, so tests that want
+a specific key map call it explicitly via ``monkeypatch.setenv`` + a fresh
+invocation rather than relying on the module-level ``_KEY_MAP``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity, check_scoring_access
+
+
+# ---------------------------------------------------------------------------
+# _build_key_map
+# ---------------------------------------------------------------------------
+
+def test_build_key_map_team_suffix_yields_team_identity(monkeypatch):
+    for k in list(__import__("os").environ):
+        if k.startswith("API_KEY_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("API_KEY_MEMBER_SUPPORT", "ms-secret")
+    monkeypatch.setenv("API_KEY_SALES", "sales-secret")
+    mapping = auth._build_key_map()
+    assert mapping["ms-secret"] == KeyIdentity(role="team", team_id="member_support")
+    assert mapping["sales-secret"] == KeyIdentity(role="team", team_id="sales")
+
+
+def test_build_key_map_privileged_suffix_yields_privileged_identity(monkeypatch):
+    for k in list(__import__("os").environ):
+        if k.startswith("API_KEY_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("API_KEY_PRIVILEGED", "priv-secret")
+    mapping = auth._build_key_map()
+    assert mapping["priv-secret"] == KeyIdentity(role="privileged", team_id=None)
+
+
+def test_build_key_map_skips_empty_values(monkeypatch):
+    monkeypatch.setenv("API_KEY_MEMBER_SUPPORT", "")
+    mapping = auth._build_key_map()
+    assert "" not in mapping
+
+
+# ---------------------------------------------------------------------------
+# require_api_key + require_team_access
+# ---------------------------------------------------------------------------
+
+def test_require_api_key_returns_key_identity(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "team-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    identity = asyncio.run(auth.require_api_key(authorization="Bearer team-tok"))
+    assert identity == KeyIdentity(role="team", team_id="member_support")
+
+
+def test_require_api_key_rejects_missing_header():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_api_key(authorization=None))
+    assert exc.value.status_code == 401
+
+
+def test_require_api_key_rejects_missing_bearer_prefix(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_api_key(authorization="tok"))
+    assert exc.value.status_code == 401
+
+
+def test_require_api_key_rejects_unknown_token(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_api_key(authorization="Bearer wrong"))
+    assert exc.value.status_code == 401
+
+
+def test_require_team_access_team_key_matching_team_passes(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "ms-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    identity = asyncio.run(auth.require_team_access(
+        team_id="member_support", authorization="Bearer ms-tok"
+    ))
+    assert identity.role == "team"
+
+
+def test_require_team_access_team_key_cross_team_rejected(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "ms-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_team_access(
+            team_id="sales", authorization="Bearer ms-tok"
+        ))
+    assert exc.value.status_code == 403
+
+
+def test_require_team_access_privileged_bypasses(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "priv-tok": KeyIdentity(role="privileged", team_id=None),
+    })
+    identity = asyncio.run(auth.require_team_access(
+        team_id="sales", authorization="Bearer priv-tok"
+    ))
+    assert identity.role == "privileged"
+
+
+# ---------------------------------------------------------------------------
+# check_scoring_access
+# ---------------------------------------------------------------------------
+
+def _stub_roster(*emails: str):
+    """Return an email_in_team_mails-shaped callable for tests."""
+    rostered = {e.lower() for e in emails}
+    return lambda email, team_id: bool(email) and email.lower() in rostered
+
+
+def test_check_scoring_access_team_key_in_roster_allows():
+    key = KeyIdentity(role="team", team_id="member_support")
+    check_scoring_access(
+        key, "member_support", "luis@landing.com",
+        email_in_team_mails=_stub_roster("luis@landing.com"),
+    )
+
+
+def test_check_scoring_access_team_key_unrostered_rejected():
+    key = KeyIdentity(role="team", team_id="member_support")
+    with pytest.raises(HTTPException) as exc:
+        check_scoring_access(
+            key, "member_support", "unknown@landing.com",
+            email_in_team_mails=_stub_roster(),
+        )
+    assert exc.value.status_code == 403
+
+
+def test_check_scoring_access_team_key_cross_team_rejected():
+    key = KeyIdentity(role="team", team_id="member_support")
+    with pytest.raises(HTTPException) as exc:
+        check_scoring_access(
+            key, "sales", "luis@landing.com",
+            email_in_team_mails=_stub_roster("luis@landing.com"),
+        )
+    assert exc.value.status_code == 403
+
+
+def test_check_scoring_access_privileged_bypasses_roster():
+    key = KeyIdentity(role="privileged", team_id=None)
+    check_scoring_access(
+        key, "sales", "contractor@external.com",
+        email_in_team_mails=_stub_roster(),  # empty roster — bypassed
+    )
+
+
+def test_check_scoring_access_team_key_missing_email_rejected():
+    key = KeyIdentity(role="team", team_id="member_support")
+    with pytest.raises(HTTPException) as exc:
+        check_scoring_access(
+            key, "member_support", None,
+            email_in_team_mails=_stub_roster("luis@landing.com"),
+        )
+    assert exc.value.status_code == 403

--- a/qa-automation/AI-Scoring/tests/test_auth.py
+++ b/qa-automation/AI-Scoring/tests/test_auth.py
@@ -117,17 +117,10 @@ def test_require_team_access_privileged_bypasses(monkeypatch):
 # check_scoring_access
 # ---------------------------------------------------------------------------
 
-def _stub_roster(*emails: str):
-    """Return an email_in_team_mails-shaped callable for tests."""
-    rostered = {e.lower() for e in emails}
-    return lambda email, team_id: bool(email) and email.lower() in rostered
-
-
 def test_check_scoring_access_team_key_in_roster_allows():
     key = KeyIdentity(role="team", team_id="member_support")
     check_scoring_access(
-        key, "member_support", "luis@landing.com",
-        email_in_team_mails=_stub_roster("luis@landing.com"),
+        key, "member_support", "luis@landing.com", is_in_roster=True,
     )
 
 
@@ -135,8 +128,7 @@ def test_check_scoring_access_team_key_unrostered_rejected():
     key = KeyIdentity(role="team", team_id="member_support")
     with pytest.raises(HTTPException) as exc:
         check_scoring_access(
-            key, "member_support", "unknown@landing.com",
-            email_in_team_mails=_stub_roster(),
+            key, "member_support", "unknown@landing.com", is_in_roster=False,
         )
     assert exc.value.status_code == 403
 
@@ -145,8 +137,7 @@ def test_check_scoring_access_team_key_cross_team_rejected():
     key = KeyIdentity(role="team", team_id="member_support")
     with pytest.raises(HTTPException) as exc:
         check_scoring_access(
-            key, "sales", "luis@landing.com",
-            email_in_team_mails=_stub_roster("luis@landing.com"),
+            key, "sales", "luis@landing.com", is_in_roster=True,
         )
     assert exc.value.status_code == 403
 
@@ -154,8 +145,7 @@ def test_check_scoring_access_team_key_cross_team_rejected():
 def test_check_scoring_access_privileged_bypasses_roster():
     key = KeyIdentity(role="privileged", team_id=None)
     check_scoring_access(
-        key, "sales", "contractor@external.com",
-        email_in_team_mails=_stub_roster(),  # empty roster — bypassed
+        key, "sales", "contractor@external.com", is_in_roster=False,
     )
 
 
@@ -163,7 +153,6 @@ def test_check_scoring_access_team_key_missing_email_rejected():
     key = KeyIdentity(role="team", team_id="member_support")
     with pytest.raises(HTTPException) as exc:
         check_scoring_access(
-            key, "member_support", None,
-            email_in_team_mails=_stub_roster("luis@landing.com"),
+            key, "member_support", None, is_in_roster=True,
         )
     assert exc.value.status_code == 403

--- a/qa-automation/AI-Scoring/tests/test_config_load.py
+++ b/qa-automation/AI-Scoring/tests/test_config_load.py
@@ -10,7 +10,7 @@ column letters live in ``score_destination.section_score_columns`` and
 
 from __future__ import annotations
 
-from backend.config.team_config import TeamConfig
+from backend.config.team_config import TeamConfig, get_all_team_ids
 
 
 def test_config_loads_and_exposes_derived_props(config: TeamConfig):
@@ -89,3 +89,12 @@ def test_score_destination_readback_col_outside_section_range(config: TeamConfig
         f"{config.team_id}: score_readback_col '{sd.score_readback_col}' "
         f"collides with a section_score_columns letter"
     )
+
+
+def test_get_all_team_ids_returns_configured_teams():
+    """Discovery helper used by resolve_team_for_agent must list every
+    team whose JSON config exists in backend/config/teams/."""
+    ids = get_all_team_ids()
+    assert "member_support" in ids
+    assert "sales" in ids
+    assert ids == sorted(ids)

--- a/qa-automation/AI-Scoring/tests/test_history_service.py
+++ b/qa-automation/AI-Scoring/tests/test_history_service.py
@@ -17,7 +17,10 @@ import os
 
 import pytest
 
-from backend.services.history_service import _email_in_mails_rows
+from backend.services.history_service import (
+    _agent_name_for_email_in_rows,
+    _email_in_mails_rows,
+)
 from tests.conftest import make_mails_sheet
 
 
@@ -69,6 +72,39 @@ def test_email_in_mails_rows_handles_short_rows():
         ["Star Rep", "star.rep@landing.com"],
     ]
     assert _email_in_mails_rows("star.rep@landing.com", rows) is True
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: _agent_name_for_email_in_rows
+# ---------------------------------------------------------------------------
+
+def test_agent_name_for_email_hit():
+    rows = make_mails_sheet(["Star Rep", "Decline Rep"])
+    assert _agent_name_for_email_in_rows("star.rep@landing.com", rows) == "Star Rep"
+
+
+def test_agent_name_for_email_miss_returns_none():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _agent_name_for_email_in_rows("nobody@landing.com", rows) is None
+
+
+def test_agent_name_for_email_case_insensitive():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _agent_name_for_email_in_rows("STAR.REP@LANDING.COM", rows) == "Star Rep"
+
+
+def test_agent_name_for_email_prefers_canonical_when_present():
+    """Col D (Canonical Name) wins over col A when set."""
+    rows = [
+        ["Agent Name", "Email", "Supervisor", "Canonical Name"],
+        ["luis", "luis@landing.com", "Sup A", "Luis Rubio"],
+    ]
+    assert _agent_name_for_email_in_rows("luis@landing.com", rows) == "Luis Rubio"
+
+
+def test_agent_name_for_email_empty_string_returns_none():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _agent_name_for_email_in_rows("", rows) is None
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_history_service.py
+++ b/qa-automation/AI-Scoring/tests/test_history_service.py
@@ -1,0 +1,105 @@
+"""Mails-roster helpers — pure-function unit tests + 1 gated live-Sheets smoke.
+
+The pure helpers (``_email_in_mails_rows``) work on synthetic
+``list[list[str]]`` rows produced by ``conftest.make_mails_sheet`` — same
+fixture pattern the team_stats tests use.
+
+The async wrappers (``email_in_team_mails``, ``resolve_team_for_agent``)
+hit real gspread. They are exercised by the smoke test at the bottom of
+this module, which is skipped unless ``AI_SCORING_LIVE_SHEETS=1`` is set
+in the environment (so CI without service-account creds stays green).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from backend.services.history_service import _email_in_mails_rows
+from tests.conftest import make_mails_sheet
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: _email_in_mails_rows
+# ---------------------------------------------------------------------------
+
+def test_email_in_mails_rows_hit():
+    rows = make_mails_sheet(["Star Rep", "Decline Rep"])
+    assert _email_in_mails_rows("star.rep@landing.com", rows) is True
+
+
+def test_email_in_mails_rows_miss():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _email_in_mails_rows("nobody@landing.com", rows) is False
+
+
+def test_email_in_mails_rows_case_insensitive():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _email_in_mails_rows("STAR.REP@LANDING.COM", rows) is True
+
+
+def test_email_in_mails_rows_whitespace_tolerant():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _email_in_mails_rows("  star.rep@landing.com  ", rows) is True
+
+
+def test_email_in_mails_rows_empty_string_false():
+    rows = make_mails_sheet(["Star Rep"])
+    assert _email_in_mails_rows("", rows) is False
+
+
+def test_email_in_mails_rows_empty_roster_false():
+    rows = [["Agent Name", "Email", "Supervisor", "Canonical Name"]]
+    assert _email_in_mails_rows("star.rep@landing.com", rows) is False
+
+
+def test_email_in_mails_rows_skips_header():
+    rows = [
+        ["Agent Name", "star.rep@landing.com", "Supervisor", "Canonical Name"],
+    ]
+    assert _email_in_mails_rows("star.rep@landing.com", rows) is False
+
+
+def test_email_in_mails_rows_handles_short_rows():
+    rows = [
+        ["Agent Name", "Email", "Supervisor"],
+        ["No-Email Rep"],  # name-only row, no col B
+        ["Star Rep", "star.rep@landing.com"],
+    ]
+    assert _email_in_mails_rows("star.rep@landing.com", rows) is True
+
+
+# ---------------------------------------------------------------------------
+# Live-Sheets smoke (skipped by default)
+# ---------------------------------------------------------------------------
+
+LIVE = os.environ.get("AI_SCORING_LIVE_SHEETS") == "1"
+
+
+@pytest.mark.skipif(not LIVE, reason="set AI_SCORING_LIVE_SHEETS=1 to hit real Sheets")
+def test_email_in_team_mails_live_smoke():
+    """Round-trip the cached SheetsProvider against the real Mails tab.
+
+    Asserts only structural facts so the test stays stable as the roster
+    changes — fetch succeeds, returns a bool, and a junk email is not a
+    member.
+    """
+    from backend.services.history_service import email_in_team_mails
+
+    result = asyncio.run(email_in_team_mails(
+        "this-is-not-a-real-agent-xyz@landing.com", "member_support"
+    ))
+    assert result is False
+
+
+@pytest.mark.skipif(not LIVE, reason="set AI_SCORING_LIVE_SHEETS=1 to hit real Sheets")
+def test_resolve_team_for_agent_live_smoke():
+    """Junk email resolves to None across all configured teams."""
+    from backend.services.history_service import resolve_team_for_agent
+
+    result = asyncio.run(
+        resolve_team_for_agent("this-is-not-a-real-agent-xyz@landing.com")
+    )
+    assert result is None

--- a/qa-automation/AI-Scoring/tests/test_lookup_route.py
+++ b/qa-automation/AI-Scoring/tests/test_lookup_route.py
@@ -1,0 +1,189 @@
+"""/lookup/scoring-permission route tests — PR 4 (LookupToScore.md)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity
+from backend.routes import lookup as lookup_module
+
+
+TEAM_MS_TOKEN = "team-ms"
+TEAM_SALES_TOKEN = "team-sales"
+PRIV_TOKEN = "priv-tok"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        TEAM_MS_TOKEN: KeyIdentity(role="team", team_id="member_support"),
+        TEAM_SALES_TOKEN: KeyIdentity(role="team", team_id="sales"),
+        PRIV_TOKEN: KeyIdentity(role="privileged", team_id=None),
+    })
+
+    # Stub Mails lookup: luis @ MS, ada @ sales, contractor unrostered.
+    async def fake_resolve(email):
+        if email == "luis@landing.com":
+            return "member_support"
+        if email == "ada@landing.com":
+            return "sales"
+        return None
+
+    monkeypatch.setattr(lookup_module, "resolve_team_for_agent", fake_resolve)
+
+    from fastapi import FastAPI
+    from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
+
+    app = FastAPI()
+    app.include_router(
+        lookup_module.router,
+        prefix="/api/{team_id}",
+        dependencies=TEAM_AUTH_DEPENDENCY,
+    )
+    app.include_router(
+        lookup_module.router,
+        prefix="/api",
+        dependencies=AUTH_DEPENDENCY,
+    )
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Team key
+# ---------------------------------------------------------------------------
+
+def test_team_key_in_roster_can_score(client):
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "luis@landing.com"},
+        headers={"Authorization": f"Bearer {TEAM_MS_TOKEN}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "agent_email": "luis@landing.com",
+        "resolved_team": "member_support",
+        "can_score": True,
+        "needs_team_pick": False,
+    }
+
+
+def test_team_key_cross_team_cannot_score(client):
+    """MS key probing a Sales agent → can_score=False (path is /sales would
+    fail auth; here we probe via /api/member_support path so the resolved
+    team differs from the key's team)."""
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "ada@landing.com"},
+        headers={"Authorization": f"Bearer {TEAM_MS_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resolved_team"] == "sales"
+    assert body["can_score"] is False
+    assert body["needs_team_pick"] is False
+
+
+def test_team_key_unrostered_cannot_score(client):
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "ghost@landing.com"},
+        headers={"Authorization": f"Bearer {TEAM_MS_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resolved_team"] is None
+    assert body["can_score"] is False
+    assert body["needs_team_pick"] is False
+
+
+def test_team_key_path_mismatch_cannot_score(client):
+    """A team key on the WRONG /api/{team_id} path is allowed through
+    TEAM_AUTH_DEPENDENCY ONLY if it matches — so this case is actually
+    a 403 from the middleware, not a can_score=False response."""
+    resp = client.get(
+        "/api/sales/lookup/scoring-permission",
+        params={"email": "luis@landing.com"},
+        headers={"Authorization": f"Bearer {TEAM_MS_TOKEN}"},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Privileged key
+# ---------------------------------------------------------------------------
+
+def test_privileged_rostered_can_score_no_pick(client):
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "luis@landing.com"},
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "agent_email": "luis@landing.com",
+        "resolved_team": "member_support",
+        "can_score": True,
+        "needs_team_pick": False,
+    }
+
+
+def test_privileged_unrostered_needs_team_pick(client):
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "contractor@external.com"},
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "agent_email": "contractor@external.com",
+        "resolved_team": None,
+        "can_score": True,
+        "needs_team_pick": True,
+    }
+
+
+def test_privileged_crosses_teams_freely(client):
+    """Privileged key on the /sales path probing an MS agent — still works."""
+    resp = client.get(
+        "/api/sales/lookup/scoring-permission",
+        params={"email": "luis@landing.com"},
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resolved_team"] == "member_support"
+    assert body["can_score"] is True
+    assert body["needs_team_pick"] is False  # rostered somewhere
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+def test_unauth_returns_401(client):
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        params={"email": "luis@landing.com"},
+    )
+    assert resp.status_code == 401
+
+
+def test_missing_email_returns_422(client):
+    """FastAPI returns 422 for missing required query param."""
+    resp = client.get(
+        "/api/member_support/lookup/scoring-permission",
+        headers={"Authorization": f"Bearer {TEAM_MS_TOKEN}"},
+    )
+    assert resp.status_code == 422

--- a/qa-automation/AI-Scoring/tests/test_score_audit.py
+++ b/qa-automation/AI-Scoring/tests/test_score_audit.py
@@ -1,0 +1,145 @@
+"""Score_Audit helpers — pure row-builder unit tests + 1 gated live append.
+
+The pure tests cover the row shape, the column order, action/role
+validation, and the empty-result-row sentinel. The live test (skipped
+unless ``AI_SCORING_LIVE_SHEETS=1``) appends a sentinel row to the real
+Score_Audit tab and verifies the gspread response parses to a positive
+row number.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from backend.config import score_audit as audit_cfg
+from backend.services.sheets_service import _build_score_audit_row
+
+
+# ---------------------------------------------------------------------------
+# COLUMNS / constants
+# ---------------------------------------------------------------------------
+
+def test_columns_are_ten_in_canonical_order():
+    """Schema lock — design pins A..J and PR 3 will reference the order."""
+    assert audit_cfg.COLUMNS == [
+        "timestamp", "api_key_role", "evaluator_email", "agent_email",
+        "agent_name", "call_id", "target_team", "action", "result_row", "notes",
+    ]
+
+
+def test_actions_set_matches_design():
+    assert audit_cfg.ACTIONS == frozenset({"scored", "denied", "approved"})
+
+
+def test_roles_set_matches_key_identity():
+    """Audit roles must stay in sync with KeyIdentity.role values."""
+    assert audit_cfg.ROLES == frozenset({"team", "privileged"})
+
+
+def test_host_team_is_member_support():
+    """Single-source audit lives on member_support per design line 195-202."""
+    assert audit_cfg.HOST_TEAM_ID == "member_support"
+
+
+# ---------------------------------------------------------------------------
+# _build_score_audit_row
+# ---------------------------------------------------------------------------
+
+def _kwargs(**overrides):
+    base = dict(
+        timestamp="2026-05-18T19:30:00Z",
+        api_key_role="team",
+        evaluator_email="ana@landing.com",
+        agent_email="luis@landing.com",
+        agent_name="Luis Rubio",
+        call_id="abc123",
+        target_team="member_support",
+        action="scored",
+        result_row=42,
+        notes="",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_build_row_writes_columns_in_order():
+    row = _build_score_audit_row(**_kwargs())
+    assert row == [
+        "2026-05-18T19:30:00Z",
+        "team",
+        "ana@landing.com",
+        "luis@landing.com",
+        "Luis Rubio",
+        "abc123",
+        "member_support",
+        "scored",
+        "42",
+        "",
+    ]
+
+
+def test_build_row_result_row_none_writes_blank():
+    """Denials don't have a result row — empty string, not '0' or 'None'."""
+    row = _build_score_audit_row(**_kwargs(result_row=None, action="denied"))
+    assert row[8] == ""
+
+
+def test_build_row_unknown_action_rejected():
+    with pytest.raises(ValueError, match="unknown audit action"):
+        _build_score_audit_row(**_kwargs(action="rejected"))
+
+
+def test_build_row_unknown_role_rejected():
+    with pytest.raises(ValueError, match="unknown api_key_role"):
+        _build_score_audit_row(**_kwargs(api_key_role="admin"))
+
+
+def test_build_row_privileged_role_accepted():
+    row = _build_score_audit_row(**_kwargs(api_key_role="privileged"))
+    assert row[1] == "privileged"
+
+
+def test_build_row_approved_action_accepted():
+    """Stage 4 finalize writes action='approved'."""
+    row = _build_score_audit_row(**_kwargs(action="approved"))
+    assert row[7] == "approved"
+
+
+def test_build_row_notes_passthrough():
+    row = _build_score_audit_row(**_kwargs(notes="no_recording"))
+    assert row[9] == "no_recording"
+
+
+# ---------------------------------------------------------------------------
+# Live-Sheets smoke (skipped by default)
+# ---------------------------------------------------------------------------
+
+LIVE = os.environ.get("AI_SCORING_LIVE_SHEETS") == "1"
+
+
+@pytest.mark.skipif(not LIVE, reason="set AI_SCORING_LIVE_SHEETS=1 to hit real Sheets")
+def test_append_score_audit_row_live_smoke():
+    """End-to-end append against the real Score_Audit tab.
+
+    Writes a sentinel row tagged with a UUID in `notes` so it's easy to
+    find + delete manually. Asserts only that the gspread response
+    parses to a positive row number.
+    """
+    from backend.services.sheets_service import append_score_audit_row
+
+    sentinel = f"smoke-{uuid.uuid4()}"
+    row_num = append_score_audit_row(
+        api_key_role="privileged",
+        evaluator_email="smoke@landing.com",
+        agent_email="smoke@landing.com",
+        agent_name="Smoke Test",
+        call_id="smoke-call-id",
+        target_team="member_support",
+        action="denied",
+        result_row=None,
+        notes=sentinel,
+    )
+    assert row_num > 0, f"append failed, got row_num={row_num}"

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -329,6 +329,65 @@ def test_score_endpoint_privileged_bypasses_roster(client, monkeypatch):
 # 400 validation
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Approve writes the audit row
+# ---------------------------------------------------------------------------
+
+def test_approve_writes_audit_row(client, monkeypatch):
+    """Stage 4 success appends a Score_Audit row with action="approved"."""
+    # Pre-seed a completed job with the metadata the approve handler reads.
+    job_id = "call-approve_Luis_Rubio"
+    key = scoring_module._job_key("member_support", job_id)
+    scoring_module._jobs[key] = {
+        "status": "complete",
+        "call_id": "call-approve",
+        "agent_email": "luis@landing.com",
+        "agent_name": "Luis Rubio",
+        "manager_email": "ana@landing.com",
+        "sheets_row": 99,
+        "scorecard": {
+            "manager_email": "ana@landing.com",
+            "agent_name": "Luis Rubio",
+            "sections": [],
+            "call_summary": "",
+            "key_strengths": "",
+            "opportunities": "",
+        },
+    }
+
+    # Stub the four sheets stages + Apps Script trigger so we don't hit gspread.
+    monkeypatch.setattr(scoring_module, "apply_analyst_edits_to_fr_ai", lambda **kw: None)
+    monkeypatch.setattr(scoring_module, "write_to_score_destination", lambda **kw: 200)
+    async def fake_readback(**kw): return "85"
+    monkeypatch.setattr(scoring_module, "read_score_and_writeback", fake_readback)
+    monkeypatch.setattr(scoring_module, "finalize_to_analyst_history", lambda **kw: 555)
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", lambda row, team_id: {"status": "ok"})
+
+    resp = client.post(
+        f"/api/member_support/score/{job_id}/approve",
+        headers={
+            "Authorization": f"Bearer {TEAM_TOKEN}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "sections": [],
+            "key_strengths": "x",
+            "opportunities": "y",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    approved = [r for r in client.audit_rows if r["action"] == "approved"]
+    assert len(approved) == 1
+    row = approved[0]
+    assert row["api_key_role"] == "team"
+    assert row["evaluator_email"] == "ana@landing.com"
+    assert row["agent_email"] == "luis@landing.com"
+    assert row["agent_name"] == "Luis Rubio"
+    assert row["call_id"] == "call-approve"
+    assert row["target_team"] == "member_support"
+    assert row["result_row"] == 555
+
+
 def test_score_endpoint_rejects_missing_agent_identity(client):
     resp = client.post(
         "/api/member_support/score",

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -1,0 +1,342 @@
+"""/score route tests — extended behavior from PR 3 (LookupToScore.md).
+
+Uses FastAPI's TestClient with monkeypatching of the imports inside
+``backend.routes.scoring`` so no real I/O (Dialpad, Sheets, Gemini)
+runs. The route's branching is what we're after — auth, idempotency,
+audio fallback, audit-row write, 422/503 mapping.
+
+The background task ``run()`` itself is never awaited in these tests;
+they assert the route's *synchronous* observable behavior (response,
+job-store entry, audit row appended).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity
+from backend.routes import scoring as scoring_module
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEAM_TOKEN = "team-ms-tok"
+PRIV_TOKEN = "priv-tok"
+
+
+@pytest.fixture
+def team_key_identity() -> KeyIdentity:
+    return KeyIdentity(role="team", team_id="member_support")
+
+
+@pytest.fixture
+def priv_key_identity() -> KeyIdentity:
+    return KeyIdentity(role="privileged", team_id=None)
+
+
+@pytest.fixture
+def client(monkeypatch, team_key_identity, priv_key_identity):
+    """FastAPI TestClient with auth and side-effects stubbed.
+
+    Each test gets a fresh ``_jobs`` dict and an empty
+    ``append_score_audit_row`` capture list at ``client.audit_rows``.
+    """
+    # Auth: register both tokens. require_team_access / require_api_key
+    # both consult _KEY_MAP via secrets.compare_digest, so dict identity
+    # doesn't matter — just the contents.
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        TEAM_TOKEN: team_key_identity,
+        PRIV_TOKEN: priv_key_identity,
+    })
+
+    # Reset module-level job + semaphore state so tests don't leak.
+    scoring_module._jobs.clear()
+    scoring_module._key_semaphores.clear()
+
+    # Capture audit appends.
+    captured: list[dict] = []
+
+    def fake_append(**kwargs):
+        captured.append(kwargs)
+        return 1
+
+    monkeypatch.setattr(scoring_module, "append_score_audit_row", fake_append)
+
+    # Stub Mails-roster check — declare luis@ in member_support.
+    async def fake_email_in_team_mails(email, team_id):
+        if not email:
+            return False
+        return (
+            email.lower() == "luis@landing.com"
+            and team_id == "member_support"
+        )
+
+    async def fake_agent_name_for_email(email, team_id):
+        if email and email.lower() == "luis@landing.com":
+            return "Luis Rubio"
+        return None
+
+    monkeypatch.setattr(scoring_module, "email_in_team_mails", fake_email_in_team_mails)
+    monkeypatch.setattr(scoring_module, "agent_name_for_email", fake_agent_name_for_email)
+
+    # Stub Dialpad metadata helpers so the success path doesn't hit the API.
+    async def fake_get_transcript(call_id):
+        return {"transcript": "(stub)"}
+
+    async def fake_get_call_details(call_id):
+        return {"call_id": call_id, "_flagged_long_call": False}
+
+    monkeypatch.setattr(scoring_module, "get_transcript", fake_get_transcript)
+    monkeypatch.setattr(scoring_module, "get_call_details", fake_get_call_details)
+
+    # Stub the FastAPI app build so we don't need .env. Build a minimal
+    # app that just mounts the scoring router exactly the way main.py does.
+    from fastapi import FastAPI
+    from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
+
+    app = FastAPI()
+    app.include_router(
+        scoring_module.router,
+        prefix="/api/{team_id}",
+        dependencies=TEAM_AUTH_DEPENDENCY,
+    )
+    app.include_router(
+        scoring_module.router,
+        prefix="/api",
+        dependencies=AUTH_DEPENDENCY,
+    )
+
+    tc = TestClient(app)
+    tc.audit_rows = captured  # attach for assertions
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# Audio-fallback path
+# ---------------------------------------------------------------------------
+
+def test_score_endpoint_without_audio_fetches_recording(client, monkeypatch):
+    """Omitting audio_file triggers download_recording(call_id)."""
+    called = {}
+
+    async def fake_download(call_id):
+        called["call_id"] = call_id
+        return b"FAKERECORDINGBYTES"
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-abc",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "pending"
+    assert called == {"call_id": "call-abc"}
+
+
+def test_score_endpoint_with_audio_skips_download(client, monkeypatch):
+    """Supplying audio_file means download_recording must NOT be called."""
+    called = {"hit": False}
+
+    async def fake_download(call_id):
+        called["hit"] = True
+        return b""
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-abc",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+        files={"audio_file": ("call.mp3", b"REALBYTES", "audio/mpeg")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert called["hit"] is False
+
+
+def test_score_endpoint_no_recording_returns_422(client, monkeypatch):
+    async def fake_download(call_id):
+        from backend.services.dialpad_client import NoRecordingAvailable
+        raise NoRecordingAvailable("none")
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-aged-out",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 422
+    assert "no recording" in resp.json()["detail"].lower()
+    # Denial audit row should mention the reason.
+    assert any(r["notes"] == "no_recording" for r in client.audit_rows)
+
+
+def test_score_endpoint_rate_limited_returns_503(client, monkeypatch):
+    async def fake_download(call_id):
+        from backend.services.dialpad_client import DialpadRateLimited
+        raise DialpadRateLimited("429")
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-throttled",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 503
+    assert any(r["notes"] == "rate_limited" for r in client.audit_rows)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+def test_score_endpoint_idempotent_on_in_flight_job(client):
+    """A POST while a prior job is 'scoring' returns the existing job_id and
+    does NOT write a second audit row.
+
+    Pre-seeds the job store so the test doesn't race the background task
+    (which TestClient awaits before returning the response).
+    """
+    # job_id = f"{call_id}_{agent_name}".replace(" ", "_")
+    # agent_name resolves from email "luis@landing.com" → "Luis Rubio"
+    expected_job_id = "call-double-click_Luis_Rubio"
+    scoring_module._jobs[
+        scoring_module._job_key("member_support", expected_job_id)
+    ] = {"status": "scoring", "call_id": "call-double-click"}
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-double-click",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+        files={"audio_file": ("c.mp3", b"BYTES", "audio/mpeg")},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"job_id": expected_job_id, "status": "scoring"}
+    # No audit row written — neither scored nor denied.
+    assert client.audit_rows == []
+
+
+# ---------------------------------------------------------------------------
+# Audit row write
+# ---------------------------------------------------------------------------
+
+def test_score_endpoint_writes_audit_row_on_success(client, monkeypatch):
+    async def fake_download(call_id):
+        return b"BYTES"
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-xyz",
+            "agent_email": "luis@landing.com",
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(client.audit_rows) == 1
+    row = client.audit_rows[0]
+    assert row["action"] == "scored"
+    assert row["api_key_role"] == "team"
+    assert row["evaluator_email"] == "ana@landing.com"
+    assert row["agent_email"] == "luis@landing.com"
+    assert row["agent_name"] == "Luis Rubio"  # resolved from email
+    assert row["call_id"] == "call-xyz"
+    assert row["target_team"] == "member_support"
+
+
+def test_score_endpoint_writes_denied_audit_on_unrostered_team_key(client, monkeypatch):
+    """Team key trying to score an agent outside their roster → 403 + denied row."""
+    async def fake_download(call_id):
+        return b"BYTES"
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-foo",
+            "agent_email": "stranger@landing.com",  # not in stubbed roster
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 403
+    assert len(client.audit_rows) == 1
+    assert client.audit_rows[0]["action"] == "denied"
+    assert client.audit_rows[0]["api_key_role"] == "team"
+
+
+def test_score_endpoint_privileged_bypasses_roster(client, monkeypatch):
+    """Privileged key on unrostered agent → success, audit shows privileged role."""
+    async def fake_download(call_id):
+        return b"BYTES"
+
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        "/api/sales/score",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+        data={
+            "call_id": "call-priv",
+            "agent_email": "contractor@external.com",
+            "agent_name": "External Contractor",
+            "manager_email": "hr@landing.com",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert client.audit_rows[0]["api_key_role"] == "privileged"
+    assert client.audit_rows[0]["target_team"] == "sales"
+
+
+# ---------------------------------------------------------------------------
+# 400 validation
+# ---------------------------------------------------------------------------
+
+def test_score_endpoint_rejects_missing_agent_identity(client):
+    resp = client.post(
+        "/api/member_support/score",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_id": "call-bare",
+            "manager_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 400
+    assert "agent_email" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Full implementation of the [Lookup-to-Score design](qa-automation/AI-Scoring/references/LookupToScore.md). Replaces the manual "download .mp3 → enter call_id → upload" workflow with one-click "Score this call" from `/lookup`. Adds a privileged-key tier so HR / leadership / dev tooling can score cross-team while team keys stay locked to their roster.

Each commit on this branch corresponds to one of the design's six logical PRs.

### Stack

| Commit | PR | Scope |
|---|---|---|
| `dafaad3` | 1 | Auth tier + Mails helpers |
| `7496a40` | 2 | Score_Audit schema + append helper |
| `4870f3f` | 3 | `/score` extension (audio fallback, idempotency, audit, semaphore) |
| `6a18efe` | 4 | `/lookup/scoring-permission` endpoint |
| `705c27e` | 5 | Frontend Score Call flow + `/scorecard/{team}/{job}` editor page |
| `911f643` | 6 | E2E smoke script + `approved` audit row + CONTRIBUTING |

### What's new for operators

- **New env var:** `API_KEY_PRIVILEGED` (cross-team key for leadership / HR / dev).
- **New pages:**
  - `/lookup/{team}` — already existed, gains a Score Call button per row.
  - `/scorecard/{team}/{job_id}` — new dedicated editor page reached via "Open editor" after a `/lookup` scoring job completes.
- **New auth UX:** API key + manager email now persisted in `localStorage` (was `sessionStorage`) so all three pages share one auth state. First load after deploy will re-prompt once.
- **New audit log:** `Score_Audit` tab on the member_support spreadsheet — one row per `/score` POST (scored / denied) and one per successful `/approve` (approved). Single log regardless of `target_team` per design line 195–202.
- **New CLI smoke:** `scripts/score_by_call_id.py` exercises the full pipeline end-to-end against a running backend.

## Operator steps before merge

1. Make sure `API_KEY_PRIVILEGED` is set in the Railway env (optional — system runs fine without it, just no cross-team scoring).
2. Create the `Score_Audit` tab once per Sheets host (local + Railway):
   ```bash
   cd qa-automation/AI-Scoring
   python3 scripts/init_score_audit_tab.py
   ```
3. After deploy, smoke-test from a browser: `/lookup/member_support` → search a rostered agent → Score Call → Open editor → Approve & Send.

## Test plan

- [x] 118 unit + route tests pass (15 auth, 13 history, 11 score_audit, 10 score_route, 9 lookup_route, 1 score_audit-tab-init + others)
- [x] Full suite green except a pre-existing unrelated `test_config_loads_and_exposes_derived_props[sales]` failure (2/19 Sales sections unclassified — tracked separately)
- [x] End-to-end manual: `/lookup` Score Call → `/scorecard` editor → Approve & Send → QA email dispatched, FR-AI + Analyst_History + Score_Audit rows all written
- [ ] Live-Sheets smoke (manual, gated): `AI_SCORING_LIVE_SHEETS=1 pytest -k live_smoke`
- [ ] `scripts/score_by_call_id.py --score-only` against a real call_id on the deployed Railway

## Deferred (separate PRs)

- `/score/batch` parity for audit/idempotency/semaphore (design line 314)
- Extract shared scorecard JS module to deduplicate `index.html` + `scorecard.html` panel rendering
- Wire `index.html` to redirect its `complete` jobs to `/scorecard/{team}/{job_id}` so the upload flow funnels through the same editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)