### PR TITLE
feat(qa-automation): AI-Scoring — honor na_applicable for numeric sections end-to-end

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/teams/sales.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/sales.json
@@ -331,7 +331,7 @@
       "history_id": "pre_send_intro",
       "name": "Pre-Send Intro",
       "section_number": 19,
-      "score_type": "yn",
+      "score_type": "manual_yn",
       "audio_dependent": false,
       "rubric_question": "Did the agent send their name and 'Landing' before sending links, options, or pricing breakdowns?",
       "na_applicable": true,

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -3,19 +3,81 @@
 from __future__ import annotations
 
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, model_validator
 
 
 class ScorecardSection(BaseModel):
     id: str
     name: str
-    score: Optional[int] = None        # 1-5 for numeric sections, null for Y/N
+    score: Optional[int] = None        # 1-5 for numeric sections; null for yn or explicit N/A
     score_type: str                     # "numeric" or "yn"
-    yn_value: Optional[str] = None     # "Y", "N", "NA" — only for Y/N sections
+    yn_value: Optional[str] = None
+    # "Y" / "N" — yn / manual_yn sections only.
+    # "NA"     — yn / manual_yn AND numeric / manual sections whose team-config
+    #            entry has `na_applicable: true`. Acts as the explicit N/A flag
+    #            for any score_type; `score` must be None when set to "NA".
     confidence: str                     # "high", "medium", "low"
     reasoning: str
     audio_dependent: bool = False
     flags: List[str] = []
+
+    @model_validator(mode="after")
+    def _validate_score_shape(self, info: ValidationInfo) -> "ScorecardSection":
+        """Cross-field consistency + optional team-config check.
+
+        Always-on (no context): catches impossible shapes regardless of source.
+            * yn_value="NA" must coexist with score=None.
+            * yn_value in {"Y","N"} requires score_type yn/manual_yn and score=None.
+            * a numeric score requires score_type numeric/manual and yn_value=None.
+
+        Context-aware (when caller passes context={"section_def": sec_def}):
+            * rejects yn_value="NA" on a section with na_applicable=False —
+              defense-in-depth against a model hallucinating NA on a section
+              that doesn't accept it.
+        """
+        yn = self.yn_value
+        score = self.score
+        st = self.score_type
+
+        if yn == "NA" and score is not None:
+            raise ValueError(
+                f"section {self.id!r}: yn_value='NA' requires score=None, got {score!r}"
+            )
+        if yn in ("Y", "N"):
+            if st not in ("yn", "manual_yn"):
+                raise ValueError(
+                    f"section {self.id!r}: yn_value={yn!r} is only valid on yn/manual_yn "
+                    f"sections, got score_type={st!r}"
+                )
+            if score is not None:
+                raise ValueError(
+                    f"section {self.id!r}: yn_value={yn!r} requires score=None, got {score!r}"
+                )
+        if score is not None:
+            if st not in ("numeric", "manual"):
+                raise ValueError(
+                    f"section {self.id!r}: numeric score={score!r} is only valid on "
+                    f"numeric/manual sections, got score_type={st!r}"
+                )
+            if yn not in (None, ""):
+                raise ValueError(
+                    f"section {self.id!r}: numeric score and yn_value={yn!r} are "
+                    f"mutually exclusive"
+                )
+
+        ctx = info.context or {}
+        sec_def = ctx.get("section_def")
+        if sec_def is None:
+            by_id = ctx.get("sections_by_id")
+            if isinstance(by_id, dict):
+                sec_def = by_id.get(self.id)
+        if sec_def is not None and yn == "NA" and not getattr(sec_def, "na_applicable", False):
+            raise ValueError(
+                f"section {self.id!r}: yn_value='NA' but team config declares "
+                f"na_applicable=false"
+            )
+
+        return self
 
 
 class Scorecard(BaseModel):

--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -59,8 +59,10 @@ def build_scoring_rubric(config: TeamConfig) -> str:
             for key, desc in sec.score_descriptions.items():
                 lines.append(f"{key}: {desc}")
 
