### PR TITLE
feat(qa-automation): AI-Scoring — Landing-wide scoring-prompt rules

### DIFF
--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -16,11 +16,29 @@ if TYPE_CHECKING:
 # Dynamic prompt builders (from TeamConfig)
 # ---------------------------------------------------------------------------
 
+# Rules that apply to every Landing team, appended after each team's
+# system_prompt_template. Kept here (not duplicated per-team JSON) so a
+# single edit propagates to every team's prompt.
+LANDING_GENERAL_INSTRUCTIONS = """
+=== GENERAL LANDING RULES ===
+- Agent name in the greeting: an agent may introduce themselves with any
+  name they choose (some teams have multiple people with the same first
+  name, so reps may differentiate via a preferred or alternate name). Do
+  NOT penalize the agent for the specific name used in the greeting. Do
+  flag if the agent uses one name in the greeting and then switches to a
+  different name later in the same call — consistency within the call is
+  required. The agent's Dialpad-recorded name is internal and is NOT the
+  ground truth for what name they must use with the lead/member.
+""".rstrip()
+
+
 def build_system_prompt(config: TeamConfig) -> str:
-    """Render the system-level instruction from config template."""
-    return config.scoring_prompt.system_prompt_template.format(
+    """Render the system-level instruction from config template, then append
+    the Landing-wide general rules block."""
+    rendered = config.scoring_prompt.system_prompt_template.format(
         company=config.company,
     )
+    return f"{rendered}\n\n{LANDING_GENERAL_INSTRUCTIONS}"
 
 
 def build_scoring_rubric(config: TeamConfig) -> str:
@@ -225,8 +243,11 @@ def build_prompt(
 
     parts.append(build_output_schema(config))
     parts.append(
-        "\n[Audio attached — score the call based on what you hear, "
-        "the transcript, and any SOP provided.]"
+        "\n[Audio attached — score the call based on what you hear; the "
+        "transcript is secondary to the audio source. If the call is in "
+        "SPANISH, ignore the transcript and base your scores solely on the "
+        "audio. DO NOT mention a lack of SOP in your score reasoning if no "
+        "SOP context was provided.]"
     )
 
     return "\n".join(parts)

--- a/qa-automation/AI-Scoring/tests/test_prompt_build.py
+++ b/qa-automation/AI-Scoring/tests/test_prompt_build.py
@@ -28,6 +28,33 @@ def test_system_prompt_renders_company(config: TeamConfig):
     assert config.company in out
 
 
+def test_system_prompt_appends_landing_general_rules(config: TeamConfig):
+    """Every team's system prompt must carry the Landing-wide rule block —
+    name-consistency in particular, since multiple agents may share a first
+    name within a team and use different greeting names by design."""
+    out = build_system_prompt(config)
+    assert "GENERAL LANDING RULES" in out
+    # Spot-check the load-bearing rule rather than the whole block — text
+    # may shift over time but this clause must remain expressible.
+    assert "consistency within the call" in out
+    assert "Dialpad-recorded name is internal" in out
+
+
+def test_full_prompt_audio_note_mentions_spanish_and_sop_handling(config: TeamConfig):
+    p = build_prompt(
+        config,
+        transcript_text="Speaker A: hola",
+        sop_title="",
+        sop_content="",
+    )
+    # Audio is primary; transcript secondary.
+    assert "audio is primary" in p.lower() or "transcript is secondary" in p.lower()
+    # Spanish escape hatch.
+    assert "SPANISH" in p
+    # When no SOP is provided, the model must not mention its absence.
+    assert "DO NOT mention a lack of SOP" in p
+
+
 def test_scoring_rubric_includes_every_section(config: TeamConfig):
     out = build_scoring_rubric(config)
     for sec in config.sections:


### PR DESCRIPTION
## Summary

Three Landing-wide scoring-prompt rules bundled into one PR. None changes per-section rubric content — they sharpen how the model interprets audio, transcripts, missing SOPs, and the agent's greeting.

- **Name-consistency rule** (new): added to `build_system_prompt` via a `LANDING_GENERAL_INSTRUCTIONS` block. Agents may introduce themselves with any name (multiple reps may share a first name within a team), but they must remain consistent within a single call. The Dialpad-recorded name is internal and is NOT the ground truth.
- **Audio is primary, transcript is secondary** (was on working tree pre-NA PR): clarifies the source-of-truth hierarchy.
- **Spanish escape hatch** (pre-NA PR): if the call is in Spanish, ignore the transcript and base scores solely on the audio.
- **No-SOP silence rule** (pre-NA PR): the model must not call out missing SOP context in reasoning when no SOP was loaded.

All rules live in `qa_scoring_prompt.py` (not per-team JSON) so one edit propagates everywhere — no duplication across team configs.

## Tests

- `test_system_prompt_appends_landing_general_rules` — every team's system prompt now carries the rule block, with spot-checks on the name-consistency clauses.
- `test_full_prompt_audio_note_mentions_spanish_and_sop_handling` — verifies the trailing audio note covers all three rules.
- Full suite: **159 passed, 6 skipped, 3 xfailed**.

## Test plan

- [x] `pytest qa-automation/AI-Scoring/tests -q` — green.
- [x] Re-score one Sales and one Member Support call in the Railway instance after merge; spot-check Gemini reasoning for:
  - No "lack of SOP" callouts on calls without SOP context.
  - For a Spanish call: scores derived from audio (transcript may be noisy).
  - Greeting section reasoning doesn't penalize a name that differs from the Dialpad-recorded name.

## Known follow-up — separate PR

The email-template scorecard (GAS / Apps Script side) renders an N/A'd section as **0/5 in red** instead of "N/A":

> Landing Guarantee Explanation — 0/5
> "The lead did not raise any tour-related objections, so the Landing Guarantee explanation was not applicable."

This is downstream of `AI-Scoring/scripts/build_config.py` — the GAS config needs an N/A-aware display fallback so "Not Applicable" cells don't get reinterpreted as 0. Likely fix: re-run `build_config.py` and add a small `Config.js` (or extend the existing one) so the email template handles the new "Not Applicable" sentinel correctly. Separate PR after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)