### PR TITLE
feat(qa-automation): AI-Scoring — live dashboard via SSE (toast + chart refresh + SPC click-through)

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -16,6 +16,7 @@ from backend.routes.dashboard import router as dashboard_router
 from backend.routes.team import router as team_router
 from backend.routes.datapoints import router as datapoints_router
 from backend.routes.lookup import router as lookup_router
+from backend.routes.events import router as events_router
 from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
 from backend.middleware.audit import AuditLogMiddleware
 
@@ -40,10 +41,11 @@ app.add_middleware(
 app.add_middleware(AuditLogMiddleware)
 
 # Team-aware routes (primary). API key's team_id must match the URL team_id.
-for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router):
+for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router, events_router):
     app.include_router(r, prefix="/api/{team_id}", dependencies=TEAM_AUTH_DEPENDENCY)
 
 # Legacy single-team shim (30-day transition). team_id defaults to 'member_support'.
+# Events router intentionally excluded — SSE is new and team-scoped only.
 for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router):
     app.include_router(r, prefix="/api", dependencies=AUTH_DEPENDENCY)
 

--- a/qa-automation/AI-Scoring/backend/middleware/auth.py
+++ b/qa-automation/AI-Scoring/backend/middleware/auth.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 import os
 import secrets
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
-from fastapi import Depends, Header, HTTPException, Request
+from fastapi import Depends, Header, HTTPException, Query, Request
 
 
 _PRIVILEGED_SUFFIXES = {"privileged"}
@@ -66,14 +66,28 @@ if not _KEY_MAP:
     )
 
 
-async def require_api_key(authorization: str = Header(None)) -> KeyIdentity:
-    """FastAPI dependency that validates the Bearer token and returns its identity."""
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Missing Authorization header")
+async def require_api_key(
+    authorization: Annotated[Optional[str], Header()] = None,
+    api_key: Annotated[Optional[str], Query()] = None,
+) -> KeyIdentity:
+    """FastAPI dependency that validates a Bearer token or ?api_key= query param.
 
-    token = authorization.removeprefix("Bearer ").strip()
-    if token == authorization:
-        raise HTTPException(status_code=401, detail="Authorization header must use Bearer scheme")
+    Header is preferred when both are present. The query-param fallback exists
+    for `EventSource` (Phase B SSE), which cannot set custom request headers.
+    """
+    token: Optional[str] = None
+    if authorization:
+        if not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Authorization header must use Bearer scheme",
+            )
+        token = authorization.removeprefix("Bearer ").strip()
+    elif api_key:
+        token = api_key.strip()
+
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing API key")
 
     for known_key, identity in _KEY_MAP.items():
         if secrets.compare_digest(token, known_key):
@@ -82,14 +96,18 @@ async def require_api_key(authorization: str = Header(None)) -> KeyIdentity:
     raise HTTPException(status_code=401, detail="Invalid API key")
 
 
-async def require_team_access(team_id: str, authorization: str = Header(None)) -> KeyIdentity:
+async def require_team_access(
+    team_id: str,
+    authorization: Annotated[Optional[str], Header()] = None,
+    api_key: Annotated[Optional[str], Query()] = None,
+) -> KeyIdentity:
     """Validate the key and enforce team scoping unless the key is privileged.
 
     Privileged keys bypass the team check on every team-prefixed route.
     Returns the resolved KeyIdentity so downstream handlers can branch on
     role (e.g. /score uses it to decide whether to enforce roster membership).
     """
-    identity = await require_api_key(authorization)
+    identity = await require_api_key(authorization=authorization, api_key=api_key)
     if identity.role == "privileged":
         return identity
     if identity.team_id != team_id:

