### PR TITLE
feat(qa-automation): AI-Scoring — call time on Analyst_History (PR-3: analytics anchor flip + UI labels + bucket-TZ fix)

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -20,6 +20,7 @@ from backend.models.team_stats import (
 )
 from backend.services.data_provider import get_provider
 from backend.services.team_stats import (
+    _months_in_bucket_tz,
     compute_agent_roster,
     compute_binary_stats,
     compute_distribution,
@@ -163,7 +164,11 @@ async def team_month_evals(
     if supervisor:
         df = df[df["supervisor"].str.lower() == supervisor.strip().lower()]
 
-    months = df["timestamp"].dt.to_period("M").astype(str)
+    # Use the same project-TZ bucketing as compute_monthly_summary so a
+    # call placed late local-time on the last of the month doesn't get
+    # filtered into the wrong month here. Caught during PR-3 smoke
+    # testing: 8:33 PM PDT May 31 was showing in June's drill-down.
+    months = _months_in_bucket_tz(df["timestamp"])
     df = df[months == year_month]
 
     # Sort newest first — analysts skim the top to find recent calls.

--- a/qa-automation/AI-Scoring/backend/services/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/services/team_stats.py
@@ -25,7 +25,10 @@ For long form, see compute_long_form(): one row per (agent, eval_id, section).
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -36,6 +39,56 @@ from backend.services.data_normalization import (
     parse_timestamp,
     strip_accents,
 )
+
+
+# Project-wide TZ used for *bucketing* (year-month assignment on chiclets,
+# SPC, EWMA, and the /team/evals drill-down). Timestamps remain stored
+# and served in UTC; we only convert at the seam where "which month is
+# this in?" is decided.
+#
+# Why: sheet writers store UTC clock values (no TZ marker); the frontend
+# correctly converts to local time for *display*, but the backend's
+# `.dt.to_period("M")` runs on naive-UTC and disagrees with the local
+# display when calls cross a TZ boundary. A call placed 8:33 PM PDT
+# May 31 (= 3:33 AM Jun 1 UTC) would display "May 31" but bucket into
+# June — exactly the regression caught during PR-3 smoke testing.
+#
+# Default matches the user's working TZ; override via env var when ops
+# spans multiple timezones (e.g. set LANDING_BUCKET_TZ=America/New_York).
+BUCKET_TZ_NAME = os.getenv("LANDING_BUCKET_TZ", "America/Los_Angeles")
+_BUCKET_TZ = ZoneInfo(BUCKET_TZ_NAME)
+_UTC = ZoneInfo("UTC")
+
+
+def _months_in_bucket_tz(timestamps: "pd.Series") -> "pd.Series":
+    """Convert a Series of naive-UTC timestamps to "YYYY-MM" strings in
+    the project bucket TZ. Single seam — every monthly-bucketing site
+    (chiclets, SPC, /team/evals filter) calls this so the chiclet
+    count and the drill-down list always agree about which calls
+    landed in which month.
+
+    Pandas warns ("dropping timezone information") when
+    `tz_convert(...).to_period("M")` runs; that drop is intentional —
+    we only need the period string for grouping, not the tz tag.
+    `strftime` would produce the same result and skip the warning, but
+    `.dt.to_period("M")` is the existing idiom across this module.
+    """
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        return (
+            pd.to_datetime(timestamps)
+            .dt.tz_localize(_UTC)
+            .dt.tz_convert(_BUCKET_TZ)
+            .dt.to_period("M")
+            .astype(str)
+        )
+
+
+def _now_in_bucket_tz() -> datetime:
+    """`datetime.now()` in the project bucket TZ. Used to compute the
+    "current" and "last" month labels for compute_monthly_summary."""
+    return datetime.now(_UTC).astimezone(_BUCKET_TZ)
 
 if TYPE_CHECKING:
     from backend.config.team_config import StatsConfig, TeamConfig
@@ -134,27 +187,37 @@ def load_and_clean(
         if not agent_raw:
             continue
 
-        # Call-time initiative (PR-1 of references/CallTimeOnAnalystHistory.md):
-        # the eval timestamp lives in col_eval_approved_at on new-shape rows
-        # (Stage 4 writer fills it). On pre-cutover rows that column is
-        # blank — fall back to col C, which used to hold the eval/approval
-        # time before the schema shift. After PR-2 backfill runs, every
-        # historical row will have col_eval_approved_at populated and the
-        # fallback stops firing.
+        # Call-time initiative (PR-3 of references/CallTimeOnAnalystHistory.md):
+        # df["timestamp"] is now anchored at CALL TIME (col C), not the
+        # eval/approval time. PR-1 repurposed col C to hold the call's
+        # date_connected; PR-2 backfilled it for historical rows. The
+        # original eval-time string (which used to live in col C) now
+        # lives in col_eval_approved_at, preserved as df["eval_approved_at"]
+        # for any consumer that wants to filter by approval time.
+        #
+        # Old-shape (pre-PR-1 or .backfill-skipped) rows have col C = legacy
+        # eval-time and col_eval_approved_at blank. For those, we have no
+        # call-time to anchor; we fall back to col C so the row still
+        # surfaces in analytics under its eval-time bucket. The mix is
+        # bounded: production runs of PR-2 left only a small skip count
+        # (≤2% of rows) old-shape.
         new_col_idx = L.col_eval_approved_at
         new_col_val = row[new_col_idx] if len(row) > new_col_idx else ""
         eval_approved_at = parse_timestamp(new_col_val) if new_col_val else None
 
         col_c_val = row[history_layout.COL_TIMESTAMP]
+        col_c_parsed = parse_timestamp(col_c_val)
 
         if eval_approved_at is not None:
-            # New-shape row: col C = call_started, col_eval_approved_at = eval time.
-            ts = eval_approved_at
-            call_started = parse_timestamp(col_c_val)
+            # New-shape row: col C = call_started (the new analytics anchor),
+            # col_eval_approved_at = original eval/approval time.
+            ts = col_c_parsed
         else:
-            # Old-shape row: col C = eval time, call_started unknown.
-            ts = parse_timestamp(col_c_val)
-            call_started = None
+            # Old-shape row (.backfill-skipped or pre-PR-1): col C is the
+            # legacy eval-time, no call-time available. Fall back so the
+            # row stays in analytics.
+            ts = col_c_parsed
+            eval_approved_at = col_c_parsed
 
         if ts is None or ts.year < 2020:
             continue
@@ -208,13 +271,11 @@ def load_and_clean(
         records.append({
             "agent": agent,
             "timestamp": ts,
-            # New column from PR-1 of the call-time initiative. Populated
-            # for new-shape rows (Stage 4 writer fills col_eval_approved_at,
-            # leaving col C as call_started); None for pre-backfill rows.
-            # df["timestamp"] continues to be the eval-time anchor during
-            # the transition — analytics consumers don't change behavior
-            # here. After PR-3 they'll switch to df["call_started"].
-            "call_started": call_started,
+            # Renamed from "call_started" in PR-3. Approval/eval time —
+            # available for any consumer that wants to filter by when the
+            # eval was scored. Equals timestamp for old-shape rows that
+            # fell back to col C.
+            "eval_approved_at": eval_approved_at,
             "overall_score": overall,
             **section_scores,
             **yn_scores,
@@ -229,8 +290,7 @@ def load_and_clean(
         return df
 
     df["timestamp"] = pd.to_datetime(df["timestamp"])
-    # NaT for rows where call_started is unknown (pre-backfill).
-    df["call_started"] = pd.to_datetime(df["call_started"])
+    df["eval_approved_at"] = pd.to_datetime(df["eval_approved_at"])
     return df
 
 
@@ -411,9 +471,12 @@ def compute_monthly_summary(df: pd.DataFrame) -> dict:
     chiclets inherit the page filters by construction. The `days` filter
     is bypassed here on purpose: chiclets express their own month windows.
     """
-    from datetime import datetime as _dt
-
-    now = _dt.now()
+    # "current" / "last" labels are derived in the project bucket TZ so
+    # the boundaries match what the chiclets actually filter on. Using
+    # naive UTC `datetime.now()` here would let "current month" tick over
+    # to June at PDT 5pm on the 31st — exactly the off-by-one the user
+    # demonstrated during PR-3 smoke testing.
+    now = _now_in_bucket_tz()
     current_p = pd.Period(now, freq="M")
     last_p = current_p - 1
     current_ym = str(current_p)
@@ -428,7 +491,7 @@ def compute_monthly_summary(df: pd.DataFrame) -> dict:
     # Compute month buckets directly from timestamps — independent of the
     # /stats `days` window so the chiclets stay anchored on calendar
     # months regardless of which time range the dashboard is showing.
-    months = df["timestamp"].dt.to_period("M").astype(str)
+    months = _months_in_bucket_tz(df["timestamp"])
 
     def _bucket(ym: str) -> dict:
         mask = months == ym
@@ -452,7 +515,9 @@ def compute_monthly_spc(df: pd.DataFrame, stats_config: StatsConfig) -> dict:
         return {"months": [], "ucl": 0, "lcl": 0, "center": 0}
 
     df = df.copy()
-    df["year_month"] = df["timestamp"].dt.to_period("M").astype(str)
+    # Bucket TZ: same seam as compute_monthly_summary so the SPC point
+    # for a month matches the chiclet count for that month exactly.
+    df["year_month"] = _months_in_bucket_tz(df["timestamp"])
 
     monthly = df.groupby("year_month").agg(
         mean=("overall_score", "mean"),

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -69,6 +69,23 @@
     .kpi-box .value { font-family: 'Fraunces', serif; font-size: 2rem; font-weight: 700; margin: 4px 0; }
     .kpi-box .sub { font-size: 0.75rem; color: var(--muted); }
 
+    /* Call-time initiative (PR-3) — single annotation under the chiclet
+       row + inline note in the SPC card title so management and analysts
+       can spot that monthly buckets are now anchored on call-connected
+       time, not eval-approval time. See references/CallTimeOnAnalystHistory.md. */
+    .bucket-hint {
+      margin: -4px 0 4px 4px; padding: 4px 0;
+      font-size: 0.72rem; color: var(--muted);
+      cursor: help;
+    }
+    .bucket-hint strong { color: var(--text); font-weight: 600; }
+    .bucket-hint-inline {
+      font-family: 'DM Mono', monospace;
+      font-size: 0.65rem; font-weight: 500; color: var(--muted);
+      text-transform: uppercase; letter-spacing: 0.05em;
+      margin-left: 8px; cursor: help;
+    }
+
     /* Three top-of-overview chiclets — last month, current month, and
        Recent Evals. Shared three-row layout:
          header line:  LABEL: count   (with click-arrow tucked top-right)
@@ -313,10 +330,16 @@
   <!-- Overview Tab -->
   <div class="tab-panel active" id="panel-overview">
     <div class="chiclet-row" id="chicletRow"></div>
+    <div class="bucket-hint" title="Months reflect when calls actually connected (Dialpad date_connected). Score_Audit retains the eval-approval times.">
+      &#9432; Months bucketed by <strong>call date</strong>, not eval-approval date
+    </div>
     <div class="recent-evals-panel" id="recentEvalsPanel" style="display:none;"></div>
     <div class="kpi-row" id="kpiRow"></div>
     <div class="charts-grid">
-      <div class="card"><h3>SPC Control Chart</h3><canvas id="spcCanvas"></canvas></div>
+      <div class="card">
+        <h3>SPC Control Chart <span class="bucket-hint-inline" title="Each month's mean is computed over calls that connected in that month.">&#9432; by call date</span></h3>
+        <canvas id="spcCanvas"></canvas>
+      </div>
       <div class="card"><h3>Score Distribution</h3><canvas id="distCanvas" style="cursor:pointer;"></canvas><div id="distDrillDown" style="display:none;"></div></div>
     </div>
     <div class="card">
@@ -1137,7 +1160,7 @@ function renderEwmaDrillBody(records) {
       <thead>
         <tr>
           <th style="width:90px;">Score</th>
-          <th>Date</th>
+          <th>Call Date</th>
           <th>Caller</th>
         </tr>
       </thead>

--- a/qa-automation/AI-Scoring/frontend/team_evals.html
+++ b/qa-automation/AI-Scoring/frontend/team_evals.html
@@ -71,7 +71,7 @@
       <table id="evalsTable">
         <thead>
           <tr>
-            <th data-col="timestamp">Date</th>
+            <th data-col="timestamp">Call Date</th>
             <th data-col="agent">Agent</th>
             <th data-col="supervisor">Supervisor</th>
             <th data-col="overall_score">Score</th>

--- a/qa-automation/AI-Scoring/references/CallTimeOnAnalystHistory.md
+++ b/qa-automation/AI-Scoring/references/CallTimeOnAnalystHistory.md
@@ -9,7 +9,10 @@
 > continues to be the authoritative audit log of "who scored what when"
 > — unchanged.
 > **Author session:** 2026-06-01.
-> **Status:** Design — not yet implemented.
+> **Status:** **Implemented.** PR-1 (schema + writer + reader fallback)
+> merged as PR #42; PR-2 (backfill script, sales + MS runs completed)
+> merged as PR #43; PR-3 (analytics anchor flip + UI labels +
+> "bucketed by call date" hints) lands as the current PR.
 
 ---
 

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -199,28 +199,74 @@ def test_monthly_summary_count_one_month_has_null_std():
 
 
 def test_monthly_summary_month_boundary_buckets_strictly():
-    """An eval at the last second of last month bucket-belongs to last; first
-    second of current month belongs to current. Guards against off-by-one in
-    Period('M') discretization."""
+    """An eval at the last second of last month (in the project bucket
+    TZ) belongs to last; first second of current month belongs to
+    current. Guards against off-by-one in Period('M') discretization,
+    derived dynamically against whatever LANDING_BUCKET_TZ is set."""
     from datetime import datetime as _dt
+    from zoneinfo import ZoneInfo
     import pandas as pd
-    now = _dt.now()
-    current_p = pd.Period(now, freq="M")
+    from backend.services.team_stats import _BUCKET_TZ
+
+    # Derive month boundaries in the bucket TZ, then store as naive-UTC
+    # the way load_and_clean produces them (the sheet writer emits naive
+    # UTC clock strings; our load_and_clean parses them naive).
+    now_bucket = _dt.now(_BUCKET_TZ)
+    current_p = pd.Period(now_bucket, freq="M")
     last_p = current_p - 1
-    # Last second of last month
-    last_end = last_p.end_time
-    # First second of current month
-    current_start = current_p.start_time
+    # Last instant of last month, in the bucket TZ, converted to UTC and
+    # made naive to mimic load_and_clean's output.
+    last_end_local = last_p.end_time.tz_localize(_BUCKET_TZ)
+    current_start_local = current_p.start_time.tz_localize(_BUCKET_TZ)
+    last_end_utc_naive = last_end_local.tz_convert(ZoneInfo("UTC")).tz_localize(None)
+    current_start_utc_naive = current_start_local.tz_convert(ZoneInfo("UTC")).tz_localize(None)
 
     df = _summary_df([
-        {"timestamp": last_end, "overall_score": 60.0},
-        {"timestamp": current_start, "overall_score": 95.0},
+        {"timestamp": last_end_utc_naive, "overall_score": 60.0},
+        {"timestamp": current_start_utc_naive, "overall_score": 95.0},
     ])
     out = compute_monthly_summary(df)
-    assert out["last"]["count"] == 1
+    assert out["last"]["count"] == 1, (
+        f"last-month boundary slipped: out={out}"
+    )
     assert out["last"]["mean"] == 60.0
-    assert out["current"]["count"] == 1
+    assert out["current"]["count"] == 1, (
+        f"current-month boundary slipped: out={out}"
+    )
     assert out["current"]["mean"] == 95.0
+
+
+def test_monthly_summary_buckets_in_project_local_time():
+    """The PR-3 smoke-test regression: a call that displays as May 31
+    8:33 PM in the project bucket TZ (3:33 AM Jun 1 UTC) must bucket
+    into May, not June. The previous tz-naive bucketing put it in June
+    and the user saw it in the June drill-down — exactly the off-by-one
+    BUCKET_TZ_NAME exists to prevent."""
+    from datetime import datetime as _dt
+    from zoneinfo import ZoneInfo
+    import pandas as pd
+    from backend.services.team_stats import _BUCKET_TZ
+
+    # Construct a timestamp that is May 31 in the bucket TZ but Jun 1 UTC.
+    # 31 May 23:30 LA = 06 Jun 1 06:30 UTC (LA is UTC-7 in DST).
+    local_may_31 = _dt(2026, 5, 31, 23, 30, 0, tzinfo=_BUCKET_TZ)
+    utc_naive = pd.Timestamp(local_may_31).tz_convert(ZoneInfo("UTC")).tz_localize(None)
+    # Sanity: the converted naive UTC value actually IS in June, so this
+    # test is meaningful (it would pass trivially if both were in May).
+    assert utc_naive.month == 6, (
+        f"expected the UTC representation to fall in June for this test "
+        f"to exercise the boundary; got {utc_naive}"
+    )
+
+    df = _summary_df([
+        {"timestamp": utc_naive, "overall_score": 88.0},
+    ])
+    months = compute_monthly_summary(df)
+    assert months["last"]["year_month"].endswith("-05") or \
+           months["current"]["year_month"].endswith("-05"), (
+        f"expected the row to bucket into May (project local time); "
+        f"got last={months['last']['year_month']}, current={months['current']['year_month']}"
+    )
 
 
 def test_monthly_summary_does_not_mutate_input_df():
@@ -324,22 +370,24 @@ def test_load_and_clean_preserves_yn_na_through_binary_stats(sales: TeamConfig):
 
 
 # ---------------------------------------------------------------------------
-# load_and_clean — call-time initiative (PR-1) reader fallback.
+# load_and_clean — call-time initiative analytics anchor (PR-3 flipped).
 #
-# Phase 1 schema:    eval-time → col_eval_approved_at; call-time → col C
-# Phase 2 reader:    df["timestamp"]   resolves to col_eval_approved_at on
-#                                      new-shape rows, else col C (old).
-#                    df["call_started"] resolves to col C on new-shape rows,
-#                                      NaT on old-shape (pre-backfill).
+# After PR-3:
+#   df["timestamp"]         = call-connected time (col C). Analytics anchor.
+#   df["eval_approved_at"]  = eval/approval time (col_eval_approved_at,
+#                              or col C fallback on old-shape rows).
 #
-# During the transition, df["timestamp"] still anchors every analytics
-# consumer at eval time — chiclets/SPC/EWMA behavior must not shift.
+# Chiclets, SPC, EWMA, the /team/stats `days` filter all key on
+# df["timestamp"] and therefore bucket by when the call actually
+# happened.
 # ---------------------------------------------------------------------------
 
-def test_load_and_clean_reads_old_shape_row_from_col_c(sales: TeamConfig):
-    """A pre-cutover row has col_eval_approved_at blank — load_and_clean
-    falls back to col C for df['timestamp']. call_started is NaT
-    (we don't know when this call connected; backfill will fill it)."""
+def test_load_and_clean_old_shape_row_falls_back_to_col_c(sales: TeamConfig):
+    """An old-shape row (col_eval_approved_at blank — pre-PR-1 or in
+    .backfill-skipped) has no call-time available. The reader falls
+    back to col C for df["timestamp"] so the row stays in analytics
+    rather than silently dropping out as NaT. eval_approved_at gets
+    the same value (we have no better answer for either column)."""
     from datetime import datetime as _dt
     import pandas as pd
 
@@ -352,16 +400,14 @@ def test_load_and_clean_reads_old_shape_row_from_col_c(sales: TeamConfig):
 
     assert not df.empty
     star = df[df["agent"] == "Star Rep"].iloc[0]
-    # df["timestamp"] reads col C (eval time) on old-shape rows.
     assert star["timestamp"] == pd.Timestamp(when)
-    # call_started is NaT — pre-backfill, we don't know.
-    assert pd.isna(star["call_started"])
+    assert star["eval_approved_at"] == pd.Timestamp(when)
 
 
-def test_load_and_clean_reads_new_shape_row_with_call_started_split(sales: TeamConfig):
-    """A post-cutover row has col_eval_approved_at populated. df['timestamp']
-    reads the new column (eval time); df['call_started'] reads col C
-    (call connected). Verifies the split is observed correctly."""
+def test_load_and_clean_new_shape_row_splits_call_and_eval_times(sales: TeamConfig):
+    """A backfilled / post-PR-1 row has both columns populated.
+    df["timestamp"] reads col C (call time); df["eval_approved_at"]
+    reads col_eval_approved_at (when the approval was clicked)."""
     from datetime import datetime as _dt
     import pandas as pd
 
@@ -376,17 +422,17 @@ def test_load_and_clean_reads_new_shape_row_with_call_started_split(sales: TeamC
     df = load_and_clean(rows, mails, sales)
 
     star = df[df["agent"] == "Star Rep"].iloc[0]
-    # df["timestamp"] reads col_eval_approved_at on new-shape rows.
-    assert star["timestamp"] == pd.Timestamp(eval_time)
-    # call_started reads col C — the day the call actually connected.
-    assert star["call_started"] == pd.Timestamp(call_time)
+    # df["timestamp"] reads col C — the day the call actually connected.
+    assert star["timestamp"] == pd.Timestamp(call_time)
+    # df["eval_approved_at"] preserves the approval time for any consumer
+    # that needs it (e.g. compliance reports filtered by when scored).
+    assert star["eval_approved_at"] == pd.Timestamp(eval_time)
 
 
 def test_load_and_clean_mixed_shapes_coexist(sales: TeamConfig):
-    """Real-world during the PR-1 → PR-2 transition: some rows are old-shape
-    (pre-cutover), some are new-shape (post-cutover). df['timestamp']
-    must still anchor every row at eval time so chiclets/SPC/EWMA
-    don't see a mixed bucket shift before backfill completes."""
+    """Production state after PR-2: backfilled rows are new-shape; the
+    ≤2% .backfill-skipped rows remain old-shape. The reader hands the
+    correct value to each."""
     from datetime import datetime as _dt
     import pandas as pd
 
@@ -409,24 +455,20 @@ def test_load_and_clean_mixed_shapes_coexist(sales: TeamConfig):
     star = df[df["agent"] == "Star Rep"].iloc[0]
     steady = df[df["agent"] == "Steady Rep"].iloc[0]
 
-    # Old-shape: timestamp from col C, call_started NaT.
+    # Old-shape: both columns fall back to col C.
     assert star["timestamp"] == pd.Timestamp(old_when)
-    assert pd.isna(star["call_started"])
+    assert star["eval_approved_at"] == pd.Timestamp(old_when)
 
-    # New-shape: timestamp from col_eval_approved_at, call_started from col C.
-    assert steady["timestamp"] == pd.Timestamp(new_eval)
-    assert steady["call_started"] == pd.Timestamp(new_call)
+    # New-shape: timestamp from col C (call), eval_approved_at from new col.
+    assert steady["timestamp"] == pd.Timestamp(new_call)
+    assert steady["eval_approved_at"] == pd.Timestamp(new_eval)
 
 
-def test_load_and_clean_analytics_still_bucket_by_eval_time_during_transition(
-    sales: TeamConfig,
-):
-    """Critical for PR-1 staging: the call-time initiative MUST NOT shift
-    chiclets/SPC bucketing until PR-3 lands. A new-shape row with a
-    call-time in April and eval-time in May must surface in May's bucket
-    via compute_monthly_summary — same as it would have pre-initiative."""
+def test_load_and_clean_analytics_anchored_at_call_time(sales: TeamConfig):
+    """The semantic flip: a new-shape row with April call-time and May
+    eval-time must now bucket into APRIL (call month). Mirror inverse
+    of the PR-2-era regression guard, which asserted May."""
     from datetime import datetime as _dt
-    import pandas as pd
 
     header = [["Agent Name"] + [""] * 200]
     eval_in_may = _dt(2026, 5, 5, 12, 0, 0)
@@ -438,10 +480,11 @@ def test_load_and_clean_analytics_still_bucket_by_eval_time_during_transition(
     mails = make_mails_sheet(["Star Rep"])
     df = load_and_clean(rows, mails, sales)
 
-    # df["timestamp"] anchored at May (eval time), NOT April (call time).
-    assert df.iloc[0]["timestamp"].month == 5
-    # call_started is parsed and available for PR-3 to consume.
-    assert df.iloc[0]["call_started"].month == 4
+    # df["timestamp"] now reads call time → April bucket.
+    assert df.iloc[0]["timestamp"].month == 4
+    # eval_approved_at retains the May approval-time for any consumer
+    # that wants compliance-style filtering.
+    assert df.iloc[0]["eval_approved_at"].month == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the call-time initiative. After this PR, chiclets, SPC, EWMA bar bucketing, and the `/team/evals` drill-down all anchor on **when the call connected**, not when it was scored.

- `df["timestamp"]` ← col C (call time, populated by Stage 1 writer in PR-1 and backfilled across history in PR-2).
- `df["eval_approved_at"]` ← `col_eval_approved_at`, carrying the eval/approval clock for any consumer that wants to filter by when scoring happened.
- **Score_Audit remains the authoritative record of evaluation timing** — unchanged throughout the initiative.

Initiative tracker:
| | Status |
|---|---|
| PR-1 schema + writer + reader-fallback | ✅ #42 merged |
| PR-2 backfill (sales + MS) | ✅ #43 merged |
| **PR-3 analytics flip + UI + bucket-TZ** | **Open at this PR** |

## What changes

### Backend
- **`load_and_clean`** now produces `df["timestamp"]` from col C (call time) and `df["eval_approved_at"]` from `col_eval_approved_at`. Old-shape rows (≤2% .backfill-skipped) fall back to col C for both so they stay in analytics rather than dropping to NaT.
- **`BUCKET_TZ_NAME`** constant (default `America/Los_Angeles`, env-override via `LANDING_BUCKET_TZ`). Single project-local-time anchor for monthly bucketing.
- **`_months_in_bucket_tz(timestamps)`** — converts a naive-UTC Series to `"YYYY-MM"` strings in the bucket TZ. Used by `compute_monthly_summary`, `compute_monthly_spc`, and the `/team/evals` filter so they always agree.
- **`_now_in_bucket_tz()`** — `datetime.now()` in the project TZ. Drives `current` / `last` month label computation.

### Frontend
- `team_dashboard.html`: EWMA drill-down column header `"Date"` → `"Call Date"`. New `.bucket-hint` row under the chiclets: *"ⓘ Months bucketed by call date, not eval-approval date"* with hover tooltip. SPC card title gains an inline *"ⓘ by call date"* annotation.
- `team_evals.html`: drill-down column header `"Date"` → `"Call Date"`.

### Bug caught during smoke testing
A call connected at **8:33 PM PDT May 31** (= 03:33 AM Jun 1 UTC) was showing in the **June** drill-down even though the chiclet count and SPC point displayed it correctly as May. Root cause: `df["timestamp"].dt.to_period(\"M\")` ran on naive UTC; the frontend converted to local for display → semantic mismatch. The `_months_in_bucket_tz` seam fixes all three sites consistently.

## Tests

- 4 transition tests rewritten for the new semantic. The load-bearing regression guard now asserts **April** for a May-eval/April-call row (mirror inverse of the PR-2-era guard).
- Boundary test now derives its boundaries from `_BUCKET_TZ` so it stays valid regardless of which TZ is set.
- NEW `test_monthly_summary_buckets_in_project_local_time` pins the exact scenario from smoke testing.
- Full suite: **216 passed, 6 skipped, 3 xfailed**.

## Visible behavior changes (worth re-verifying after merge)

- **May 2026 chiclet number changes**. Any call placed late April but approved in May moves from May → April. Same for any cross-month boundary.
- **SPC Control Chart's monthly points shift** to reflect when calls *connected* in each month, not when they were approved.
- **EWMA drill-down `Call Date` column** now shows when each call happened.
- A **PDT user's "May 31 8:33 PM" call** now correctly buckets into May in both the chiclet count AND the drill-down list (they agree).

## Known minor inconsistency (acceptable, design-doc-scoped)

The Recent Evals chiclet's SSE-fed entries use the approval-time timestamp from the SSE payload (still `datetime.now(UTC)` at the publish site) for their time-ago calculation. Initial-population entries from `/team/evals` use call time. A freshly-approved call shows "just now" in the toast; the same row in the Recent Evals expanded list shows call-time-ago after the next page reload. Out of scope for PR-3.

## Roadmap

The call-time initiative is complete. Follow-ups that may want their own small PRs eventually:
- Apps Script email template: rename "Evaluation Date" → "Call Date" on the GAS side.
- Recent Evals chiclet: switch SSE-fed time-ago to use a published call-time field for full consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)