### PR TITLE
fix(qa-automation): AI-Scoring — count manual_yn sections in config test

### DIFF
--- a/qa-automation/AI-Scoring/tests/test_config_load.py
+++ b/qa-automation/AI-Scoring/tests/test_config_load.py
@@ -15,22 +15,32 @@ from backend.config.team_config import TeamConfig, get_all_team_ids
 
 def test_config_loads_and_exposes_derived_props(config: TeamConfig):
     """All variants validate cleanly and the derived properties are
-    consistent with the raw section list."""
+    consistent with the raw section list.
+
+    Four score_types exist today: ``numeric`` and ``yn`` (AI-scored),
+    plus ``manual`` and ``manual_yn`` (analyst-entered 1-5 score / Y-N
+    value, respectively). ``auto_value`` is an orthogonal axis — any
+    score_type can have a hardcoded value the writer injects.
+    """
     assert len(config.sections) >= 1
     assert config.team_id
 
     n_numeric = sum(1 for s in config.sections if s.score_type == "numeric")
     n_yn = sum(1 for s in config.sections if s.score_type == "yn")
     n_manual = sum(1 for s in config.sections if s.score_type == "manual")
+    n_manual_yn = sum(1 for s in config.sections if s.score_type == "manual_yn")
     n_auto_value = sum(1 for s in config.sections if s.auto_value is not None)
-    assert n_numeric + n_yn + n_manual == len(config.sections)
+    assert n_numeric + n_yn + n_manual + n_manual_yn == len(config.sections)
 
-    # numeric_sections includes manual; yn_sections includes auto_value.
-    # ai_scored_sections excludes BOTH manual AND auto_value (Gemini sees
-    # neither — manual is analyst-filled, auto_value is writer-hardcoded).
+    # Rollup partitions (see TeamConfig section-partition properties):
+    #   numeric_sections = numeric + manual         (any 1-5 stored value)
+    #   yn_sections      = yn      + manual_yn      (any Y/N stored value)
+    #   manual_sections  = manual  + manual_yn      (any analyst-entered value)
+    # ai_scored_sections excludes both manual variants AND auto_value (Gemini
+    # sees neither — manual is analyst-filled, auto_value is writer-hardcoded).
     assert len(config.numeric_sections) == n_numeric + n_manual
-    assert len(config.yn_sections) == n_yn
-    assert len(config.manual_sections) == n_manual
+    assert len(config.yn_sections) == n_yn + n_manual_yn
+    assert len(config.manual_sections) == n_manual + n_manual_yn
     assert len(config.auto_value_sections) == n_auto_value
     assert len(config.ai_scored_sections) == (n_numeric + n_yn) - n_auto_value
 


### PR DESCRIPTION
## Summary

Fixes the long-standing `test_config_loads_and_exposes_derived_props[sales]` failure (`AssertionError: assert ((4 + 13) + 0) == 19`). The test was missing `manual_yn` from its tally — a real score_type used by Sales's `pb_creation` and `mc_call_notes` sections for analyst Y/N entries.

`manual_yn` is already handled correctly by the production code paths (scoring_service, sheets_service stage 2 metadata writer, approve handler's manual-input gathering). Only the test was out of sync.

## Changes

- Add `n_manual_yn` to the section-type tally.
- Update the sum assertion: `n_numeric + n_yn + n_manual + n_manual_yn == len(sections)`.
- Update rollup assertions:
  - `len(yn_sections) == n_yn + n_manual_yn`
  - `len(manual_sections) == n_manual + n_manual_yn`
- Refresh the docstring + inline comments to spell out the four score_types and the orthogonal `auto_value` axis.

## Test plan

- [x] `pytest tests/test_config_load.py` — 16 passed (was 14 passed + 1 failed)
- [x] Full suite: 118 passed / 0 failed (was 117 / 1)

## Context

Surfaced during the Lookup-to-Score work (PR #28). Tracked as a separate follow-up since it's unrelated to that scope. First of four planned follow-ups now that #28 is live and stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)