### PR TITLE
feat(qa-automation): AI-Scoring — last/current-month chiclets on team dashboard

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -85,6 +85,11 @@ async def serve_team_dashboard(team_id: str):
     return FileResponse(_frontend_dir / "team_dashboard.html", headers=_HTML_NO_CACHE)
 
 
+@app.get("/dashboard/{team_id}/evals", include_in_schema=False)
+async def serve_team_evals_page(team_id: str):
+    return FileResponse(_frontend_dir / "team_evals.html", headers=_HTML_NO_CACHE)
+
+
 @app.get("/lookup/{team_id}", include_in_schema=False)
 async def serve_lookup_page(team_id: str):
     return FileResponse(_frontend_dir / "lookup.html", headers=_HTML_NO_CACHE)

--- a/qa-automation/AI-Scoring/backend/models/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/models/team_stats.py
@@ -55,6 +55,25 @@ class MonthlyPoint(BaseModel):
     count: int
 
 
+class MonthlySummary(BaseModel):
+    """One month's headline stats. Drives the last/current-month chiclets.
+
+    mean / std are Optional so the UI can distinguish "no evals this month
+    yet" (null) from "everyone scored 0" (0.0). std stays null when
+    count < 2 since sample std isn't defined.
+    """
+    year_month: str            # "YYYY-MM"
+    count: int
+    mean: Optional[float] = None
+    std: Optional[float] = None
+
+
+class MonthlyBlock(BaseModel):
+    """Last- and current-month summaries for the dashboard chiclets."""
+    last: MonthlySummary
+    current: MonthlySummary
+
+
 class SPCData(BaseModel):
     months: list[MonthlyPoint]
     ucl: float
@@ -122,6 +141,7 @@ class TeamStatsResponse(BaseModel):
     coverage_regime: str  # "manager_sample" | "full_coverage"
 
     kpis: dict
+    monthly: MonthlyBlock
     roster: list[AgentRosterEntry]
     outliers: list[OutlierRecord]
     spc: SPCData
@@ -131,6 +151,25 @@ class TeamStatsResponse(BaseModel):
     ewma: list[EWMAEntry]
     distribution: list[DistributionBin]
     filters_applied: dict  # days, active_only, supervisor
+
+
+class TeamEvalRow(BaseModel):
+    """One row in the month-drill-down evals list."""
+    agent: str
+    timestamp: datetime
+    overall_score: float
+    dialpad_link: str = ""
+    eval_id: str = ""
+    supervisor: Optional[str] = None
+
+
+class TeamEvalsResponse(BaseModel):
+    """Envelope for /api/{team_id}/team/evals?year_month=YYYY-MM."""
+    schema_version: str = "1.1"
+    team_id: str
+    year_month: str
+    rows: list[TeamEvalRow]
+    filters_applied: dict  # active_only, supervisor (no days — month is the window)
 
 
 class LongFormRow(BaseModel):

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -12,6 +12,10 @@ from backend.models.team_stats import (
     LongFormResponse,
     LongFormRow,
     MailsEntry,
+    MonthlyBlock,
+    MonthlySummary,
+    TeamEvalRow,
+    TeamEvalsResponse,
     TeamStatsResponse,
 )
 from backend.services.data_provider import get_provider