-        # NA note for Y/N sections
-        if sec.score_type == "yn" and sec.na_applicable:
+        # NA note — applies to any section flagged na_applicable, including
+        # numeric. For numeric NA, the model emits yn_value="NA" and leaves
+        # score null.
+        if sec.na_applicable and sec.score_type in ("yn", "numeric"):
             lines.append(
                 "Mark NA if not applicable (e.g. internal call or "
                 "no sensitive info discussed)."
@@ -99,9 +101,15 @@ def build_output_schema(config: TeamConfig) -> str:
         is_last = i == len(config.ai_scored_sections) - 1
 
         if sec.score_type == "numeric":
-            score_val = f"<{sec.score_range[0]}-{sec.score_range[1]} integer>"
-            yn_val = "null"
+            assert sec.score_range is not None, f"numeric section {sec.id} missing score_range"
+            lo, hi = sec.score_range
             score_type_str = "numeric"
+            if sec.na_applicable:
+                score_val = f"<{lo}-{hi} integer, or null if NA>"
+                yn_val = "<null or NA>"
+            else:
+                score_val = f"<{lo}-{hi} integer>"
+                yn_val = "null"
         else:
             score_val = "null"
             yn_val = "<Y or N or NA>" if sec.na_applicable else "<Y or N>"

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -464,6 +464,18 @@ async def approve_scorecard(
     job["status"] = "approving"
     config = get_team_config(team_id)
 
+    # Defense-in-depth: re-validate the analyst's payload against team
+    # config so a client can't send yn_value="NA" on a section declared
+    # na_applicable=false. The frontend already gates the dropdown, but
+    # we don't trust it on the server side.
+    sections_by_id = {s.id: s for s in config.sections}
+    try:
+        approval = ApprovalRequest.model_validate(
+            approval.model_dump(), context={"sections_by_id": sections_by_id}
+        )
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Approval payload invalid: {e}")
+
     try:
         sections_dicts = [s.model_dump() for s in approval.sections]
         sc = job["scorecard"]

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -115,7 +115,10 @@ async def score_audio(
         )
 
         raw = _extract_json(response.text)
-        return Scorecard(**raw)
+        sections_by_id = {s.id: s for s in config.sections}
+        return Scorecard.model_validate(
+            raw, context={"sections_by_id": sections_by_id}
+        )
 
     finally:
         # Clean up temp file and Gemini upload

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -108,7 +108,15 @@ def _sheets_configured(team_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def _format_ai_score(sec_def: SectionDef, ai_section: dict) -> str:
-    """Convert AI-output section dict to a score-cell string."""
+    """Convert AI-output section dict to a score-cell string.
+
+    Explicit N/A wins regardless of score_type: when ``yn_value == "NA"``,
+    render "Not Applicable" even for numeric sections (only valid when the
+    team config declares ``na_applicable: true`` — the ScorecardSection
+    validator enforces this when context is supplied).
+    """
+    if ai_section.get("yn_value") == "NA":
+        return YN_DISPLAY["NA"]
     if sec_def.score_type == "yn":
         yn = ai_section.get("yn_value") or "NA"
         return YN_DISPLAY.get(yn, "Not Applicable")
@@ -328,8 +336,13 @@ def apply_analyst_edits_to_fr_ai(
         # Manual sections carry an analyst-entered value rather than the
         # AI's. `manual` stores a 1-5 score; `manual_yn` stores a Y/N/NA
         # in yn_value (rendered via the same display map as AI yn).
-        if sec_def.score_type == "manual":
-            score_value = str(section.get("score", ""))
+        # Explicit N/A (yn_value="NA") wins for both shapes — analyst can
+        # mark a manual numeric section N/A when the team config allows.
+        if section.get("yn_value") == "NA":
+            score_value = YN_DISPLAY["NA"]
+        elif sec_def.score_type == "manual":
+            score = section.get("score")
+            score_value = str(score) if score is not None else ""
         elif sec_def.score_type == "manual_yn":
             yn = section.get("yn_value") or "NA"
             score_value = YN_DISPLAY.get(yn, "Not Applicable")

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -415,17 +415,19 @@ function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
     .filter(ts => !ts.auto_value)
     .map(ts => {
       if (ts.score_type === 'manual' || ts.score_type === 'manual_yn') {
+        const manualNaOpt = ts.na_applicable ? `<option value="NA">N/A</option>` : '';
         const options = ts.score_type === 'manual_yn'
           ? `<option value="" selected>—</option>
              <option value="Y">Y</option>
              <option value="N">N</option>
-             <option value="NA">NA</option>`
+             ${manualNaOpt}`
           : `<option value="" selected>—</option>
              <option value="1">1/5</option>
              <option value="2">2/5</option>
              <option value="3">3/5</option>
              <option value="4">4/5</option>
-             <option value="5">5/5</option>`;
+             <option value="5">5/5</option>
+             ${manualNaOpt}`;
         return `
           <div class="section-row" style="border-left:3px solid var(--warning);">
             <div>
@@ -453,16 +455,24 @@ function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
         ? `<div class="section-flags">${s.flags.join(', ')}</div>` : '';
       const audioTag = s.audio_dependent ? ' <span style="color:var(--muted); font-size:0.68rem;">[audio]</span>' : '';
 
+      // Dropdown shape is driven by team config (ts), not by the AI's
+      // echoed score_type — the AI can drift (e.g. return "numeric" on a
+      // yn section). The selected-value attributes still consult s.* so
+      // the current AI value renders correctly.
       let scoreControl;
-      if (s.score_type === 'yn') {
+      const naOpt = ts.na_applicable
+        ? `<option value="NA" ${s.yn_value==='NA'?'selected':''}>N/A</option>`
+        : '';
+      if (ts.score_type === 'yn') {
         scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="yn_value">
           <option value="Y" ${s.yn_value==='Y'?'selected':''}>Y</option>
           <option value="N" ${s.yn_value==='N'?'selected':''}>N</option>
-          <option value="NA" ${s.yn_value==='NA'?'selected':''}>NA</option>
+          ${naOpt}
         </select>`;
       } else {
         scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="score">
           ${[1,2,3,4,5].map(v => `<option value="${v}" ${s.score===v?'selected':''}>${v}/5</option>`).join('')}
+          ${naOpt}
         </select>`;
       }
 
@@ -586,12 +596,27 @@ async function approveScorecard(jobId) {
     const confEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="confidence"]`);
     const reasonEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="reasoning"]`);
 
+    // Numeric+na_applicable selects expose an "NA" option inside the
+    // score select. Split it: explicit NA -> score=null, yn_value="NA";
+    // otherwise the numeric value parses as int.
+    let score = null;
+    let yn_value = null;
+    if (ynEl) {
+      yn_value = ynEl.value || null;
+    } else if (scoreEl) {
+      if (scoreEl.value === 'NA') {
+        yn_value = 'NA';
+      } else {
+        score = parseInt(scoreEl.value);
+      }
+    }
+
     return {
       id: s.id,
       name: s.name,
-      score: scoreEl ? parseInt(scoreEl.value) : null,
+      score,
       score_type: s.score_type,
-      yn_value: ynEl ? ynEl.value : null,
+      yn_value,
       confidence: confEl ? confEl.value : s.confidence,
       reasoning: reasonEl ? reasonEl.value : s.reasoning,
       audio_dependent: s.audio_dependent,
@@ -607,12 +632,24 @@ async function approveScorecard(jobId) {
       const rawValue = scoreEl && scoreEl.value ? scoreEl.value : '';
       const isYn = ms.score_type === 'manual_yn';
       const reasoning = (reasonEl && reasonEl.value || '').trim();
+
+      // Explicit NA wins for either shape — score=null, yn_value="NA".
+      let score = null;
+      let yn_value = null;
+      if (rawValue === 'NA') {
+        yn_value = 'NA';
+      } else if (isYn && rawValue) {
+        yn_value = rawValue;
+      } else if (!isYn && rawValue) {
+        score = parseInt(rawValue);
+      }
+
       sections.push({
         id: ms.id,
         name: ms.name,
-        score: !isYn && rawValue ? parseInt(rawValue) : null,
+        score,
         score_type: ms.score_type,
-        yn_value: isYn && rawValue ? rawValue : null,
+        yn_value,
         confidence: 'manual',
         reasoning: reasoning || 'Scored manually by manager.',
         audio_dependent: false,

--- a/qa-automation/AI-Scoring/references/NumericNAOption.md
+++ b/qa-automation/AI-Scoring/references/NumericNAOption.md
@@ -1,0 +1,262 @@
+# Numeric-section N/A — design doc
+
+> **Purpose:** Honor `na_applicable` in the scorecard UI for numeric sections,
+> and honor it in the *negative* direction for Y/N sections too. Today the
+> dropdown only respects score_type, not `na_applicable`, so:
+> - **Numeric + `na_applicable: true` → N/A option missing.** (Reported case;
+>   user screenshot on `flex_long_stay_pitch`.)
+> - **Y/N + `na_applicable: false` → N/A option leaks.** Member Support has
+>   several yn sections where N/A should not be selectable but currently is.
+> **Author session:** 2026-05-25.
+> **Status:** Design — not yet implemented.
+
+---
+
+## Decisions locked (2026-05-25)
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Storage of explicit N/A on numeric | Reuse `yn_value="NA"` on `ScorecardSection` | Smallest model change. `score` stays `Optional[int]`; `yn_value="NA"` is the explicit N/A flag for any score_type. |
+| Scope | Fix both directions (numeric+NA missing, yn+NA leak) | One pass, one consistent rule: dropdown options are derived from `score_type` × `na_applicable`. |
+| Source of `score_type` in the UI | Switch from `aiById[*].score_type` to `_teamSections[*].score_type` | Team config is the source of truth. AI response can drift (and currently does — see screenshot anomaly below). |
+| AI prompt | Numeric+`na_applicable: true` emits `score: <1-5 integer or null>, yn_value: <null or NA>` | Lets Gemini explicitly return NA on numeric sections where the question doesn't apply. |
+| Sheet display | Continue reusing `YN_DISPLAY["NA"] = "Not Applicable"` for any N/A, regardless of score_type | One display string, one parse rule downstream. |
+
+---
+
+## Goal + motivation
+
+Today, `teams/sales.json` declares e.g. `flex_long_stay_pitch` with
+`na_applicable: true`, but the scorecard UI offers only `1/5 … 5/5` in the
+dropdown — there's no way for an analyst to mark the section N/A. The AI also
+has no way to do so via the prompt schema for numeric sections, even though
+the team config says N/A is meaningful.
+
+The mirror problem exists on Y/N sections: the UI always renders the N/A
+option for *any* yn section, even when the team config says
+`na_applicable: false`. The result is sections like `member_support.json`'s
+`identity_verified` (yn, `na_applicable: false`) where analysts can pick N/A
+and there's no schema gate stopping them.
+
+**After this work**, the dropdown for every section is derived from team
+config:
+
+| `score_type` | `na_applicable` | Dropdown options |
+|---|---|---|
+| `numeric` | `false` | `1/5, 2/5, 3/5, 4/5, 5/5` |
+| `numeric` | `true`  | `1/5, 2/5, 3/5, 4/5, 5/5, N/A` |
+| `yn`      | `false` | `Y, N` |
+| `yn`      | `true`  | `Y, N, NA` |
+| `manual`  | (same as numeric) | as above |
+| `manual_yn` | (same as yn)    | as above |
+
+---
+
+## Scope
+
+**In scope:**
+- `ScorecardSection`: document that `yn_value: "NA"` is now valid for any
+  `score_type`. No new fields.
+- `qa_scoring_prompt.build_output_schema`: emit N/A as a valid output for
+  numeric sections where `na_applicable: true`.
+- `frontend/scorecard.html`: derive dropdown options from `ts.score_type` ×
+  `ts.na_applicable`. Stop branching on `aiById[*].score_type`.
+- `frontend/scorecard.html` approval payload: when the analyst picks N/A on a
+  numeric section, send `score: null, yn_value: "NA"`.
+- `sheets_service._format_ai_score`: honor `yn_value == "NA"` before
+  formatting numeric. (`stage_1.5` apply_analyst_edits goes through the same
+  helper.)
+- Dashboard read path: `load_and_clean` already coerces "Not Applicable" to
+  `np.nan` for numeric cols (line 158-161) — N/A and "AI didn't score" become
+  indistinguishable in aggregates, which matches today's behavior for
+  unscored cells. Acceptable for v1; flagged as follow-up.
+
+**Out of scope:**
+- Distinguishing "explicit N/A" from "missing data" in stats. Today both
+  coalesce to NaN. If we want to count N/A rate per section, that's a
+  separate analytics feature.
+- Pre-existing yn-NA coercion bug in `load_and_clean:170` — `"Not Applicable"
+  .upper()[:1] == "N"`, so historical N/A on yn columns has been miscoded as
+  N. Out of scope; tracked separately.
+- Backfill of historical numeric rows. Existing sheet cells stay as-is.
+
+---
+
+## Screenshot anomaly (must fix as part of this work)
+
+The reported screenshot is on `flex_long_stay_pitch`, which `sales.json:185`
+declares as `score_type: "yn"` — yet the UI shows a `1/5..5/5` dropdown. The
+cause is `scorecard.html:457`:
+
+```js
+if (s.score_type === 'yn') { ... }  // s = aiById[ts.id]
+```
+
+The frontend branches on the AI's echoed `score_type`, not the team config's.
+If Gemini returns `score_type: "numeric"` for a yn section (or if the AI row
+was written before sales.json was updated), the dropdown silently flips
+shape. Switching the branch source to `ts.score_type` fixes this and removes
+a class of UI-state-drift bugs.
+
+---
+
+## Schema deltas
+
+### `backend/models/scorecard.py`
+
+```python
+class ScorecardSection(BaseModel):
+    id: str
+    name: str
+    score: Optional[int] = None   # 1-5 for numeric (or null for yn / explicit N/A)
+    score_type: str               # "numeric" | "yn" | "manual" | "manual_yn"
+    yn_value: Optional[str] = None
+    # "Y" / "N" — yn sections only
+    # "NA"    — yn sections AND numeric sections with na_applicable: true
+    confidence: str
+    reasoning: str
+    audio_dependent: bool = False
+    flags: List[str] = []
+```
+
+No field added or removed — just a docstring/comment update. Validator
+optional: forbid `yn_value="NA"` when the team config says
+`na_applicable: false` (defense in depth; the UI already won't offer it).
+
+### `qa_scoring_prompt.build_output_schema`
+
+Today (line 101-108):
+```python
+if sec.score_type == "numeric":
+    score_val = "<1-5 integer>"; yn_val = "null"
+else:
+    yn_val = "<Y or N or NA>" if sec.na_applicable else "<Y or N>"
+```
+
+After:
+```python
+if sec.score_type == "numeric":
+    if sec.na_applicable:
+        score_val = "<1-5 integer or null if NA>"
+        yn_val = "<null or NA>"
+    else:
+        score_val = "<1-5 integer>"
+        yn_val = "null"
+else:
+    yn_val = "<Y or N or NA>" if sec.na_applicable else "<Y or N>"
+```
+
+Rubric block (line 63) also extends: numeric+`na_applicable: true` gets the
+"Mark NA if …" note.
+
+### Frontend — `scorecard.html` lines 415-467
+
+Single render rule, driven by team config:
+
+```js
+// inside _teamSections.map(ts => ...)
+const naOpt = ts.na_applicable
+  ? `<option value="NA" ${s.yn_value==='NA'?'selected':''}>N/A</option>`
+  : '';
+
+if (ts.score_type === 'yn') {            // NB: ts, not s
+  scoreControl = `<select ... data-field="yn_value">
+    <option value="Y" ...>Y</option>
+    <option value="N" ...>N</option>
+    ${naOpt}
+  </select>`;
+} else {
+  scoreControl = `<select ... data-field="score">
+    ${[1,2,3,4,5].map(v => `<option value="${v}" ...>${v}/5</option>`).join('')}
+    ${naOpt}
+  </select>`;
+}
+```
+
+The numeric `<select>` keeps `data-field="score"` for 1-5 options, but the
+N/A option's `value="NA"` lives in the same select. The approval-payload
+serializer needs to detect `"NA"` and split it: `score: null, yn_value: "NA"`.
+
+Manual section dropdown (line 417-440) gets the same treatment.
+
+### `sheets_service._format_ai_score`
+
+```python
+def _format_ai_score(sec_def: SectionDef, ai_section: dict) -> str:
+    yn = ai_section.get("yn_value")
+    if yn == "NA":
+        return YN_DISPLAY["NA"]            # "Not Applicable"
+    if sec_def.score_type == "yn":
+        return YN_DISPLAY.get(yn or "NA", "Not Applicable")
+    score = ai_section.get("score")
+    return str(score) if score is not None else "N/A"
+```
+
+N/A check moves to the top so it short-circuits regardless of score_type.
+`apply_analyst_edits_to_fr_ai` already routes through this for AI sections;
+the `manual` branch (line 331) needs the same N/A-first check added.
+
+---
+
+## Implementation phases + pytest checkpoints
+
+1. **Phase 0 — Schema doc**
+   - Update `ScorecardSection` docstring/comment on `yn_value`.
+   - No behavior change. Tests still green: `pytest qa-automation/AI-Scoring/tests -q`.
+
+2. **Phase 1 — Prompt builder**
+   - Extend `build_output_schema` + `build_scoring_rubric` for numeric+na.
+   - Add tests in `tests/test_qa_scoring_prompt.py` (or wherever the prompt
+     tests live — TBC) for two cases:
+       - numeric + `na_applicable: true` → `<null or NA>` appears in schema.
+       - numeric + `na_applicable: false` → `yn_val == "null"` unchanged.
+   - Checkpoint: prompt tests green; no integration tests touched yet.
+
+3. **Phase 2 — sheets_service**
+   - Move N/A check to top of `_format_ai_score`.
+   - Update `apply_analyst_edits_to_fr_ai` manual branch.
+   - Tests: round-trip a `ScorecardSection(score_type="numeric",
+     yn_value="NA")` through the formatter, assert "Not Applicable".
+   - Checkpoint: sheets tests green.
+
+4. **Phase 3 — Frontend**
+   - Switch dropdown branch to `ts.score_type`.
+   - Add `naOpt` to both branches; gate on `ts.na_applicable`.
+   - Approval-payload serializer: when the numeric select's value === "NA",
+     emit `score: null, yn_value: "NA"`.
+   - Manual section dropdown: same treatment.
+   - No automated UI tests today; manual verification (load a scored call on
+     sales, confirm NA appears on `flex_long_stay_pitch` if it ever returns
+     to numeric, confirm member_support yn sections with
+     `na_applicable: false` no longer show NA).
+
+5. **Phase 4 — Full sanity pass**
+   - `pytest qa-automation/AI-Scoring/tests -q`.
+   - Re-score one Sales call end-to-end, watch FR-AI row.
+   - PR.
+
+---
+
+## Open questions — resolved 2026-05-25
+
+1. **Validator for `yn_value="NA"` on a section without `na_applicable`?**
+   **Resolved: yes — add it.** Future model abstractions / non-Gemini providers
+   may hallucinate NA on non-NA sections; cheap defense-in-depth. Implemented
+   as two layers on `ScorecardSection`:
+   - **Always-on cross-field validator** (no team config needed): if
+     `yn_value == "NA"`, `score` must be None; if `score` is set, `yn_value`
+     must be None; etc.
+   - **Context-aware validator** (runs only when caller passes
+     `context={"section_def": sec_def}` to `model_validate`): rejects
+     `yn_value == "NA"` when `sec_def.na_applicable is False`.
+   The scoring pipeline parses AI responses with the context attached; tests
+   and stored-data round-trips parse without context (relaxed).
+2. **Count `yn_value="NA"` as "scored" for the approval gate?**
+   **Resolved: yes.** Explicit N/A is a complete analyst decision.
+   `approveScorecard` and `checkManualScores` should treat `"NA"` (or empty
+   for plain N/A on numeric) the same as a real score. Wire in Phase 3.
+3. **`team_stats.compute_long_form` treatment of explicit numeric N/A.**
+   **Resolved: known tech debt.** Numeric N/A coalesces to `np.nan` today —
+   indistinguishable from "unscored." Document with an `xfail` test in
+   `test_analytics.py` so the gap surfaces when we revisit during the
+   SQL/analytics migration. No code change in this work.

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -9,6 +9,8 @@ against regression.
 
 from __future__ import annotations
 
+import pytest
+
 from backend.config.team_config import TeamConfig
 from backend.services.team_stats import (
     compute_agent_roster,
@@ -114,6 +116,58 @@ def test_binary_stats_empty_when_no_yn_sections(sales_lite: TeamConfig):
     df = load_and_clean(history, mails, sales_lite)
     binary = compute_binary_stats(df, sales_lite.yn_section_labels)
     assert binary == []
+
+
+# ---------------------------------------------------------------------------
+# Known tech debt — long-form analytics cannot distinguish explicit N/A
+# from "unscored" on numeric sections.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason=(
+        "TECH DEBT (NumericNAOption.md, open Q3, 2026-05-25) — "
+        "compute_long_form coalesces explicit numeric N/A ('Not Applicable' "
+        "in the sheet cell) to np.nan in load_and_clean, the same value used "
+        "for missing/unscored. Downstream cannot count an N/A rate per "
+        "section. Revisit during the SQL / deeper-analytics migration: "
+        "either widen the long-form schema with an `na_flag` column or pivot "
+        "to a typed Union score column."
+    ),
+    strict=False,
+)
+def test_compute_long_form_distinguishes_explicit_na_from_missing(sales: TeamConfig):
+    from datetime import datetime
+    import numpy as np
+
+    history = [
+        ["Agent Name"] + [""] * 100,  # header
+        # Row 1: explicit N/A on first numeric section
+        make_history_row(
+            sales, agent="Star Rep", when=datetime(2026, 4, 1, 9, 0, 0),
+            overall=90,
+            section_scores={sales.numeric_history_ids[0]: "Not Applicable"},  # type: ignore[dict-item]
+            yn_scores={y: "Y" for y in sales.yn_history_ids},
+        ),
+        # Row 2: blank/missing on the same section
+        make_history_row(
+            sales, agent="Star Rep", when=datetime(2026, 4, 2, 9, 0, 0),
+            overall=90,
+            section_scores={sales.numeric_history_ids[0]: ""},  # type: ignore[dict-item]
+            yn_scores={y: "Y" for y in sales.yn_history_ids},
+        ),
+    ]
+    mails = make_mails_sheet(["Star Rep"])
+    df = load_and_clean(history, mails, sales)
+    long_df = compute_long_form(df, sales)
+
+    target_rows = long_df[long_df["section_id"] == sales.numeric_history_ids[0]]
+    target_rows = target_rows[target_rows["agent"] == "Star Rep"]
+    # Today both rows collapse to NaN. When the gap is closed, one row should
+    # be marked NA and the other should remain missing.
+    na_rows = target_rows[target_rows["score"].astype(str).str.upper() == "NA"]
+    missing_rows = target_rows[target_rows["score"].isna()]
+    assert len(na_rows) == 1, "explicit N/A row was not distinguishable in long form"
+    assert len(missing_rows) == 1, "missing row was not preserved as NaN"
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_prompt_build.py
+++ b/qa-automation/AI-Scoring/tests/test_prompt_build.py
@@ -56,11 +56,67 @@ def test_output_schema_score_range_uses_section_range(config: TeamConfig):
             assert sec.score_range is not None, (
                 f"numeric section {sec.id} missing score_range"
             )
-            expected = f"<{sec.score_range[0]}-{sec.score_range[1]} integer>"
-            assert expected in out, (
+            lo, hi = sec.score_range
+            # Either the plain integer token or the NA-augmented token must
+            # appear, depending on na_applicable.
+            plain = f"<{lo}-{hi} integer>"
+            na_aug = f"<{lo}-{hi} integer, or null if NA>"
+            assert (plain in out) or (na_aug in out), (
                 f"output schema for '{sec.id}' did not render expected "
-                f"range token '{expected}'"
+                f"range token (plain={plain!r} or na_aug={na_aug!r})"
             )
+
+
+# ---------------------------------------------------------------------------
+# N/A handling — numeric + na_applicable
+# ---------------------------------------------------------------------------
+
+def test_numeric_na_applicable_section_schema_allows_na(sales: TeamConfig):
+    """A numeric+na_applicable section's schema must let the model return NA.
+
+    Sales has no numeric+na_applicable section today (all numeric sections
+    are na_applicable=false). We mutate a copy of the config to exercise the
+    branch and assert the prompt surfaces NA correctly.
+    """
+    numeric_sec = next(
+        s for s in sales.ai_scored_sections if s.score_type == "numeric"
+    )
+    numeric_sec.na_applicable = True
+    try:
+        out = build_output_schema(sales)
+        lo, hi = numeric_sec.score_range  # type: ignore[misc]
+        # Surrounding section id ensures we're inspecting the right block.
+        idx = out.find(f'"id": "{numeric_sec.id}"')
+        assert idx != -1, f"section {numeric_sec.id} missing from output schema"
+        block = out[idx:idx + 600]
+        assert f"<{lo}-{hi} integer, or null if NA>" in block
+        assert '"yn_value": "<null or NA>"' in block
+
+        rubric = build_scoring_rubric(sales)
+        # The NA note should now appear within this section's rubric block.
+        r_idx = rubric.find(numeric_sec.name)
+        assert r_idx != -1
+        r_block = rubric[r_idx:r_idx + 1500]
+        assert "Mark NA if not applicable" in r_block
+    finally:
+        numeric_sec.na_applicable = False
+
+
+def test_numeric_non_na_section_schema_unchanged(sales: TeamConfig):
+    """Regression: a numeric section with na_applicable=false must NOT mention NA."""
+    numeric_sec = next(
+        s for s in sales.ai_scored_sections
+        if s.score_type == "numeric" and not s.na_applicable
+    )
+    out = build_output_schema(sales)
+    idx = out.find(f'"id": "{numeric_sec.id}"')
+    assert idx != -1
+    block = out[idx:idx + 600]
+    assert "or null if NA" not in block, (
+        f"numeric section {numeric_sec.id} with na_applicable=false leaked "
+        f"the NA token into the schema"
+    )
+    assert '"yn_value": null' in block
 
 
 def test_full_prompt_assembles_without_error(config: TeamConfig):

--- a/qa-automation/AI-Scoring/tests/test_scorecard_roundtrip.py
+++ b/qa-automation/AI-Scoring/tests/test_scorecard_roundtrip.py
@@ -20,8 +20,9 @@ import inspect
 import pytest
 
 from backend.config.team_config import TeamConfig
-from backend.models.scorecard import Scorecard
+from backend.models.scorecard import ApprovalRequest, Scorecard, ScorecardSection
 from backend.services import sheets_service
+from pydantic import ValidationError
 
 from tests.conftest import make_gemini_scoring_json
 
@@ -91,3 +92,246 @@ def test_sheets_service_does_not_hardcode_section_slicing():
         "sheets_service re-introduced [:8] section slicing — Stage 2 must "
         "iterate score_destination.section_score_columns"
     )
+
+
+# ---------------------------------------------------------------------------
+# ScorecardSection cross-field validator (always on)
+# ---------------------------------------------------------------------------
+
+def _base_section_kwargs(**overrides):
+    base = dict(
+        id="sec_x",
+        name="Section X",
+        score=None,
+        score_type="numeric",
+        yn_value=None,
+        confidence="high",
+        reasoning="ok",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_section_validator_accepts_numeric_score():
+    ScorecardSection(**_base_section_kwargs(score=4))
+
+
+def test_section_validator_accepts_yn_value_with_yn_type():
+    ScorecardSection(**_base_section_kwargs(score_type="yn", yn_value="Y"))
+
+
+def test_section_validator_accepts_explicit_na_with_numeric_type():
+    # numeric section, analyst/AI marked it N/A
+    ScorecardSection(**_base_section_kwargs(score_type="numeric", yn_value="NA"))
+
+
+def test_section_validator_rejects_na_with_numeric_score():
+    with pytest.raises(ValidationError, match="requires score=None"):
+        ScorecardSection(**_base_section_kwargs(yn_value="NA", score=3))
+
+
+def test_section_validator_rejects_yn_value_on_numeric_section():
+    with pytest.raises(ValidationError, match="only valid on yn"):
+        ScorecardSection(**_base_section_kwargs(score_type="numeric", yn_value="Y"))
+
+
+def test_section_validator_rejects_numeric_score_on_yn_section():
+    with pytest.raises(ValidationError, match="only valid on numeric"):
+        ScorecardSection(**_base_section_kwargs(score_type="yn", score=4))
+
+
+def test_section_validator_rejects_score_and_yn_together():
+    # Y/N section can't have a numeric score; numeric type with yn_value=Y also rejected.
+    with pytest.raises(ValidationError):
+        ScorecardSection(**_base_section_kwargs(score=4, yn_value="Y"))
+
+
+# ---------------------------------------------------------------------------
+# Context-aware validator — team config gates yn_value="NA"
+# ---------------------------------------------------------------------------
+
+def test_section_validator_rejects_na_when_team_config_disallows(sales: TeamConfig):
+    """Defense-in-depth: future model providers may hallucinate NA on a section
+    declared na_applicable=false. The context-aware validator rejects it."""
+    sec_def = next(
+        s for s in sales.ai_scored_sections
+        if s.score_type == "numeric" and not s.na_applicable
+    )
+    data = _base_section_kwargs(id=sec_def.id, score_type="numeric", yn_value="NA")
+    with pytest.raises(ValidationError, match="na_applicable=false"):
+        ScorecardSection.model_validate(data, context={"section_def": sec_def})
+
+
+def test_section_validator_allows_na_when_team_config_permits(sales: TeamConfig):
+    sec_def = next(
+        s for s in sales.ai_scored_sections if s.na_applicable
+    )
+    score_type = sec_def.score_type
+    data = _base_section_kwargs(id=sec_def.id, score_type=score_type, yn_value="NA")
+    # Should not raise.
+    ScorecardSection.model_validate(data, context={"section_def": sec_def})
+
+
+def test_section_validator_no_context_relaxed():
+    """Without context, the team-config check is skipped — round-tripping stored
+    data (where the team config isn't available) must still work."""
+    ScorecardSection.model_validate(
+        _base_section_kwargs(score_type="numeric", yn_value="NA")
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_ai_score — NA wins regardless of score_type (Phase 2)
+# ---------------------------------------------------------------------------
+
+def _section_def(sales: TeamConfig, score_type: str, na_applicable: bool):
+    """Find a section in sales matching score_type + na_applicable."""
+    for s in sales.sections:
+        if s.score_type == score_type and s.na_applicable is na_applicable:
+            return s
+    raise AssertionError(
+        f"no section with score_type={score_type!r} and na_applicable={na_applicable}"
+    )
+
+
+def test_format_ai_score_numeric_with_na_renders_not_applicable(sales: TeamConfig):
+    """Explicit yn_value='NA' on a numeric section must render 'Not Applicable'.
+
+    This is the reported bug: numeric+na_applicable could not be marked N/A.
+    The formatter now short-circuits on yn_value=='NA' before score_type."""
+    sec_def = next(
+        s for s in sales.ai_scored_sections if s.score_type == "numeric"
+    )
+    ai_section = {
+        "id": sec_def.id,
+        "score": None,
+        "score_type": "numeric",
+        "yn_value": "NA",
+        "confidence": "high",
+        "reasoning": "not applicable for this call",
+    }
+    assert sheets_service._format_ai_score(sec_def, ai_section) == "Not Applicable"
+
+
+def test_format_ai_score_numeric_with_score_unchanged(sales: TeamConfig):
+    """Regression: a normal numeric score still renders as '4' (string)."""
+    sec_def = next(
+        s for s in sales.ai_scored_sections if s.score_type == "numeric"
+    )
+    ai_section = {
+        "id": sec_def.id,
+        "score": 4,
+        "score_type": "numeric",
+        "yn_value": None,
+        "confidence": "high",
+        "reasoning": "solid",
+    }
+    assert sheets_service._format_ai_score(sec_def, ai_section) == "4"
+
+
+def test_format_ai_score_unscored_numeric_renders_na_sentinel(sales: TeamConfig):
+    """Regression: when AI didn't score (both None), curt 'N/A' (not 'Not
+    Applicable') — preserves distinction from explicit analyst N/A."""
+    sec_def = next(
+        s for s in sales.ai_scored_sections if s.score_type == "numeric"
+    )
+    ai_section = {
+        "id": sec_def.id,
+        "score": None,
+        "score_type": "numeric",
+        "yn_value": None,
+        "confidence": "low",
+        "reasoning": "could not score",
+    }
+    assert sheets_service._format_ai_score(sec_def, ai_section) == "N/A"
+
+
+def test_format_ai_score_yn_section_unchanged(sales: TeamConfig):
+    """Regression: yn sections still map Y/N/NA through YN_DISPLAY."""
+    sec_def = next(s for s in sales.ai_scored_sections if s.score_type == "yn")
+    for yn, expected in [("Y", "Yes"), ("N", "No"), ("NA", "Not Applicable")]:
+        ai_section = {
+            "id": sec_def.id,
+            "score": None,
+            "score_type": "yn",
+            "yn_value": yn,
+            "confidence": "high",
+            "reasoning": "ok",
+        }
+        assert sheets_service._format_ai_score(sec_def, ai_section) == expected
+
+
+def test_scorecard_validates_with_sections_by_id_context(sales: TeamConfig):
+    """Scorecard-level model_validate must propagate sections_by_id context to
+    each ScorecardSection child, so the team-config check fires at the parse
+    site used by the scoring pipeline."""
+    bad_section_id = next(
+        s.id for s in sales.ai_scored_sections
+        if s.score_type == "numeric" and not s.na_applicable
+    )
+    raw = {
+        "sections": [
+            {
+                "id": bad_section_id,
+                "name": "x",
+                "score": None,
+                "score_type": "numeric",
+                "yn_value": "NA",
+                "confidence": "high",
+                "reasoning": "model hallucinated NA",
+            }
+        ],
+        "key_strengths": "k",
+        "opportunities": "o",
+    }
+    sections_by_id = {s.id: s for s in sales.sections}
+    with pytest.raises(ValidationError, match="na_applicable=false"):
+        Scorecard.model_validate(raw, context={"sections_by_id": sections_by_id})
+
+
+def test_approval_request_with_context_rejects_bad_na(sales: TeamConfig):
+    """ApprovalRequest mirrors Scorecard's section validation; the route
+    re-validates with context to enforce team-config compliance. Today no
+    production team has a yn+na_applicable=false section, but a future team
+    might — flip a yn section's na_applicable to exercise the path."""
+    bad = next(s for s in sales.ai_scored_sections if s.score_type == "yn")
+    bad.na_applicable = False
+    try:
+        raw = {
+            "sections": [
+                {
+                    "id": bad.id,
+                    "name": bad.name,
+                    "score": None,
+                    "score_type": "yn",
+                    "yn_value": "NA",
+                    "confidence": "high",
+                    "reasoning": "tampered payload",
+                }
+            ],
+            "key_strengths": "",
+            "opportunities": "",
+        }
+        sections_by_id = {s.id: s for s in sales.sections}
+        with pytest.raises(ValidationError, match="na_applicable=false"):
+            ApprovalRequest.model_validate(raw, context={"sections_by_id": sections_by_id})
+    finally:
+        bad.na_applicable = True
+
+
+def test_scorecard_section_model_dump_round_trips_through_formatter(sales: TeamConfig):
+    """The full path used by Stage 1: ScorecardSection -> .model_dump() ->
+    _format_ai_score. An explicit numeric N/A must survive the round trip."""
+    sec_def = next(
+        s for s in sales.ai_scored_sections if s.score_type == "numeric"
+    )
+    section = ScorecardSection(
+        id=sec_def.id,
+        name=sec_def.name,
+        score=None,
+        score_type="numeric",
+        yn_value="NA",
+        confidence="high",
+        reasoning="not applicable",
+    )
+    assert sheets_service._format_ai_score(sec_def, section.model_dump()) == "Not Applicable"


### PR DESCRIPTION
## Summary

- **Numeric + `na_applicable: true` sections now expose N/A end-to-end** — AI prompt schema, frontend dropdown, approval payload, validator, and sheet writer. Sales Q9 `landing_guarantee` was the trigger: Gemini was instructed to mark N/A when no tour-related objection was raised but had no schema-valid way to express it and fell back to 1/5, pulling agents' overall scores down for an N/A scenario.
- **Symmetric fix: yn sections also respect `na_applicable`** — N/A option hidden when `na_applicable: false`. No current team has yn+`na_applicable=false`, but a future one could.
- **Frontend dropdown shape now derives from team config**, not the AI-echoed `score_type`. Removes a class of drift bugs (e.g. yn section briefly rendering as numeric if the AI echoes the wrong type).
- **Sales Q19 `pre_send_intro` flipped from `yn` → `manual_yn`** — analyst-scored, exercising the new `manual_yn` + `na_applicable` dropdown path on the same UI.

## Design

[`references/NumericNAOption.md`](../blob/feat/numeric-na-option/qa-automation/AI-Scoring/references/NumericNAOption.md) — design-doc-first, three open questions resolved and recorded inline.

## Layers touched

| Layer | Change |
|---|---|
| `models/scorecard.py` | Cross-field + context-aware `model_validator` on `ScorecardSection`. `yn_value="NA"` valid for any `score_type` when team config permits. |
| `prompts/qa_scoring_prompt.py` | `build_output_schema` + `build_scoring_rubric` emit NA-eligible shapes for numeric+`na_applicable`. |
| `services/sheets_service.py` | `_format_ai_score` short-circuits on `yn_value="NA"` regardless of `score_type`. Manual branch in `apply_analyst_edits_to_fr_ai` mirrors it. |
| `services/audio_service.py` | Gemini parse passes `sections_by_id` context → hallucinated NA on a non-NA section fails parsing. |
| `routes/scoring.py` | `/approve` re-validates with context — server-side defense against tampered payloads. |
| `frontend/scorecard.html` | Dropdown derives from team config; serializer splits `"NA"` → `score: null, yn_value: "NA"`. |
| `config/teams/sales.json` | Q19 `pre_send_intro` → `manual_yn`. |

## Tests

17 new tests; full suite **153 passed, 6 skipped, 3 xfailed** (1 new xfail documents long-form analytics tech debt for the SQL/analytics migration).

## Test plan

- [x] `pytest qa-automation/AI-Scoring/tests -q` — green.
- [x] Local end-to-end: scored Sales call, confirmed N/A option appears on Q9 `landing_guarantee` and Q19 `pre_send_intro` dropdowns.
- [ ] Re-score one call in the Railway-deployed instance after merge; verify FR-AI row writes "Not Applicable" for an analyst-selected NA.

## Follow-up (not in this PR)

Separate PR will pick up the pre-session changes to `qa_scoring_prompt.py` (Spanish audio note + no-SOP-mention rule) and add a general greeting-name-consistency instruction (agents may use any name in the greeting but must remain consistent for the rest of the call; their Dialpad name is internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)