--- a/qa-automation/AI-Scoring/backend/routes/events.py
+++ b/qa-automation/AI-Scoring/backend/routes/events.py
@@ -1,0 +1,76 @@
+"""Server-Sent Events endpoint for live dashboard updates.
+
+Single endpoint: GET /events/team/{team_id}?api_key=...
+
+Auth is the same `require_api_key` used everywhere else; the
+query-param fallback (Phase 0 of LiveDashboard.md) exists for
+`EventSource`, which cannot set Authorization headers.
+
+Stream protocol:
+  - On connect: yields a SSE comment (": connected") to flush headers
+    immediately past any buffering proxy.
+  - On publish: yields `event: <name>\\ndata: <json>\\n\\n` per event.
+  - Every 15s of idleness: yields a SSE comment heartbeat to keep
+    Railway's proxy from closing the connection (default idle ~60s).
+  - On client disconnect: the consumer iterator stops; the `finally`
+    block unsubscribes from the bus.
+
+Caller filter-state isn't tracked here. Every subscriber on a given
+team gets every event; client-side handlers decide what to do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from backend.middleware.auth import team_id_from_path
+from backend.services.event_bus import get_event_bus
+
+
+router = APIRouter(tags=["events"])
+
+# Heartbeat cadence. Tuned shorter than Railway's default idle close
+# (~60s) so a quiet team's dashboard stays connected.
+_HEARTBEAT_SECONDS = 15.0
+
+
+async def _stream(team_id: str) -> AsyncIterator[bytes]:
+    bus = get_event_bus()
+    q = bus.subscribe(team_id)
+    # SSE comment lines (start with `:`) are ignored by EventSource but
+    # flush headers and keep intermediaries warm.
+    yield b": connected\n\n"
+    try:
+        while True:
+            try:
+                evt = await asyncio.wait_for(q.get(), timeout=_HEARTBEAT_SECONDS)
+            except asyncio.TimeoutError:
+                yield b": heartbeat\n\n"
+                continue
+            payload = json.dumps(evt["data"], default=str)
+            yield f"event: {evt['event']}\ndata: {payload}\n\n".encode("utf-8")
+    finally:
+        bus.unsubscribe(team_id, q)
+
+
+@router.get("/events/stream")
+async def stream_team_events(request: Request) -> StreamingResponse:
+    # team_id comes from the router-mount prefix (/api/{team_id}/...).
+    # Auth is enforced by the router-level TEAM_AUTH_DEPENDENCY mount in
+    # main.py (and mirrored in the test fixture). No inner Depends here.
+    team_id = team_id_from_path(request)
+    return StreamingResponse(
+        _stream(team_id),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            # Disable buffering on nginx-style proxies if any sit in front.
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -8,7 +8,7 @@ Registered twice in main.py:
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, UploadFile, File, Form
@@ -27,6 +27,7 @@ from backend.services.history_service import (
     agent_name_for_email,
     email_in_team_mails,
 )
+from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
     append_score_audit_row,
@@ -536,6 +537,29 @@ async def approve_scorecard(
             result_row=history_row,
             notes="",
         )
+
+        # Publish "eval_approved" to subscribed dashboards. Fires AFTER
+        # the audit row is written (no event for a half-finalized eval)
+        # and BEFORE Apps Script dispatch (the toast races the email,
+        # which is fine — the dashboard reflects approved state; the
+        # email is the deliverable). Truncates free-text fields to 280
+        # chars to bound per-client SSE payload bytes (LiveDashboard.md
+        # resolved Q2). Full text remains available via /datapoint.
+        def _truncate(s: str, n: int = 280) -> str:
+            s = s or ""
+            return s if len(s) <= n else s[: n - 1] + "…"
+
+        await get_event_bus().publish(team_id, "eval_approved", {
+            "call_id": job.get("call_id", ""),
+            "history_row": history_row,
+            "agent": job.get("agent_name") or sc.get("agent_name") or "",
+            "overall_score": overall_score,
+            "summary": _truncate(sc.get("call_summary", "")),
+            "strengths": _truncate(approval.key_strengths),
+            "opportunities": _truncate(approval.opportunities),
+            "dialpad_link": sc.get("dialpad_link", ""),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
 
         # Stage 5 — dispatch QA email via Apps Script (reads AH row).
         print(f"[approve] Triggering Apps Script doPost (history_row={history_row})...")

--- a/qa-automation/AI-Scoring/backend/services/event_bus.py
+++ b/qa-automation/AI-Scoring/backend/services/event_bus.py
@@ -1,0 +1,83 @@
+"""In-process pub/sub bus for live dashboard updates.
+
+Today's deployment is single-replica (per `feedback_railway_isolation`),
+so an in-memory `asyncio.Queue` fanout per team is enough. The
+`EventBus` Protocol exists so a Redis (or Postgres LISTEN/NOTIFY) impl
+can be swapped in by changing `get_event_bus()` alone — no caller
+edits.
+
+Lifecycle:
+    bus = get_event_bus()
+    queue = bus.subscribe("member_support")
+    try:
+        evt = await queue.get()            # blocks until a publish
+        # render evt["event"], evt["data"]
+    finally:
+        bus.unsubscribe("member_support", queue)
+
+Publish is `async` because future implementations (Redis) will be
+network-bound; today's InMemory impl is sync under the hood but
+preserves the contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Protocol
+
+
+# Event envelope shape pushed onto subscriber queues.
+# `event` is the SSE event name (e.g. "eval_approved"); `data` is the
+# JSON-serializable payload.
+Event = dict[str, Any]
+
+
+class EventBus(Protocol):
+    async def publish(self, team_id: str, event: str, payload: dict) -> None: ...
+    def subscribe(self, team_id: str) -> asyncio.Queue: ...
+    def unsubscribe(self, team_id: str, queue: asyncio.Queue) -> None: ...
+
+
+class InMemoryEventBus:
+    """Per-team fanout. Each subscriber gets its own bounded queue.
+
+    Bounded so a slow/disconnected subscriber can't grow memory without
+    limit. `publish` uses `put_nowait` and DROPS events for any queue
+    that's full — preferable to back-pressuring the approval handler
+    while the dashboard is the bottleneck.
+    """
+
+    def __init__(self, queue_maxsize: int = 100) -> None:
+        self._subscribers: dict[str, set[asyncio.Queue]] = defaultdict(set)
+        self._queue_maxsize = queue_maxsize
+
+    async def publish(self, team_id: str, event: str, payload: dict) -> None:
+        evt: Event = {"event": event, "data": payload}
+        # Iterate a snapshot — subscribers may unsubscribe mid-publish if
+        # their stream closes concurrently.
+        for q in list(self._subscribers.get(team_id, ())):
+            try:
+                q.put_nowait(evt)
+            except asyncio.QueueFull:
+                # Drop event for this slow subscriber. A correctly-behaving
+                # SSE client drains in tight loop; if it can't keep up,
+                # better to lose toasts than block the publisher.
+                pass
+
+    def subscribe(self, team_id: str) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue(maxsize=self._queue_maxsize)
+        self._subscribers[team_id].add(q)
+        return q
+
+    def unsubscribe(self, team_id: str, queue: asyncio.Queue) -> None:
+        self._subscribers.get(team_id, set()).discard(queue)
+
+
+# Module-level singleton. Swap implementation by reassigning here (or by
+# extending `get_event_bus` to read an env var) — no caller changes.
+_bus: EventBus = InMemoryEventBus()
+
+
+def get_event_bus() -> EventBus:
+    return _bus

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -132,6 +132,35 @@
     /* Loading */
     .loading { text-align: center; padding: 60px; color: var(--muted); font-size: 0.9rem; }
 
