### PR TITLE
fix(qa-automation): AI-Scoring — Dialpad link uses entry_point_call_id

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/dialpad_client.py
+++ b/qa-automation/AI-Scoring/backend/services/dialpad_client.py
@@ -266,9 +266,23 @@ async def get_calls_for_agent(
     return calls
 
 
-def build_dialpad_link(call_id: str) -> str:
-    """Construct the Dialpad web link for a call (used by scoring pipeline)."""
-    return f"https://dialpad.com/callhistory/callreview/{call_id}"
+def build_dialpad_link(call_id: str, entry_point_call_id: str = "") -> str:
+    """Construct the Dialpad web link for a call (used by scoring pipeline).
+
+    Dialpad's recording-page URL is keyed by ``entry_point_call_id`` — the
+    id Dialpad assigns to the call's *entry point* (queue, ring group, etc.)
+    — NOT the per-leg ``call_id`` returned by ``/api/v2/call/{id}``. For
+    inbound calls that go through a queue the two differ; for direct calls
+    they may match. The recording page only exists at the entry-point URL,
+    so analysts clicking through to "the call in Dialpad" need that one.
+
+    ``entry_point_call_id`` is preferred when supplied (callers should pass
+    it from ``get_call_details``'s response); falls back to ``call_id`` so
+    code paths that don't have the entry-point id still produce a working
+    link for direct calls and for callers that haven't been updated.
+    """
+    target = (entry_point_call_id or "").strip() or call_id
+    return f"https://dialpad.com/callhistory/callreview/{target}"
 
 
 async def get_recording_share_link(
@@ -328,6 +342,12 @@ async def get_call_details(call_id: str) -> dict:
         "total_duration": 0,
         "target_name": "",
         "target_type": "",
+        # The master call_id is what the API is keyed by; entry_point_call_id
+        # is the id Dialpad uses in the recording-page URL agents actually see.
+        # For inbound→queue→agent flows they differ; for direct calls they may
+        # match. Always returned so build_dialpad_link can route the user to
+        # the page that exists in their Dialpad UI.
+        "entry_point_call_id": "",
     }
 
     if not os.getenv("DIALPAD_API_KEY"):
@@ -371,6 +391,7 @@ async def get_call_details(call_id: str) -> dict:
         "total_duration": data.get("total_duration", 0),
         "target_name": target.get("name", "") or "",
         "target_type": target.get("type", "") or "",
+        "entry_point_call_id": str(data.get("entry_point_call_id", "") or ""),
     }
 
 

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -93,7 +93,7 @@ async def score_call(
         call_id=call_id,
         agent_name=agent_name,
         manager_email=manager_email,
-        dialpad_link=build_dialpad_link(call_id),
+        dialpad_link=build_dialpad_link(call_id, call_details.get("entry_point_call_id", "")),
         duration_ms=duration_ms,
         flagged_long_call=flagged_long,
         sop_used=sop_data["sop_title"] or None,

--- a/qa-automation/AI-Scoring/tests/test_dialpad_client.py
+++ b/qa-automation/AI-Scoring/tests/test_dialpad_client.py
@@ -1,0 +1,49 @@
+"""Unit tests for dialpad_client pure helpers.
+
+Most of dialpad_client is async + HTTP-bound; this file only covers the
+pure helpers that don't touch the network. Live-API smokes live under
+scripts/.
+"""
+
+from __future__ import annotations
+
+from backend.services.dialpad_client import build_dialpad_link
+
+
+# ---------------------------------------------------------------------------
+# build_dialpad_link — entry_point_call_id precedence
+# ---------------------------------------------------------------------------
+
+def test_build_dialpad_link_prefers_entry_point_id():
+    """Dialpad's recording page is keyed by entry_point_call_id. When the
+    caller supplies it, the link must use it, not the per-leg call_id."""
+    link = build_dialpad_link(
+        call_id="leg-123",
+        entry_point_call_id="entry-999",
+    )
+    assert link == "https://dialpad.com/callhistory/callreview/entry-999"
+
+
+def test_build_dialpad_link_falls_back_to_call_id():
+    """Direct calls (and callers that haven't been updated) pass no
+    entry_point_call_id; the link uses call_id directly."""
+    link = build_dialpad_link("leg-123")
+    assert link == "https://dialpad.com/callhistory/callreview/leg-123"
+
+
+def test_build_dialpad_link_treats_empty_entry_point_as_absent():
+    """An empty/whitespace entry_point_call_id should NOT produce a
+    /callreview/ URL (the trailing path would be empty/whitespace and
+    404 in Dialpad). Fall back to call_id instead."""
+    link = build_dialpad_link("leg-123", entry_point_call_id="")
+    assert link == "https://dialpad.com/callhistory/callreview/leg-123"
+    link = build_dialpad_link("leg-123", entry_point_call_id="   ")
+    assert link == "https://dialpad.com/callhistory/callreview/leg-123"
+
+
+def test_build_dialpad_link_default_entry_point_is_empty():
+    """Default-arg behavior unchanged from pre-refactor for existing
+    callers that pass only call_id."""
+    link = build_dialpad_link("leg-123")
+    assert "leg-123" in link
+    assert "callreview" in link


### PR DESCRIPTION
## Summary

Analysts clicking through to "the call in Dialpad" from a scorecard were hitting 404s or landing on the wrong recording page. Dialpad's recording-page URL is keyed by `entry_point_call_id` (the id assigned to the call's entry point — queue, ring group, etc.) — **not** the per-leg `call_id` that `GET /api/v2/call/{id}` returns. For inbound calls routed through a queue the two differ; for direct calls they may match.

## Changes

### `backend/services/dialpad_client.py`

- `build_dialpad_link(call_id, entry_point_call_id="")` — optional second arg, preferred when supplied; falls back to `call_id` for direct calls and for callers that haven't been updated. Whitespace-only `entry_point_call_id` is treated as absent (a `/callreview/` URL with an empty path 404s).
- `get_call_details` now returns `entry_point_call_id` (both in the empty-defaults dict and from the API response), so callers can pass it straight through to the link builder.

### `backend/services/scoring_service.py`

- `score_call` passes `call_details["entry_point_call_id"]` when building the `ScorecardWithMeta.dialpad_link`.

## Edge case — one-time deploy boundary

Idempotent overwriting in `sheets_service._find_row_by_dialpad_link` matches on the full URL string. In-flight evaluations spanning the deploy boundary will:
- Have a saved row with the OLD master-id URL
- Re-score with the NEW entry-id URL → no match → append duplicate

Acceptable one-time cost. Future re-scores of the same call use entry-id consistently and idempotency holds again.

## Test plan

- [x] `tests/test_dialpad_client.py` (new): 4 pure cases on `build_dialpad_link`.
- [x] Full suite: **134 passed / 0 failed** (was 130).
- [ ] Post-deploy: score a call that went through a Dialpad queue (where master ≠ entry_point). Click the Dialpad link from the resulting Analyst_History / Scorecard. Confirm it lands on the recording page that exists in the agent's Dialpad UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)