### PR TITLE
feat(qa-automation): AI-Scoring — call time on Analyst_History (PR-1: schema + writer + reader fallback)

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/history_layout.py
+++ b/qa-automation/AI-Scoring/backend/config/history_layout.py
@@ -8,11 +8,11 @@ Layout (0-indexed columns)::
 
     0           agent_name
     1           agent_email
-    2           timestamp
+    2           timestamp               (call_connected — see semantic note)
     3           evaluator_email
     4           dialpad_link
     5           overall_score
-    6 .. 6+N-1  section scores       (one per section, in section_number order)
+    6 .. 6+N-1  section scores          (one per section, in section_number order)
     6+N .. 6+2N-1  reasoning per section
     6+2N .. 6+3N-1 confidence per section
     6+3N        key_strengths
@@ -21,10 +21,31 @@ Layout (0-indexed columns)::
     6+3N+3      caller_name
     6+3N+4      caller_phone
     6+3N+5      source
+    6+3N+6      eval_approved_at        (NEW — see semantic note)
 
-Total width: 6 + 3N + 6 columns.
+Total width: 6 + 3N + 7 columns.
 
-For Sales (N=19) → 69 cols (A–BQ). For MS (N=10) → 42 cols (A–AP).
+For Sales (N=19) → 70 cols (A–BR). For MS (N=10) → 43 cols (A–AQ).
+
+----------------------------------------------------------------------
+Timestamp semantic — see references/CallTimeOnAnalystHistory.md
+----------------------------------------------------------------------
+PR-1 of the call-time initiative repurposes ``COL_TIMESTAMP`` (col C)
+to hold the call's ``date_connected`` from Dialpad (the time the call
+actually happened) and introduces a new trailing column,
+``col_eval_approved_at``, to hold the eval/approval-time UTC string
+that historically lived in col C.
+
+During the transition, ``load_and_clean`` reads ``col_eval_approved_at``
+first, falling back to col C when the new column is blank (i.e. on
+pre-cutover rows). Once the backfill (PR-2) populates the new column
+for every historical row, the fallback path stops firing and the two
+columns are coherent across the dataset. PR-3 then flips the analytics
+anchor from "eval time" to "call time" by switching ``df["timestamp"]``
+to the col C value.
+
+Score_Audit remains the canonical record of "when was each row
+scored/approved" — unaffected by this schema shift.
 """
 
 from __future__ import annotations
@@ -33,13 +54,13 @@ from __future__ import annotations
 # Fixed prefix (positions 0-5)
 COL_AGENT_NAME = 0
 COL_AGENT_EMAIL = 1
-COL_TIMESTAMP = 2
+COL_TIMESTAMP = 2           # call_connected (PR-1 of call-time initiative)
 COL_EVALUATOR_EMAIL = 3
 COL_DIALPAD_LINK = 4
 COL_OVERALL_SCORE = 5
 
 PREFIX_WIDTH = 6
-TRAILING_WIDTH = 6
+TRAILING_WIDTH = 7          # bumped 6 → 7 to seat col_eval_approved_at
 
 
 class HistoryLayout:
@@ -117,6 +138,16 @@ class HistoryLayout:
     @property
     def col_source(self) -> int:
         return self.confidence_end + 5
+
+    @property
+    def col_eval_approved_at(self) -> int:
+        """New trailing column. Holds the eval/approval-time UTC string
+        that used to live in ``COL_TIMESTAMP`` before the call-time
+        initiative (see module docstring). The writer fills it at
+        Stage 4 (`finalize_to_analyst_history`). Blank on pre-cutover
+        rows until PR-2's backfill script runs; ``load_and_clean``
+        falls back to col C during that window."""
+        return self.confidence_end + 6
 
     @property
     def total_width(self) -> int:

--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -102,6 +102,22 @@ class ScoreDestinationConfig(BaseModel):
     - Sales: dialpad_link, timestamp, agent_name, evaluator_email,
       feedback_combined (single cell, key_strengths + opportunities
       concatenated)
+
+    Call-time initiative (PR-1) — see
+    references/CallTimeOnAnalystHistory.md: the ``timestamp`` field
+    now semantically holds the call's ``date_connected`` from Dialpad,
+    sourced via `fr_ai_row[COL_TIMESTAMP]` in Stage 2. The JSON column
+    letters didn't change — only the meaning. The Apps Script email
+    pipeline's "Evaluation Date" line consequently renders as the call
+    date going forward.
+    """
+
+    metadata_cols_note: Optional[str] = None
+    """Free-form doc string for the per-team JSON to record any
+    team-specific semantic notes about ``metadata_cols``. Never read
+    by Python — purely a hint for reviewers who jump straight to the
+    JSON without opening this file. Mirrors the ``comment`` sibling
+    on :class:`WeightsReferenceConfig`.
     """
 
     weights_reference: Optional[WeightsReferenceConfig] = None

--- a/qa-automation/AI-Scoring/backend/config/teams/member_support.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/member_support.json
@@ -55,7 +55,8 @@
         "key_strengths": "N",
         "opportunities": "O",
         "dialpad_link": "P"
-      }
+      },
+      "metadata_cols_note": "Call-time initiative (PR-1): `timestamp` (col A) now semantically holds the call's date_connected from Dialpad, not the eval/approval clock. Sourced via fr_ai_row[COL_TIMESTAMP] in Stage 2 — the FR-AI tab's col C was repurposed by sheets_service.write_draft_to_fr_ai. The JSON value 'A' didn't change; only the meaning of what lands there did. See references/CallTimeOnAnalystHistory.md."
     },
     "mails_tab": "Mails"
   },

--- a/qa-automation/AI-Scoring/backend/config/teams/sales.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/sales.json
@@ -63,6 +63,7 @@
         "evaluator_email": "D",
         "dialpad_link": "E"
       },
