### PR TITLE
feat(qa-scoring): treat audio as source of truth for non-English calls

### DIFF
--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -29,6 +29,9 @@ LANDING_GENERAL_INSTRUCTIONS = """
   different name later in the same call — consistency within the call is
   required. The agent's Dialpad-recorded name is internal and is NOT the
   ground truth for what name they must use with the lead/member.
+- Source of truth: the audio is authoritative for scoring. If the call is
+  detected as non-English, score from the audio content and treat the
+  transcript as unreliable.
 """.rstrip()
 
 


### PR DESCRIPTION
When the detected call language is non-English, instruct the scorer to rely on audio content and assume the transcript is inaccurate.