### PR TITLE
feat(qa-automation): AI-Scoring — /score/batch audit + idempotency + semaphore parity

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -317,15 +317,31 @@ async def get_score_result(request: Request, job_id: str):
 async def score_batch(
     request: Request,
     background_tasks: BackgroundTasks,
+    identity: KeyIdentity = Depends(require_api_key),
     audio_files: list[UploadFile] = File(...),
     call_ids: str = Form(...),        # comma-separated, matching order of audio_files
     agent_name: str = Form(...),
     manager_email: str = Form(...),
     durations_ms: str = Form(default=""),  # comma-separated, matching order
 ):
-    """
-    Score multiple calls in one submission.
-    audio_files and call_ids must be in the same order.
+    """Score multiple calls in one submission.
+
+    ``audio_files`` and ``call_ids`` must be in the same order. Each row
+    in the batch goes through the same plumbing as a single ``/score``
+    POST: an in-flight (``pending``/``scoring``) job for the same key
+    short-circuits (no duplicate scheduling, no second audit row), a
+    Score_Audit row is appended before the background task is scheduled,
+    and the Gemini ``score_call`` await runs inside the per-``KeyIdentity``
+    concurrent-jobs semaphore.
+
+    Unlike ``/score``, ``audio_files`` is still required — the batch
+    upload form is the path that provides files directly. The Dialpad
+    download fallback is single-call only (``/score``).
+
+    Roster check: ``/score/batch`` does NOT enforce the team-key roster
+    membership rule that ``/score`` does. The form has no ``agent_email``
+    field; tightening this would change the upload UI contract. Audit
+    rows still capture the operator's key role + chosen agent_name.
     """
     team_id = team_id_from_path(request)
     id_list = [cid.strip() for cid in call_ids.split(",")]
@@ -338,27 +354,56 @@ async def score_batch(
         )
 
     config = get_team_config(team_id)
-    job_ids = []
+    semaphore = _semaphore_for_key(identity)
+    job_ids: list[str] = []
     for i, (audio_file, call_id) in enumerate(zip(audio_files, id_list)):
-        audio_bytes = await audio_file.read()
         duration = dur_list[i] if i < len(dur_list) else 0
         job_id = _make_job_id(call_id, agent_name)
         key = _job_key(team_id, job_id)
-        _jobs[key] = {"status": "pending", "call_id": call_id}
         job_ids.append(job_id)
+
+        # Idempotency — a row that already has an in-flight job reuses
+        # that job_id, no new background task, no second audit row.
+        existing = _jobs.get(key)
+        if existing and existing.get("status") in {"pending", "scoring"}:
+            continue
+
+        audio_bytes = await audio_file.read()
+        _jobs[key] = {
+            "status": "pending",
+            "call_id": call_id,
+            # Persisted so /score/{job_id}/approve can write a complete
+            # audit row (batch entries don't carry an agent_email).
+            "agent_email": "",
+            "agent_name": agent_name,
+            "manager_email": manager_email,
+        }
+
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=manager_email,
+            agent_email="",
+            agent_name=agent_name,
+            call_id=call_id,
+            target_team=team_id,
+            action=audit_cfg.ACTION_SCORED,
+            result_row=None,
+            notes="batch_upload",
+        )
 
         async def run(ab=audio_bytes, fn=audio_file.filename, cid=call_id, k=key, dur=duration):
             try:
                 _jobs[k]["status"] = "scoring"
-                scorecard = await score_call(
-                    audio_bytes=ab,
-                    filename=fn,
-                    call_id=cid,
-                    agent_name=agent_name,
-                    manager_email=manager_email,
-                    config=config,
-                    duration_ms=dur,
-                )
+                async with semaphore:
+                    scorecard = await score_call(
+                        audio_bytes=ab,
+                        filename=fn,
+                        call_id=cid,
+                        agent_name=agent_name,
+                        manager_email=manager_email,
+                        config=config,
+                        duration_ms=dur,
+                    )
                 row_num = write_draft_to_fr_ai(scorecard, config)
                 _jobs[k]["status"] = "complete"
                 _jobs[k]["sheets_row"] = row_num

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -399,3 +399,112 @@ def test_score_endpoint_rejects_missing_agent_identity(client):
     )
     assert resp.status_code == 400
     assert "agent_email" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /score/batch — parity with /score for audit / idempotency / semaphore
+# ---------------------------------------------------------------------------
+
+def _batch_files(*pairs):
+    """Build httpx files-tuples for multiple audio uploads.
+
+    httpx's TestClient repeats the ``audio_files`` field when given a
+    list of 2-tuples (field, filetuple), matching FastAPI's expectation.
+    """
+    return [("audio_files", (name, body, "audio/mpeg")) for name, body in pairs]
+
+
+def test_batch_writes_one_audit_row_per_call(client):
+    resp = client.post(
+        "/api/member_support/score/batch",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_ids": "call-a,call-b,call-c",
+            "agent_name": "Luis Rubio",
+            "manager_email": "ana@landing.com",
+        },
+        files=_batch_files(
+            ("a.mp3", b"AAA"),
+            ("b.mp3", b"BBB"),
+            ("c.mp3", b"CCC"),
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 3
+    assert len(body["job_ids"]) == 3
+
+    scored = [r for r in client.audit_rows if r["action"] == "scored"]
+    assert len(scored) == 3
+    assert all(r["api_key_role"] == "team" for r in scored)
+    assert all(r["agent_name"] == "Luis Rubio" for r in scored)
+    assert all(r["target_team"] == "member_support" for r in scored)
+    assert all(r["notes"] == "batch_upload" for r in scored)
+    assert sorted(r["call_id"] for r in scored) == ["call-a", "call-b", "call-c"]
+
+
+def test_batch_idempotent_on_in_flight_row(client):
+    """A row whose job is already pending/scoring is returned unchanged
+    — no duplicate audit row, no second background task scheduled."""
+    expected_job_id = "call-existing_Luis_Rubio"
+    scoring_module._jobs[
+        scoring_module._job_key("member_support", expected_job_id)
+    ] = {"status": "scoring", "call_id": "call-existing"}
+
+    resp = client.post(
+        "/api/member_support/score/batch",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_ids": "call-existing,call-new",
+            "agent_name": "Luis Rubio",
+            "manager_email": "ana@landing.com",
+        },
+        files=_batch_files(
+            ("a.mp3", b"AAA"),
+            ("b.mp3", b"BBB"),
+        ),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Both job_ids returned (idempotent caller still gets a stable handle).
+    assert body["job_ids"] == [expected_job_id, "call-new_Luis_Rubio"]
+    # Only ONE audit row — the new call. The in-flight one is skipped.
+    scored = [r for r in client.audit_rows if r["action"] == "scored"]
+    assert len(scored) == 1
+    assert scored[0]["call_id"] == "call-new"
+
+
+def test_batch_mismatch_returns_400(client):
+    resp = client.post(
+        "/api/member_support/score/batch",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data={
+            "call_ids": "call-a,call-b",
+            "agent_name": "Luis Rubio",
+            "manager_email": "ana@landing.com",
+        },
+        files=_batch_files(("a.mp3", b"AAA")),  # 1 file, 2 ids
+    )
+    assert resp.status_code == 400
+    assert "mismatch" in resp.json()["detail"].lower()
+    # No audit rows for a malformed request.
+    assert client.audit_rows == []
+
+
+def test_batch_privileged_role_recorded_in_audit(client):
+    resp = client.post(
+        "/api/sales/score/batch",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+        data={
+            "call_ids": "call-priv-batch",
+            "agent_name": "External Contractor",
+            "manager_email": "hr@landing.com",
+        },
+        files=_batch_files(("c.mp3", b"BYTES")),
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(client.audit_rows) == 1
+    row = client.audit_rows[0]
+    assert row["api_key_role"] == "privileged"
+    assert row["target_team"] == "sales"
+    assert row["notes"] == "batch_upload"


### PR DESCRIPTION
## Summary

Brings `/score/batch` up to the same plumbing standard as `/score` (added in PR #28 for the Lookup-to-Score work). Closes the deferred follow-up called out in [`references/LookupToScore.md` line 314](../blob/main/qa-automation/AI-Scoring/references/LookupToScore.md) (Open question #4).

## Changes

### `backend/routes/scoring.py` — `/score/batch` handler

- **Auth identity captured** via `Depends(require_api_key)` — used for the audit row's `api_key_role` and as the semaphore-cache key.
- **Per-row idempotency:** if `_jobs[key]` is already `pending`/`scoring`, the row's `job_id` is still returned in the response but **no** duplicate background task is scheduled and **no** second audit row is appended. Matches `/score`'s behavior for double-submits.
- **Audit row per new row:** `append_score_audit_row` called with `notes="batch_upload"` before background-task scheduling, so batch rows are distinguishable from single-`/score` rows in the audit log.
- **Per-`KeyIdentity` semaphore** (cap 5) wraps the `score_call()` await inside each background task. Without this, a large bulk upload from one operator could fan out 50+ in-flight Gemini requests at once.
- **Job-dict shape aligned with `/score`:** persists `agent_email` (empty for batch), `agent_name`, `manager_email` so `/score/{job_id}/approve` can write a complete audit row regardless of which path created the job.

### Intentionally NOT changed

- `audio_files` stays required. Dialpad download fallback is single-call only.
- No `check_scoring_access` roster check. `/score/batch` has no `agent_email` form field, and adding one would change the upload UI contract. Team-key team-scoping is still enforced by `TEAM_AUTH_DEPENDENCY` at the path level.

## Test plan

- [x] 4 new TestClient cases in `tests/test_scoring_route.py`:
  - `test_batch_writes_one_audit_row_per_call` — 3-row batch → 3 audit rows
  - `test_batch_idempotent_on_in_flight_row` — pre-seeded `scoring` job → only new row gets an audit
  - `test_batch_mismatch_returns_400` — files-vs-ids mismatch → 400, no audit rows
  - `test_batch_privileged_role_recorded_in_audit` — privileged key → `api_key_role="privileged"`
- [x] Full suite: 122 passed / 0 failed (was 118)
- [ ] Manual upload smoke: re-test the `/score` page batch upload flow once deployed; verify multiple files still score concurrently capped at 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)