### PR TITLE
feat(database): migration 005 — command_center.* tables

### DIFF
--- a/database/migrations/005_command_center_tables.sql
+++ b/database/migrations/005_command_center_tables.sql
@@ -1,0 +1,232 @@
+-- ============================================================================
+-- Migration 005: command_center.* tables
+-- Spec: database/SQLMigration.md §4
+--
+-- Six tables that make CC's runtime state durable across Railway redeploys:
+--
+--   webhook_events           Append-only log; truth for state derivation
+--                            (§4.1). Replay rebuilds in-memory state via
+--                            the same handler used live.
+--   calls                    Per-call materialized aggregate; load-bearing
+--                            FK target for qa.evaluations and the
+--                            calls-received-vs-scored ratio (§4.2).
+--   chiclets                 Stable per-surfaced-chiclet identity (§4.3).
+--   chiclet_events           SSE emission log (§4.4).
+--   frequent_callers_cache   Per-team Looker snapshot (§4.5).
+--   dialpad_agents           Dialpad agent-id ↔ display-name registry (§4.6).
+--
+-- Sequenced before 006 because qa.evaluations.command_center_call_id is a
+-- nullable FK → command_center.calls.id (§3.4 + §4.2 + §7.6).
+-- Hold-intervals are NOT modeled (§4.7) — derived from webhook_events when
+-- needed; total_hold_seconds rollup on `calls` covers the 95% case.
+-- The dormant call_state_snapshots DDL in §4.1.3 is intentionally NOT
+-- applied here — reserved for the day the perf tripwire fires.
+-- ============================================================================
+
+
+-- ── command_center.webhook_events (§4.1) ────────────────────────────────────
+-- Discriminated by event_kind: call events and agent-status events share the
+-- log but each gets its own dedupe key (see partial UNIQUEs below).
+--
+-- event_timestamp is from the Dialpad payload (event time), NOT received_at
+-- (our clock) — replay-order correctness depends on this distinction.
+
+CREATE TABLE command_center.webhook_events (
+    id                          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    received_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    team_id                     TEXT NOT NULL REFERENCES public.teams(id),
+    event_kind                  TEXT NOT NULL,
+    dialpad_call_id             TEXT,
+    dialpad_master_call_id      TEXT,
+    dialpad_agent_id            TEXT,
+    state                       TEXT NOT NULL,
+    event_timestamp             TIMESTAMPTZ NOT NULL,
+    raw_payload                 JSONB NOT NULL,
+    processed_at                TIMESTAMPTZ,
+    CONSTRAINT webhook_events_event_kind_check
+        CHECK (event_kind IN ('call', 'agent_status')),
+    -- Call events MUST carry a dialpad_call_id (agent-status events may not).
+    CONSTRAINT webhook_events_call_id_when_call
+        CHECK (event_kind <> 'call' OR dialpad_call_id IS NOT NULL),
+    -- Per §4.1.1, monitored_states are:
+    --   ringing, connected, hold, hangup, recording, call_transcription,
+    --   recap_summary
+    -- Agent-status events use a separate vocabulary defined by Dialpad's
+    -- agent-status webhook (available / busy / etc.). We keep `state` as
+    -- TEXT NOT NULL but do not constrain its values here — a CHECK that
+    -- ages with Dialpad's vocabulary would be fragile.
+    CONSTRAINT webhook_events_state_not_blank CHECK (length(state) > 0)
+);
+
+-- Partial UNIQUE indexes per §4.1: event-kind-aware dedupe so an
+-- accidental replay of the same call-event payload is a no-op, and an
+-- agent-status event with the same timestamp as an unrelated call event
+-- on the same id doesn't collide.
+CREATE UNIQUE INDEX uq_webhook_call ON command_center.webhook_events
+    (dialpad_call_id, state, event_timestamp)
+    WHERE event_kind = 'call';
+
+CREATE UNIQUE INDEX uq_webhook_agent ON command_center.webhook_events
+    (dialpad_agent_id, state, event_timestamp)
+    WHERE event_kind = 'agent_status';
+
+
+-- ── command_center.calls (§4.2) ─────────────────────────────────────────────
+-- Per-call materialized aggregate. Universe of every call CC has observed
+-- (scored or not). Written-through by the same handler that processes
+-- webhook_events — live and replay are the same function (§4.1.2 invariant).
+--
+-- `scored` is monotonic — never flips back to FALSE even if the
+-- corresponding evaluation is later deleted. Deletion flips
+-- `evaluation_orphaned` instead (§3.9, §4.2).
+
+CREATE TABLE command_center.calls (
+    id                          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id                     TEXT NOT NULL REFERENCES public.teams(id),
+    dialpad_call_id             TEXT NOT NULL,
+    dialpad_master_call_id      TEXT,
+    dialpad_entry_point_call_id TEXT,
+    -- Call lifecycle clocks from Dialpad's get_call_details(). connected_at
+    -- is the call-time source of truth (per CallTimeOnAnalystHistory.md).
+    started_at                  TIMESTAMPTZ,
+    rang_at                     TIMESTAMPTZ,
+    connected_at                TIMESTAMPTZ,
+    ended_at                    TIMESTAMPTZ,
+    total_duration_ms           BIGINT,
+    direction                   TEXT,
+    external_number             TEXT,
+    internal_number             TEXT,
+    group_id                    TEXT,
+    -- Denormalized agent fields for fast queries. The dialpad_agents
+    -- registry (§4.6) is the source of truth for the id ↔ name mapping.
+    dialpad_agent_id            TEXT,
+    agent_name                  TEXT,
+    caller_name                 TEXT,
+    caller_phone_e164           TEXT,
+    caller_email                TEXT,
+    target_name                 TEXT,
+    target_type                 TEXT,
+    target_phone                TEXT,
+    mos_score                   NUMERIC(3,2),
+    was_recorded                BOOLEAN,
+    is_transferred              BOOLEAN,
+    -- Normalized recording-URL shape per §3.4.2: {audio: [...], screen: [...]}
+    recording_urls              JSONB,
+    last_state                  TEXT,
+    last_state_at               TIMESTAMPTZ,
+    -- Accumulated across hold cycles; derived from webhook_events on each
+    -- write. NOT NULL DEFAULT 0 so rollup queries never have to coalesce.
+    total_hold_seconds          INTEGER NOT NULL DEFAULT 0,
+    -- Forward-compat catch-all. Per §4.2, planned post-v1 retention nulls
+    -- this column past 2 years; first-class columns persist forever.
+    raw_call_details            JSONB,
+    -- Load-bearing scored/orphaned flags per §4.2 + §3.9. Monotonic.
+    scored                      BOOLEAN NOT NULL DEFAULT FALSE,
+    scored_at                   TIMESTAMPTZ,
+    evaluation_orphaned         BOOLEAN NOT NULL DEFAULT FALSE,
+    evaluation_orphaned_at      TIMESTAMPTZ,
+    -- Provenance of CC's awareness of this call:
+    --   webhook        CC saw it live via Dialpad webhook
+    --   qa_on_demand   QA scored a call CC never saw live (UPSERT path 2)
+    --   qa_backfill    Phase-B stub created from Analyst_History (path 3)
+    seen_via                    TEXT NOT NULL,
+    first_seen_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT calls_seen_via_check
+        CHECK (seen_via IN ('webhook', 'qa_on_demand', 'qa_backfill')),
+    -- scored timestamp paired with the flag: either both NULL or both set.
+    CONSTRAINT calls_scored_pair_check
+        CHECK (scored = FALSE OR scored_at IS NOT NULL),
+    -- Same pair invariant for the orphan flag.
+    CONSTRAINT calls_orphaned_pair_check
+        CHECK (evaluation_orphaned = FALSE OR evaluation_orphaned_at IS NOT NULL),
+    -- §4.2 explicit UNIQUE constraint — names the constraint so the
+    -- ON CONFLICT target is stable.
+    CONSTRAINT uq_calls_team_call_id UNIQUE (team_id, dialpad_call_id)
+);
+
+
+-- ── command_center.chiclets (§4.3) ──────────────────────────────────────────
+-- Stable identity per surfaced chiclet. Permanent retention; `data` JSONB
+-- carries per-type live fields written-through on every chiclet_updated SSE
+-- emit (CC P2.2 — snapshot endpoint becomes a single indexed read).
+
+CREATE TABLE command_center.chiclets (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id           TEXT NOT NULL REFERENCES public.teams(id),
+    type              TEXT NOT NULL,
+    tier              TEXT NOT NULL,
+    status            TEXT NOT NULL,
+    border_state      TEXT,
+    source_event_id   BIGINT REFERENCES command_center.webhook_events(id),
+    caller_phone_e164 TEXT,
+    agent_name        TEXT,
+    summary           TEXT NOT NULL,
+    data              JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at       TIMESTAMPTZ,
+    resolved_by       TEXT,
+    CONSTRAINT chiclets_type_check
+        CHECK (type IN ('hold', 'repeated', 'frequent', 'qa_outlier',
+                        'sheets_update', 'mass_notif', 'profanity')),
+    CONSTRAINT chiclets_tier_check
+        CHECK (tier IN ('T1', 'T2', 'T3')),
+    CONSTRAINT chiclets_status_check
+        CHECK (status IN ('active', 'resolved')),
+    -- resolved pair: resolved status MUST carry resolved_at + resolved_by.
+    CONSTRAINT chiclets_resolved_pair_check
+        CHECK (status <> 'resolved'
+               OR (resolved_at IS NOT NULL AND resolved_by IS NOT NULL))
+);
+
+
+-- ── command_center.chiclet_events (§4.4) ────────────────────────────────────
+-- Append-only SSE-emission log. 30-day rolling retention (pruning is a
+-- cron concern, not a schema concern).
+
+CREATE TABLE command_center.chiclet_events (
+    id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    chiclet_id  BIGINT NOT NULL REFERENCES command_center.chiclets(id)
+                ON DELETE CASCADE,
+    event_type  TEXT NOT NULL,
+    payload     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    emitted_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chiclet_events_type_check
+        CHECK (event_type IN ('created', 'updated', 'escalated', 'resolved'))
+);
+
+
+-- ── command_center.frequent_callers_cache (§4.5) ────────────────────────────
+-- Per-team Looker registry snapshot. Two-snapshot retention; trimming runs
+-- via cron.
+
+CREATE TABLE command_center.frequent_callers_cache (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id           TEXT NOT NULL REFERENCES public.teams(id),
+    caller_phone_e164 TEXT NOT NULL,
+    caller_name       TEXT,
+    unit              TEXT,
+    category          TEXT,
+    flag_reason       TEXT,
+    last_call_at      TIMESTAMPTZ,
+    total_calls_30d   INTEGER,
+    snapshot_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    snapshot_id       BIGINT NOT NULL
+);
+
+
+-- ── command_center.dialpad_agents (§4.6) ────────────────────────────────────
+-- Per-team Dialpad agent-id → display-name map. Drives both CC's live
+-- agent-name resolution and the nightly reconciliation sweep
+-- (qa.agents.dialpad_agent_id backfill per §3.11).
+
+CREATE TABLE command_center.dialpad_agents (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id           TEXT NOT NULL REFERENCES public.teams(id),
+    dialpad_agent_id  TEXT NOT NULL,
+    display_name      TEXT NOT NULL,
+    email             TEXT,
+    first_seen_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_dialpad_agents_team_agent UNIQUE (team_id, dialpad_agent_id)
+);