+    /* Toast (SSE eval_approved notifications) */
+    .toast-container {
+      position: fixed; bottom: 24px; right: 24px; z-index: 1000;
+      display: flex; flex-direction: column; gap: 10px; max-width: 360px;
+    }
+    .toast {
+      background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--accent);
+      border-radius: 10px; padding: 12px 14px; box-shadow: 0 6px 20px rgba(21,25,45,0.18);
+      cursor: pointer; transition: transform 0.18s, opacity 0.18s;
+      animation: toast-slide-in 0.22s ease-out;
+    }
+    .toast:hover { transform: translateX(-3px); }
+    .toast.dismissing { opacity: 0; transform: translateX(20px); }
+    .toast .toast-row {
+      display: flex; align-items: baseline; gap: 8px; font-size: 0.8rem;
+    }
+    .toast .toast-agent { font-weight: 600; color: var(--text); }
+    .toast .toast-score {
+      font-family: 'Fraunces', serif; font-weight: 700; font-size: 0.95rem; margin-left: auto;
+    }
+    .toast .toast-summary {
+      font-size: 0.75rem; color: var(--muted); margin-top: 6px; line-height: 1.4;
+      overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    }
+    @keyframes toast-slide-in {
+      from { opacity: 0; transform: translateX(40px); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+
     /* Responsive */
     @media (max-width: 640px) {
       .kpi-row { grid-template-columns: repeat(2, 1fr); }
@@ -225,6 +254,9 @@
       </tr></thead><tbody></tbody></table></div>
     </div>
   </div>
+
+  <!-- Toast container for SSE eval_approved notifications -->
+  <div class="toast-container" id="toastContainer"></div>
 
   <!-- Supervisors Tab -->
   <div class="tab-panel" id="panel-supervisors">
@@ -474,7 +506,34 @@ function renderSpcChart() {
         { label: 'Center', data: labels.map(() => spc.center), borderColor: '#5a6478', borderDash: [4, 4], pointRadius: 0, borderWidth: 1.5 }
       ]
     },
-    options: { responsive: true, scales: { y: { min: 60, max: 100, ticks: { stepSize: 5 } } }, plugins: { legend: { position: 'bottom' } } }
+    options: {
+      responsive: true,
+      scales: { y: { min: 60, max: 100, ticks: { stepSize: 5 } } },
+      plugins: { legend: { position: 'bottom' } },
+      // Phase E (LiveDashboard.md): clicking a monthly-mean point opens
+      // the same /evals?month=YYYY-MM page the chiclets use, preserving
+      // the dashboard's active_only + supervisor filters. Closes the
+      // loop: viewer can drill from any trend point to its underlying
+      // evals without leaving the app.
+      onHover: (e, items) => {
+        e.native && (e.native.target.style.cursor = items.length ? 'pointer' : 'default');
+      },
+      onClick: (event, activeElements) => {
+        if (!activeElements.length) return;
+        // Only react to the Monthly Mean dataset (index 0). Clicking on
+        // UCL/LCL/Center lines (datasets 1–3) is meaningless.
+        const hit = activeElements.find(a => a.datasetIndex === 0);
+        if (!hit) return;
+        const m = spc.months[hit.index];
+        if (!m || !m.month) return;
+        const params = new URLSearchParams({
+          month: m.month,
+          active_only: activeOnly,
+        });
+        if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+        location.href = `/dashboard/${TEAM_ID}/evals?${params.toString()}`;
+      },
+    },
   });
 }
 