+      "metadata_cols_note": "Call-time initiative (PR-1): `timestamp` (col C) now semantically holds the call's date_connected from Dialpad, not the eval/approval clock. Sourced via fr_ai_row[COL_TIMESTAMP] in Stage 2 — the FR-AI tab's col C was repurposed by sheets_service.write_draft_to_fr_ai. The JSON value 'C' didn't change; only the meaning of what lands there did. See references/CallTimeOnAnalystHistory.md.",
       "weights_reference": {
         "tab_name": "Weighing",
         "range": "B2:B20",

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, ValidationInfo, model_validator
 
@@ -106,5 +107,16 @@ class ScorecardWithMeta(Scorecard):
     sop_used: Optional[str] = None      # SOP title injected, if any
     caller_name: Optional[str] = None   # From Dialpad get_call_details
     caller_phone: Optional[str] = None  # From Dialpad get_call_details
+    # Call-time initiative (PR-1) — see references/CallTimeOnAnalystHistory.md
+    call_started_at_utc: Optional[datetime] = None
+    """Dialpad `date_connected` for this call, normalized to a UTC-aware
+    datetime by `_epoch_ms_to_utc_datetime`. None when get_call_details
+    failed or the field was missing — the writer treats None as
+    'leave the col C cell blank; backfill will fix it.'"""
+    call_ended_at_utc: Optional[datetime] = None
+    """Dialpad `date_ended`, same normalization. Plumbed but NOT written
+    to Analyst_History in this phase — only fed to the
+    `compute_call_duration` stub. Writing it to a dedicated column is a
+    future-project decision."""
     transcript_display: List[dict] = []  # [{timestamp, speaker, text}, ...]
     moments_display: List[dict] = []     # [{timestamp, type}, ...]

--- a/qa-automation/AI-Scoring/backend/services/dialpad_client.py
+++ b/qa-automation/AI-Scoring/backend/services/dialpad_client.py
@@ -6,7 +6,7 @@ recording download.
 
 import asyncio
 import os
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 import httpx
 
@@ -221,6 +221,44 @@ def _epoch_to_iso(val) -> str:
         return datetime.fromtimestamp(ts).isoformat()
     except (ValueError, TypeError, OSError):
         return str(val)
+
+
+def _epoch_ms_to_utc_datetime(val) -> Optional[datetime]:
+    """Convert a Dialpad epoch-ms timestamp to a UTC-aware datetime.
+
+    Used by the call-time initiative (PR-1 of
+    references/CallTimeOnAnalystHistory.md): `get_call_details` returns
+    `date_connected` / `date_ended` as numeric epoch-ms strings (or
+    empty when Dialpad didn't supply one). The writer needs a real
+    `datetime` for formatting + plumbing through `ScorecardWithMeta`.
+
+    Returns None on any failure so the writer can detect "we don't know"
+    and leave the cell blank, rather than guessing.
+    """
+    if val is None or val == "":
+        return None
+    try:
+        secs = int(val) / 1000
+        return datetime.fromtimestamp(secs, tz=timezone.utc)
+    except (ValueError, TypeError, OSError):
+        return None
+
+
+def compute_call_duration(
+    call_started_at_utc: Optional[datetime],
+    call_ended_at_utc: Optional[datetime],
+) -> Optional[timedelta]:
+    """Difference between Dialpad's `date_ended` and `date_connected`.
+
+    Plumbed in the call-time initiative (PR-1) but NOT consumed by any
+    production code yet. The future "call duration as an analytics
+    dimension" project will pick this up without having to re-touch
+    scoring_service / ScorecardWithMeta. Returns None when either input
+    is missing.
+    """
+    if call_started_at_utc is None or call_ended_at_utc is None:
+        return None
+    return call_ended_at_utc - call_started_at_utc
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/backend/services/history_service.py
+++ b/qa-automation/AI-Scoring/backend/services/history_service.py
@@ -10,7 +10,7 @@ columns.
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import time as _time
@@ -150,6 +150,19 @@ class SheetsProvider(DataProvider):
         ts = _parse_timestamp(_safe(row, history_layout.COL_TIMESTAMP))
         if ts is None:
             return None
+        # Sheet writer stamps `MM/DD/YYYY HH:MM:SS` in UTC clock terms but
+        # without a TZ marker (matches the pre-existing format). pydantic
+        # serializes a naive datetime as `"2026-05-31T03:44:15"`, which
+        # JS `new Date(iso)` interprets as **local** time — putting the
+        # value hours into the past or future for non-UTC browsers and
+        # showing the wrong date when call-time crosses a TZ boundary
+        # (e.g. May 30 9:44 PM local writes as 5/31 03:44 UTC; frontend
+        # reads it back as 5/31 03:44 *local*). Tagging UTC at the
+        # boundary makes the wire format unambiguous so the browser
+        # converts to local time correctly. Mirrors routes/team.py's
+        # `_to_utc` (the chiclet PR landed the same fix on /team/evals).
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
 
         # Build sections dict keyed by history_id (preserves the existing
         # API contract).
@@ -224,7 +237,12 @@ class SheetsProvider(DataProvider):
         self, agent_name: str, days: int = 30
     ) -> list[EvaluationRecord]:
         """Return evaluations for *agent_name* within the last *days* days."""
-        cutoff = datetime.now() - timedelta(days=days)
+        # tz-aware UTC: `_parse_row` returns tz-aware timestamps (call-time
+        # initiative PR-1 patch — naive datetimes serialized without a TZ
+        # marker were being parsed as local time on the JS side). A naive
+        # cutoff would TypeError on the comparison; downstream the route
+        # would 500 and the frontend would show "no evaluations found."
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
         cached = _get_cached_raw(self._history_cache_key)
         if cached is not None:
             all_rows = cached
@@ -271,7 +289,8 @@ class SheetsProvider(DataProvider):
             all_rows = self._ws.get_all_values()
             _set_cached_raw(self._history_cache_key, all_rows)
 
-        cutoff = datetime.now() - timedelta(days=days)
+        # tz-aware UTC — see get_agent_history comment for context.
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
         records: list[EvaluationRecord] = []
         for row in all_rows[1:]:  # skip header
             if not row:

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, Optional
 
 from backend.models.scorecard import ScorecardWithMeta
 from backend.services.audio_service import score_audio
-from backend.services.dialpad_client import get_transcript, get_call_details, build_dialpad_link, CALL_DURATION_FLAG_MS
+from backend.services.dialpad_client import (
+    CALL_DURATION_FLAG_MS,
+    _epoch_ms_to_utc_datetime,
+    build_dialpad_link,
+    get_call_details,
+    get_transcript,
+)
 from backend.services.notion_service import fetch_sop_for_call
 
 if TYPE_CHECKING:
@@ -99,6 +105,9 @@ async def score_call(
         sop_used=sop_data["sop_title"] or None,
         caller_name=call_details.get("caller_name", ""),
         caller_phone=call_details.get("caller_phone", ""),
+        # Call-time initiative (PR-1) — see references/CallTimeOnAnalystHistory.md
+        call_started_at_utc=_epoch_ms_to_utc_datetime(call_details.get("date_connected")),
+        call_ended_at_utc=_epoch_ms_to_utc_datetime(call_details.get("date_ended")),
         transcript_display=transcript_data.get("transcript_display", []),
         moments_display=transcript_data.get("moments_display", []),
     )

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -107,6 +107,23 @@ def _sheets_configured(team_id: str) -> bool:
 # Format + lookup helpers
 # ---------------------------------------------------------------------------
 
+def _format_call_started(call_started_at_utc) -> str:
+    """Render the call's `date_connected` for COL_TIMESTAMP (col C).
+
+    Returns the canonical sheet timestamp string ("MM/DD/YYYY HH:MM:SS",
+    UTC clock) when supplied, or "" when the call's date_connected
+    wasn't surfaced by Dialpad. Sentinel-blank lets `load_and_clean`'s
+    PR-2 fallback path keep working for rows the backfill will visit
+    later. See references/CallTimeOnAnalystHistory.md.
+    """
+    if call_started_at_utc is None:
+        return ""
+    # call_started_at_utc is a UTC-aware datetime per
+    # _epoch_ms_to_utc_datetime. strftime emits the wall-clock value
+    # (UTC) without a TZ marker, matching the existing convention.
+    return call_started_at_utc.strftime("%m/%d/%Y %H:%M:%S")
+
+
 def _format_ai_score(sec_def: SectionDef, ai_section: dict) -> str:
     """Convert AI-output section dict to a score-cell string.
 
@@ -240,8 +257,15 @@ def write_draft_to_fr_ai(scorecard: ScorecardWithMeta, config: TeamConfig) -> in
 
     row = [""] * L.total_width
     row[history_layout.COL_AGENT_NAME] = scorecard.agent_name or ""
-    row[history_layout.COL_TIMESTAMP] = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
+    # Call-time initiative (PR-1): col C now holds the call's
+    # `date_connected` from Dialpad (when the call actually happened),
+    # not the draft/approval clock. Blank when get_call_details didn't
+    # surface a date_connected — backfill (PR-2) will fill it later.
+    # See references/CallTimeOnAnalystHistory.md.
+    row[history_layout.COL_TIMESTAMP] = _format_call_started(scorecard.call_started_at_utc)
     row[history_layout.COL_DIALPAD_LINK] = scorecard.dialpad_link or ""
+    # eval_approved_at (new trailing column) is filled at Stage 4 by
+    # finalize_to_analyst_history. Leave blank here.
 
     for i, sec_def in enumerate(config.sections_by_number):
         if sec_def.auto_value is not None:
@@ -398,6 +422,15 @@ def write_to_score_destination(
     their declared value; manual sections fall back to
     ``manual_default_value`` if the analyst left the FR-AI cell blank.
 
+    Call-time initiative (PR-1) — see
+    references/CallTimeOnAnalystHistory.md: the ``timestamp`` cell in
+    ``metadata_cols`` (FR1 col A for MS, col C for Sales) is sourced
+    from ``fr_ai_row[COL_TIMESTAMP]``, which Stage 1 now populates from
+    the call's ``date_connected`` instead of the draft clock. The Apps
+    Script email's "Evaluation Date" line therefore renders as the
+    call date going forward — usually what agents/managers actually
+    want to see. Renaming that label on the GAS side is a follow-up.
+
     Returns the destination tab's appended row number.
     """
     L = config.history_layout
