### PR TITLE
feat(qa-automation): AI-Scoring — Recent Evals chiclet uses eval-approval time for "how long ago"

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/team_stats.py
+++ b/qa-automation/AI-Scoring/backend/models/team_stats.py
@@ -157,6 +157,14 @@ class TeamEvalRow(BaseModel):
     """One row in the month-drill-down evals list."""
     agent: str
     timestamp: datetime
+    """Call's connected time (df["timestamp"] after PR-3). Drives the
+    month-drill-down "Call Date" column and the chiclet bucketing."""
+    eval_approved_at: Optional[datetime] = None
+    """Eval/approval clock (df["eval_approved_at"] after PR-3). Powers
+    the Recent Evals chiclet's "how long ago was this eval approved"
+    semantic — the one place where the eval clock takes the front
+    seat. Optional so older clients without the field continue to
+    parse without error."""
     overall_score: float
     dialpad_link: str = ""
     eval_id: str = ""

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -174,6 +174,8 @@ async def team_month_evals(
     # Sort newest first — analysts skim the top to find recent calls.
     df = df.sort_values("timestamp", ascending=False)
 
+    import pandas as pd
+
     def _to_utc(ts):
         """Ensure outgoing ISO timestamps carry an explicit UTC marker.
 
@@ -187,9 +189,13 @@ async def team_month_evals(
         and tripping the time-ago helper's "just now" fallback.
         Stamping them as UTC restores correct relative-time math
         regardless of where the dashboard is viewed.
+
+        Also handles `pd.NaT` — needed because `df["eval_approved_at"]`
+        can be NaT on rare rows where parse_timestamp fails. None on
+        NaT lets pydantic accept the Optional[datetime] field cleanly.
         """
-        if ts is None:
-            return ts
+        if ts is None or pd.isna(ts):
+            return None
         # Pandas Timestamp and datetime both have .tzinfo / .tz; treat
         # naive as UTC. Already-aware values pass through unchanged.
         try:
@@ -203,6 +209,14 @@ async def team_month_evals(
         TeamEvalRow(
             agent=str(r["agent"]),
             timestamp=_to_utc(r["timestamp"]),
+            # Drives the Recent Evals chiclet's time-ago semantic so
+            # initial-populate (this endpoint) and SSE-fed entries (which
+            # already carry approval-time as `timestamp`) agree about
+            # "how long ago was this eval approved". On old-shape rows
+            # load_and_clean populated eval_approved_at as a fallback to
+            # col C; on new-shape rows it carries the original approval
+            # clock that lived in col_eval_approved_at.
+            eval_approved_at=_to_utc(r.get("eval_approved_at")),
             overall_score=float(r["overall_score"]),
             # Wide-form df doesn't carry dialpad_link directly — reconstruct
             # the canonical URL from eval_id (the [LONG CALL] suffix isn't

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -761,14 +761,24 @@ async function initRecentEvalsBuffer() {
     );
     if (!r.ok) return;
     const data = await r.json();
+    // For the Recent Evals chiclet specifically, "time-ago" means time
+    // since approval, not time since the call connected — this is the
+    // one place where the eval clock takes the front seat. /team/evals
+    // post-PR-3 returns `timestamp` (call date, for the drill-down
+    // page's "Call Date" column) and `eval_approved_at` (eval-approval
+    // clock). We prefer eval_approved_at so initial-populate matches
+    // SSE-fed entries (the SSE `timestamp` field is already set to
+    // `datetime.now(UTC)` at publish time). Fall back to call time only
+    // when an old client/sheet didn't carry eval_approved_at.
+    const _evalClock = (row) => row.eval_approved_at || row.timestamp;
     const rows = (data.rows || [])
       .slice()
-      .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+      .sort((a, b) => new Date(_evalClock(b)) - new Date(_evalClock(a)))
       .slice(0, RECENT_EVALS_MAX)
       .map(r => ({
         agent: r.agent,
         overall_score: r.overall_score,
-        timestamp: r.timestamp,
+        timestamp: _evalClock(r),
         eval_id: r.eval_id,
         evaluator_email: r.evaluator_email,
       }));


### PR DESCRIPTION
## Summary

Closes the consistency gap noted in PR #44's body: SSE-fed entries used **approval time** (the publish-site `datetime.now(UTC)`); initial-populate from `/team/evals` used **call time** after PR-3's analytics flip. The Recent Evals chiclet's whole vocabulary — "N today" header count, latest time-ago in the body, the time column in the expanded list — keys on a single `timestamp` field, so the two paths disagreed about whether a row was "5 minutes ago" or "12 hours ago" until a page reload normalized them.

**The Recent Evals chiclet is the one place where eval-approval time should be the front-seat clock.** Analyst_History keeps `date_connected` as col C; chiclets/SPC/EWMA/team-evals page keep bucketing by call date.

## What changes

### Backend
- `models/team_stats.py`: `TeamEvalRow.eval_approved_at: Optional[datetime]`. Optional so older clients keep parsing.
- `routes/team.py`: `/team/evals` populates `eval_approved_at` from `df["eval_approved_at"]` via the existing `_to_utc` boundary helper. `_to_utc` gains a `pd.isna(...)` guard so NaT — which can appear on rare rows where `parse_timestamp` failed — round-trips as `None` instead of leaking into pydantic.

### Frontend
- `team_dashboard.html`: `initRecentEvalsBuffer` reads `r.eval_approved_at` (fallback to `r.timestamp` for safety), stores it as `timestamp` in the buffer. SSE-fed entries already carry approval-time as `timestamp` at the publish site, so buffer entries from both paths are now in the same clock domain. Sort key changes too so newest-by-approval-time wins.

## What does NOT change

- **Drill-down page** (`/dashboard/<team>/evals?month=...`): still shows call date in its "Call Date" column.
- **Month-chiclet bucketing, SPC, EWMA**: still anchored on call time.
- **SSE payload shape**: already publishes approval time as `timestamp`. No backend publish-site change needed.
- **Score_Audit**: unchanged throughout the initiative.

## Tests

No new tests — pure frontend rewire on top of a model addition. Existing surface area unchanged. Full suite: **216 passed, 6 skipped, 3 xfailed**.

## Manual verification still owed (after merge)

- [ ] Approve a call older than today. Toast shows "just now"; Recent Evals chiclet row also shows "just now" (not the call's actual date).
- [ ] Page reload. The same row continues to show approval-time-ago, not call-time-ago. Pre-this-PR, reload would flip the displayed time to call-time.

## Initiative status

The call-time initiative is now fully closed out — three behavior PRs (#42, #43, #44), the Lookup-nav + GAS-label polish (#45), and this consistency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)