--- a/database/migrations/005_command_center_tables_down.sql
+++ b/database/migrations/005_command_center_tables_down.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- Migration 005 — DOWN
+--
+-- Drops in dependency order, no CASCADE: if migration 006 is still applied
+-- (qa.evaluations FKs to command_center.calls), DROP TABLE calls will fail
+-- — that's the fail-loud behavior we want. Operator must down 006 first.
+-- Partial UNIQUE indexes drop automatically with their table.
+-- ============================================================================
+
+DROP TABLE IF EXISTS command_center.chiclet_events;
+DROP TABLE IF EXISTS command_center.chiclets;
+DROP TABLE IF EXISTS command_center.calls;
+DROP TABLE IF EXISTS command_center.frequent_callers_cache;
+DROP TABLE IF EXISTS command_center.dialpad_agents;
+DROP TABLE IF EXISTS command_center.webhook_events;

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_005.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_005.py
@@ -1,0 +1,544 @@
+"""Tests for migration 005 — command_center.* tables.
+
+Per SQLMigration.md §11.5 floor:
+  - ≥1 CHECK test per declared CHECK constraint
+  - ≥1 UPSERT-idempotency test per UNIQUE conflict target
+
+Plus a runner-level integration test that applies 004+005 in sequence and
+rolls back to confirm the down script leaves the database in the state
+004 alone would (schemas + teams, no CC tables).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from database import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
+UP_005 = (MIGRATIONS_DIR / "005_command_center_tables.sql").read_text()
+DOWN_005 = (MIGRATIONS_DIR / "005_command_center_tables_down.sql").read_text()
+
+
+@pytest_asyncio.fixture
+async def pg_005(clean_pg: asyncpg.Connection) -> asyncpg.Connection:
+    """clean_pg + 004 + 005 applied. Common precondition."""
+    await clean_pg.execute(UP_004)
+    await clean_pg.execute(UP_005)
+    return clean_pg
+
+
+# ---------------------------------------------------------------------------
+# webhook_events — CHECKs + partial UNIQUEs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_event_kind_rejects_invalid_value(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.webhook_events
+                (team_id, event_kind, dialpad_call_id, state,
+                 event_timestamp, raw_payload)
+            VALUES ('sales', 'unknown_kind', 'c1', 'connected',
+                    NOW(), '{}'::jsonb)
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_call_event_requires_call_id(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """event_kind='call' MUST have dialpad_call_id — otherwise the partial
+    UNIQUE for call dedupe would collapse on NULL keys."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.webhook_events
+                (team_id, event_kind, state, event_timestamp, raw_payload)
+            VALUES ('sales', 'call', 'connected', NOW(), '{}'::jsonb)
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_agent_status_event_without_call_id_ok(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """The call_id_when_call CHECK is conditional on event_kind — an
+    agent_status event without a call_id is valid."""
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.webhook_events
+            (team_id, event_kind, dialpad_agent_id, state,
+             event_timestamp, raw_payload)
+        VALUES ('sales', 'agent_status', 'a1', 'available',
+                NOW(), '{}'::jsonb)
+        """
+    )
+    n = await pg_005.fetchval("SELECT COUNT(*) FROM command_center.webhook_events")
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_blank_state_rejected(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.webhook_events
+                (team_id, event_kind, dialpad_call_id, state,
+                 event_timestamp, raw_payload)
+            VALUES ('sales', 'call', 'c1', '', NOW(), '{}'::jsonb)
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_partial_unique_dedupes_call_kind(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """The (dialpad_call_id, state, event_timestamp) UNIQUE applies only
+    to event_kind='call' — a replayed call payload with the same triple
+    must collide."""
+    ts = "2026-06-23T10:00:00Z"
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.webhook_events
+            (team_id, event_kind, dialpad_call_id, state,
+             event_timestamp, raw_payload)
+        VALUES ('sales', 'call', 'c1', 'connected', $1::timestamptz, '{}'::jsonb)
+        """,
+        ts,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.webhook_events
+                (team_id, event_kind, dialpad_call_id, state,
+                 event_timestamp, raw_payload)
+            VALUES ('sales', 'call', 'c1', 'connected', $1::timestamptz, '{}'::jsonb)
+            """,
+            ts,
+        )
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_partial_unique_dedupes_agent_status(
+    pg_005: asyncpg.Connection,
+) -> None:
+    ts = "2026-06-23T10:00:00Z"
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.webhook_events
+            (team_id, event_kind, dialpad_agent_id, state,
+             event_timestamp, raw_payload)
+        VALUES ('sales', 'agent_status', 'a1', 'busy', $1::timestamptz, '{}'::jsonb)
+        """,
+        ts,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.webhook_events
+                (team_id, event_kind, dialpad_agent_id, state,
+                 event_timestamp, raw_payload)
+            VALUES ('sales', 'agent_status', 'a1', 'busy', $1::timestamptz, '{}'::jsonb)
+            """,
+            ts,
+        )
+
+
+@pytest.mark.asyncio
+async def test_webhook_events_different_kinds_same_timestamp_both_ok(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """Two partial UNIQUEs are independent — a call event and an
+    agent_status event with the same timestamp do NOT collide."""
+    ts = "2026-06-23T10:00:00Z"
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.webhook_events
+            (team_id, event_kind, dialpad_call_id, state,
+             event_timestamp, raw_payload)
+        VALUES ('sales', 'call', 'c1', 'connected', $1::timestamptz, '{}'::jsonb)
+        """,
+        ts,
+    )
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.webhook_events
+            (team_id, event_kind, dialpad_agent_id, state,
+             event_timestamp, raw_payload)
+        VALUES ('sales', 'agent_status', 'a1', 'busy', $1::timestamptz, '{}'::jsonb)
+        """,
+        ts,
+    )
+    n = await pg_005.fetchval("SELECT COUNT(*) FROM command_center.webhook_events")
+    assert n == 2
+
+
+# ---------------------------------------------------------------------------
+# calls — CHECKs + scored/orphan pair invariants + team_call_id UNIQUE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_calls_seen_via_rejects_invalid(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.calls
+                (team_id, dialpad_call_id, seen_via)
+            VALUES ('sales', 'c1', 'NOT_A_KNOWN_SOURCE')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_calls_scored_pair_requires_scored_at_when_true(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """If `scored=TRUE`, `scored_at` must be populated. The flag pair is
+    a load-bearing invariant for the calls-received-vs-scored ratio
+    (§4.2) and for the orphan-detection workflow (§3.9)."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.calls
+                (team_id, dialpad_call_id, seen_via, scored)
+            VALUES ('sales', 'c1', 'qa_on_demand', TRUE)
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_calls_scored_pair_allows_both_set(
+    pg_005: asyncpg.Connection,
+) -> None:
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.calls
+            (team_id, dialpad_call_id, seen_via, scored, scored_at)
+        VALUES ('sales', 'c1', 'qa_on_demand', TRUE, NOW())
+        """
+    )
+    assert (
+        await pg_005.fetchval("SELECT scored FROM command_center.calls WHERE dialpad_call_id = 'c1'")
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_calls_orphaned_pair_requires_orphaned_at(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.calls
+                (team_id, dialpad_call_id, seen_via, evaluation_orphaned)
+            VALUES ('sales', 'c1', 'qa_on_demand', TRUE)
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_calls_team_call_id_unique_blocks_duplicate(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """`uq_calls_team_call_id` is the load-bearing constraint behind the
+    write paths in §4.2 (every UPSERT targets ON CONFLICT (team_id,
+    dialpad_call_id))."""
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.calls
+            (team_id, dialpad_call_id, seen_via)
+        VALUES ('sales', 'c1', 'webhook')
+        """
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.calls
+                (team_id, dialpad_call_id, seen_via)
+            VALUES ('sales', 'c1', 'qa_on_demand')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_calls_upsert_on_team_call_id_round_trips(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """End-to-end demo of the ON CONFLICT pattern §4.2 write paths use."""
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.calls
+            (team_id, dialpad_call_id, seen_via, agent_name)
+        VALUES ('sales', 'c1', 'webhook', 'Alpha Agent')
+        ON CONFLICT (team_id, dialpad_call_id) DO UPDATE
+            SET agent_name = EXCLUDED.agent_name,
+                last_updated_at = NOW()
+        """
+    )
+    # Second writer (e.g. QA scoring path) refreshes the agent name.
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.calls
+            (team_id, dialpad_call_id, seen_via, agent_name)
+        VALUES ('sales', 'c1', 'qa_on_demand', 'Alpha Agent (corrected)')
+        ON CONFLICT (team_id, dialpad_call_id) DO UPDATE
+            SET agent_name = EXCLUDED.agent_name,
+                last_updated_at = NOW()
+        """
+    )
+    rows = await pg_005.fetch(
+        "SELECT agent_name, seen_via FROM command_center.calls WHERE dialpad_call_id = 'c1'"
+    )
+    # `seen_via` is set on insert and not touched by the ON CONFLICT clause
+    # → first writer's value wins. Application code MUST NOT include
+    # seen_via in the SET list per §4.2 ("seen_via='webhook' on insert;
+    # never overwritten").
+    assert len(rows) == 1
+    assert rows[0]["agent_name"] == "Alpha Agent (corrected)"
+    assert rows[0]["seen_via"] == "webhook"
+
+
+# ---------------------------------------------------------------------------
+# chiclets + chiclet_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chiclets_type_rejects_invalid(pg_005: asyncpg.Connection) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.chiclets
+                (team_id, type, tier, status, summary)
+            VALUES ('sales', 'unknown_type', 'T1', 'active', 'x')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_chiclets_tier_rejects_invalid(pg_005: asyncpg.Connection) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.chiclets
+                (team_id, type, tier, status, summary)
+            VALUES ('sales', 'hold', 'T9', 'active', 'x')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_chiclets_status_rejects_invalid(pg_005: asyncpg.Connection) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.chiclets
+                (team_id, type, tier, status, summary)
+            VALUES ('sales', 'hold', 'T1', 'pending', 'x')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_chiclets_resolved_pair_requires_resolved_at_and_by(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.chiclets
+                (team_id, type, tier, status, summary)
+            VALUES ('sales', 'hold', 'T1', 'resolved', 'x')
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_chiclets_active_does_not_require_resolved_fields(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """The pair CHECK is conditional on status='resolved'. An active
+    chiclet with NULL resolved_at/resolved_by is valid."""
+    await pg_005.execute(
+        """
+        INSERT INTO command_center.chiclets
+            (team_id, type, tier, status, summary, data)
+        VALUES ('sales', 'hold', 'T1', 'active', 'x', '{"seconds": 45}'::jsonb)
+        """
+    )
+    data = await pg_005.fetchval(
+        "SELECT data FROM command_center.chiclets WHERE summary = 'x'"
+    )
+    assert json.loads(data) == {"seconds": 45}
+
+
+@pytest.mark.asyncio
+async def test_chiclet_events_event_type_rejects_invalid(
+    pg_005: asyncpg.Connection,
+) -> None:
+    cid = await pg_005.fetchval(
+        """
+        INSERT INTO command_center.chiclets
+            (team_id, type, tier, status, summary)
+        VALUES ('sales', 'hold', 'T1', 'active', 'x')
+        RETURNING id
+        """
+    )
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_005.execute(
+            "INSERT INTO command_center.chiclet_events (chiclet_id, event_type) "
+            "VALUES ($1, 'unknown_event')",
+            cid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_chiclet_events_cascade_delete_with_parent(
+    pg_005: asyncpg.Connection,
+) -> None:
+    """ON DELETE CASCADE on chiclet_id means deleting a chiclet wipes
+    its event history. (Chiclets are permanent in normal flow, but the
+    cascade prevents orphan events if cleanup is ever needed.)"""
+    cid = await pg_005.fetchval(
+        """
+        INSERT INTO command_center.chiclets
+            (team_id, type, tier, status, summary)
+        VALUES ('sales', 'hold', 'T1', 'active', 'x')
+        RETURNING id
+        """
+    )
+    await pg_005.execute(
+        "INSERT INTO command_center.chiclet_events (chiclet_id, event_type) "
+        "VALUES ($1, 'created'), ($1, 'updated')",
+        cid,
+    )
+    await pg_005.execute("DELETE FROM command_center.chiclets WHERE id = $1", cid)
+    assert (
+        await pg_005.fetchval(
+            "SELECT COUNT(*) FROM command_center.chiclet_events WHERE chiclet_id = $1",
+            cid,
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# dialpad_agents — UNIQUE (team_id, dialpad_agent_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dialpad_agents_unique_team_agent(
+    pg_005: asyncpg.Connection,
+) -> None:
+    await pg_005.execute(
+        "INSERT INTO command_center.dialpad_agents (team_id, dialpad_agent_id, display_name) "
+        "VALUES ('sales', 'a1', 'Alpha')"
+    )
+    # Same agent on a DIFFERENT team is fine — partial UNIQUE is per team.
+    await pg_005.execute(
+        "INSERT INTO command_center.dialpad_agents (team_id, dialpad_agent_id, display_name) "
+        "VALUES ('member_support', 'a1', 'Alpha (MS)')"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_005.execute(
+            "INSERT INTO command_center.dialpad_agents (team_id, dialpad_agent_id, display_name) "
+            "VALUES ('sales', 'a1', 'Alpha duplicate')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-table — team_id FKs reject unknown teams
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_id_fk_rejects_unknown_team(
+    pg_005: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_005.execute(
+            """
+            INSERT INTO command_center.calls
+                (team_id, dialpad_call_id, seen_via)
+            VALUES ('nonexistent_team', 'c1', 'webhook')
+            """
+        )
+
+
+# ---------------------------------------------------------------------------
+# Down — drops every command_center.* table cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_cc_tables(pg_005: asyncpg.Connection) -> None:
+    await pg_005.execute(DOWN_005)
+    rows = await pg_005.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'command_center'"
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — 004 then 005 then down 005
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_applies_004_and_005_in_sequence(
+    clean_pg: asyncpg.Connection, tmp_path: Path
+) -> None:
+    import shutil
+    migdir = tmp_path / "migrations"
+    migdir.mkdir()
+    for name in [
+        "004_create_schemas_and_teams.sql",
+        "004_create_schemas_and_teams_down.sql",
+        "005_command_center_tables.sql",
+        "005_command_center_tables_down.sql",
+    ]:
+        shutil.copy(MIGRATIONS_DIR / name, migdir)
+
+    rc = await runner.cmd_up(clean_pg, migrations_dir=migdir)
+    assert rc == 0
+
+    applied = await clean_pg.fetch(
+        "SELECT version, name FROM public.schema_migrations ORDER BY version"
+    )
+    assert [(r["version"], r["name"]) for r in applied] == [
+        (4, "create_schemas_and_teams"),
+        (5, "command_center_tables"),
+    ]
+
+    # Rolling back 005 only must leave 004's state intact.
+    rc = await runner.cmd_down(clean_pg)
+    assert rc == 0
+    tables = await clean_pg.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'command_center'"
+    )
+    assert tables == []
+    # public.teams still has its seed rows — 004 untouched.
+    assert await clean_pg.fetchval("SELECT COUNT(*) FROM public.teams") == 2


### PR DESCRIPTION
## Summary
- Six `command_center.*` tables (§4) that make CC's runtime state durable across Railway redeploys: `webhook_events` (append-only truth), `calls` (per-call materialized aggregate; FK target for `qa.evaluations`), `chiclets`, `chiclet_events`, `frequent_callers_cache`, `dialpad_agents`.
- 11 CHECK constraints (event_kind, conditional call_id, non-blank state, seen_via, scored/orphaned pair invariants, type/tier/status/resolved-pair on chiclets, event_type on chiclet_events). 2 UNIQUE constraints + 2 partial UNIQUEs by `event_kind` on webhook_events. Sequenced before 006 so the cross-schema FK can target `command_center.calls.id`.
- 19 tests at `tests/integration/test_migration_005.py` covering every CHECK + UNIQUE positive/negative, partial-UNIQUE independence (call + agent_status sharing a timestamp both insert), team_id FK enforcement, chiclet_events ON DELETE CASCADE, runner integration (004 → 005 → down 005 leaves 004 state intact).

## Test plan
- [ ] `make test-integration` — 19 tests in test_migration_005.py should pass
- [ ] Confirm hold-intervals are NOT modeled (§4.7 — total_hold_seconds rollup covers the 95% case)
- [ ] Confirm the dormant `call_state_snapshots` DDL (§4.1.3) is intentionally not applied

## Stacked on
[#52 — migration 004](https://github.com/mxg108/Landing-scripts/pull/52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)