@@ -22,6 +26,7 @@ from backend.services.team_stats import (
     compute_ewma,
     compute_long_form,
     compute_monthly_spc,
+    compute_monthly_summary,
     compute_outliers,
     compute_section_analysis,
     compute_supervisor_stats,
@@ -63,6 +68,7 @@ async def team_stats(
             generated_at=datetime.now(timezone.utc),
             coverage_regime=_COVERAGE_REGIME,
             kpis={"total_evals": 0, "avg_score": 0, "std_score": 0, "analyst_count": 0},
+            monthly=compute_monthly_summary(df),
             roster=[],
             outliers=[],
             spc={"months": [], "ucl": 0, "lcl": 0, "center": 0},
@@ -77,11 +83,6 @@ async def team_stats(
             filters_applied=filters,
         )
 
-    # Apply time filter (days=0 means all time)
-    if days > 0:
-        cutoff = datetime.now() - timedelta(days=days)
-        df = df[df["timestamp"] >= cutoff]
-
     # Apply active filter
     if active_only:
         df = df[df["is_active"]]
@@ -89,6 +90,17 @@ async def team_stats(
     # Apply supervisor filter
     if supervisor:
         df = df[df["supervisor"].str.lower() == supervisor.strip().lower()]
+
+    # Monthly chiclets honor active/supervisor but NOT the days filter —
+    # they express their own (last/current calendar month) windows.
+    # Compute before applying days so the current-month chiclet still
+    # populates when the user is viewing days=30 on the last day of a
+    # month and the cutoff drops half the month.
+    monthly = compute_monthly_summary(df)
+
+    if days > 0:
+        cutoff = datetime.now() - timedelta(days=days)
+        df = df[df["timestamp"] >= cutoff]
 
     kpis = {
         "total_evals": len(df),
@@ -103,6 +115,7 @@ async def team_stats(
         generated_at=datetime.now(timezone.utc),
         coverage_regime=_COVERAGE_REGIME,
         kpis=kpis,
+        monthly=monthly,
         roster=compute_agent_roster(df, config),
         outliers=compute_outliers(df, config.stats),
         spc=compute_monthly_spc(df, config.stats),
@@ -111,6 +124,74 @@ async def team_stats(
         supervisor_stats=compute_supervisor_stats(df),
         ewma=compute_ewma(df, config.stats),
         distribution=compute_distribution(df),
+        filters_applied=filters,
+    )
+
+
+@router.get("/evals", response_model=TeamEvalsResponse)
+async def team_month_evals(
+    request: Request,
+    year_month: str = Query(..., pattern=r"^\d{4}-(0[1-9]|1[0-2])$"),
+    active_only: bool = Query(default=True),
+    supervisor: str = Query(default=""),
+):
+    """Return every eval in `year_month` (YYYY-MM), respecting active/supervisor.
+
+    Powers the month-chiclet drill-down. The `days` filter is intentionally
+    not accepted here: the month string IS the time window.
+    """
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    provider = await get_provider(team_id)
+
+    raw_history = provider._ws.get_all_values()
+    raw_mails = provider._get_mails_sheet()
+
+    df = load_and_clean(raw_history, raw_mails, config)
+    filters = {"active_only": active_only, "supervisor": supervisor}
+
+    if df.empty:
+        return TeamEvalsResponse(
+            team_id=team_id,
+            year_month=year_month,
+            rows=[],
+            filters_applied=filters,
+        )
+
+    if active_only:
+        df = df[df["is_active"]]
+    if supervisor:
+        df = df[df["supervisor"].str.lower() == supervisor.strip().lower()]
+
+    months = df["timestamp"].dt.to_period("M").astype(str)
+    df = df[months == year_month]
+
+    # Sort newest first — analysts skim the top to find recent calls.
+    df = df.sort_values("timestamp", ascending=False)
+
+    rows = [
+        TeamEvalRow(
+            agent=str(r["agent"]),
+            timestamp=r["timestamp"],
+            overall_score=float(r["overall_score"]),
+            # Wide-form df doesn't carry dialpad_link directly — reconstruct
+            # the canonical URL from eval_id (the [LONG CALL] suffix isn't
+            # preserved through load_and_clean, which is fine for the
+            # drill-down list).
+            dialpad_link=(
+                f"https://dialpad.com/callhistory/callreview/{r['eval_id']}"
+                if r.get("eval_id") else ""
+            ),
+            eval_id=str(r.get("eval_id", "")),
+            supervisor=str(r.get("supervisor", "")) or None,
+        )
+        for r in df.to_dict(orient="records")
+    ]
+
+    return TeamEvalsResponse(
+        team_id=team_id,
+        year_month=year_month,
+        rows=rows,
         filters_applied=filters,
     )
 

--- a/qa-automation/AI-Scoring/backend/services/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/services/team_stats.py
@@ -357,6 +357,65 @@ def compute_ewma(df: pd.DataFrame, stats_config: StatsConfig) -> list[dict]:
 # compute_monthly_spc
 # ---------------------------------------------------------------------------
 
+def compute_monthly_summary(df: pd.DataFrame) -> dict:
+    """Per-month headline stats for the last and current calendar month.
+
+    Returns a dict shaped like `MonthlyBlock`:
+        {
+          "last":    {"year_month": "YYYY-MM", "count": int,
+                      "mean": float|None, "std": float|None},
+          "current": {"year_month": "YYYY-MM", "count": int,
+                      "mean": float|None, "std": float|None},
+        }
+
+    "Current" is the calendar month containing `datetime.now()`. "Last" is
+    the immediately preceding calendar month. Both year_month strings are
+    always populated even if count == 0 so the UI can label the empty
+    chiclet ("0 evals in 2026-04").
+
+    mean/std are None — not 0 — when undefined (no evals, or count < 2 for
+    std). The frontend renders "—" for these so an empty month isn't
+    confused with a month where everyone scored 0.
+
+    Assumes `df` is already filter-applied (active_only / supervisor); the
+    chiclets inherit the page filters by construction. The `days` filter
+    is bypassed here on purpose: chiclets express their own month windows.
+    """
+    from datetime import datetime as _dt
+
+    now = _dt.now()
+    current_p = pd.Period(now, freq="M")
+    last_p = current_p - 1
+    current_ym = str(current_p)
+    last_ym = str(last_p)
+
+    def _empty(ym: str) -> dict:
+        return {"year_month": ym, "count": 0, "mean": None, "std": None}
+
+    if df.empty:
+        return {"last": _empty(last_ym), "current": _empty(current_ym)}
+
+    # Compute month buckets directly from timestamps — independent of the
+    # /stats `days` window so the chiclets stay anchored on calendar
+    # months regardless of which time range the dashboard is showing.
+    months = df["timestamp"].dt.to_period("M").astype(str)
+
+    def _bucket(ym: str) -> dict:
+        mask = months == ym
+        n = int(mask.sum())
+        if n == 0:
+            return _empty(ym)
+        scores = df.loc[mask, "overall_score"]
+        return {
+            "year_month": ym,
+            "count": n,
+            "mean": round(float(scores.mean()), 1),
+            "std": round(float(scores.std(ddof=1)), 1) if n > 1 else None,
+        }
+
+    return {"last": _bucket(last_ym), "current": _bucket(current_ym)}
+
+
 def compute_monthly_spc(df: pd.DataFrame, stats_config: StatsConfig) -> dict:
     """Monthly team average with Shewhart-style ±k·sigma control limits."""
     if df.empty:

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -69,6 +69,32 @@
     .kpi-box .value { font-family: 'Fraunces', serif; font-size: 2rem; font-weight: 700; margin: 4px 0; }
     .kpi-box .sub { font-size: 0.75rem; color: var(--muted); }
 
+    /* Month chiclet row — two side-by-side clickable cards above the KPI row */
+    .chiclet-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .chiclet {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+      padding: 16px 20px; cursor: pointer; text-decoration: none; color: inherit;
+      display: flex; align-items: center; justify-content: space-between; gap: 16px;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .chiclet:hover { border-color: var(--accent); transform: translateY(-1px); }
+    .chiclet .chiclet-left { display: flex; flex-direction: column; gap: 2px; }
+    .chiclet .chiclet-label {
+      font-size: 0.7rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .chiclet .chiclet-count {
+      font-family: 'Fraunces', serif; font-size: 1.6rem; font-weight: 700; line-height: 1.1;
+    }
+    .chiclet .chiclet-month { font-size: 0.7rem; color: var(--muted); }
+    .chiclet .chiclet-right { text-align: right; font-size: 0.8rem; color: var(--muted); }
+    .chiclet .chiclet-meanstd {
+      font-family: 'Fraunces', serif; font-size: 0.95rem; color: var(--text); font-weight: 600;
+    }
+    .chiclet .chiclet-arrow { color: var(--accent); font-size: 1.1rem; }
+    @media (max-width: 640px) {
+      .chiclet-row { grid-template-columns: 1fr; }
+    }
+
     /* Charts grid */
     .charts-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
 
@@ -148,6 +174,7 @@
 <div class="container">
   <!-- Overview Tab -->
   <div class="tab-panel active" id="panel-overview">
+    <div class="chiclet-row" id="chicletRow"></div>
     <div class="kpi-row" id="kpiRow"></div>
     <div class="charts-grid">
       <div class="card"><h3>SPC Control Chart</h3><canvas id="spcCanvas"></canvas></div>
@@ -374,6 +401,8 @@ function attachSort(tableId, data, renderFn) {
 
 // --- Overview ---
 function renderOverview() {
+  renderChiclets();
+
   const k = teamData.kpis || {};
   document.getElementById('kpiRow').innerHTML = [
     { label: 'Total Evals', value: k.total_evals ?? '--' },
@@ -388,6 +417,43 @@ function renderOverview() {
   renderSpcChart();
   renderDistChart();
   renderEwmaChart();
+}
+
+function renderChiclets() {
+  const monthly = teamData.monthly || {};
+  const target = document.getElementById('chicletRow');
+  if (!target) return;
+
+  function _chiclet(label, m) {
+    if (!m) return '';
+    // Drill-down preserves the page's active/supervisor filters; the month
+    // string is the time window so the days filter is not propagated.
+    const params = new URLSearchParams({
+      month: m.year_month,
+      active_only: activeOnly,
+    });
+    if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+    const href = `/dashboard/${TEAM_ID}/evals?${params.toString()}`;
+
+    const meanLabel = m.mean != null ? fmt(m.mean) : '—';
+    const stdLabel = m.std != null ? `± ${fmt(m.std)}` : '';
+    const meanColor = m.mean != null ? scoreColor(m.mean) : 'var(--muted)';
+
+    return `<a class="chiclet" href="${href}">
+      <div class="chiclet-left">
+        <div class="chiclet-label">${label}</div>
+        <div class="chiclet-count">${m.count} eval${m.count === 1 ? '' : 's'}</div>
+        <div class="chiclet-month">${m.year_month}</div>
+      </div>
+      <div class="chiclet-right">
+        <div class="chiclet-meanstd" style="color:${meanColor}">${meanLabel} ${stdLabel}</div>
+        <div style="font-size:0.65rem;text-transform:uppercase;letter-spacing:0.05em;">mean ± std</div>
+        <div class="chiclet-arrow">&rsaquo;</div>
+      </div>
+    </a>`;
+  }
+
+  target.innerHTML = _chiclet('Last Month', monthly.last) + _chiclet('Current Month', monthly.current);
 }
 
 function renderSpcChart() {

--- a/qa-automation/AI-Scoring/frontend/team_evals.html
+++ b/qa-automation/AI-Scoring/frontend/team_evals.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Month Evaluations — Team Analytics</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --navy: #15192D; --accent: #1A61D9; --bg: #E7EFFB; --surface: #ffffff;
+      --border: #c9d5e8; --text: #15192D; --muted: #5a6478;
+      --green: #28A745; --amber: #E8A317; --red: #D9534F;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    .header {
+      background: var(--navy); color: #fff; padding: 16px 24px;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    .header-left { display: flex; align-items: center; gap: 16px; }
+    .header h1 { font-size: 1.2rem; font-weight: 600; }
+    .header a.back {
+      font-family: 'DM Mono', monospace; font-size: 0.82rem; padding: 6px 14px;
+      border: 1px solid rgba(255,255,255,0.3); border-radius: 6px; color: #fff;
+      text-decoration: none; transition: background 0.2s;
+    }
+    .header a.back:hover { background: rgba(255,255,255,0.1); }
+    .meta { font-size: 0.8rem; color: rgba(255,255,255,0.7); }
+
+    .container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+    .summary { display: flex; gap: 24px; align-items: baseline; margin-bottom: 16px; flex-wrap: wrap; }
+    .summary .count {
+      font-family: 'Fraunces', serif; font-size: 1.8rem; font-weight: 700;
+    }
+    .summary .meanstd { font-size: 0.9rem; color: var(--muted); }
+    .summary .filters { margin-left: auto; font-size: 0.75rem; color: var(--muted); }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    th, td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    th {
+      font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+      cursor: pointer; user-select: none; position: sticky; top: 0; background: var(--surface);
+    }
+    th:hover { color: var(--text); }
+    tr:hover { background: var(--bg); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .score { font-weight: 700; }
+    .loading, .empty { text-align: center; padding: 60px; color: var(--muted); font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-left">
+    <a class="back" id="backLink" href="#">&larr; Dashboard</a>
+    <h1 id="pageTitle">Month Evaluations</h1>
+  </div>
+  <div class="meta" id="metaLine"></div>
+</div>
+
+<div class="container">
+  <div class="card">
+    <div class="summary" id="summary"></div>
+    <div style="overflow-x:auto">
+      <table id="evalsTable">
+        <thead>
+          <tr>
+            <th data-col="timestamp">Date</th>
+            <th data-col="agent">Agent</th>
+            <th data-col="supervisor">Supervisor</th>
+            <th data-col="overall_score">Score</th>
+            <th>Dialpad</th>
+          </tr>
+        </thead>
+        <tbody id="evalsBody"></tbody>
+      </table>
+    </div>
+    <div id="emptyState" class="empty" style="display:none;">No evaluations for this month under the current filters.</div>
+    <div id="loadingState" class="loading">Loading…</div>
+  </div>
+</div>
+
+<script>
+// --- Auth (mirrors team_dashboard.html) ---
+function getApiKey() {
+  let key = sessionStorage.getItem('qa_api_key');
+  if (!key) {
+    key = prompt('Enter your QA API key:');
+    if (key) sessionStorage.setItem('qa_api_key', key);
+  }
+  return key;
+}
+function authHeaders() {
+  const key = getApiKey();
+  return key ? { 'Authorization': 'Bearer ' + key } : {};
+}
+
+const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+
+const url = new URL(location.href);
+const month = url.searchParams.get('month') || '';
+const activeOnly = url.searchParams.get('active_only') !== 'false';
+const supervisor = url.searchParams.get('supervisor') || '';
+
+document.getElementById('backLink').href = `/dashboard/${TEAM_ID}`;
+document.getElementById('pageTitle').textContent = `Evaluations — ${month || '—'}`;
+
+const metaBits = [];
+metaBits.push(activeOnly ? 'Active analysts' : 'All analysts');
+if (supervisor) metaBits.push(`Supervisor: ${supervisor}`);
+document.getElementById('metaLine').textContent = metaBits.join(' · ');
+
+let _rows = [];
+let _sortKey = 'timestamp';
+let _sortAsc = false;
+
+function fmt(v, d = 1) { return v != null ? Number(v).toFixed(d) : '—'; }
+function scoreColor(v) { return v >= 85 ? '#28A745' : v >= 70 ? '#E8A317' : '#D9534F'; }
+function escapeHtml(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+function fmtDate(iso) {
+  const d = new Date(iso);
+  if (isNaN(d)) return iso || '—';
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function renderTable() {
+  const tbody = document.getElementById('evalsBody');
+  if (!_rows.length) {
+    tbody.innerHTML = '';
+    document.getElementById('emptyState').style.display = 'block';
+    return;
+  }
+  document.getElementById('emptyState').style.display = 'none';
+
+  const sorted = [..._rows].sort((a, b) => {
+    let va = a[_sortKey], vb = b[_sortKey];
+    if (va == null) return 1; if (vb == null) return -1;
+    if (typeof va === 'string') return _sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+    if (_sortKey === 'timestamp') { va = new Date(va).getTime(); vb = new Date(vb).getTime(); }
+    return _sortAsc ? va - vb : vb - va;
+  });
+
+  tbody.innerHTML = sorted.map(r => {
+    // Score links to this call's /datapoint page — closes the loop so a
+    // viewer can drill from "month list → individual eval breakdown"
+    // without leaving the app. eval_id is the call_id parsed out of the
+    // Dialpad link upstream (services/team_stats.py:_parse_row).
+    const scoreCell = r.eval_id
+      ? `<a href="/datapoint/${TEAM_ID}/${encodeURIComponent(r.eval_id)}"
+            class="score" style="color:${scoreColor(r.overall_score)};">${fmt(r.overall_score)}</a>`
+      : `<span class="score" style="color:${scoreColor(r.overall_score)};">${fmt(r.overall_score)}</span>`;
+    return `
+    <tr>
+      <td>${fmtDate(r.timestamp)}</td>
+      <td>${escapeHtml(r.agent)}</td>
+      <td>${escapeHtml(r.supervisor || '')}</td>
+      <td>${scoreCell}</td>
+      <td>${r.dialpad_link ? `<a href="${escapeHtml(r.dialpad_link)}" target="_blank" rel="noopener">Open &rsaquo;</a>` : ''}</td>
+    </tr>
+  `;}).join('');
+}
+
+document.querySelectorAll('th[data-col]').forEach(th => {
+  th.onclick = () => {
+    const col = th.dataset.col;
+    if (_sortKey === col) _sortAsc = !_sortAsc;
+    else { _sortKey = col; _sortAsc = false; }
+    renderTable();
+  };
+});
+
+async function fetchEvals() {
+  if (!month) {
+    document.getElementById('loadingState').textContent = 'No month specified.';
+    return;
+  }
+  try {
+    const params = new URLSearchParams({ year_month: month, active_only: activeOnly });
+    if (supervisor) params.set('supervisor', supervisor);
+    const r = await fetch(`${API_BASE}/team/evals?${params}`, { headers: authHeaders() });
+    if (r.status === 401) {
+      sessionStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      return;
+    }
+    if (!r.ok) throw new Error(r.statusText);
+    const data = await r.json();
+    _rows = data.rows || [];
+
+    // Summary line
+    const meanList = _rows.map(r => r.overall_score).filter(v => v != null);
+    const n = _rows.length;
+    const mean = n ? meanList.reduce((a, b) => a + b, 0) / n : null;
+    const variance = n > 1 ? meanList.reduce((a, b) => a + (b - mean) ** 2, 0) / (n - 1) : null;
+    const std = variance != null ? Math.sqrt(variance) : null;
+    document.getElementById('summary').innerHTML = `
+      <div class="count">${n} eval${n === 1 ? '' : 's'}</div>
+      <div class="meanstd">${mean != null ? `mean ${fmt(mean)} ± ${fmt(std)}` : ''}</div>
+      <div class="filters">${month}</div>
+    `;
+
+    document.getElementById('loadingState').style.display = 'none';
+    renderTable();
+  } catch (e) {
+    console.error('Failed to fetch evals:', e);
+    document.getElementById('loadingState').textContent = 'Failed to load evaluations.';
+  }
+}
+
+fetchEvals();
+</script>
+</body>
+</html>

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -19,6 +19,7 @@ from backend.services.team_stats import (
     compute_ewma,
     compute_long_form,
     compute_monthly_spc,
+    compute_monthly_summary,
     compute_outliers,
     compute_section_analysis,
     compute_supervisor_stats,
@@ -116,6 +117,123 @@ def test_binary_stats_empty_when_no_yn_sections(sales_lite: TeamConfig):
     df = load_and_clean(history, mails, sales_lite)
     binary = compute_binary_stats(df, sales_lite.yn_section_labels)
     assert binary == []
+
+
+# ---------------------------------------------------------------------------
+# compute_monthly_summary — month chiclets (Phase A)
+# ---------------------------------------------------------------------------
+
+def _summary_df(rows: list[dict]) -> "pd.DataFrame":
+    """Build a minimal df matching the load_and_clean schema for the chiclet
+    computation. compute_monthly_summary only reads timestamp + overall_score,
+    so the other columns can be omitted."""
+    import pandas as pd
+    if not rows:
+        return pd.DataFrame()
+    df = pd.DataFrame(rows)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    return df
+
+
+def test_monthly_summary_empty_df_returns_zero_count_blocks():
+    out = compute_monthly_summary(_summary_df([]))
+    assert out["last"]["count"] == 0
+    assert out["last"]["mean"] is None
+    assert out["last"]["std"] is None
+    assert out["current"]["count"] == 0
+    assert out["current"]["mean"] is None
+    assert out["current"]["std"] is None
+    # year_month strings always populated so the empty chiclet still has a label
+    assert out["last"]["year_month"]
+    assert out["current"]["year_month"]
+
+
+def test_monthly_summary_buckets_current_and_last_correctly():
+    from datetime import datetime as _dt
+    import pandas as pd
+    now = _dt.now()
+    current_p = pd.Period(now, freq="M")
+    last_p = current_p - 1
+    current_ym = str(current_p)
+    last_ym = str(last_p)
+
+    df = _summary_df([
+        # 3 evals in current month
+        {"timestamp": f"{current_ym}-05 10:00:00", "overall_score": 80.0},
+        {"timestamp": f"{current_ym}-12 10:00:00", "overall_score": 90.0},
+        {"timestamp": f"{current_ym}-20 10:00:00", "overall_score": 70.0},
+        # 2 evals in last month
+        {"timestamp": f"{last_ym}-08 10:00:00", "overall_score": 85.0},
+        {"timestamp": f"{last_ym}-15 10:00:00", "overall_score": 75.0},
+        # 1 eval two months back — must be ignored
+        {"timestamp": f"{str(last_p - 1)}-10 10:00:00", "overall_score": 50.0},
+    ])
+    out = compute_monthly_summary(df)
+    assert out["current"]["year_month"] == current_ym
+    assert out["current"]["count"] == 3
+    assert out["current"]["mean"] == 80.0
+    assert out["current"]["std"] is not None and out["current"]["std"] > 0
+
+    assert out["last"]["year_month"] == last_ym
+    assert out["last"]["count"] == 2
+    assert out["last"]["mean"] == 80.0
+    # n=2 → sample std defined; n<2 path tested separately
+    assert out["last"]["std"] is not None
+
+
+def test_monthly_summary_count_one_month_has_null_std():
+    """Sample std requires n >= 2 — a one-eval month returns mean but null std."""
+    from datetime import datetime as _dt
+    import pandas as pd
+    now = _dt.now()
+    current_ym = str(pd.Period(now, freq="M"))
+
+    df = _summary_df([
+        {"timestamp": f"{current_ym}-10 10:00:00", "overall_score": 88.0},
+    ])
+    out = compute_monthly_summary(df)
+    assert out["current"]["count"] == 1
+    assert out["current"]["mean"] == 88.0
+    assert out["current"]["std"] is None
+
+
+def test_monthly_summary_month_boundary_buckets_strictly():
+    """An eval at the last second of last month bucket-belongs to last; first
+    second of current month belongs to current. Guards against off-by-one in
+    Period('M') discretization."""
+    from datetime import datetime as _dt
+    import pandas as pd
+    now = _dt.now()
+    current_p = pd.Period(now, freq="M")
+    last_p = current_p - 1
+    # Last second of last month
+    last_end = last_p.end_time
+    # First second of current month
+    current_start = current_p.start_time
+
+    df = _summary_df([
+        {"timestamp": last_end, "overall_score": 60.0},
+        {"timestamp": current_start, "overall_score": 95.0},
+    ])
+    out = compute_monthly_summary(df)
+    assert out["last"]["count"] == 1
+    assert out["last"]["mean"] == 60.0
+    assert out["current"]["count"] == 1
+    assert out["current"]["mean"] == 95.0
+
+
+def test_monthly_summary_does_not_mutate_input_df():
+    """Defensive: chiclet computation must not add the helper 'year_month'
+    column to the caller's df (other compute_* functions read this df after)."""
+    from datetime import datetime as _dt
+    import pandas as pd
+    current_ym = str(pd.Period(_dt.now(), freq="M"))
+    df = _summary_df([
+        {"timestamp": f"{current_ym}-05 10:00:00", "overall_score": 80.0},
+    ])
+    cols_before = set(df.columns)
+    compute_monthly_summary(df)
+    assert set(df.columns) == cols_before
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two clickable chiclets above the existing KPI row on the team dashboard, showing the **last** and **current** calendar month's eval count, mean, and std. Clicking either navigates to a new shareable page (`/dashboard/<team>/evals?month=YYYY-MM`) listing every eval in that month — sortable by date / agent / score / supervisor.

The **Score column in the drill-down is itself a link** to that call's `/datapoint/<team>/<call_id>` breakdown, closing the loop so an outsider can drill *chiclet → month list → individual eval* without leaving the app. Dialpad column remains the external link to the recording.

This is **Phase A** of the live-dashboard initiative. No SSE yet — that lands in a separate design-doc'd PR.

## Filter semantics

Chiclets honor the dashboard's `active_only` and `supervisor` filters by construction (computed off the same filtered DataFrame). The `days` filter is bypassed — the month string is the time window. Drill-down page propagates the same two filters via the URL.

## Backend changes

| File | Change |
|---|---|
| `models/team_stats.py` | `MonthlySummary` + `MonthlyBlock`; `TeamStatsResponse.monthly` field. New `TeamEvalRow` / `TeamEvalsResponse`. |
| `services/team_stats.py` | `compute_monthly_summary(df)` — mean/std/count for last and current calendar month via `pd.Period('M')`. `None` (not 0) for empty months and for std when count<2 so the UI can distinguish "no data" from "everyone scored 0". Non-mutating. |
| `routes/team.py` | `/team/stats` wires `monthly` in (computed before days-filter is applied so chiclets always show the full month). New `GET /team/evals?year_month=YYYY-MM` for the drill-down. Reconstructs Dialpad link from `eval_id`. |
| `main.py` | `/dashboard/<team>/evals` page route. |

## Frontend changes

| File | Change |
|---|---|
| `frontend/team_dashboard.html` | `.chiclet-row` above `.kpi-row`. `renderChiclets()` builds two clickable cards with `mean ± std` and an arrow indicator. |
| `frontend/team_evals.html` | NEW — header with back link, summary line (`N evals · mean ± std`), sortable table. Score cells link to `/datapoint/<team>/<call_id>`. |

## Tests

5 new unit tests in `test_analytics.py` covering:
- empty df → both blocks have `count: 0`, `mean/std: None`
- last vs. current bucketing across mixed-month data
- `count=1` month → mean defined, std `None` (sample std undefined)
- month boundary precision (last second of last month vs first second of current month)
- non-mutation of the caller's df (other `compute_*` consumers read it after)

Full suite: **164 passed, 6 skipped, 3 xfailed**.

## Test plan

- [x] `pytest qa-automation/AI-Scoring/tests -q` — green.
- [ ] After merge: open `/dashboard/member_support`, confirm two chiclets appear with current-month numbers. Click → `/dashboard/member_support/evals` loads sortable list. Click a score cell → lands on `/datapoint/<team>/<call_id>`. Verify the `Active Only` toggle and `Supervisor` filter propagate through the URL.

## Roadmap

Next: design doc (`LiveDashboard.md`) covering Phases B–D — `EventBus` abstraction + SSE endpoint + approval-handler publish + toast + live chart updates via debounced refetch + Recent-Evals expandable chiclet. Will follow design-doc-first per `feedback_design_doc_first`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)