@@ -774,9 +833,106 @@ function fillSupervisorTable(data) {
   </tr>`).join('');
 }
 
+// --- Live updates via SSE (Phases B–C + E from LiveDashboard.md) ---
+//
+// On dashboard load, open a long-lived EventSource. The server publishes
+// `eval_approved` events on `/api/<team>/events/stream` whenever an
+// approval completes Stage 4 (Analyst_History row finalized).
+//
+// On each event:
+//   - render a toast (max 3 concurrent, 6s auto-dismiss, FIFO drop);
+//   - schedule a 3s-debounced re-fetch of /team/stats so every chart
+//     (top-3 KPIs, SPC, EWMA, Distribution, etc.) reflects the new data
+//     without manual refresh.
+//
+// Auth: EventSource cannot set Authorization headers, so the API key
+// rides along as ?api_key=... (Phase 0 added the fallback in
+// backend/middleware/auth.py).
+let _eventSource = null;
+let _refetchTimer = null;
+const MAX_TOASTS = 3;
+const TOAST_TTL_MS = 6000;
+
+function openEventStream() {
+  if (_eventSource) return;  // idempotent if init runs twice
+  const key = getApiKey();
+  if (!key) return;
+  const url = `${API_BASE}/events/stream?api_key=${encodeURIComponent(key)}`;
+  _eventSource = new EventSource(url);
+  _eventSource.addEventListener('eval_approved', e => {
+    try {
+      const data = JSON.parse(e.data);
+      showToast(data);
+      scheduleStatsRefetch();
+    } catch (err) {
+      console.error('Failed to parse eval_approved payload:', err);
+    }
+  });
+  // EventSource auto-reconnects on its own; no manual cap (per design Q3).
+  _eventSource.addEventListener('error', () => {
+    // Browser will retry. Log so devtools shows a breadcrumb.
+    console.warn('SSE connection error; browser will retry.');
+  });
+}
+
+function scheduleStatsRefetch() {
+  if (_refetchTimer) clearTimeout(_refetchTimer);
+  _refetchTimer = setTimeout(() => {
+    _refetchTimer = null;
+    fetchTeamStats();
+  }, 3000);
+}
+
+function showToast(data) {
+  const container = document.getElementById('toastContainer');
+  if (!container) return;
+
+  // FIFO drop: when 3 toasts already showing, evict the oldest before
+  // adding the new one. Predictable footprint, no infinite stack.
+  while (container.children.length >= MAX_TOASTS) {
+    container.firstElementChild.remove();
+  }
+
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  const linkHref = data.call_id
+    ? `/datapoint/${TEAM_ID}/${encodeURIComponent(data.call_id)}`
+    : null;
+
+  const scoreColored = data.overall_score != null
+    ? `<span class="toast-score" style="color:${scoreColor(data.overall_score)}">${fmt(data.overall_score)}</span>`
+    : '';
+
+  toast.innerHTML = `
+    <div class="toast-row">
+      <span class="toast-agent">${escapeHtml(data.agent || '—')}</span>
+      ${scoreColored}
+    </div>
+    <div class="toast-summary">${escapeHtml(data.summary || '')}</div>
+  `;
+  // Whole toast is clickable when we have a call_id. Don't wrap in <a>
+  // because the score span has its own coloring; use a JS handler.
+  if (linkHref) {
+    toast.style.cursor = 'pointer';
+    toast.addEventListener('click', () => { location.href = linkHref; });
+  } else {
+    toast.addEventListener('click', () => dismissToast(toast));
+  }
+  container.appendChild(toast);
+
+  setTimeout(() => dismissToast(toast), TOAST_TTL_MS);
+}
+
+function dismissToast(toast) {
+  if (!toast || !toast.parentElement) return;
+  toast.classList.add('dismissing');
+  setTimeout(() => toast.remove(), 200);
+}
+
 // --- Init ---
 fetchMails();
 fetchTeamStats();
+openEventStream();
 </script>
 </body>
 </html>

--- a/qa-automation/AI-Scoring/references/LiveDashboard.md
+++ b/qa-automation/AI-Scoring/references/LiveDashboard.md
@@ -1,0 +1,362 @@
+# Live Dashboard via SSE — design doc
+
+> **Purpose:** Make the team dashboard react in real time as evaluations
+> are approved. Adds a server-sent-events (SSE) channel that the approval
+> handler publishes to; connected dashboards show a toast for each new
+> eval and refresh their charts. Closes the loop opened by PR #36 (month
+> chiclets) so a viewer sitting on `/dashboard/<team>` sees new data
+> arrive without manual reload.
+> **Author session:** 2026-05-25.
+> **Status:** Design — not yet implemented. Phase A (month chiclets)
+> merged as PR #36. This doc covers Phases B–E.
+
+---
+
+## Decisions locked (2026-05-25)
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Multi-replica posture | Single replica today; design for swap | In-memory `asyncio.Queue` bus, wrapped behind an `EventBus` interface so a Redis impl is a one-file change later. |
+| SSE update strategy | Server pushes thin event → client refetches `/team/stats` | One aggregation path in the codebase. Server stays stateless about client filter state. Debounced 3s burst window so a flurry of approvals = one refetch. |
+| Auth on the SSE stream | `?api_key=` query param | Extend `require_api_key` (or sibling) to accept query-string keys. `EventSource` can't set Authorization headers. Internal tool; query-string logging is acceptable. |
+| Phasing | A separate (merged), then B+C bundled, then D, plus E folded into B | Phase A landed standalone. B+C are intertwined (SSE infra serves chart liveness). D needs B's event history. E is a small frontend-only addition. |
+| Toast lifecycle | 6s auto-dismiss, max 3 concurrent, FIFO drop | Predictable; no scrolling toast tower if a batch lands. |
+| Recent-evals retention | No server-side ring buffer | On dashboard load, populate the "Recent Evals" list from the current-month chiclet's existing data; append SSE events afterward. Refresh loses history — but the source of truth is one fetch away. |
+
+---
+
+## Phase A recap (merged in PR #36 — context only)
+
+- `compute_monthly_summary(df)` returns `{last, current}` blocks.
+- `/team/stats` carries `monthly` field.
+- `GET /team/evals?year_month=YYYY-MM` lists every eval in a month.
+- Frontend: two clickable chiclets above the KPI row; new `/dashboard/<team>/evals` page; score column in that page links to `/datapoint/<team>/<call_id>`.
+
+Phase A intentionally avoided SSE. Everything below builds on it.
+
+---
+
+## Phase B — SSE infrastructure + approval publish + toast
+
+### Backend
+
+```
+backend/services/event_bus.py        — NEW.
+  class EventBus(Protocol):
+      async def publish(team_id: str, event: str, payload: dict) -> None
+      def subscribe(team_id: str) -> asyncio.Queue[Event]
+      def unsubscribe(team_id: str, queue: asyncio.Queue[Event]) -> None
+
+  class InMemoryEventBus(EventBus):
+      _subscribers: dict[str, set[asyncio.Queue]] = defaultdict(set)
+
+      async def publish(team_id, event, payload):
+          for q in self._subscribers[team_id]:
+              await q.put({"event": event, "data": payload})
+
+      # subscribe/unsubscribe are sync — they just mutate the set.
+
+  _bus = InMemoryEventBus()
+  def get_event_bus() -> EventBus: return _bus
+```
+
+Single module-level singleton, accessed via `get_event_bus()`. Adding
+Redis later means a new `RedisEventBus(EventBus)` class and changing
+`get_event_bus()` to return it — no caller changes.
+
+```
+backend/routes/events.py             — NEW.
+  GET /events/stream
+    Auth: ?api_key=... (validated via the same key map as Authorization
+    header). On invalid key → 401 before opening the stream.
+    Returns: StreamingResponse(_stream(team_id), media_type="text/event-stream")
+
+  async def _stream(team_id):
+      q = bus.subscribe(team_id)
+      try:
+          yield ": connected\n\n"           # comment line, primes the stream
+          while True:
+              try:
+                  evt = await asyncio.wait_for(q.get(), timeout=15)
+                  yield f"event: {evt['event']}\ndata: {json.dumps(evt['data'])}\n\n"
+              except asyncio.TimeoutError:
+                  yield ": heartbeat\n\n"   # keeps proxies from closing
+      finally:
+          bus.unsubscribe(team_id, q)
+```
+
+Heartbeat every 15s keeps Railway's proxy alive (default idle close
+~60s). `Cache-Control: no-cache` + `Connection: keep-alive` headers.
+
+### Auth extension
+
+`require_api_key` currently checks the `Authorization: Bearer <key>`
+header. SSE can't set headers via `EventSource`, so:
+
+```
+backend/middleware/auth.py
+  def require_api_key(request, ...):
+      key = (
+          _extract_bearer(request) or
+          request.query_params.get("api_key")
+      )
+      ...
+```
+
+Or, less invasive, a sibling `require_api_key_loose` accepting query
+params. **Decision needed (open Q1).**
+
+### Approval-handler publish
+
+`backend/routes/scoring.py` — `POST /score/{job_id}/approve`, after Stage
+4 (`finalize_to_analyst_history` returns `history_row`) and the audit
+write, before Stage 5 (Apps Script dispatch):
+
+```python
+await get_event_bus().publish(team_id, "eval_approved", {
+    "eval_id": str(history_row),
+    "agent": job.get("agent_name") or sc.get("agent_name") or "",
+    "overall_score": overall_score,
+    "summary": sc.get("call_summary", ""),
+    "strengths": approval.key_strengths,
+    "opportunities": approval.opportunities,
+    "dialpad_link": sc.get("dialpad_link", ""),
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+})
+```
+
+Publish AFTER the audit row is written (no event for a half-finalized
+eval) and BEFORE the Apps Script call (so the toast races the email,
+which is fine — the dashboard reflects approved state; the email is the
+deliverable).
+
+### Frontend (`team_dashboard.html`)
+
+```js
+// On load:
+const es = new EventSource(`/api/${TEAM_ID}/events/team/${TEAM_ID}?api_key=${encodeURIComponent(getApiKey())}`);
+es.addEventListener('eval_approved', e => {
+  const data = JSON.parse(e.data);
+  showToast(data);
+  // ...client-side handlers for Phase C and D added later
+});
+es.addEventListener('error', () => {
+  // Reconnect with exponential backoff; EventSource auto-reconnects but
+  // we cap the rate so a permanently-down server doesn't spam.
+});
+
+// Toast: max 3 concurrent, 6s auto-dismiss, FIFO drop.
+//        Slides in from bottom-right; click-to-dismiss.
+//        Content: agent name, score (colored), one-line summary,
+//        link to /datapoint/<team>/<eval_id>.
+```
+
+CSS: new `.toast-container` fixed bottom-right; `.toast` card with same
+brand language as the chiclets (`border-radius: 12px`, `border: 1px
+solid var(--border)`, subtle drop shadow).
+
+### Phase B deliverables
+
+- `backend/services/event_bus.py` (new)
+- `backend/routes/events.py` (new)
+- `backend/main.py` mounts events router
+- `backend/middleware/auth.py` accepts `?api_key=`
+- `backend/routes/scoring.py` publishes on Stage-4 success
+- `frontend/team_dashboard.html` opens EventSource + shows toast
+- Tests:
+  - `EventBus` pub/sub round-trip with two subscribers.
+  - `auth` accepts query-string key (parity with Bearer).
+  - Route test: `/events/team/{id}` returns 401 without key.
+  - Approval-route test: a successful `/approve` enqueues an
+    `eval_approved` event on the bus (use `monkeypatch` to replace the
+    bus with a capture instance).
+
+---
+
+## Phase C — live chart updates via debounced refetch
+
+No new infra — purely wires Phase B's events to existing fetch logic.
+
+### Frontend
+
+```js
+let _refetchTimer = null;
+function scheduleStatsRefetch() {
+  if (_refetchTimer) clearTimeout(_refetchTimer);
+  _refetchTimer = setTimeout(() => {
+    _refetchTimer = null;
+    fetchTeamStats();          // existing function; re-renders all charts
+  }, 3000);
+}
+
+es.addEventListener('eval_approved', e => {
+  showToast(JSON.parse(e.data));
+  scheduleStatsRefetch();      // coalesces bursts
+});
+```
+
+That's it. Top-3 KPIs, SPC, EWMA, Distribution, Section Analysis,
+Supervisor charts — all re-render because they all read from `teamData`
+and `fetchTeamStats()` reassigns it then calls `renderTab()`.
+
+### Phase C deliverables
+
+- 1 file changed: `frontend/team_dashboard.html`.
+- No backend, no new tests (the existing `fetchTeamStats` path is
+  unchanged — we just call it more often).
+
+### Trade-off accepted
+
+Each approval triggers one extra `/team/stats` per active dashboard
+client (after the 3s debounce). With manager_sample coverage (~30–100
+evals/month/team), this is bounded — even during a "scoring sprint"
+half-hour where 20 evals land back-to-back, the debounce collapses them
+into ≤10 refetches per dashboard. Each refetch is one sheet read + 8
+aggregator runs (~1–2s wall clock today). Acceptable.
+
+If load becomes a concern: cache the `load_and_clean(df)` result with a
+short TTL (e.g. 5s) keyed by `(team_id, sheet_etag)`. Out of scope for
+this PR.
+
+---
+
+## Phase D — Recent Evals expandable chiclet
+
+A third chiclet next to the existing two, showing the **N most recent
+approved evals** as a compact list. Collapsed: count + most-recent
+agent/score. Expanded: scrollable list of last 10 events.
+
+### Frontend
+
+```
+- New chiclet card at the right of the chiclet row (3-column grid on
+  desktop, stacked on mobile).
+- Collapsed: "Recent · Mich Palacios 92.0 · 12 min ago" + expand arrow.
+- Expanded: vertical list of {timestamp, agent, score (colored), summary
+  truncated to 1 line, link to /datapoint/<team>/<eval_id>}.
+- Backed by a client-side ring buffer (size 50) of SSE events.
+- Initial population: on first `/team/stats` fetch, ALSO call
+  `/team/evals?year_month=<current>` (already exists from Phase A),
+  pre-fill the buffer with the 10 most recent. Subsequent SSE events
+  prepend to the buffer.
+```
+
+### Backend changes
+
+None beyond the existing `/team/evals` endpoint from Phase A.
+
+### Phase D deliverables
+
+- `frontend/team_dashboard.html`: third chiclet, expand/collapse JS,
+  ring-buffer state, initial-load fetch.
+- No new tests (frontend-only; behavior is observable via manual
+  verification).
+
+---
+
+## Phase E — SPC chart datapoint click-through
+
+Small, additive, frontend-only. Each monthly mean point on the SPC
+control chart becomes a click target → opens
+`/dashboard/<team>/evals?month=YYYY-MM` for that point's month, with the
+dashboard's current `active_only` + `supervisor` filters propagated.
+
+### Why bundle with Phase B?
+
+Same scope of "dashboard UX polish on top of A." Ships with the toast.
+Trivial to implement (Chart.js `onClick` handler reads the datapoint
+index → `spc.months[index].month` → builds the URL).
+
+### Frontend
+
+```js
+// inside renderSpcChart()
+options: {
+  onClick: (evt, items) => {
+    if (!items.length) return;
+    const i = items[0].index;
+    const m = spc.months[i];
+    if (!m) return;
+    const params = new URLSearchParams({
+      month: m.month,
+      active_only: activeOnly,
+    });
+    if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+    location.href = `/dashboard/${TEAM_ID}/evals?${params.toString()}`;
+  },
+  ...
+}
+// Cursor: change to pointer on hover over a point.
+```
+
+### Phase E deliverables
+
+- `frontend/team_dashboard.html`: ~15 lines added to `renderSpcChart`.
+
+---
+
+## Implementation phases + pytest checkpoints
+
+1. **Phase 0 — Auth extension**
+   - Accept `?api_key=` query param in `require_api_key`.
+   - Test: query-string key validates equivalently to Bearer header;
+     missing/invalid → 401.
+   - Checkpoint: `pytest tests -q` green.
+
+2. **Phase 1 — EventBus + tests**
+   - `services/event_bus.py` with `InMemoryEventBus`.
+   - Test: pub/sub round-trip; multi-subscriber fanout; unsubscribe
+     removes from set.
+   - No route wiring yet. Checkpoint green.
+
+3. **Phase 2 — SSE endpoint + approval publish**
+   - `routes/events.py` + mount in `main.py`.
+   - `routes/scoring.py` calls `bus.publish` on Stage-4 success.
+   - Test: approval route enqueues event (monkeypatch bus); SSE route
+     401 without key.
+   - Checkpoint green.
+
+4. **Phase 3 — Frontend toast + SSE wiring**
+   - `team_dashboard.html`: EventSource, toast container, toast queue,
+     reconnect strategy.
+   - Manual verification: approve a call, dashboard shows toast.
+
+5. **Phase 4 — Debounced refetch (Phase C)**
+   - Add `scheduleStatsRefetch` + wire into SSE handler.
+   - Manual verification: top-3 KPIs and charts update without page
+     reload after an approval.
+
+6. **Phase 5 — SPC click-through (Phase E)**
+   - 15-line addition to `renderSpcChart`. Cursor pointer + onClick.
+   - Manual verification: click a point → lands on the right
+     `/evals?month=...&active_only=&supervisor=` URL.
+
+7. **Phase 6 — Recent Evals chiclet (Phase D)**
+   - Third chiclet, expand/collapse, ring buffer, initial-load
+     `/team/evals?year_month=<current>` fetch.
+
+**PR boundaries:**
+- **PR-1**: Phases 0–5 (auth + bus + endpoint + publish + toast + live charts + SPC click). One cohesive "dashboard goes live" change.
+- **PR-2**: Phase 6 (Recent Evals chiclet) on its own.
+
+---
+
+## Open questions — resolved 2026-05-25
+
+1. **Auth extension shape:** **Uniform.** `require_api_key` accepts
+   either `Authorization: Bearer <key>` or `?api_key=<key>`, applied
+   across every route. Internal tool; query-string logs are tolerable.
+2. **Per-eval-approved event payload bytes:** **Truncate to 280
+   chars.** SSE payload trims `summary` (and applies the same cap to
+   `strengths` / `opportunities` if they're similarly long) to bound
+   per-client bytes per event. Full text remains available via
+   `/datapoint/<team>/<eval_id>` when the user clicks through.
+3. **Reconnect strategy:** **No manual cap.** Default `EventSource`
+   auto-reconnect is sufficient. Revisit if we see storms in prod.
+4. **Toast persistence after navigation:** **Acceptable.** Going SPA
+   isn't in scope; toast destruction on navigation is fine.
+5. **Other dashboards subscribing to SSE:** **Out of scope for these
+   PRs.** Phase B–E wire `/dashboard/<team>` only. A future custom
+   dashboard utilizing Dialpad webhooks/websockets for real-time call
+   events is planned as a separate project — that data may flow into
+   the agent dashboard later, but it's a different project entirely.

--- a/qa-automation/AI-Scoring/tests/test_auth.py
+++ b/qa-automation/AI-Scoring/tests/test_auth.py
@@ -82,6 +82,58 @@ def test_require_api_key_rejects_unknown_token(monkeypatch):
     assert exc.value.status_code == 401
 
 
+# ---------------------------------------------------------------------------
+# ?api_key= query-param fallback (Phase 0 — for SSE EventSource which
+# cannot set Authorization headers).
+# ---------------------------------------------------------------------------
+
+def test_require_api_key_accepts_query_param(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "team-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    identity = asyncio.run(auth.require_api_key(authorization=None, api_key="team-tok"))
+    assert identity == KeyIdentity(role="team", team_id="member_support")
+
+
+def test_require_api_key_query_param_rejects_unknown_token(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_api_key(authorization=None, api_key="wrong"))
+    assert exc.value.status_code == 401
+
+
+def test_require_api_key_header_preferred_over_query_when_both_present(monkeypatch):
+    """Header wins so a client that already authenticates via Authorization
+    can't be downgraded by a tampered URL. The query-param path is purely a
+    fallback for EventSource."""
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "header-tok": KeyIdentity(role="team", team_id="sales"),
+        "query-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    identity = asyncio.run(auth.require_api_key(
+        authorization="Bearer header-tok", api_key="query-tok",
+    ))
+    assert identity.team_id == "sales"
+
+
+def test_require_api_key_rejects_when_neither_provided():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.require_api_key(authorization=None, api_key=None))
+    assert exc.value.status_code == 401
+
+
+def test_require_team_access_accepts_query_param(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        "ms-tok": KeyIdentity(role="team", team_id="member_support"),
+    })
+    identity = asyncio.run(auth.require_team_access(
+        team_id="member_support", authorization=None, api_key="ms-tok",
+    ))
+    assert identity.team_id == "member_support"
+
+
 def test_require_team_access_team_key_matching_team_passes(monkeypatch):
     monkeypatch.setattr(auth, "_KEY_MAP", {
         "ms-tok": KeyIdentity(role="team", team_id="member_support"),

--- a/qa-automation/AI-Scoring/tests/test_event_bus.py
+++ b/qa-automation/AI-Scoring/tests/test_event_bus.py
@@ -1,0 +1,111 @@
+"""Unit tests for the InMemoryEventBus pub/sub fanout."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.services.event_bus import InMemoryEventBus
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_publish_delivers_to_single_subscriber():
+    bus = InMemoryEventBus()
+    q = bus.subscribe("member_support")
+
+    async def go():
+        await bus.publish("member_support", "eval_approved", {"agent": "Mich"})
+        return await q.get()
+
+    evt = _run(go())
+    assert evt["event"] == "eval_approved"
+    assert evt["data"] == {"agent": "Mich"}
+
+
+def test_publish_fans_out_to_all_subscribers():
+    """Two dashboards on the same team must both see the event."""
+    bus = InMemoryEventBus()
+    q1 = bus.subscribe("sales")
+    q2 = bus.subscribe("sales")
+
+    async def go():
+        await bus.publish("sales", "eval_approved", {"score": 92})
+        return await q1.get(), await q2.get()
+
+    e1, e2 = _run(go())
+    assert e1["data"]["score"] == 92
+    assert e2["data"]["score"] == 92
+
+
+def test_publish_isolated_per_team():
+    """A publish to team A must NOT leak to a subscriber on team B."""
+    bus = InMemoryEventBus()
+    q_ms = bus.subscribe("member_support")
+    q_sales = bus.subscribe("sales")
+
+    async def go():
+        await bus.publish("sales", "eval_approved", {"agent": "x"})
+        # ms queue should be empty
+        return q_ms.qsize(), await q_sales.get()
+
+    ms_size, sales_evt = _run(go())
+    assert ms_size == 0
+    assert sales_evt["data"]["agent"] == "x"
+
+
+def test_unsubscribe_stops_delivery():
+    bus = InMemoryEventBus()
+    q = bus.subscribe("member_support")
+    bus.unsubscribe("member_support", q)
+
+    async def go():
+        await bus.publish("member_support", "eval_approved", {})
+        return q.qsize()
+
+    assert _run(go()) == 0
+
+
+def test_publish_to_team_with_no_subscribers_is_noop():
+    """A team nobody's watching must not raise — approval handler shouldn't
+    care whether a dashboard happens to be open."""
+    bus = InMemoryEventBus()
+
+    async def go():
+        await bus.publish("unknown_team", "eval_approved", {})
+
+    _run(go())  # no exception → pass
+
+
+def test_full_queue_drops_event_for_slow_subscriber():
+    """A subscriber whose queue fills up loses subsequent events instead
+    of back-pressuring the publisher. The publisher must not raise."""
+    bus = InMemoryEventBus(queue_maxsize=2)
+    q = bus.subscribe("member_support")
+
+    async def go():
+        await bus.publish("member_support", "e", {"i": 1})
+        await bus.publish("member_support", "e", {"i": 2})
+        await bus.publish("member_support", "e", {"i": 3})  # dropped
+        return q.qsize()
+
+    # Slow subscriber kept 2 events; the third was silently dropped.
+    assert _run(go()) == 2
+
+
+def test_unsubscribe_removes_correct_queue_among_multiple():
+    bus = InMemoryEventBus()
+    q1 = bus.subscribe("member_support")
+    q2 = bus.subscribe("member_support")
+    bus.unsubscribe("member_support", q1)
+
+    async def go():
+        await bus.publish("member_support", "e", {"v": 1})
+        return q1.qsize(), q2.qsize()
+
+    s1, s2 = _run(go())
+    assert s1 == 0  # unsubscribed
+    assert s2 == 1  # still subscribed

--- a/qa-automation/AI-Scoring/tests/test_events_route.py
+++ b/qa-automation/AI-Scoring/tests/test_events_route.py
@@ -1,0 +1,122 @@
+"""/events/team/{team_id} SSE route — auth + wiring smoke tests.
+
+Full streaming behavior isn't unit-testable cleanly with TestClient; the
+EventBus pub/sub fanout is covered by `test_event_bus.py`. This file
+asserts the things that ARE testable without a long-lived connection:
+auth enforcement (both Authorization and ?api_key= paths) and that the
+approve publish hook calls into the bus.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity, TEAM_AUTH_DEPENDENCY
+from backend.routes import events as events_module
+from backend.routes import scoring as scoring_module
+
+
+TEAM_TOKEN = "team-ms-tok"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        TEAM_TOKEN: KeyIdentity(role="team", team_id="member_support"),
+    })
+
+    # The real _stream is an infinite generator (heartbeats every 15s) and
+    # TestClient context exit waits for the response to drain — so an
+    # unmocked test hangs. Replace with a terminating one-chunk generator
+    # for auth tests; the publish/fanout path is covered by test_event_bus.
+    async def _short_stream(team_id):
+        yield b": connected\n\n"
+
+    monkeypatch.setattr(events_module, "_stream", _short_stream)
+
+    app = FastAPI()
+    app.include_router(
+        events_module.router,
+        prefix="/api/{team_id}",
+        dependencies=TEAM_AUTH_DEPENDENCY,
+    )
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Auth on /events
+# ---------------------------------------------------------------------------
+
+def test_events_endpoint_rejects_missing_auth(client):
+    """No header AND no query param → 401 before the stream opens."""
+    resp = client.get("/api/member_support/events/stream")
+    assert resp.status_code == 401
+
+
+def test_events_endpoint_rejects_wrong_team_token(client):
+    """Team-scoped key for the WRONG team → 403."""
+    # Register a sales-only key for this test.
+    auth._KEY_MAP["sales-tok"] = KeyIdentity(role="team", team_id="sales")
+    try:
+        resp = client.get(
+            "/api/member_support/events/stream",
+            headers={"Authorization": "Bearer sales-tok"},
+        )
+        assert resp.status_code == 403
+    finally:
+        auth._KEY_MAP.pop("sales-tok", None)
+
+
+def test_events_endpoint_accepts_query_param_auth(client):
+    """EventSource cannot set headers — confirm ?api_key= path passes auth.
+
+    The fixture replaces _stream with a one-chunk generator so the request
+    terminates cleanly. We assert: auth passed, content-type is SSE, and
+    the priming chunk reaches the client."""
+    resp = client.get(
+        f"/api/member_support/events/stream?api_key={TEAM_TOKEN}",
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert b": connected" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Approval-handler publish wiring
+# ---------------------------------------------------------------------------
+
+def test_approve_handler_calls_event_bus_publish():
+    """The approve route must call get_event_bus().publish on success.
+
+    Source-presence check rather than a full integration test — the
+    approve pipeline runs five sheet-side stages, all of which need
+    stubs that don't exist in this repo yet. The fanout itself is
+    tested in test_event_bus.py."""
+    src = inspect.getsource(scoring_module)
+    assert "get_event_bus()" in src, (
+        "approve handler no longer calls get_event_bus() — the SSE "
+        "publish hook has regressed"
+    )
+    assert '"eval_approved"' in src, (
+        "approve handler no longer publishes the 'eval_approved' event"
+    )
+
+
+def test_approve_publish_truncates_long_text():
+    """The 280-char cap (LiveDashboard.md Q2) is implemented as a local
+    _truncate function inside the approve handler. Source-presence
+    check — fail if the cap is silently raised/lowered or removed."""
+    src = inspect.getsource(scoring_module)
+    assert "_truncate" in src, "_truncate helper is missing from scoring.py"
+    assert "280" in src, "_truncate's 280-char default has been changed"


### PR DESCRIPTION
## Summary

Team dashboard now reacts in real time as evaluations are approved. On every approval that finalizes Stage 4, the server publishes an `eval_approved` event on a per-team SSE channel; every connected dashboard shows a toast and silently re-fetches `/team/stats` after a 3s debounce so top-3 KPIs, SPC, EWMA, Distribution, section/supervisor charts all reflect new data without a manual reload.

This bundles **Phases B–E** from [`references/LiveDashboard.md`](../blob/feat/live-dashboard-sse/qa-automation/AI-Scoring/references/LiveDashboard.md). Phase F (Recent Evals expandable chiclet) follows in its own PR.

## What changed

### Backend

| File | Change |
|---|---|
| `middleware/auth.py` | `require_api_key` + `require_team_access` accept `Authorization: Bearer <k>` OR `?api_key=<k>`. Header wins when both present. Switched to `Annotated[Optional[str], Header()]` so direct-invocation tests see plain `None`. |
| `services/event_bus.py` | NEW. `EventBus` Protocol + `InMemoryEventBus` (per-team `asyncio.Queue` fanout, bounded maxsize=100, drops events for slow subscribers). Module-level singleton via `get_event_bus()`. Swap to Redis later = one-file change. |
| `routes/events.py` | NEW. `GET /events/stream` (mounted at `/api/{team_id}/events/stream`). Heartbeats every 15s. Excluded from the legacy `/api` shim. |
| `routes/scoring.py` | Approve handler publishes `eval_approved` AFTER Score_Audit row write, BEFORE Apps Script dispatch. Truncates `summary` / `strengths` / `opportunities` to **280 chars** per design Q2. |

### Frontend (`frontend/team_dashboard.html`)

- **Toast** — fixed bottom-right, max 3 concurrent, 6s auto-dismiss, FIFO drop. Click → `/datapoint/<team>/<call_id>`.
- **Live refetch** — `scheduleStatsRefetch()` debounces SSE events 3s and coalesces bursts. One aggregation path; charts get a free ride.
- **SPC click-through (Phase E)** — clicking a monthly-mean point opens `/dashboard/<team>/evals?month=YYYY-MM` with the dashboard's current `active_only` + `supervisor` filters. Cursor flips to pointer on hover.
- **EventSource** opens on init with `?api_key=<k>`; browser auto-reconnect (no manual cap per design Q3).

## Tests

17 new tests, full suite **181 passed, 6 skipped, 3 xfailed**:
- `test_auth.py` (+5): `?api_key=` parity with Bearer, header preference, both-missing 401.
- `test_event_bus.py` (+7): single + fanout delivery, per-team isolation, unsubscribe, no-subscriber no-op, slow-subscriber drop, multi-subscriber unsubscribe correctness.
- `test_events_route.py` (+5): 401 without auth, 403 wrong team, query-param auth happy path, source-presence checks on `get_event_bus()` publish + 280-char truncate cap.

## Manual verification (completed)

- Two dashboard tabs + approve in a third tab → toast appears in both with agent + score + summary; top-3 KPIs and charts refresh within ~3s.
- Click toast → lands on `/datapoint/<team>/<call_id>`.
- Click SPC datapoint → lands on `/dashboard/<team>/evals?month=YYYY-MM` with current filters propagated.

## Design decisions worth flagging

1. **`/events/stream` not `/events/team/{id}`** — the `/api/{team_id}/...` prefix mount already supplies team_id; a sub-path with the same param name caused FastAPI to reject the mount.
2. **Slow-subscriber drop** — `InMemoryEventBus.publish` uses `put_nowait` and discards events for full queues. Better to lose toasts than block the approval handler. Acceptable in a manager_sample regime (~30–100 evals/team/month).
3. **Annotated auth pattern** — switching from `authorization: str = Header(None)` to `Annotated[Optional[str], Header()] = None` preserves existing direct-invocation test ergonomics while adding the query-param fallback cleanly.
4. **SSE auth test mocks `_stream`** — the real generator is infinite (heartbeats); TestClient hangs waiting for response drain. Auth runs *before* the stream, so the mock doesn't compromise the assertion. Real pub/sub is covered by `test_event_bus.py`.

## Roadmap

- **PR-2** (next): Phase F — Recent Evals expandable chiclet. Third chiclet, client-side ring buffer of last 50 events, initial-load fetch from `/team/evals?year_month=<current>`.
- **Future** (separate project): Dialpad webhook/websocket-driven real-time dashboard. Per `project_future_dialpad_dashboard` memory — does NOT extend the SSE pipeline here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)