### PR TITLE
feat(qa-automation): persistent Lookup nav button + GAS email "Call · " date label

### DIFF
--- a/qa-automation/AI-Scoring/frontend/dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/dashboard.html
@@ -239,6 +239,7 @@
   <div class="header">
     <div style="display:flex;align-items:center;gap:16px;">
       <a id="team-view-link" href="/dashboard/member_support" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Team View</a>
+      <a id="lookup-link" href="/lookup/member_support" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Lookup</a>
       <h1 id="headerTitle">Agent Dashboard</h1>
     </div>
     <div class="header-controls">
@@ -325,6 +326,8 @@
     document.addEventListener('DOMContentLoaded', () => {
       const teamLink = document.getElementById('team-view-link');
       if (teamLink) teamLink.href = `/dashboard/${TEAM_ID}`;
+      const lookupLink = document.getElementById('lookup-link');
+      if (lookupLink) lookupLink.href = `/lookup/${TEAM_ID}`;
     });
     let selectedDays = 30;
     let trendChartInstance = null;

--- a/qa-automation/AI-Scoring/frontend/index.html
+++ b/qa-automation/AI-Scoring/frontend/index.html
@@ -258,7 +258,10 @@
       <h1>Landing QA Scoring</h1>
       <p>AI-assisted call evaluation — Phase 1. Human review required before scores reach agents.</p>
     </div>
-    <a id="team-dashboard-link" href="/dashboard/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Team Dashboard</a>
+    <div style="display:flex;gap:8px;">
+      <a id="lookup-link" href="/lookup/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Lookup</a>
+      <a id="team-dashboard-link" href="/dashboard/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Team Dashboard</a>
+    </div>
   </div>
 </header>
 
@@ -311,6 +314,8 @@
   document.addEventListener('DOMContentLoaded', () => {
     const dashLink = document.getElementById('team-dashboard-link');
     if (dashLink) dashLink.href = `/dashboard/${TEAM_ID}`;
+    const lookupLink = document.getElementById('lookup-link');
+    if (lookupLink) lookupLink.href = `/lookup/${TEAM_ID}`;
   });
 
   // localStorage (not sessionStorage) so /lookup, /scorecard, and /score

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -302,6 +302,7 @@
 <div class="header">
   <div style="display:flex;align-items:center;gap:16px;">
     <a id="scoring-link" href="/score/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Scoring</a>
+    <a id="lookup-link" href="/lookup/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Lookup</a>
     <h1>Team Analytics Dashboard</h1>
   </div>
   <div class="header-controls">
@@ -429,6 +430,8 @@ const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
 document.addEventListener('DOMContentLoaded', () => {
   const scoringLink = document.getElementById('scoring-link');
   if (scoringLink) scoringLink.href = `/score/${TEAM_ID}`;
+  const lookupLink = document.getElementById('lookup-link');
+  if (lookupLink) lookupLink.href = `/lookup/${TEAM_ID}`;
 });
 let selectedDays = 90;
 let activeOnly = true;

--- a/qa-automation/src/HtmlRenderer.js
+++ b/qa-automation/src/HtmlRenderer.js
@@ -76,8 +76,12 @@ class HtmlRenderer {
          // Meta row
          + '<table role="presentation" width="100%" cellpadding="0" cellspacing="0">'
          + '<tr>'
+         // "Call · <date>" — the date is the call's connected time
+         // (col C, populated by the call-time initiative on the Python
+         // side). Explicit label so the manager doesn't read it as
+         // "the day this email arrived" or "the day scoring happened."
          + '<td style="font-size:12px;color:' + CONFIG.COLORS.LIGHT_BLUE + ';">'
-         + '&#128197; ' + this.entry.formattedDate + '</td>'
+         + '&#128197; Call &middot; ' + this.entry.formattedDate + '</td>'
          + '<td style="text-align:right;">'
          + '<span style="font-size:12px;color:' + CONFIG.COLORS.WHITE + ';'
          + 'border:1px solid ' + CONFIG.COLORS.LIGHT_BLUE + ';'


### PR DESCRIPTION
## Summary

Two small UI/UX follow-ups to the call-time initiative (PRs #42–44), bundled because they share the same theme: making the post-PR-3 semantics visible in the parts of the product users actually look at.

### 1. Persistent "Lookup" button across top-level views

`/score/<team>`, `/dashboard/<team>`, and `/dashboard/<team>/agent/<name>` all gain a **Lookup** link styled to match each page's existing nav-link convention (the Scoring / Team Dashboard / Team View buttons). Each link's href resolves dynamically to `/lookup/<TEAM_ID>` via the same `DOMContentLoaded` hook the existing links use, so member_support and sales users land on their own team's lookup page.

**Policy override**: the original 2026-04-27 `project_lookup_design` memory recorded `/lookup` as discoverable-by-URL-only — explicitly no nav from team UIs. The cross-team data surface didn't change; the access pattern did. Updated the memory in this PR so future sessions don't propose re-hiding it.

### 2. GAS email header: "Call · &lt;date&gt;" label

`QAEntry.formattedDate` reads `this.timestamp` (col C). After the call-time initiative, col C holds the call's `date_connected` — not the eval-approval clock. Prepending `"Call · "` in `HtmlRenderer.js` makes that explicit so the manager doesn't read the date as "when scoring happened."

Uses `&middot;` (·) so the visual weight matches the surrounding compact-meta-row chrome.

## Files

| File | Change |
|---|---|
| `frontend/index.html` | NEW `#lookup-link` next to the Team Dashboard link; DOMContentLoaded sets href to `/lookup/<TEAM_ID>`. |
| `frontend/team_dashboard.html` | NEW `#lookup-link` next to the Scoring link; same dynamic-href pattern. |
| `frontend/dashboard.html` (Agent) | NEW `#lookup-link` next to the Team View link; same dynamic-href pattern. |
| `src/HtmlRenderer.js` | Email header date cell prefixed with `"Call · "` before `formattedDate`. |

## Tests

Frontend-only HTML/JS + GAS source-string change. Full backend suite remains at 216 passed (sanity-checked before branching).

## Manual verification

- [x] Open Scoring / team dashboard / agent dashboard. Confirm Lookup button appears and routes to the correct `/lookup/<team_id>`.
- [ ] After GAS deploy via `./push.sh qa-member-support` and/or `./push.sh qa-sales` (per `reference_gas_deployment_pipeline` memory), trigger a QA email and confirm the header reads "📅 Call · Jun 02, 2026" instead of the bare emoji+date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)