### PR TITLE
feat(qa-automation): unified persistent header + custom date-range filter

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from dotenv import load_dotenv
 import os
@@ -56,6 +57,11 @@ async def health():
 
 # Serve the frontend HTML at the root
 _frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
+
+# Shared CSS/JS for the persistent top-bar (header.css, header.js) lives
+# under frontend/static/. Mounted here so both team_dashboard.html and
+# dashboard.html can <link>/<script> from a single source of truth.
+app.mount("/static", StaticFiles(directory=_frontend_dir / "static"), name="static")
 
 # The HTML pages embed all JS/CSS inline, so a stale HTML response means
 # a stale app. no-cache forces the browser to revalidate on every reload

--- a/qa-automation/AI-Scoring/backend/routes/dashboard.py
+++ b/qa-automation/AI-Scoring/backend/routes/dashboard.py
@@ -5,6 +5,8 @@ legacy (/api/...).  team_id is extracted from the path via
 ``team_id_from_path``; legacy routes default to ``member_support``.
 """
 
+from datetime import date, datetime, time, timezone
+
 from fastapi import APIRouter, HTTPException, Query, Request
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
@@ -13,6 +15,38 @@ from backend.services.data_provider import get_provider
 from backend.services.progression_service import get_progression
 
 router = APIRouter(tags=["dashboard"])
+
+# Mirrors the team-route cap (see backend/routes/team.py:_MAX_RANGE_DAYS).
+_MAX_RANGE_DAYS = 730
+
+
+def _resolve_window(
+    date_from: str | None,
+    date_to: str | None,
+) -> tuple[datetime, datetime] | None:
+    """Parse the custom-range params into a tz-aware UTC (from, to) tuple.
+
+    Returns None when neither is set. Raises 422 on malformed, inverted, or
+    > 730-day ranges. UTC-aware because agent_history records carry tz-aware
+    UTC timestamps (see history_service comments).
+    """
+    if not date_from and not date_to:
+        return None
+    if not (date_from and date_to):
+        raise HTTPException(422, "date_from and date_to must be provided together")
+    try:
+        d_from = date.fromisoformat(date_from)
+        d_to = date.fromisoformat(date_to)
+    except ValueError:
+        raise HTTPException(422, "date_from / date_to must be ISO YYYY-MM-DD")
+    if d_to < d_from:
+        raise HTTPException(422, "date_to must be on or after date_from")
+    if (d_to - d_from).days + 1 > _MAX_RANGE_DAYS:
+        raise HTTPException(422, f"range exceeds {_MAX_RANGE_DAYS}-day cap")
+    return (
+        datetime.combine(d_from, time.min, tzinfo=timezone.utc),
+        datetime.combine(d_to, time.max, tzinfo=timezone.utc),
+    )
 
 
 @router.get("/agents", response_model=list[str])
@@ -24,10 +58,38 @@ async def list_agents(request: Request):
 
 
 @router.get("/agents/{name}/history", response_model=list[EvaluationRecord])
-async def agent_history(request: Request, name: str, days: int = Query(default=30, ge=1, le=365)):
-    """Return evaluation records for an agent within a time window."""
+async def agent_history(
+    request: Request,
+    name: str,
+    days: int = Query(default=30, ge=1, le=730),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
+):
+    """Return evaluation records for an agent within a time window.
+
+    When date_from/date_to are both provided, they override `days`. The
+    service is still fetched with a days-back cutoff (sized to reach
+    date_from), then results are filtered to drop anything after date_to —
+    keeps the provider API unchanged.
+    """
     team_id = team_id_from_path(request)
     provider = await get_provider(team_id)
+    window = _resolve_window(date_from, date_to)
+
+    if window is not None:
+        # Reach back far enough to cover date_from, then post-filter to
+        # drop anything after date_to (covers bonus windows that end in
+        # the past, e.g. "May 1 — May 15" viewed in June).
+        fetch_days = max(1, (datetime.now(timezone.utc) - window[0]).days + 1)
+        fetch_days = min(fetch_days, _MAX_RANGE_DAYS)
+        records = await provider.get_agent_history(name, fetch_days)
+        records = [r for r in records if window[0] <= r.timestamp <= window[1]]
+        if not records:
+            raise HTTPException(
+                404, f"No evaluations found for '{name}' between {date_from} and {date_to}"
+            )
+        return records
+
     records = await provider.get_agent_history(name, days)
     if not records:
         raise HTTPException(404, f"No evaluations found for '{name}' in the last {days} days")
@@ -35,8 +97,13 @@ async def agent_history(request: Request, name: str, days: int = Query(default=3
 
 
 @router.get("/agents/{name}/progression", response_model=ProgressionAssessment)
-async def agent_progression(request: Request, name: str, days: int = Query(default=30, ge=1, le=365)):
-    """Return Gemini-generated progression assessment for an agent."""
+async def agent_progression(request: Request, name: str, days: int = Query(default=30, ge=1, le=730)):
+    """Return Gemini-generated progression assessment for an agent.
+
+    Progression remains days-only — the Gemini prompt and cache key are
+    keyed on a days window. Frontend skips refresh when a custom range is
+    active and falls back to the last preset assessment.
+    """
     team_id = team_id_from_path(request)
     config = get_team_config(team_id)
     provider = await get_provider(team_id)

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
@@ -43,6 +43,41 @@ router = APIRouter(prefix="/team", tags=["team"])
 # need to filter long_form by regime to keep statistics comparable.
 _COVERAGE_REGIME = "manager_sample"
 
+# Max window length for an explicit date_from/date_to range — matches the
+# 730-day cap on `days` so a manager can't pull 2+ years of evals in one
+# request via the custom-range picker.
+_MAX_RANGE_DAYS = 730
+
+
+def _resolve_window(
+    date_from: str | None,
+    date_to: str | None,
+) -> tuple[datetime, datetime] | None:
+    """Parse the optional custom-range params into a (from, to) datetime tuple.
+
+    Returns None when neither is set — caller falls through to the `days`
+    filter. Raises 422 if dates are malformed, inverted, or span > 730 days.
+    Returns naive datetimes (start-of-day for `from`, end-of-day for `to`)
+    to match the naive `timestamp` column produced by load_and_clean.
+    """
+    if not date_from and not date_to:
+        return None
+    if not (date_from and date_to):
+        raise HTTPException(422, "date_from and date_to must be provided together")
+    try:
+        d_from = date.fromisoformat(date_from)
+        d_to = date.fromisoformat(date_to)
+    except ValueError:
+        raise HTTPException(422, "date_from / date_to must be ISO YYYY-MM-DD")
+    if d_to < d_from:
+        raise HTTPException(422, "date_to must be on or after date_from")
+    if (d_to - d_from).days + 1 > _MAX_RANGE_DAYS:
+        raise HTTPException(422, f"range exceeds {_MAX_RANGE_DAYS}-day cap")
+    return (
+        datetime.combine(d_from, time.min),
+        datetime.combine(d_to, time.max),
+    )
+
 
 @router.get("/stats", response_model=TeamStatsResponse)
 async def team_stats(
@@ -50,6 +85,8 @@ async def team_stats(
     days: int = Query(default=90, ge=0, le=730),
     active_only: bool = Query(default=True),
     supervisor: str = Query(default=""),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
 ):
     """Return all team-level statistical computations in one response."""
     team_id = team_id_from_path(request)
@@ -60,7 +97,14 @@ async def team_stats(
     raw_mails = provider._get_mails_sheet()
 
     df = load_and_clean(raw_history, raw_mails, config)
-    filters = {"days": days, "active_only": active_only, "supervisor": supervisor}
+    window = _resolve_window(date_from, date_to)
+    filters = {
+        "days": days,
+        "active_only": active_only,
+        "supervisor": supervisor,
+        "date_from": date_from,
+        "date_to": date_to,
+    }
 
     if df.empty:
         return TeamStatsResponse(
@@ -99,7 +143,11 @@ async def team_stats(
     # month and the cutoff drops half the month.
     monthly = compute_monthly_summary(df)
 
-    if days > 0:
+    # Explicit date_from/date_to (custom-range chiclet) overrides `days`.
+    # When neither is set, falls back to the days-back cutoff.
+    if window is not None:
+        df = df[(df["timestamp"] >= window[0]) & (df["timestamp"] <= window[1])]
+    elif days > 0:
         cutoff = datetime.now() - timedelta(days=days)
         df = df[df["timestamp"] >= cutoff]
 
@@ -247,6 +295,8 @@ async def team_long_form(
     days: int = Query(default=90, ge=0, le=730),
     active_only: bool = Query(default=True),
     supervisor: str = Query(default=""),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
 ):
     """Return the canonical long-form analytical shape.
 
