### PR TITLE
fix(qa-automation): AI-Scoring — preserve yn N/A through load_and_clean

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/services/team_stats.py
@@ -167,7 +167,7 @@ def load_and_clean(
             if yn_idx is None or len(row) <= yn_idx:
                 yn_scores[yn_name] = ""
                 continue
-            yn_scores[yn_name] = str(row[yn_idx]).strip().upper()[:1]
+            yn_scores[yn_name] = _parse_yn_cell(row[yn_idx])
 
         manager = (
             str(row[history_layout.COL_EVALUATOR_EMAIL]).strip().lower()
@@ -602,11 +602,54 @@ def compute_supervisor_stats(df: pd.DataFrame) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Y/N cell parsing
+# ---------------------------------------------------------------------------
+
+def _parse_yn_cell(val: object) -> str:
+    """Map a raw Y/N sheet cell to a normalized sentinel: 'Y' | 'N' | 'NA' | ''.
+
+    The legacy implementation was `str(val).strip().upper()[:1]`, which
+    silently coerced "Not Applicable" (the YN_DISPLAY['NA'] string written
+    by sheets_service) to "N" — historical N/A rows were miscoded as
+    failures and dragged binary-stats percentages down. This explicit
+    parser preserves NA so `_compute_binary_pct` excludes it from the
+    denominator (it already filters by 'Y'|'N' — anything else falls out
+    of both numerator and total).
+
+    Recognized inputs (case-insensitive):
+        ''                               → ''
+        'Y' / 'Yes' / 'YES'              → 'Y'
+        'N' / 'No'  / 'NO'               → 'N'
+        'NA' / 'N/A' / 'Not Applicable'  → 'NA'
+        anything else                    → '' (defensive — keeps an
+                                              unrecognized cell out of
+                                              the binary denominator).
+    """
+    s = str(val).strip()
+    if not s:
+        return ""
+    upper = s.upper()
+    if upper in ("NA", "N/A") or upper == "NOT APPLICABLE":
+        return "NA"
+    first = upper[:1]
+    if first == "Y":
+        return "Y"
+    if first == "N":
+        return "N"
+    return ""
+
+
+# ---------------------------------------------------------------------------
 # _compute_binary_pct (helper)
 # ---------------------------------------------------------------------------
 
 def _compute_binary_pct(series: pd.Series) -> float:
-    """Compute percentage of 'Y' out of valid Y/N responses."""
+    """Compute percentage of 'Y' out of valid Y/N responses.
+
+    NA rows (yn_value=='NA') fall out of both numerator and denominator —
+    they're excluded from binary-stats calculations entirely. Only Y and
+    N count toward the denominator.
+    """
     yes = int((series == "Y").sum())
     total = int(((series == "Y") | (series == "N")).sum())
     return round(100.0 * yes / total, 1) if total > 0 else 0.0

--- a/qa-automation/AI-Scoring/references/NumericNAOption.md
+++ b/qa-automation/AI-Scoring/references/NumericNAOption.md
@@ -77,7 +77,11 @@ config:
   separate analytics feature.
 - Pre-existing yn-NA coercion bug in `load_and_clean:170` — `"Not Applicable"
   .upper()[:1] == "N"`, so historical N/A on yn columns has been miscoded as
-  N. Out of scope; tracked separately.
+  N. ~~Out of scope; tracked separately.~~ **Resolved 2026-05-27** in a
+  follow-up PR: `_parse_yn_cell` helper replaces the `[:1]` slice and
+  preserves "Not Applicable" / "NA" / "N/A" as the "NA" sentinel.
+  Historical rows are re-parsed correctly on the next read — no data
+  migration needed.
 - Backfill of historical numeric rows. Existing sheet cells stay as-is.
 
 ---

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -13,6 +13,7 @@ import pytest
 
 from backend.config.team_config import TeamConfig
 from backend.services.team_stats import (
+    _parse_yn_cell,
     compute_agent_roster,
     compute_binary_stats,
     compute_distribution,
@@ -234,6 +235,92 @@ def test_monthly_summary_does_not_mutate_input_df():
     cols_before = set(df.columns)
     compute_monthly_summary(df)
     assert set(df.columns) == cols_before
+
+
+# ---------------------------------------------------------------------------
+# _parse_yn_cell — preserves "Not Applicable" instead of coercing to "N"
+# (NumericNAOption.md scope note resolved here).
+# ---------------------------------------------------------------------------
+
+def test_parse_yn_cell_handles_each_recognized_form():
+    assert _parse_yn_cell("Y") == "Y"
+    assert _parse_yn_cell("Yes") == "Y"
+    assert _parse_yn_cell("YES") == "Y"
+    assert _parse_yn_cell("N") == "N"
+    assert _parse_yn_cell("No") == "N"
+    assert _parse_yn_cell("NO") == "N"
+
+
+def test_parse_yn_cell_preserves_not_applicable_sentinel():
+    """The bug: 'Not Applicable'.upper()[:1] == 'N' — historical NA rows
+    were miscoded as failures and pulled binary-stats percentages down.
+    Each canonical NA spelling must round-trip to the 'NA' sentinel."""
+    assert _parse_yn_cell("Not Applicable") == "NA"
+    assert _parse_yn_cell("not applicable") == "NA"
+    assert _parse_yn_cell("NA") == "NA"
+    assert _parse_yn_cell("N/A") == "NA"
+    assert _parse_yn_cell("  Not Applicable  ") == "NA"
+
+
+def test_parse_yn_cell_empty_and_unknown_to_empty():
+    """Anything we don't recognize falls out of the binary denominator —
+    safer than misclassifying as Y or N."""
+    assert _parse_yn_cell("") == ""
+    assert _parse_yn_cell("   ") == ""
+    assert _parse_yn_cell("???") == ""
+    # 'Maybe' starts with 'M' — not Y or N. Defaults to empty, which
+    # `_compute_binary_pct` excludes from both numerator and denominator.
+    assert _parse_yn_cell("Maybe") == ""
+
+
+def test_load_and_clean_preserves_yn_na_through_binary_stats(sales: TeamConfig):
+    """End-to-end: a sheet row holding 'Not Applicable' for a yn section
+    must NOT count as a failure in the binary-stats percentage.
+
+    Before this fix: 'Not Applicable' was coerced to 'N' inside
+    load_and_clean, dragging the team's Y% down on every NA row.
+    """
+    from datetime import datetime
+    import pandas as pd
+
+    yn_ids = sales.yn_history_ids
+    assert yn_ids, "sales fixture must declare at least one yn section"
+    target_yn = yn_ids[0]
+
+    # Two rows for Star Rep: one passed (Y), one explicit Not Applicable.
+    # The Y% on target_yn must read 100.0% (1 of 1 valid), NOT 50.0%.
+    rows = [["Agent Name"] + [""] * 200]  # header
+    rows.append(make_history_row(
+        sales, agent="Star Rep", when=datetime(2026, 4, 1, 9, 0),
+        overall=90, section_scores={hid: 5 for hid in sales.numeric_history_ids},
+        yn_scores={y: ("Y" if y == target_yn else "Y") for y in yn_ids},
+    ))
+    rows.append(make_history_row(
+        sales, agent="Star Rep", when=datetime(2026, 4, 2, 9, 0),
+        overall=90, section_scores={hid: 5 for hid in sales.numeric_history_ids},
+        # Write the production sentinel (what sheets_service emits via
+        # YN_DISPLAY['NA']) on target_yn; Y on the rest so they're valid.
+        yn_scores={y: ("Not Applicable" if y == target_yn else "Y") for y in yn_ids},
+    ))
+
+    mails = make_mails_sheet(["Star Rep"])
+    df = load_and_clean(rows, mails, sales)
+
+    # The "NA" sentinel made it through load_and_clean unmolested.
+    star = df[df["agent"] == "Star Rep"]
+    target_vals = sorted(star[target_yn].tolist())
+    assert target_vals == ["NA", "Y"], (
+        f"expected ['NA', 'Y'] after load_and_clean — got {target_vals}. "
+        f"'Not Applicable' was probably re-coerced to 'N' (the original bug)."
+    )
+
+    # Y% reads 100.0 (the NA row drops out of the denominator entirely).
+    binary = compute_binary_stats(df, sales.yn_section_labels)
+    target_stats = next(b for b in binary if b["section_id"] == target_yn)
+    assert target_stats["team_pct"] == 100.0, (
+        f"Y% should be 100.0 (1 Y of 1 valid), got {target_stats['team_pct']}. "
+        f"NA row probably got counted as a failure."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`load_and_clean` was coercing every Y/N cell with `.strip().upper()[:1]`, which silently mapped `"Not Applicable"` (the `YN_DISPLAY['NA']` sentinel `sheets_service` writes for analyst-marked N/A cells) to `"N"`. Historical N/A rows were re-coded as **failures** and dragged binary-stats Y% down on every section that allowed N/A — Sales `flex_long_stay_pitch`, `pricing_explanation`, `book_attempt`, etc.

Was flagged in [`references/NumericNAOption.md`](../blob/main/qa-automation/AI-Scoring/references/NumericNAOption.md) as "out of scope; tracked separately." That note is now updated to mark this as resolved.

## Fix

New `_parse_yn_cell(val)` helper colocated with `_compute_binary_pct`. Replaces the `[:1]` slice in `load_and_clean`:

| Input (case-insensitive) | Output |
|---|---|
| `""` / whitespace | `""` |
| `"Y"` / `"Yes"` | `"Y"` |
| `"N"` / `"No"` | `"N"` |
| `"NA"` / `"N/A"` / `"Not Applicable"` | `"NA"` |
| Anything else | `""` (defensive — keeps unrecognized cells out of the binary denominator) |

## Downstream impact

**Zero new code in consumers.** Every yn consumer (`_compute_binary_pct`, `compute_binary_stats`, `compute_agent_roster.binary_pcts`) already filters by `(series == "Y") | (series == "N")` — so anything else falls out of both numerator and denominator. Adding `"NA"` to the universe just flows through correctly.

`compute_long_form` now propagates the `"NA"` sentinel as the score value — analytically meaningful instead of a silent miscode. The existing `xfail` test about numeric N/A in long-form is separate and still applies.

## Data migration

None needed. Historical `Analyst_History` rows are re-parsed correctly on the next `/team/stats` request.

## Tests

4 new tests in `test_analytics.py`:
- Each recognized form maps correctly.
- Each canonical NA spelling (`"Not Applicable"`, `"NA"`, `"N/A"`, mixed case, padded) preserves the NA sentinel.
- Empty + unknown values default to `""` (defensive).
- **End-to-end**: a Y + "Not Applicable" pair through `load_and_clean` → `compute_binary_stats` yields `team_pct == 100.0`, not 50.0 (which is what the old code produced).

Full suite: **186 passed, 6 skipped, 3 xfailed**.

## Mirrors PR #35

Same shape of fix landed earlier on the GAS side (`QAEntry._parseYesNoStatic` was also doing `charAt(0)` and returning `false` for "Not Applicable"). This PR closes the symmetric Python-side hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)