@@ -456,6 +489,12 @@ def write_to_score_destination(
     key_strengths = fr_ai_row[L.col_key_strengths]
     opportunities = fr_ai_row[L.col_opportunities]
     metadata_values = {
+        # "timestamp" semantically = the call's date_connected since the
+        # call-time initiative (PR-1) flipped col C. Pre-cutover rows
+        # passing through Stage 2 (rare; only re-approvals of historical
+        # drafts) still carry the legacy eval-time value in col C —
+        # acceptable transient. Backfill (PR-2) makes the semantic
+        # uniform across all rows.
         "timestamp": fr_ai_row[history_layout.COL_TIMESTAMP],
         "agent_name": fr_ai_row[history_layout.COL_AGENT_NAME],
         "dialpad_link": fr_ai_row[history_layout.COL_DIALPAD_LINK],
@@ -551,9 +590,15 @@ def finalize_to_analyst_history(
     """Stage 4: copy the now-complete FR-AI row to Analyst_History.
 
     Resolves agent_email via the Mails lookup, sets evaluator_email,
-    refreshes the timestamp to "approval time" (UTC). Both tabs share
-    the derived layout — this is essentially a row-copy with a few
-    metadata cells overridden.
+    and stamps the approval time on the new ``col_eval_approved_at``
+    trailing column.
+
+    Call-time initiative (PR-1) — see
+    references/CallTimeOnAnalystHistory.md: this no longer overrides
+    col C. COL_TIMESTAMP was set at Stage 1 (`write_draft_to_fr_ai`)
+    from the call's `date_connected`; it travels untouched into
+    Analyst_History. The approval-time UTC string that used to live
+    in col C now lives in `col_eval_approved_at`.
 
     Returns the Analyst_History row number.
     """
@@ -569,7 +614,10 @@ def finalize_to_analyst_history(
     history_row = list(fr_ai_row)
     history_row[history_layout.COL_AGENT_EMAIL] = agent_email
     history_row[history_layout.COL_EVALUATOR_EMAIL] = evaluator_email
-    history_row[history_layout.COL_TIMESTAMP] = datetime.now(timezone.utc).strftime(
+    # NOTE: COL_TIMESTAMP intentionally NOT touched here — it holds
+    # call_connected from Stage 1. The approval clock writes to the new
+    # trailing column instead.
+    history_row[L.col_eval_approved_at] = datetime.now(timezone.utc).strftime(
         "%m/%d/%Y %H:%M:%S"
     )
 

--- a/qa-automation/AI-Scoring/backend/services/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/services/team_stats.py
@@ -134,7 +134,28 @@ def load_and_clean(
         if not agent_raw:
             continue
 
-        ts = parse_timestamp(row[history_layout.COL_TIMESTAMP])
+        # Call-time initiative (PR-1 of references/CallTimeOnAnalystHistory.md):
+        # the eval timestamp lives in col_eval_approved_at on new-shape rows
+        # (Stage 4 writer fills it). On pre-cutover rows that column is
+        # blank — fall back to col C, which used to hold the eval/approval
+        # time before the schema shift. After PR-2 backfill runs, every
+        # historical row will have col_eval_approved_at populated and the
+        # fallback stops firing.
+        new_col_idx = L.col_eval_approved_at
+        new_col_val = row[new_col_idx] if len(row) > new_col_idx else ""
+        eval_approved_at = parse_timestamp(new_col_val) if new_col_val else None
+
+        col_c_val = row[history_layout.COL_TIMESTAMP]
+
+        if eval_approved_at is not None:
+            # New-shape row: col C = call_started, col_eval_approved_at = eval time.
+            ts = eval_approved_at
+            call_started = parse_timestamp(col_c_val)
+        else:
+            # Old-shape row: col C = eval time, call_started unknown.
+            ts = parse_timestamp(col_c_val)
+            call_started = None
+
         if ts is None or ts.year < 2020:
             continue
 
@@ -187,6 +208,13 @@ def load_and_clean(
         records.append({
             "agent": agent,
             "timestamp": ts,
+            # New column from PR-1 of the call-time initiative. Populated
+            # for new-shape rows (Stage 4 writer fills col_eval_approved_at,
+            # leaving col C as call_started); None for pre-backfill rows.
+            # df["timestamp"] continues to be the eval-time anchor during
+            # the transition — analytics consumers don't change behavior
+            # here. After PR-3 they'll switch to df["call_started"].
+            "call_started": call_started,
             "overall_score": overall,
             **section_scores,
             **yn_scores,
@@ -201,6 +229,8 @@ def load_and_clean(
         return df
 
     df["timestamp"] = pd.to_datetime(df["timestamp"])
+    # NaT for rows where call_started is unknown (pre-backfill).
+    df["call_started"] = pd.to_datetime(df["call_started"])
     return df
 
 

--- a/qa-automation/AI-Scoring/references/CallTimeOnAnalystHistory.md
+++ b/qa-automation/AI-Scoring/references/CallTimeOnAnalystHistory.md
@@ -1,0 +1,411 @@
+# Call time vs eval time on Analyst_History — design doc
+
+> **Purpose:** Separate "when the call happened" from "when we scored it"
+> on Analyst_History. Today `COL_TIMESTAMP` (col C) holds the approval
+> time and every downstream consumer (chiclets, SPC, EWMA, days filter,
+> /team/evals drill-down) buckets by it. After this initiative, col C
+> means "call connected at" (from Dialpad's `date_connected`), and the
+> eval/approval time moves to a new trailing column. Score_Audit
+> continues to be the authoritative audit log of "who scored what when"
+> — unchanged.
+> **Author session:** 2026-06-01.
+> **Status:** Design — not yet implemented.
+
+---
+
+## Decisions locked (2026-06-01)
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Schema shape on Analyst_History / FR-AI | Repurpose col C → call_connected; eval timestamp moves to a new trailing column | TRAILING_WIDTH 6 → 7. Long-term semantic: col C = "the time of the thing the row is about." |
+| FR1 score_destination tab `metadata.timestamp` | Switch to call_connected | Apps Script email's "Evaluation Date" line becomes the call date — usually what agent/manager actually want. |
+| When analytics shift bucketing from eval → call | After backfill is complete (PR-3) | Avoids a window where chiclets/SPC bucket old rows by eval time and new rows by call time. |
+| Backfill script | Separate PR after schema PR | PR-1 ships schema + writer + reader-with-fallback. PR-2 ships backfill. PR-3 flips analytics. |
+| Fallback when `date_connected` is missing on a new approval | Empty cell | Truthful "we don't know" — downstream readers treat blank as missing; backfill script can retry later. |
+
+---
+
+## What stays the same
+
+- **Score_Audit tab** is unchanged. `append_score_audit_row` keeps writing
+  the approval timestamp at the moment of `/score` and `/approve`. This is
+  the legal-grade record of "who scored what when."
+- **Section/reasoning/confidence column positions** in Analyst_History.
+  The new column is **trailing**, so no shift in section columns — the
+  Apps Script side reading section scores by letter is unaffected.
+- **`history_layout.HistoryLayout.col_score(i)` etc.** semantics. Only
+  `TRAILING_WIDTH` changes; everything else shifts naturally via the
+  derived properties.
+
+---
+
+## Schema deltas
+
+### `backend/config/history_layout.py`
+
+```python
+TRAILING_WIDTH = 7        # was 6 — new column for eval_approved_at
+
+# COL_TIMESTAMP semantic shift:
+#   was → eval/approval time (UTC clock, written by sheets_service)
+#   now → call's `date_connected` from Dialpad get_call_details
+COL_TIMESTAMP = 2         # column letter unchanged; meaning changed
+
+class HistoryLayout:
+    ...
+    @property
+    def col_eval_approved_at(self) -> int:
+        """New trailing column. Holds the approval-time UTC string that
+        used to live in col C. Stays blank when the writer cannot
+        compute it (defensive — should never happen since the writer
+        always knows when *it* fired)."""
+        return self.confidence_end + 6
+```
+
+(Existing `col_source` becomes `confidence_end + 5`; the new column is
+positioned after it.)
+
+### `backend/config/teams/<team>.json` — FR1 metadata_cols
+
+```jsonc
+"metadata_cols": {
+  "timestamp": "A",         // now stores call_connected (date_connected, UTC string)
+  "manager_email": "B",
+  "agent_name": "C",
+  "key_strengths": "N",
+  "opportunities": "O",
+  "dialpad_link": "P"
+  // No new FR1 column for eval-approved-at; that's now only on
+  // Analyst_History + Score_Audit. The FR1 tab is purely the email
+  // pipeline's input — eval time isn't needed there.
+}
+```
+
+Both `member_support.json` and `sales.json` need the comment/doc note that
+`timestamp` now means call time. The literal JSON value (`"A"`) doesn't
+change — only the semantic.
+
+---
+
+## Writer path changes
+
+### `backend/services/scoring_service.py`
+
+`ScorecardWithMeta` gains two optional fields (open Q1 resolution —
+capture `date_ended` too so the duration helper has both inputs from
+day one):
+
+```python
+class ScorecardWithMeta(...):
+    ...
+    call_started_at_utc: Optional[datetime] = None
+    """Dialpad `date_connected` for this call, normalized to UTC datetime.
+    None when get_call_details failed or the field was missing — the
+    writer treats None as 'leave the cell blank, backfill will fix it.'"""
+
+    call_ended_at_utc: Optional[datetime] = None
+    """Dialpad `date_ended`, same normalization. Plumbed but NOT written
+    to Analyst_History in this phase — only consumed by the
+    `compute_call_duration` stub (see services/dialpad_client.py).
+    Writing it to a column is a follow-up project's call."""
+```
+
+`score_call` populates both from `call_details["date_connected"]` and
+`call_details["date_ended"]`. We already have the helper `_epoch_to_iso`
+in `dialpad_client.py`; add a sibling `_epoch_ms_to_utc_datetime` for
+the writer's `datetime` typing.
+
+### `services/dialpad_client.py` — duration stub
+
+```python
+def compute_call_duration(
+    call_started_at_utc: Optional[datetime],
+    call_ended_at_utc: Optional[datetime],
+) -> Optional[timedelta]:
+    """Difference between Dialpad's `date_ended` and `date_connected`.
+
+    STUB: returned for any caller that wants it, but no production code
+    consumes it yet. Plumbed in this PR so a future "call duration as
+    an analytics dimension" project doesn't have to re-touch
+    scoring_service / ScorecardWithMeta. Returns None when either input
+    is missing.
+    """
+    if call_started_at_utc is None or call_ended_at_utc is None:
+        return None
+    return call_ended_at_utc - call_started_at_utc
+```
+
+Test surface: a happy-path returns the right timedelta, missing-input
+returns None. Two tests, both in `test_dialpad_client.py`.
+
+### `backend/services/sheets_service.py`
+
+**`write_draft_to_fr_ai`** (Stage 1) — currently writes the *draft*
+timestamp at col C. After:
+
+```python
+row[history_layout.COL_TIMESTAMP] = _format_call_time(scorecard.call_started_at_utc)
+row[L.col_eval_approved_at] = ""   # filled at Stage 4 (approval)
+```
+
+`_format_call_time` returns `"MM/DD/YYYY HH:MM:SS"` (UTC, matching the
+existing format) or `""` when `call_started_at_utc is None`.
+
+**`finalize_to_analyst_history`** (Stage 4) — currently overrides col C
+with `datetime.now(UTC)`. After:
+
+```python
+# Stop overriding col C — it was set at Stage 1 from call data.
+# Write the approval time to the new trailing column.
+history_row[L.col_eval_approved_at] = datetime.now(timezone.utc).strftime(
+    "%m/%d/%Y %H:%M:%S"
+)
+```
+
+**`write_to_score_destination`** (Stage 2) — already pulls the
+timestamp from FR-AI col C. No code change required; the *value* shifts
+from approval-time to call-connected automatically, which is what we
+want for the FR1 tab. Apps Script email reads it via
+`metadata_cols.timestamp`.
+
+---
+
+## Reader path during the transition
+
+The transition spans three PRs. During PR-1 and PR-2, analytics must
+keep producing stable results — which means continuing to bucket by
+**eval time** until the backfill makes call_started universally
+available.
+
+`load_and_clean` reads col C today as the canonical timestamp. After
+PR-1 lands, col C on **new rows** is the call connected time, and the
+new trailing column holds eval time. On **historical rows**, col C is
+still eval time and the new trailing column is blank.
+
+So during the transition, "what eval time is" is computed as:
+
+```python
+eval_ts = parse_timestamp(row[L.col_eval_approved_at]) or parse_timestamp(row[COL_TIMESTAMP])
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^   new rows                ^^^^^^^^^^^^^^^^^^^^^^   old rows fallback
+```
+
+And "what call time is" is computed as:
+
+```python
+call_ts = parse_timestamp(row[COL_TIMESTAMP]) if has_call_time_been_backfilled(row) else None
+```
+
+For PR-1, `load_and_clean` keeps writing `df["timestamp"]` from the
+eval-time path so chiclets/SPC/EWMA/days-cutoff behavior is unchanged.
+A second column `df["call_started"]` gets added (None where unknown)
+so PR-3 can flip analytics without another `load_and_clean` touch.
+
+The "has it been backfilled" question is resolved naturally: PR-2
+backfill writes call_started to col C and moves the original col C
+value (eval time) to the new trailing column for every historical row.
+After backfill completes, every row satisfies "trailing column =
+eval time, col C = call time" coherently.
+
+---
+
+## Score_Audit unchanged
+
+The Score_Audit tab is the canonical audit log. `append_score_audit_row`
+writes a fresh approval timestamp at /score time and at /approve time.
+That doesn't move. Even after PR-3 flips analytics to call-time
+bucketing, the audit answer to "when was this call scored" is one
+Score_Audit row away.
+
+---
+
+## Backfill script (PR-2)
+
+`qa-automation/AI-Scoring/scripts/backfill_call_started.py`:
+
+- Reads Analyst_History rows.
+- For each row where the new trailing column is blank:
+  - Parse `call_id` from `dialpad_link` (col E).
+  - `get_call_details(call_id)` → `date_connected`.
+  - **Two-cell update**: write the old col C value into the trailing
+    column (eval time relocation), then overwrite col C with the
+    formatted `date_connected` (call time).
+  - Rate-limit (≤ 5 req/s per Dialpad's published limit).
+  - Sleep + retry on 429.
+  - Skip + log when get_call_details returns no `date_connected`.
+- Per-row audit: append a record to a new local
+  `.backfill-log` file (gitignored) so a partial run can resume.
+- `--dry-run` mode: prints planned mutations, writes nothing.
+- `--max-rows N`: cap for incremental runs.
+- `--team-id <id>`: process one team at a time.
+
+Rate-limit math: 5 req/s × 600s = 3,000 rows/run upper bound. For
+member_support (~3k rows) one run; for sales (~600 rows) one run.
+
+---
+
+## Analytics shift (PR-3)
+
+Single edit in `load_and_clean`:
+
+```python
+# Before:
+df["timestamp"] = ...  # eval time
+
+# After:
+df["timestamp"] = df["call_started"]   # populated by load_and_clean from col C
+df["eval_approved_at"] = ...           # the now-trailing eval-approval-time column
+```
+
+Every chiclet/SPC/EWMA/days-filter/outlier consumer reads
+`df["timestamp"]` and gets call-bucketed data automatically. The
+`eval_approved_at` column stays available for any consumer that wants
+to filter or display by approval time.
+
+Manual verification at PR-3 time:
+- May 2026 chiclet shifts from "evals approved in May" → "calls placed
+  in May". Visible numerical change expected.
+- A call placed late April but scored early May moves from May → April
+  bucket. Worth flagging in the PR-3 PR body so reviewers don't see it
+  as a regression.
+
+---
+
+## Edge cases + fallback policy
+
+1. **`date_connected` missing or `get_call_details` failed at /score time.**
+   `call_started_at_utc` stays None. `write_draft_to_fr_ai` writes
+   `""` to col C. Finalize writes the eval-approval-time to the new
+   trailing column. The row's "what time was the call" answer is
+   blank — picked up by the next backfill run if Dialpad returns the
+   info later.
+
+2. **Long-call flag** (`flagged_long_call` is True). Doesn't change call
+   time semantics; the flag stays on its dialpad_link `[LONG CALL]`
+   suffix as today.
+
+3. **Approval long after scoring.** Common; the call-time stays
+   stable across draft → approve. Stage 4 only sets the trailing
+   approval-time column.
+
+4. **Manual upload with no Dialpad metadata.** `score_call` calls
+   `get_call_details(call_id)`. If `call_id` is fake/external, the
+   call returns blank and col C stays empty. Acceptable — the analyst
+   knew this was a non-Dialpad call when uploading.
+
+5. **Frontend "Date" displays.** The `/team/evals` drill-down's Date
+   column, EWMA expansion's Date column, and Recent Evals' time-ago all
+   currently read `timestamp`. After PR-3 they show call time. Worth
+   labeling clearly in the UI ("Call date" instead of "Date") in the
+   PR-3 PR.
+
+6. **Existing `_to_utc` boundary fix on `/team/evals`** (from PR #39
+   chiclets work) covers naive timestamps. The new column writes UTC
+   strings the same way the existing one did, so the fix continues to
+   apply.
+
+---
+
+## Implementation phases + pytest checkpoints
+
+1. **Phase 0 — Schema bump (no behavior change)**
+   - `TRAILING_WIDTH` 6 → 7.
+   - `col_eval_approved_at` property on `HistoryLayout`.
+   - Update `total_width` assertions.
+   - Tests: layout returns the right column index for the new field at
+     N=10, N=19, and N=1 boundary.
+   - Checkpoint: `pytest tests -q` green.
+
+2. **Phase 1 — Writer plumbing (Stage 1 + Stage 4)**
+   - `ScorecardWithMeta.call_started_at_utc` field.
+   - `scoring_service.score_call` populates from `date_connected`.
+   - `write_draft_to_fr_ai` writes formatted call-time to col C; blank
+     to col_eval_approved_at.
+   - `finalize_to_analyst_history` stops overriding col C; writes
+     approval time to col_eval_approved_at instead.
+   - Tests: writer path produces the expected row shape under (a)
+     call_details with valid date_connected, (b) call_details missing,
+     (c) call_details failed (None). Mock the sheet writer.
+   - Checkpoint: green.
+
+3. **Phase 2 — Reader with fallback**
+   - `load_and_clean` produces `df["timestamp"]` from
+     col_eval_approved_at if present else col C. New column
+     `df["call_started"]` parsed from col C when the new col is
+     populated (heuristic that the row is "new shape"), else None.
+   - Tests: an old-style row (only col C populated) still yields a
+     valid `df["timestamp"]`. A new-style row yields
+     `df["timestamp"]` from the trailing column and
+     `df["call_started"]` from col C.
+   - Checkpoint: green. No analytics behavior change; chiclets/SPC/etc
+     still bucket by `df["timestamp"]` which is eval time during the
+     transition.
+
+4. **Phase 3 — FR1 metadata.timestamp semantic shift**
+   - JSON comments only (no schema change to the JSON keys).
+   - Update `write_to_score_destination` docstring to note the cell now
+     holds call time.
+   - No code change to the actual write logic — it already copies col C
+     verbatim.
+   - Apps Script side note: the email template's "Evaluation Date"
+     label should change to "Call Date" — separate PR on the GAS side
+     after this lands.
+
+5. **Phase 4 — PR open**
+   - PR body warns: "this lands the schema and writer; analytics still
+     bucket by eval time. Backfill (PR-2) and analytics shift (PR-3)
+     are follow-ups."
+
+After PR-1 merges:
+
+6. **Phase 5 — Backfill script (PR-2)** — separate PR, see "Backfill
+   script" section above.
+
+7. **Phase 6 — Analytics shift (PR-3)** — separate PR, single edit in
+   `load_and_clean` plus UI labels.
+
+---
+
+## Open questions — resolved 2026-06-01
+
+1. **Capture `date_ended` + plumb a duration helper.** **Resolved: yes.**
+   Capture `date_ended` on the same path as `date_connected`. Stub a
+   `compute_call_duration(call_started_at_utc, call_ended_at_utc) -> Optional[timedelta]`
+   helper in `services/dialpad_client.py` (or a new `services/call_metrics.py`)
+   that is **wired into the writer but not yet consumed by analytics** —
+   plumbing only. Implementation of "what to do with the duration"
+   (display, analytics bucket, outlier inputs) is deferred to a later
+   project. This avoids re-touching `ScorecardWithMeta` /
+   `sheets_service` later when the duration feature lands.
+2. **Backfill rate limit.** **Confirmed: 5 req/s** is still the
+   Dialpad standard. Slower run is the right trade for reliability;
+   the script will stay well under the cap with a small jitter.
+3. **PR-3 tooltip.** **Resolved: yes.** Bucket-shift would be
+   confusing to management on its own — chiclets, SPC chart, and SPC
+   datapoint hover get a brief "bucketed by call date" annotation
+   when PR-3 lands. Specific copy decided at PR-3 time.
+
+### Newly-raised risk — backfill ID mismatch
+
+Historical rows store `dialpad_link` keyed by `entry_point_call_id`
+(per PR #32 fix), but `get_call_details(call_id)` is documented
+against the master `call_id`. For direct calls the two ids coincide;
+for queue-routed inbound calls they diverge. The backfill script
+must handle both cases:
+
+- **Lookup attempt 1**: call `get_call_details(eval_id)` where
+  `eval_id` is parsed from `dialpad_link`. For direct calls this
+  works; the response carries `date_connected` and `date_ended`.
+- **Lookup attempt 2** (queue calls): if attempt 1 returns 404 or
+  blank, try `get_recent_calls` (already exists) to search by
+  `entry_point_call_id` and recover the master id. If that's
+  unworkable, log the row's `eval_id` to the backfill audit and
+  skip — analyst can resolve manually.
+
+Skipped rows stay readable under the PR-2 fallback (`load_and_clean`
+falls back to col C for non-backfilled rows). After PR-3 flips
+analytics, skipped rows show "—" for the date in the UI — a known
+incomplete-data state, not a corrupted one.
+
+Recommend the backfill script emit a `.backfill-skipped.csv` with
+columns (`row_num`, `agent`, `eval_id`, `reason`) so the gaps are
+discoverable and triagable in bulk rather than buried in a log file.

--- a/qa-automation/AI-Scoring/tests/conftest.py
+++ b/qa-automation/AI-Scoring/tests/conftest.py
@@ -152,13 +152,26 @@ def make_history_row(
     evaluator_email: str = "evaluator@landing.com",
     dialpad_link: str = "",
     source: str = "ai",
+    call_started: datetime | None = None,
 ) -> list[str]:
     """Build one Analyst_History row matching the derived layout.
 
-    Writes prefix (cols 0-5), section scores (cols 6 to 6+N-1) in
-    section_number order, and trailing metadata cells. Reasoning and
-    confidence cells are left blank — production rows fill them post-
-    approval.
+    `when` is always the eval/approval time the caller wants to assert
+    against. The new-shape / old-shape switch is controlled by
+    `call_started`:
+
+      * ``call_started=None`` (default) → **old-shape row**: col C
+        holds `when` (eval time), `col_eval_approved_at` is left blank.
+        Exercises `load_and_clean`'s fallback path. Matches every
+        synthetic row that existed before the call-time initiative.
+
+      * ``call_started=<datetime>`` → **new-shape row**: col C holds
+        the call's connected time, `col_eval_approved_at` holds the
+        eval time (`when`). Matches what `finalize_to_analyst_history`
+        writes after the Phase 1 schema shift.
+
+    Reasoning and confidence cells are left blank — production rows
+    fill them post-approval.
     """
     L = config.history_layout
     row = _empty_row(L.total_width)
@@ -166,7 +179,13 @@ def make_history_row(
     # Prefix
     row[history_layout.COL_AGENT_NAME] = agent
     row[history_layout.COL_AGENT_EMAIL] = f"{agent.lower().replace(' ', '.')}@landing.com"
-    row[history_layout.COL_TIMESTAMP] = when.strftime("%m/%d/%Y %H:%M:%S")
+    if call_started is None:
+        # Old-shape: col C is the eval time.
+        row[history_layout.COL_TIMESTAMP] = when.strftime("%m/%d/%Y %H:%M:%S")
+    else:
+        # New-shape: col C is the call's connected time; eval time
+        # lands in the new trailing column below.
+        row[history_layout.COL_TIMESTAMP] = call_started.strftime("%m/%d/%Y %H:%M:%S")
     row[history_layout.COL_EVALUATOR_EMAIL] = evaluator_email
     row[history_layout.COL_DIALPAD_LINK] = (
         dialpad_link
@@ -200,6 +219,8 @@ def make_history_row(
     row[L.col_caller_name] = "Syn Caller"
     row[L.col_caller_phone] = "+15555550100"
     row[L.col_source] = source
+    if call_started is not None:
+        row[L.col_eval_approved_at] = when.strftime("%m/%d/%Y %H:%M:%S")
 
     return row
 

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -324,6 +324,127 @@ def test_load_and_clean_preserves_yn_na_through_binary_stats(sales: TeamConfig):
 
 
 # ---------------------------------------------------------------------------
+# load_and_clean — call-time initiative (PR-1) reader fallback.
+#
+# Phase 1 schema:    eval-time → col_eval_approved_at; call-time → col C
+# Phase 2 reader:    df["timestamp"]   resolves to col_eval_approved_at on
+#                                      new-shape rows, else col C (old).
+#                    df["call_started"] resolves to col C on new-shape rows,
+#                                      NaT on old-shape (pre-backfill).
+#
+# During the transition, df["timestamp"] still anchors every analytics
+# consumer at eval time — chiclets/SPC/EWMA behavior must not shift.
+# ---------------------------------------------------------------------------
+
+def test_load_and_clean_reads_old_shape_row_from_col_c(sales: TeamConfig):
+    """A pre-cutover row has col_eval_approved_at blank — load_and_clean
+    falls back to col C for df['timestamp']. call_started is NaT
+    (we don't know when this call connected; backfill will fill it)."""
+    from datetime import datetime as _dt
+    import pandas as pd
+
+    header = [["Agent Name"] + [""] * 200]
+    when = _dt(2026, 4, 15, 10, 30, 0)
+    # Default call_started=None → old-shape row.
+    rows = header + [make_history_row(sales, agent="Star Rep", when=when, overall=92)]
+    mails = make_mails_sheet(["Star Rep"])
+    df = load_and_clean(rows, mails, sales)
+
+    assert not df.empty
+    star = df[df["agent"] == "Star Rep"].iloc[0]
+    # df["timestamp"] reads col C (eval time) on old-shape rows.
+    assert star["timestamp"] == pd.Timestamp(when)
+    # call_started is NaT — pre-backfill, we don't know.
+    assert pd.isna(star["call_started"])
+
+
+def test_load_and_clean_reads_new_shape_row_with_call_started_split(sales: TeamConfig):
+    """A post-cutover row has col_eval_approved_at populated. df['timestamp']
+    reads the new column (eval time); df['call_started'] reads col C
+    (call connected). Verifies the split is observed correctly."""
+    from datetime import datetime as _dt
+    import pandas as pd
+
+    header = [["Agent Name"] + [""] * 200]
+    eval_time = _dt(2026, 5, 10, 14, 0, 0)
+    call_time = _dt(2026, 5, 9, 9, 15, 0)   # call happened day before scoring
+    rows = header + [make_history_row(
+        sales, agent="Star Rep", when=eval_time, overall=92,
+        call_started=call_time,
+    )]
+    mails = make_mails_sheet(["Star Rep"])
+    df = load_and_clean(rows, mails, sales)
+
+    star = df[df["agent"] == "Star Rep"].iloc[0]
+    # df["timestamp"] reads col_eval_approved_at on new-shape rows.
+    assert star["timestamp"] == pd.Timestamp(eval_time)
+    # call_started reads col C — the day the call actually connected.
+    assert star["call_started"] == pd.Timestamp(call_time)
+
+
+def test_load_and_clean_mixed_shapes_coexist(sales: TeamConfig):
+    """Real-world during the PR-1 → PR-2 transition: some rows are old-shape
+    (pre-cutover), some are new-shape (post-cutover). df['timestamp']
+    must still anchor every row at eval time so chiclets/SPC/EWMA
+    don't see a mixed bucket shift before backfill completes."""
+    from datetime import datetime as _dt
+    import pandas as pd
+
+    header = [["Agent Name"] + [""] * 200]
+    old_when = _dt(2026, 3, 1, 12, 0, 0)
+    new_eval = _dt(2026, 5, 5, 12, 0, 0)
+    new_call = _dt(2026, 5, 3, 10, 0, 0)
+    rows = header + [
+        # Old-shape row.
+        make_history_row(sales, agent="Star Rep", when=old_when, overall=88),
+        # New-shape row.
+        make_history_row(
+            sales, agent="Steady Rep", when=new_eval, overall=82,
+            call_started=new_call,
+        ),
+    ]
+    mails = make_mails_sheet(["Star Rep", "Steady Rep"])
+    df = load_and_clean(rows, mails, sales)
+
+    star = df[df["agent"] == "Star Rep"].iloc[0]
+    steady = df[df["agent"] == "Steady Rep"].iloc[0]
+
+    # Old-shape: timestamp from col C, call_started NaT.
+    assert star["timestamp"] == pd.Timestamp(old_when)
+    assert pd.isna(star["call_started"])
+
+    # New-shape: timestamp from col_eval_approved_at, call_started from col C.
+    assert steady["timestamp"] == pd.Timestamp(new_eval)
+    assert steady["call_started"] == pd.Timestamp(new_call)
+
+
+def test_load_and_clean_analytics_still_bucket_by_eval_time_during_transition(
+    sales: TeamConfig,
+):
+    """Critical for PR-1 staging: the call-time initiative MUST NOT shift
+    chiclets/SPC bucketing until PR-3 lands. A new-shape row with a
+    call-time in April and eval-time in May must surface in May's bucket
+    via compute_monthly_summary — same as it would have pre-initiative."""
+    from datetime import datetime as _dt
+    import pandas as pd
+
+    header = [["Agent Name"] + [""] * 200]
+    eval_in_may = _dt(2026, 5, 5, 12, 0, 0)
+    call_in_apr = _dt(2026, 4, 28, 10, 0, 0)  # 7 days before scoring
+    rows = header + [make_history_row(
+        sales, agent="Star Rep", when=eval_in_may, overall=90,
+        call_started=call_in_apr,
+    )]
+    mails = make_mails_sheet(["Star Rep"])
+    df = load_and_clean(rows, mails, sales)
+
+    # df["timestamp"] anchored at May (eval time), NOT April (call time).
+    assert df.iloc[0]["timestamp"].month == 5
+    # call_started is parsed and available for PR-3 to consume.
+    assert df.iloc[0]["call_started"].month == 4
+
+
+# ---------------------------------------------------------------------------
 # Known tech debt — long-form analytics cannot distinguish explicit N/A
 # from "unscored" on numeric sections.
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_config_load.py
+++ b/qa-automation/AI-Scoring/tests/test_config_load.py
@@ -66,10 +66,15 @@ def test_score_destination_columns_reference_real_sections(config: TeamConfig):
 
 
 def test_history_layout_width_matches_formula(config: TeamConfig):
-    """Derived layout width follows the canonical 6 + 3N + 6 formula."""
+    """Derived layout width follows the canonical 6 + 3N + 7 formula.
+
+    Trailing width is 7 since the call-time initiative landed
+    `col_eval_approved_at` as a trailing column (see
+    references/CallTimeOnAnalystHistory.md).
+    """
     L = config.history_layout
     n = len(config.sections)
-    assert L.total_width == 6 + 3 * n + 6
+    assert L.total_width == 6 + 3 * n + 7
     # Range invariants: scores → reasoning → confidence are contiguous, each width N
     assert L.scores_end - L.scores_start == n
     assert L.reasoning_end - L.reasoning_start == n
@@ -79,6 +84,47 @@ def test_history_layout_width_matches_formula(config: TeamConfig):
     # Trailing fixed cells immediately follow confidence range
     assert L.col_key_strengths == L.confidence_end
     assert L.col_source == L.confidence_end + 5
+    # New trailing column for the call-time initiative
+    assert L.col_eval_approved_at == L.confidence_end + 6
+    # eval_approved_at is the LAST trailing column — total_width math
+    # would silently break if a future trailing cell landed without
+    # bumping TRAILING_WIDTH here.
+    assert L.col_eval_approved_at == L.total_width - 1
+
+
+def test_history_layout_eval_approved_at_does_not_collide_with_existing_trailing_cells(
+    config: TeamConfig,
+):
+    """Regression guard: col_eval_approved_at must not overlap any of the
+    six prior trailing cells. Catches an accidental re-numbering."""
+    L = config.history_layout
+    prior_trailing = {
+        L.col_key_strengths,
+        L.col_opportunities,
+        L.col_call_summary,
+        L.col_caller_name,
+        L.col_caller_phone,
+        L.col_source,
+    }
+    assert L.col_eval_approved_at not in prior_trailing
+
+
+def test_history_layout_eval_approved_at_indices_at_n_boundaries():
+    """N=1 (smallest legal), N=10 (member_support shape), N=19 (sales
+    shape). Asserts col_eval_approved_at lands at the documented offset
+    relative to confidence_end for each."""
+    from backend.config.history_layout import HistoryLayout
+
+    for n in (1, 10, 19):
+        L = HistoryLayout(n)
+        # confidence_end = 6 + 3n; col_eval_approved_at = confidence_end + 6
+        expected = 6 + 3 * n + 6
+        assert L.col_eval_approved_at == expected, (
+            f"N={n}: col_eval_approved_at expected at index {expected}, "
+            f"got {L.col_eval_approved_at}"
+        )
+        # And it's the last column.
+        assert L.total_width == L.col_eval_approved_at + 1
 
 
 def test_section_numbers_are_unique(config: TeamConfig):

--- a/qa-automation/AI-Scoring/tests/test_dialpad_client.py
+++ b/qa-automation/AI-Scoring/tests/test_dialpad_client.py
@@ -7,7 +7,13 @@ scripts/.
 
 from __future__ import annotations
 
-from backend.services.dialpad_client import build_dialpad_link
+from datetime import datetime, timedelta, timezone
+
+from backend.services.dialpad_client import (
+    _epoch_ms_to_utc_datetime,
+    build_dialpad_link,
+    compute_call_duration,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -47,3 +53,73 @@ def test_build_dialpad_link_default_entry_point_is_empty():
     link = build_dialpad_link("leg-123")
     assert "leg-123" in link
     assert "callreview" in link
+
+
+# ---------------------------------------------------------------------------
+# _epoch_ms_to_utc_datetime + compute_call_duration — call-time initiative
+# plumbing (PR-1 of references/CallTimeOnAnalystHistory.md).
+# ---------------------------------------------------------------------------
+
+def test_epoch_ms_to_utc_datetime_roundtrips_to_utc_aware():
+    """A known epoch-ms value parses to the expected UTC instant. Result
+    is tz-aware so downstream callers don't trip the naive-vs-aware
+    pitfall the chiclet PR fixed for /team/evals timestamps."""
+    expected = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    epoch_ms = int(expected.timestamp() * 1000)
+    dt = _epoch_ms_to_utc_datetime(epoch_ms)
+    assert dt is not None
+    assert dt.tzinfo is timezone.utc
+    assert dt == expected
+
+
+def test_epoch_ms_to_utc_datetime_accepts_string_epoch():
+    """Dialpad returns date_connected as a string in some payload shapes;
+    int casting must handle that without raising."""
+    expected = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    dt = _epoch_ms_to_utc_datetime(str(int(expected.timestamp() * 1000)))
+    assert dt is not None
+    assert dt == expected
+
+
+def test_epoch_ms_to_utc_datetime_none_for_missing_inputs():
+    """None / empty-string / unparseable → None so the writer sees 'we
+    don't know' and leaves the col C cell blank."""
+    assert _epoch_ms_to_utc_datetime(None) is None
+    assert _epoch_ms_to_utc_datetime("") is None
+    assert _epoch_ms_to_utc_datetime("not-a-number") is None
+
+
+def test_compute_call_duration_happy_path():
+    """date_ended - date_connected → call duration timedelta."""
+    started = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    ended = datetime(2026, 6, 1, 12, 8, 30, tzinfo=timezone.utc)
+    assert compute_call_duration(started, ended) == timedelta(minutes=8, seconds=30)
+
+
+def test_compute_call_duration_returns_none_when_either_missing():
+    """Either side missing → None (no guessing, no zero-duration fallback).
+    Plumbing-only stub; downstream consumers will read None as 'unknown
+    duration' rather than 'zero-length call.'"""
+    started = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert compute_call_duration(started, None) is None
+    assert compute_call_duration(None, started) is None
+    assert compute_call_duration(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# _format_call_started (sheets_service helper) — exercised here because
+# it's a sibling pure function that consumes _epoch_ms_to_utc_datetime's
+# output and writes the sheet-side format string.
+# ---------------------------------------------------------------------------
+
+def test_format_call_started_renders_utc_clock_string():
+    from backend.services.sheets_service import _format_call_started
+    dt = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert _format_call_started(dt) == "06/01/2026 12:00:00"
+
+
+def test_format_call_started_none_renders_blank():
+    """None → "" so the col C cell stays empty for backfill (PR-2) to
+    fill later. NOT "None" or some sentinel string."""
+    from backend.services.sheets_service import _format_call_started
+    assert _format_call_started(None) == ""


### PR DESCRIPTION
## Summary

Repurposes `COL_TIMESTAMP` (col C) on Analyst_History / Form Responses AI to hold the call's `date_connected` from Dialpad, and introduces a new trailing column `col_eval_approved_at` for the eval/approval-time UTC string that historically lived in col C. **Score_Audit remains the authoritative record of "who scored what when" — unchanged.**

This is **PR-1 of three**. Analytics still bucket every row by eval time during the transition window. Design: [`references/CallTimeOnAnalystHistory.md`](../blob/feat/call-time-on-analyst-history-doc/qa-automation/AI-Scoring/references/CallTimeOnAnalystHistory.md).

| | Status | Scope |
|---|---|---|
| PR-1 (this) | Open | Schema + writer + reader-with-fallback |
| PR-2 | Pending | Backfill script (rate-limited, resumable, `.backfill-skipped.csv` for ID-mismatch cases) |
| PR-3 | Pending | Flip `df["timestamp"]` to call time + UI labels + "bucketed by call date" tooltip |

## Phases delivered

| Phase | Files |
|---|---|
| 0 — Schema | `history_layout.py` (TRAILING_WIDTH 6→7, new `col_eval_approved_at` property), `test_config_load.py` (+2 tests, N=1/10/19 boundary + collision guard) |
| 1 — Writer | `scorecard.py` (+ `call_started_at_utc`, `call_ended_at_utc`), `dialpad_client.py` (`_epoch_ms_to_utc_datetime`, `compute_call_duration` stub), `scoring_service.py` (populates from `date_connected`/`date_ended`), `sheets_service.py` (Stage 1 writes call-time to col C; Stage 4 stops overriding col C, writes approval-time to the new trailing column), `test_dialpad_client.py` (+7 tests) |
| 2 — Reader fallback | `team_stats.py` (`load_and_clean` reads new column first, falls back to col C; adds `df["call_started"]`), `conftest.py` (`make_history_row` opt-in `call_started` param), `test_analytics.py` (+4 transition tests including the **May-eval/April-call bucket regression guard**) |
| 3 — FR1 doc | `sheets_service.py` (docstring + inline metadata-values comment), `team_config.py` (new optional `metadata_cols_note`), both team JSONs populated. No code change to Stage 2 — already copies col C verbatim. |

## TZ patch (bundled — same PR scope, same TZ logic)

Surfaced during smoke testing: a call placed May 30 9:44 PM local was rendering as "5/31 03:44 AM" on the Score Trend chart and `/datapoint` page. Two-layer cascade:

1. Sheet stores UTC clock as naive string → pydantic serialized naive → JS `new Date(iso)` parses as **local** time.
2. **Fix 1** (`_parse_row`): tag `tzinfo=timezone.utc` at the boundary. Mirrors `routes/team.py`'s `_to_utc` from the chiclet PR.
3. **Cascading bug**: `get_agent_history` / `get_all_history` use `datetime.now() - timedelta(...)` (naive) for the cutoff. tz-aware vs naive comparison raises TypeError → 500 → `fetchJSON` returns null → "No evaluations found" placeholder.
4. **Fix 2**: both cutoffs → `datetime.now(timezone.utc)`.

## Tests

**Full suite**: 201 passed, 6 skipped, 3 xfailed (+13 new tests).

**Load-bearing regression guard**: `test_load_and_clean_analytics_still_bucket_by_eval_time_during_transition` — a new-shape row with April call-time and May eval-time must surface in May's bucket via `compute_monthly_summary`. Breaks loudly if anyone accidentally flips `df["timestamp"]` before PR-3.

## Manual verification (completed)

- [x] Score a call placed today + a call placed May 30 → Score Trend orders them correctly (today's after May 30's) despite scoring today's first.
- [x] `/datapoint/<team>/<call_id>` page shows correct local date for both.
- [x] Agent dashboard renders evaluations (TZ patch unblocks the cutoff comparison).
- [x] Team chiclets / roster unchanged from pre-PR — analytics anchor stays on eval time during the transition.

## Roadmap

**PR-2 (next, separate)**: `scripts/backfill_call_started.py` with `--dry-run`, `--team-id`, `--max-rows`, resumable via `.backfill-log`, ID-mismatch handling per the design doc's risk section.

**PR-3 (after PR-2 backfill completes)**: single `load_and_clean` edit to flip the anchor; UI label updates ("Date" → "Call Date" in EWMA drill-down, `/team/evals` page, Recent Evals chiclet); brief "bucketed by call date" tooltip on chiclets + SPC chart.

**Future / separate**: rename "Evaluation Date" → "Call Date" on the GAS email template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)