@@ -264,10 +314,19 @@ async def team_long_form(
     raw_mails = provider._get_mails_sheet()
 
     df = load_and_clean(raw_history, raw_mails, config)
-    filters = {"days": days, "active_only": active_only, "supervisor": supervisor}
+    window = _resolve_window(date_from, date_to)
+    filters = {
+        "days": days,
+        "active_only": active_only,
+        "supervisor": supervisor,
+        "date_from": date_from,
+        "date_to": date_to,
+    }
 
     if not df.empty:
-        if days > 0:
+        if window is not None:
+            df = df[(df["timestamp"] >= window[0]) & (df["timestamp"] <= window[1])]
+        elif days > 0:
             cutoff = datetime.now() - timedelta(days=days)
             df = df[df["timestamp"] >= cutoff]
         if active_only:

--- a/qa-automation/AI-Scoring/frontend/dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/dashboard.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/header.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <style>
     :root {
@@ -33,54 +34,7 @@
 
     h1, h2, h3 { font-family: 'Fraunces', serif; }
 
-    /* Header */
-    .header {
-      background: var(--navy);
-      color: #fff;
-      padding: 16px 24px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-    .header h1 { font-size: 1.25rem; font-weight: 600; }
-    .header-controls {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-    .header select {
-      font-family: 'DM Mono', monospace;
-      padding: 6px 12px;
-      border-radius: 6px;
-      border: 1px solid var(--border);
-      font-size: 0.85rem;
-      background: var(--surface);
-      color: var(--text);
-    }
-    .time-buttons {
-      display: flex;
-      gap: 4px;
-    }
-    .time-buttons button {
-      font-family: 'DM Mono', monospace;
-      padding: 6px 12px;
-      border: 1px solid rgba(255,255,255,0.3);
-      background: transparent;
-      color: #fff;
-      border-radius: 6px;
-      cursor: pointer;
-      font-size: 0.8rem;
-      transition: background 0.2s, border-color 0.2s;
-    }
-    .time-buttons button:hover { background: rgba(255,255,255,0.1); }
-    .time-buttons button.active {
-      background: var(--accent);
-      border-color: var(--accent);
-      color: #fff;
-    }
+    /* Header CSS lives in /static/header.css (shared with team_dashboard.html). */
 
     /* Layout */
     .container {
@@ -231,27 +185,11 @@
       .stats-row { grid-template-columns: repeat(2, 1fr); }
       .section-grid { grid-template-columns: 1fr; }
       .chart-wrapper { height: 240px; }
-      .header { flex-direction: column; align-items: flex-start; }
     }
   </style>
 </head>
 <body>
-  <div class="header">
-    <div style="display:flex;align-items:center;gap:16px;">
-      <a id="team-view-link" href="/dashboard/member_support" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Team View</a>
-      <a id="lookup-link" href="/lookup/member_support" style="color:rgba(255,255,255,0.7);text-decoration:none;font-size:0.8rem;border:1px solid rgba(255,255,255,0.3);padding:4px 12px;border-radius:6px;">Lookup</a>
-      <h1 id="headerTitle">Agent Dashboard</h1>
-    </div>
-    <div class="header-controls">
-      <div class="time-buttons">
-        <button data-days="7">7d</button>
-        <button data-days="14">14d</button>
-        <button data-days="30" class="active">30d</button>
-        <button data-days="60">60d</button>
-        <button data-days="90">90d</button>
-      </div>
-    </div>
-  </div>
+  <div id="appHeader"></div>
 
   <div class="container">
     <div id="placeholder" class="placeholder">Select an agent to view their progression.</div>
@@ -307,6 +245,7 @@
 
   <div id="footer" class="footer"></div>
 
+  <script src="/static/header.js"></script>
   <script>
     // --- Auth ---
     function getApiKey() {
@@ -323,13 +262,15 @@
     }
     const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)\/agent\//) || [, 'member_support'])[1];
     const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
-    document.addEventListener('DOMContentLoaded', () => {
-      const teamLink = document.getElementById('team-view-link');
-      if (teamLink) teamLink.href = `/dashboard/${TEAM_ID}`;
-      const lookupLink = document.getElementById('lookup-link');
-      if (lookupLink) lookupLink.href = `/lookup/${TEAM_ID}`;
-    });
+
+    // Filter state mirrored from QAHeader (header.js). `selectedDays` is
+    // null when a custom range is active — in that case `dateFrom`/`dateTo`
+    // are used. The AI Assessment endpoint is days-only, so we hide that
+    // card while a custom range is active (see loadDashboard).
     let selectedDays = 30;
+    let dateFrom = null;
+    let dateTo = null;
+    let qaHeader = null;
     let trendChartInstance = null;
     let sectionChartInstance = null;
 
@@ -418,14 +359,29 @@
       _resetAIButton();
       document.getElementById('assessmentPlaceholder').classList.remove('hidden');
       document.getElementById('assessmentContent').classList.add('hidden');
+      // Backend progression endpoint is days-only; hide the AI card while
+      // a custom range is active so the button can't generate a window
+      // mismatch ("last 30 days" assessment shown next to a bonus-range
+      // chart). Falls back to whatever the last preset would have shown.
+      const customActive = !!(dateFrom && dateTo);
+      document.getElementById('assessmentCard').classList.toggle('hidden', customActive);
       document.getElementById('footer').textContent = '';
 
+      const params = new URLSearchParams();
+      if (customActive) {
+        params.set('date_from', dateFrom);
+        params.set('date_to', dateTo);
+      } else {
+        params.set('days', selectedDays);
+      }
       const history = await fetchJSON(
-        `${API_BASE}/agents/${encodeURIComponent(agentName)}/history?days=${selectedDays}`
+        `${API_BASE}/agents/${encodeURIComponent(agentName)}/history?${params}`
       );
 
       if (!history) {
-        document.getElementById('placeholder').textContent = `No evaluations found for "${agentName}" in the last ${selectedDays} days.`;
+        const windowLabel = customActive ? `${dateFrom} – ${dateTo}` : `the last ${selectedDays} days`;
+        document.getElementById('placeholder').textContent =
+          `No evaluations found for "${agentName}" in ${windowLabel}.`;
         return;
       }
 
@@ -434,13 +390,16 @@
       renderTrendChart(history);
       renderSectionChart(history);
 
+      const windowLabel = customActive ? `${dateFrom} – ${dateTo}` : `Last ${selectedDays} days`;
       document.getElementById('footer').textContent =
-        `Data source: Google Sheets | ${history.length} evaluations | Last ${selectedDays} days`;
+        `Data source: Google Sheets | ${history.length} evaluations | ${windowLabel}`;
 
-      // Restore cached AI assessment if available
-      const cachedAssessment = _getCachedAssessment();
-      if (cachedAssessment) {
-        _showAssessment(cachedAssessment);
+      // Restore cached AI assessment if available (preset-windows only).
+      if (!customActive) {
+        const cachedAssessment = _getCachedAssessment();
+        if (cachedAssessment) {
+          _showAssessment(cachedAssessment);
+        }
       }
     }
 
@@ -694,21 +653,29 @@
 
     }
 
-    // Event listeners
-    document.querySelectorAll('.time-buttons button').forEach(btn => {
-      btn.addEventListener('click', function () {
-        document.querySelectorAll('.time-buttons button').forEach(b => b.classList.remove('active'));
-        this.classList.add('active');
-        selectedDays = parseInt(this.dataset.days);
+    // QAHeader (header.js) owns the time-window chiclets / custom-range
+    // popover. Active Only / Supervisor are rendered disabled on this page
+    // (they don't apply to a single agent) — see header.js init for the
+    // page='agent' branch.
+    qaHeader = window.QAHeader.init({
+      page: 'agent',
+      team: TEAM_ID,
+      agent: currentAgent,
+      title: currentAgent || 'Agent Dashboard',
+      onChange: ({ days, dateFrom: f, dateTo: t }) => {
+        selectedDays = days;
+        dateFrom = f;
+        dateTo = t;
         if (currentAgent) loadDashboard(currentAgent);
-      });
+      },
     });
 
-    // Init — load team sections first, then dashboard
+    // Init — load team sections first, then dashboard. QAHeader's first
+    // onChange already triggered loadDashboard, but it ran before sections
+    // were ready; we re-run after to make sure section labels are populated.
     (async () => {
       await loadTeamSections();
       if (currentAgent) {
-        document.getElementById('headerTitle').textContent = currentAgent;
         loadDashboard(currentAgent);
       } else {
         document.getElementById('placeholder').textContent = 'No agent specified in URL.';

--- a/qa-automation/AI-Scoring/frontend/static/header.css
+++ b/qa-automation/AI-Scoring/frontend/static/header.css
@@ -1,0 +1,189 @@
+/* Shared persistent header for team_dashboard.html + dashboard.html.
+   Markup is rendered by /static/header.js into <div id="appHeader">.
+   Page-specific styles (tab-bar, cards, etc.) stay in each page's
+   <style> block. Color variables are duplicated locally on each page
+   so this file can render correctly even before a page's own :root
+   declarations cascade. */
+
+.qa-header :where(*, *::before, *::after) {
+  box-sizing: border-box;
+}
+
+.qa-header {
+  background: var(--navy, #15192D);
+  color: #fff;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-family: 'DM Mono', monospace;
+}
+
+.qa-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.qa-header h1 {
+  font-family: 'Fraunces', serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* Nav buttons (Scoring / Team View / Lookup). Single style so the
+   chrome reads the same across both pages — replaces the per-page
+   inline styling that drifted (one used 6px 14px, the other 4px 12px). */
+.qa-nav-btn {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.82rem;
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  color: #fff;
+  text-decoration: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+.qa-nav-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+.qa-nav-btn[hidden] { display: none; }
+
+.qa-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  position: relative;  /* anchor for the custom-range popover */
+}
+
+/* Active Only toggle + supervisor select share styling for the dark
+   header. Both render on every page; the agent view gets `disabled`
+   added so they appear identical but inert. */
+.qa-toggle-btn,
+.qa-header select {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.85rem;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+}
+.qa-header select option {
+  background: var(--navy, #15192D);
+  color: #fff;
+}
+.qa-toggle-btn.active {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+}
+.qa-toggle-btn:disabled,
+.qa-header select:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Time-window chiclets (1w / 1mo / 3mo / 6mo / All / Custom …) */
+.qa-time-buttons {
+  display: flex;
+  gap: 4px;
+}
+.qa-time-buttons button {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+.qa-time-buttons button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+.qa-time-buttons button.active {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+  color: #fff;
+}
+
+/* Custom range popover. Anchored under .qa-header-controls; toggled by
+   header.js (hidden attr). Light surface inside the dark header — manager
+   workflow is "pick two dates, hit Apply", so it borrows the page's
+   neutral surface to look like a dialog, not part of the dark bar. */
+.qa-custom-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  background: var(--surface, #ffffff);
+  color: var(--text, #15192D);
+  border: 1px solid var(--border, #c9d5e8);
+  border-radius: 10px;
+  padding: 14px;
+  box-shadow: 0 8px 24px rgba(21, 25, 45, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 260px;
+}
+.qa-custom-popover[hidden] { display: none; }
+.qa-custom-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+}
+.qa-custom-row label {
+  width: 48px;
+  color: var(--muted, #5a6478);
+}
+.qa-custom-row input[type="date"] {
+  flex: 1;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  border: 1px solid var(--border, #c9d5e8);
+  border-radius: 6px;
+  background: var(--bg, #E7EFFB);
+  color: var(--text, #15192D);
+}
+.qa-custom-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+}
+.qa-custom-actions button {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.78rem;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #c9d5e8);
+  background: var(--surface, #ffffff);
+  color: var(--text, #15192D);
+  cursor: pointer;
+}
+.qa-custom-actions .qa-custom-apply {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+  color: #fff;
+}
+.qa-custom-error {
+  font-size: 0.72rem;
+  color: var(--red, #D9534F);
+  min-height: 1em;
+}
+
+@media (max-width: 640px) {
+  .qa-header { padding: 12px 16px; }
+  .qa-custom-popover { right: 0; left: 0; }
+}

--- a/qa-automation/AI-Scoring/frontend/static/header.js
+++ b/qa-automation/AI-Scoring/frontend/static/header.js
@@ -1,0 +1,342 @@
+/* Shared persistent header for team_dashboard.html + dashboard.html.
+   Exposes window.QAHeader.init(opts) — opts shape:
+     {
+       page:        'team' | 'agent',
+       team:        team_id string (e.g. 'member_support'),
+       agent:       agent display name (agent page only),
+       title:       string shown as <h1> (team page passes team title; agent
+                    page passes the agent name),
+       supervisors: list of supervisor names (team page only; populates the
+                    <select>),
+       onChange:    callback fired on every control change with
+                    { days, dateFrom, dateTo, activeOnly, supervisor }
+     }
+
+   State is read from the URL on init (?days=, ?from=&to=, ?supervisor=,
+   ?activeOnly=) so navigating Team↔Agent via the nav buttons carries the
+   chosen window. On every change we rewrite the URL and the nav-button
+   hrefs to keep that round-trip working. */
+
+(function () {
+  'use strict';
+
+  const PRESETS = [
+    { label: '1w',  days: 7   },
+    { label: '1mo', days: 30  },
+    { label: '3mo', days: 90  },
+    { label: '6mo', days: 180 },
+    { label: 'All', days: 0   },
+  ];
+  const DEFAULT_DAYS = 30;
+  const MAX_RANGE_DAYS = 730;
+
+  // --- URL state ----------------------------------------------------------
+  function readUrlState() {
+    const u = new URL(window.location.href);
+    const q = u.searchParams;
+    const from = q.get('from');
+    const to   = q.get('to');
+    const daysRaw = q.get('days');
+    const days = daysRaw != null && daysRaw !== '' ? parseInt(daysRaw, 10) : null;
+    return {
+      dateFrom: from || null,
+      dateTo:   to   || null,
+      // Custom range wins when both dates present; otherwise the
+      // ?days= value (if valid); otherwise the default.
+      days: (from && to)
+        ? null
+        : (Number.isFinite(days) && days >= 0 ? days : DEFAULT_DAYS),
+      activeOnly: q.get('activeOnly') !== '0',  // default true
+      supervisor: q.get('supervisor') || '',
+    };
+  }
+
+  function writeUrlState(state) {
+    const u = new URL(window.location.href);
+    const q = u.searchParams;
+    if (state.dateFrom && state.dateTo) {
+      q.set('from', state.dateFrom);
+      q.set('to',   state.dateTo);
+      q.delete('days');
+    } else {
+      q.delete('from');
+      q.delete('to');
+      if (state.days != null) q.set('days', String(state.days));
+      else q.delete('days');
+    }
+    // Only persist supervisor/activeOnly on the team page — agent page
+    // ignores them and we don't want them sticking in the URL.
+    if (state.page === 'team') {
+      if (state.supervisor) q.set('supervisor', state.supervisor);
+      else q.delete('supervisor');
+      // activeOnly defaults true; only persist the non-default.
+      if (state.activeOnly === false) q.set('activeOnly', '0');
+      else q.delete('activeOnly');
+    }
+    window.history.replaceState({}, '', u.toString());
+  }
+
+  // Rewrite nav-button hrefs to carry the current window across pages.
+  function buildNavHref(base, state) {
+    const u = new URL(base, window.location.origin);
+    if (state.dateFrom && state.dateTo) {
+      u.searchParams.set('from', state.dateFrom);
+      u.searchParams.set('to',   state.dateTo);
+    } else if (state.days != null && state.days !== DEFAULT_DAYS) {
+      u.searchParams.set('days', String(state.days));
+    }
+    return u.pathname + (u.search ? u.search : '');
+  }
+
+  // --- Markup -------------------------------------------------------------
+  function renderInto(host, opts) {
+    const navLinks = [
+      { key: 'scoring',  label: 'Batch Scoring', href: `/score/${opts.team}`,     showOn: 'both'  },
+      { key: 'teamview', label: 'Team View',     href: `/dashboard/${opts.team}`, showOn: 'agent' },
+      { key: 'lookup',   label: 'Lookup',        href: `/lookup/${opts.team}`,    showOn: 'both'  },
+    ];
+    // Batch Scoring stays exposed on both views — it's the entry point to
+    // the bulk-scoring flow, which is being extended later and shouldn't
+    // be reachable only from the agent page. Team View is hidden on the
+    // team page itself (it IS the current page).
+    const navHtml = navLinks
+      .filter(n => n.showOn === 'both' || n.showOn === opts.page)
+      .map(n => `<a class="qa-nav-btn" data-nav="${n.key}" href="${n.href}">${n.label}</a>`)
+      .join('');
+
+    const supervisorOpts = (opts.supervisors || [])
+      .map(s => `<option value="${escapeAttr(s)}">${escapeHtml(s)}</option>`)
+      .join('');
+
+    const presetBtns = PRESETS
+      .map(p => `<button type="button" data-days="${p.days}">${p.label}</button>`)
+      .join('');
+
+    host.classList.add('qa-header');
+    host.innerHTML = `
+      <div class="qa-header-nav">
+        ${navHtml}
+        <h1 id="qaHeaderTitle">${escapeHtml(opts.title || '')}</h1>
+      </div>
+      <div class="qa-header-controls">
+        <button type="button" class="qa-toggle-btn" data-role="active-only">Active Only</button>
+        <select data-role="supervisor">
+          <option value="">All Supervisors</option>
+          ${supervisorOpts}
+        </select>
+        <div class="qa-time-buttons" data-role="time-buttons">
+          ${presetBtns}
+          <button type="button" data-role="custom">Custom …</button>
+        </div>
+        <div class="qa-custom-popover" data-role="custom-popover" hidden>
+          <div class="qa-custom-row">
+            <label for="qaCustomFrom">From</label>
+            <input type="date" id="qaCustomFrom" />
+          </div>
+          <div class="qa-custom-row">
+            <label for="qaCustomTo">To</label>
+            <input type="date" id="qaCustomTo" />
+          </div>
+          <div class="qa-custom-error" data-role="custom-error"></div>
+          <div class="qa-custom-actions">
+            <button type="button" class="qa-custom-clear">Clear</button>
+            <button type="button" class="qa-custom-apply">Apply</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function escapeHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+  function escapeAttr(s) { return escapeHtml(s).replace(/"/g, '&quot;'); }
+
+  // --- Public API ---------------------------------------------------------
+  function init(opts) {
+    const host = document.getElementById('appHeader');
+    if (!host) {
+      console.error('QAHeader.init: <div id="appHeader"></div> not found');
+      return;
+    }
+
+    const state = Object.assign(
+      { page: opts.page, supervisor: '', activeOnly: true, days: DEFAULT_DAYS, dateFrom: null, dateTo: null },
+      readUrlState()
+    );
+
+    renderInto(host, opts);
+
+    const $ = sel => host.querySelector(sel);
+    const $$ = sel => Array.from(host.querySelectorAll(sel));
+
+    // Hydrate controls from URL state.
+    const supervisorSel = $('select[data-role="supervisor"]');
+    if (state.supervisor) supervisorSel.value = state.supervisor;
+
+    const activeBtn = $('[data-role="active-only"]');
+    activeBtn.classList.toggle('active', state.activeOnly);
+    activeBtn.textContent = state.activeOnly ? 'Active Only' : 'All Agents';
+
+    // On the agent page, Active Only / Supervisor are visually identical
+    // but inert — the controls are meaningless for one agent. Keeps the
+    // banner chrome consistent between views.
+    if (opts.page === 'agent') {
+      activeBtn.disabled = true;
+      activeBtn.title = 'Not applicable on agent view';
+      supervisorSel.disabled = true;
+      supervisorSel.title = 'Not applicable on agent view';
+    }
+
+    markActiveChiclet(host, state);
+
+    // Persist + propagate ----------------------------------------------------
+    function emit() {
+      writeUrlState(Object.assign({ page: opts.page }, state));
+      // Rewrite nav-button hrefs so navigation carries the window.
+      $$('.qa-nav-btn').forEach(a => {
+        const base = a.getAttribute('href').split('?')[0];
+        a.setAttribute('href', buildNavHref(base, state));
+      });
+      if (typeof opts.onChange === 'function') {
+        opts.onChange({
+          days:       state.days,
+          dateFrom:   state.dateFrom,
+          dateTo:     state.dateTo,
+          activeOnly: state.activeOnly,
+          supervisor: state.supervisor,
+        });
+      }
+    }
+
+    // Wire up controls -------------------------------------------------------
+    activeBtn.addEventListener('click', () => {
+      if (activeBtn.disabled) return;
+      state.activeOnly = !state.activeOnly;
+      activeBtn.classList.toggle('active', state.activeOnly);
+      activeBtn.textContent = state.activeOnly ? 'Active Only' : 'All Agents';
+      emit();
+    });
+
+    supervisorSel.addEventListener('change', () => {
+      state.supervisor = supervisorSel.value;
+      emit();
+    });
+
+    $$('.qa-time-buttons button[data-days]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.days = parseInt(btn.dataset.days, 10);
+        state.dateFrom = null;
+        state.dateTo = null;
+        markActiveChiclet(host, state);
+        emit();
+      });
+    });
+
+    // Custom popover --------------------------------------------------------
+    const popover = $('[data-role="custom-popover"]');
+    const customBtn = $('[data-role="custom"]');
+    const fromInput = $('#qaCustomFrom');
+    const toInput   = $('#qaCustomTo');
+    const errLabel  = $('[data-role="custom-error"]');
+    const applyBtn  = $('.qa-custom-apply');
+    const clearBtn  = $('.qa-custom-clear');
+
+    function openPopover() {
+      // Pre-fill with current range if active, otherwise leave blank.
+      fromInput.value = state.dateFrom || '';
+      toInput.value   = state.dateTo   || '';
+      errLabel.textContent = '';
+      popover.hidden = false;
+    }
+    function closePopover() { popover.hidden = true; }
+
+    customBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      if (popover.hidden) openPopover(); else closePopover();
+    });
+
+    // Click-outside dismisses the popover (but not on the chiclet itself).
+    document.addEventListener('click', e => {
+      if (popover.hidden) return;
+      if (popover.contains(e.target) || customBtn.contains(e.target)) return;
+      closePopover();
+    });
+
+    applyBtn.addEventListener('click', () => {
+      const f = fromInput.value;
+      const t = toInput.value;
+      if (!f || !t) { errLabel.textContent = 'Pick both dates.'; return; }
+      if (t < f)    { errLabel.textContent = 'To must be on or after From.'; return; }
+      // Span check matches the backend cap.
+      const spanDays = Math.round(
+        (new Date(t) - new Date(f)) / (1000 * 60 * 60 * 24)
+      ) + 1;
+      if (spanDays > MAX_RANGE_DAYS) {
+        errLabel.textContent = `Range exceeds ${MAX_RANGE_DAYS}-day cap.`;
+        return;
+      }
+      state.dateFrom = f;
+      state.dateTo   = t;
+      state.days     = null;
+      markActiveChiclet(host, state);
+      closePopover();
+      emit();
+    });
+
+    clearBtn.addEventListener('click', () => {
+      state.dateFrom = null;
+      state.dateTo   = null;
+      state.days     = DEFAULT_DAYS;
+      markActiveChiclet(host, state);
+      closePopover();
+      emit();
+    });
+
+    // Initial fire so the page can fetch with the URL-resolved window.
+    // Rewrites nav hrefs even when state matches default.
+    emit();
+
+    // Expose a tiny update API so the team page can populate supervisors
+    // after fetching them async (Mails sheet is loaded after init).
+    return {
+      setSupervisors(list) {
+        const cur = supervisorSel.value;
+        supervisorSel.innerHTML =
+          '<option value="">All Supervisors</option>' +
+          (list || []).map(s => `<option value="${escapeAttr(s)}">${escapeHtml(s)}</option>`).join('');
+        // Restore prior selection if it's still in the list.
+        if (cur && [...supervisorSel.options].some(o => o.value === cur)) {
+          supervisorSel.value = cur;
+        }
+      },
+      setTitle(t) {
+        const h = host.querySelector('#qaHeaderTitle');
+        if (h) h.textContent = t;
+      },
+      getState() { return Object.assign({}, state); },
+    };
+  }
+
+  function markActiveChiclet(host, state) {
+    const btns = host.querySelectorAll('.qa-time-buttons button');
+    btns.forEach(b => b.classList.remove('active'));
+    if (state.dateFrom && state.dateTo) {
+      const custom = host.querySelector('[data-role="custom"]');
+      if (custom) {
+        custom.classList.add('active');
+        custom.textContent = `Custom: ${state.dateFrom} – ${state.dateTo}`;
+      }
+      return;
+    }
+    // Reset custom label when a preset is active.
+    const custom = host.querySelector('[data-role="custom"]');
+    if (custom) custom.textContent = 'Custom …';
+    const match = host.querySelector(`.qa-time-buttons button[data-days="${state.days}"]`);
+    if (match) match.classList.add('active');
+  }
+
+  window.QAHeader = { init };
+})();

--- a/qa-automation/AI-Scoring/frontend/team_dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/team_dashboard.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/header.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
   <style>
     :root {
@@ -18,26 +19,7 @@
     body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
     h1, h2, h3 { font-family: 'Fraunces', serif; }
 
-    /* Header */
-    .header {
-      background: var(--navy); color: #fff; padding: 16px 24px;
-      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
-    }
-    .header h1 { font-size: 1.25rem; font-weight: 600; }
-    .header-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-    .header select, .header .toggle-btn {
-      font-family: 'DM Mono', monospace; padding: 6px 12px; border-radius: 6px;
-      border: 1px solid rgba(255,255,255,0.3); font-size: 0.85rem; background: transparent; color: #fff; cursor: pointer;
-    }
-    .header select option { background: var(--navy); color: #fff; }
-    .toggle-btn.active { background: var(--accent); border-color: var(--accent); }
-    .time-buttons { display: flex; gap: 4px; }
-    .time-buttons button {
-      font-family: 'DM Mono', monospace; padding: 6px 12px; border: 1px solid rgba(255,255,255,0.3);
-      background: transparent; color: #fff; border-radius: 6px; cursor: pointer; font-size: 0.8rem; transition: background 0.2s;
-    }
-    .time-buttons button:hover { background: rgba(255,255,255,0.1); }
-    .time-buttons button.active { background: var(--accent); border-color: var(--accent); }
+    /* Header CSS lives in /static/header.css (shared with dashboard.html). */
 
     /* Tabs */
     .tab-bar {
@@ -291,7 +273,6 @@
     @media (max-width: 640px) {
       .kpi-row { grid-template-columns: repeat(2, 1fr); }
       .charts-grid { grid-template-columns: 1fr; }
-      .header { padding: 12px 16px; }
       .container { padding: 16px; }
       .tab-btn { padding: 8px 12px; font-size: 0.75rem; }
     }
@@ -299,25 +280,7 @@
 </head>
 <body>
 
-<div class="header">
-  <div style="display:flex;align-items:center;gap:16px;">
-    <a id="scoring-link" href="/score/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Scoring</a>
-    <a id="lookup-link" href="/lookup/member_support" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:6px 14px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;transition:background 0.2s;">Lookup</a>
-    <h1>Team Analytics Dashboard</h1>
-  </div>
-  <div class="header-controls">
-    <button class="toggle-btn active" id="activeToggle" onclick="toggleActive()">Active Only</button>
-    <select id="supervisorSelect" onchange="changeSupervisor(this.value)">
-      <option value="">All Supervisors</option>
-    </select>
-    <div class="time-buttons">
-      <button onclick="setDays(0)">All</button>
-      <button onclick="setDays(180)">6mo</button>
-      <button onclick="setDays(90)" class="active">3mo</button>
-      <button onclick="setDays(30)">1mo</button>
-    </div>
-  </div>
-</div>
+<div id="appHeader"></div>
 
 <div class="tab-bar">
   <button class="tab-btn active" onclick="switchTab('overview')">Overview</button>
@@ -410,6 +373,7 @@
   </div>
 </div>
 
+<script src="/static/header.js"></script>
 <script>
 // --- Auth ---
 function getApiKey() {
@@ -427,15 +391,17 @@ function authHeaders() {
 
 const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)/) || [, 'member_support'])[1];
 const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
-document.addEventListener('DOMContentLoaded', () => {
-  const scoringLink = document.getElementById('scoring-link');
-  if (scoringLink) scoringLink.href = `/score/${TEAM_ID}`;
-  const lookupLink = document.getElementById('lookup-link');
-  if (lookupLink) lookupLink.href = `/lookup/${TEAM_ID}`;
-});
-let selectedDays = 90;
+
+// Filter state owned by QAHeader (header.js). Hydrated from the URL on
+// init and emitted via the onChange callback we wire in below. Defaults
+// match QAHeader's DEFAULT_DAYS so the first paint and the first /team/stats
+// fetch agree on which chiclet is active.
+let selectedDays = 30;
+let dateFrom = null;
+let dateTo = null;
 let activeOnly = true;
 let selectedSupervisor = '';
+let qaHeader = null;
 let teamData = null;
 let currentTab = 'overview';
 let sortState = {};
@@ -446,7 +412,14 @@ let sectionAvgChart = null, sectionVarChart = null, supervisorChart = null;
 // --- Fetch ---
 async function fetchTeamStats() {
   collapseDistDrill();  // collapse drill-down on timeframe/filter change
-  const params = new URLSearchParams({ days: selectedDays, active_only: activeOnly });
+  const params = new URLSearchParams({ active_only: activeOnly });
+  // Custom-range chiclet (dateFrom + dateTo) takes precedence over `days`.
+  if (dateFrom && dateTo) {
+    params.set('date_from', dateFrom);
+    params.set('date_to', dateTo);
+  } else {
+    params.set('days', selectedDays);
+  }
   if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
   try {
     const r = await fetch(`${API_BASE}/team/stats?${params}`, { headers: authHeaders() });
@@ -478,32 +451,14 @@ async function fetchMails() {
     }
     if (!r.ok) return;
     const mails = await r.json();
-    const sel = document.getElementById('supervisorSelect');
     const supervisors = [...new Set(mails.map(m => m.supervisor).filter(Boolean))].sort();
-    supervisors.forEach(s => {
-      const o = document.createElement('option');
-      o.value = s; o.textContent = s;
-      sel.appendChild(o);
-    });
+    if (qaHeader) qaHeader.setSupervisors(supervisors);
   } catch (e) { console.error('Failed to fetch mails:', e); }
 }
 
-// --- Controls ---
-function toggleActive() {
-  activeOnly = !activeOnly;
-  document.getElementById('activeToggle').classList.toggle('active', activeOnly);
-  document.getElementById('activeToggle').textContent = activeOnly ? 'Active Only' : 'All Agents';
-  fetchTeamStats();
-}
-
-function changeSupervisor(v) { selectedSupervisor = v; fetchTeamStats(); }
-
-function setDays(d) {
-  selectedDays = d;
-  document.querySelectorAll('.time-buttons button').forEach(b => b.classList.remove('active'));
-  event.target.classList.add('active');
-  fetchTeamStats();
-}
+// QAHeader (header.js) owns the chiclets / Active Only / Supervisor /
+// custom-range popover. It emits a single onChange with the resolved
+// filter state; we mirror it into the page-level locals + refetch.
 
 // --- Tabs ---
 function switchTab(tab) {
@@ -1132,12 +1087,18 @@ async function openEwmaDrill(ewmaEntry) {
     <div class="ewma-drill-empty" id="ewmaDrillBody">Loading…</div>
   `;
 
-  // Time window respects the dashboard's current days filter (1mo/3mo/6mo/All).
-  // days=0 (All) maps to a generous 730-day max — same cap the backend accepts.
-  const days = selectedDays && selectedDays > 0 ? selectedDays : 365;
+  // Time window respects the dashboard's current filter: a preset chiclet
+  // (days), the custom range (date_from/date_to), or "All" (days=0 → 730 cap).
+  const params = new URLSearchParams();
+  if (dateFrom && dateTo) {
+    params.set('date_from', dateFrom);
+    params.set('date_to', dateTo);
+  } else {
+    params.set('days', selectedDays && selectedDays > 0 ? selectedDays : 730);
+  }
   try {
     const r = await fetch(
-      `${API_BASE}/agents/${encodeURIComponent(ewmaEntry.agent)}/history?days=${days}`,
+      `${API_BASE}/agents/${encodeURIComponent(ewmaEntry.agent)}/history?${params}`,
       { headers: authHeaders() }
     );
     if (r.status === 404) {
@@ -1468,8 +1429,24 @@ function dismissToast(toast) {
 }
 
 // --- Init ---
+qaHeader = window.QAHeader.init({
+  page: 'team',
+  team: TEAM_ID,
+  title: 'Team Analytics Dashboard',
+  onChange: ({ days, dateFrom: f, dateTo: t, activeOnly: a, supervisor: s }) => {
+    // Detect whether anything that changes the data window actually changed.
+    // The initial emit fires once with the URL-resolved defaults; skipping
+    // the no-op refetch would require tracking "first call", which is more
+    // moving parts than just letting it fetch once.
+    selectedDays = days;
+    dateFrom = f;
+    dateTo = t;
+    activeOnly = a;
+    selectedSupervisor = s;
+    fetchTeamStats();
+  },
+});
 fetchMails();
-fetchTeamStats();
 openEventStream();
 _scheduleMidnightRerender();
 </script>


### PR DESCRIPTION
## Summary

- Normalizes the persistent top-of-page banner across `team_dashboard.html` and `dashboard.html` into a single shared component (`frontend/static/header.{css,js}`). Both pages now expose identical chiclets: **1w / 1mo / 3mo / 6mo / All / Custom …**.
- Adds a **Custom …** date-range picker so managers can scope arbitrary bonus-evaluation windows. State persists in the URL (`?from&to` or `?days`) so navigating Team ↔ Agent via the nav buttons carries the selected window.
- `Active Only` and `All Supervisors` render on both views; on the agent page they're styled identically but `disabled` with a tooltip so the chrome reads the same without lying about behavior.
- **Batch Scoring** nav button now appears on both views (was only on the agent page) — keeps the bulk-scoring flow discoverable as it gets extended.

### Backend
- `/team/stats`, `/team/long_form`, `/agents/{name}/history` accept optional `date_from` / `date_to` (ISO `YYYY-MM-DD`).
- 730-day cap on custom ranges (matches existing team `days` cap). 422 on malformed / inverted / over-cap ranges.
- Custom range overrides `days` when both dates are set; otherwise behavior is unchanged.
- Bumped the agent endpoints' `days` cap from 365 → 730 so a 6mo+ custom retro doesn't clip.

### Known limitation
Agent **AI Assessment** stays days-only — the Gemini prompt and cache key are keyed on a days window. The agent page auto-hides the AI Assessment card while a custom range is active; it returns when a preset chiclet is selected.

## Test plan
- [x] Team page loads with `1mo` active by default.
- [x] Click `Custom …` → pick a date range → table/charts update and URL gains `?from=…&to=…`.
- [x] Click `Lookup` from the team page and confirm `?from&to` rides along to that page.
- [x] Agent page: `Active Only` + supervisor select render greyed-out with tooltip.
- [x] Agent page: custom range hides the AI Assessment card; switching back to `1mo` brings it back with cached assessment.
- [x] `Batch Scoring` nav button visible and routes to `/score/<team>` from both views.
- [x] Validation: inverted dates / >730d span surface the inline popover error; backend would 422 if bypassed.
- [x] `pytest tests/` — 216 pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)