### PR TITLE
feat(database): migration 006 — qa.* tables

### DIFF
--- a/database/migrations/006_qa_tables.sql
+++ b/database/migrations/006_qa_tables.sql
@@ -1,0 +1,382 @@
+-- ============================================================================
+-- Migration 006: qa.* tables
+-- Spec: database/SQLMigration.md §3, §3.4.3, §3.12, §3.13, §7.6, §9.2
+--
+-- Nine tables that replace the Sheets-as-DB QA pipeline:
+--
+--   agents                       Replaces per-team Mails sheet (§3.3)
+--   formula_versions             Archived overall-score formula JSON per
+--                                team, write-path from FastAPI startup
+--                                loader (§3.12)
+--   evaluations                  One row per scored call across its full
+--                                lifecycle (draft→approved→finalized),
+--                                replacing the FR-AI + Score destination +
+--                                Analyst_History row triplet (§3.4)
+--   evaluation_sections          Normalized per-section scores with per-
+--                                section provider provenance (§3.5)
+--   formula_compliance_sweeps    Historic-compliance sweep results,
+--                                one row per (evaluation × formula_version)
+--                                — replaces v1's transient parity column,
+--                                preserves iteration history (§3.13)
+--   score_audit                  Action-level audit log, 1:1 with the
+--                                Sheets `Score_Audit` tab (§3.9)
+--   score_audit_archive          Same shape as score_audit; rows >180d
+--                                are moved here by a daily cron (§3.9)
+--   api_audit_log                Request-level audit + cost attribution;
+--                                permanent retention (§3.10)
+--   agent_stat_points            Per-finalize EWMA/SPC point per agent;
+--                                drives CC sparklines, outlier chiclets,
+--                                PDF assessments (§9.2)
+--
+-- CHECK constraints are the relaxed-pre-cutover variants (§3.4.3). The
+-- strict post-cutover tightening lands in migration 012 per team via
+-- ADD CONSTRAINT … NOT VALID + VALIDATE CONSTRAINT.
+--
+-- §3.4.1 partial UNIQUE dedupe indexes ship with this migration (not
+-- deferred to 008) because they enforce schema invariants, not perf.
+-- Analytics indexes (§9.1 + §9.2 idx_stat_points_agent + §3.12 +
+-- §3.13 lookup indexes) ship in migration 008.
+-- ============================================================================
+
+
+-- ── qa.agents (§3.3) ────────────────────────────────────────────────────────
+-- Replaces the per-team Mails sheet. UNIQUE on (team_id, LOWER(name)) so
+-- agent lookups by name are case-insensitive without changing call sites.
+
+CREATE TABLE qa.agents (
+    id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id             TEXT NOT NULL REFERENCES public.teams(id),
+    name                TEXT NOT NULL,
+    canonical_name      TEXT,
+    email               TEXT NOT NULL,
+    supervisor_email    TEXT,
+    -- Eager-resolved at Stage 1 per §3.11; nightly sweep as backstop.
+    dialpad_agent_id    TEXT,
+    active              BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uq_agents_team_lower_name
+    ON qa.agents (team_id, LOWER(name));
+
+
+-- ── qa.formula_versions (§3.12) ─────────────────────────────────────────────
+-- Archived formula JSONs. Write path: FastAPI startup loader hashes the
+-- loaded JSON; if no row matches (team_id, formula_version, hash), insert
+-- it and mark any prior version's `effective_until = NOW()`. Old rows
+-- remain reproducible forever — even after their section IDs disappear
+-- from the active team config.
+--
+-- `formula_version` is UNIQUE NOT NULL so qa.evaluations.formula_version
+-- can FK to it directly (FK by string).
+
+CREATE TABLE qa.formula_versions (
+    id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    formula_version     TEXT NOT NULL UNIQUE,
+    team_id             TEXT NOT NULL REFERENCES public.teams(id),
+    formula_json        JSONB NOT NULL,
+    effective_from      TIMESTAMPTZ NOT NULL,
+    effective_until     TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+
+-- ── qa.evaluations (§3.4) ───────────────────────────────────────────────────
+-- One row per call across its entire lifecycle. CHECKs are the §3.4.3
+-- relaxed pre-cutover form — every evaluation passes through an
+-- approved-with-NULL-overall_score window because Stage 3 (ARRAYFORMULA
+-- readback) is a separate call. Migration 012 tightens these per team
+-- once Phase C completes.
+
+CREATE TABLE qa.evaluations (
+    id                            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id                       TEXT NOT NULL REFERENCES public.teams(id),
+    -- agent_id may stay NULL until Stage 4 finalize resolves it via Mails
+    -- lookup; do not enforce NOT NULL here.
+    agent_id                      BIGINT REFERENCES qa.agents(id),
+    agent_name_raw                TEXT NOT NULL,
+    agent_email                   TEXT,
+    evaluator_email               TEXT,
+    state                         TEXT NOT NULL,
+    source                        TEXT NOT NULL,
+    -- Call lifecycle clocks (§3.4 + CallTimeOnAnalystHistory.md).
+    call_connected_at             TIMESTAMPTZ,
+    call_started_at               TIMESTAMPTZ,
+    call_ended_at                 TIMESTAMPTZ,
+    call_duration_ms              INTEGER,
+    call_type                     TEXT,
+    -- en / es / future; writer sets at Stage 1, no default — silent
+    -- defaults would mask language-detection bugs.
+    language                      TEXT,
+    -- Dialpad ids — durable join keys, even when CC didn't see the call live.
+    dialpad_call_id               TEXT,
+    dialpad_master_call_id        TEXT,
+    dialpad_entry_point_call_id   TEXT,
+    -- Transition-period dedupe key (§3.4.1). NULL allowed for backfilled
+    -- rows whose link couldn't be reconstructed.
+    dialpad_link                  TEXT,
+    -- Cross-schema nullable FK to command_center.calls (§3.4 + §4.2).
+    -- NULL on Phase B backfilled rows that pre-date CC and on rows
+    -- written during a CC outage. Stage 1 writer flips
+    -- command_center.calls.scored = TRUE in the same transaction.
+    command_center_call_id        BIGINT REFERENCES command_center.calls(id),
+    mos_score                     NUMERIC(3,2),
+    -- Normalized {audio: [...], screen: [...]} per §3.4.2; full original
+    -- (recording_details with ids, durations, start_time) lives in
+    -- dialpad_call_metadata for forensics.
+    recording_urls                JSONB,
+    -- Forward-compat catch-all (§3.7).
+    dialpad_call_metadata         JSONB,
+    caller_name                   TEXT,
+    caller_phone                  TEXT,
+    caller_email                  TEXT,
+    call_summary                  TEXT,
+    -- LandGPT Qwen2-Audio output. NULL pre-LandGPT and on Gemini-only
+    -- rows. Schema in §8.2.
+    annotated_transcript          JSONB,
+    key_strengths                 TEXT,
+    -- Renamed from §003 stub's `improvements`.
+    opportunities                 TEXT,
+    overall_score                 NUMERIC(5,1),
+    -- FK-by-string to qa.formula_versions(formula_version). NULL on
+    -- pre-cutover and backfilled historic rows whose implicit Sheet
+    -- formula has no version row.
+    formula_version               TEXT REFERENCES qa.formula_versions(formula_version),
+    -- Cascade provenance per §8.1. NOT NULL because every scored
+    -- evaluation has at least the text model recorded — even pre-LandGPT,
+    -- this is `{"text": {"provider":"gemini","model":"gemini-2.5-flash"}}`.
+    models_used                   JSONB NOT NULL,
+    -- Indexable convenience summary of models_used. NULL allowed because
+    -- legacy rows backfilled from Sheets won't have cascade provenance.
+    ai_provider_primary           TEXT,
+    -- Cloud-API cost (Gemini); NULL for pure-LandGPT runs (§8.1).
+    estimated_cost_usd            NUMERIC(8,4),
+    csat_score                    NUMERIC(3,1),
+    -- Future FK to embeddings.sop_documents(id) — NOT declared as a FK
+    -- here because 006/007 are independent (§7.6). Column ships now so
+    -- the LandGPT v2 RAG cutover doesn't need an evaluations ALTER.
+    sop_used_document_id          BIGINT,
+    sampling_status               TEXT NOT NULL DEFAULT 'not_sampled',
+    scoring_status                TEXT NOT NULL DEFAULT 'complete',
+    created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    approved_at                   TIMESTAMPTZ,
+    finalized_at                  TIMESTAMPTZ,
+    -- §3.4.3 relaxed pre-cutover state CHECKs ----------------------------
+    CONSTRAINT evaluations_state_check
+        CHECK (state IN ('draft', 'approved', 'finalized')),
+    CONSTRAINT evaluations_source_check
+        CHECK (source IN ('ai', 'manual', 'ai_reviewed')),
+    CONSTRAINT evaluations_finalized_requires_score
+        CHECK (state <> 'finalized' OR overall_score IS NOT NULL),
+    CONSTRAINT evaluations_approved_requires_evaluator_and_approved_at
+        CHECK (state = 'draft'
+               OR (evaluator_email IS NOT NULL AND approved_at IS NOT NULL)),
+    CONSTRAINT evaluations_finalized_requires_finalized_at
+        CHECK (state <> 'finalized' OR finalized_at IS NOT NULL),
+    CONSTRAINT evaluations_scoring_status_check
+        CHECK (scoring_status IN ('complete', 'flagged_long_call', 'errored',
+                                  'landgpt_unavailable_routed_to_gemini')),
+    CONSTRAINT evaluations_ai_provider_primary_check
+        CHECK (ai_provider_primary IS NULL OR ai_provider_primary IN
+               ('gemini', 'landgpt', 'landgpt_with_gemini_fallback'))
+);
+
+-- §3.4.1 dedupe — both partial UNIQUEs ship together; Phase B
+-- reconciliation decides which to drop later.
+CREATE UNIQUE INDEX uq_eval_team_call_id
+    ON qa.evaluations (team_id, dialpad_call_id)
+    WHERE dialpad_call_id IS NOT NULL;
+
+CREATE UNIQUE INDEX uq_eval_team_link
+    ON qa.evaluations (team_id, dialpad_link)
+    WHERE dialpad_link IS NOT NULL;
+
+
+-- ── qa.evaluation_sections (§3.5) ───────────────────────────────────────────
+-- Normalized per-section rows. `ai_provider` is per-section because Plan B
+-- (§8.3a) can route specific sections (e.g. matching_the_moment) back to
+-- Gemini while others stay on LandGPT.
+
+CREATE TABLE qa.evaluation_sections (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    evaluation_id   BIGINT NOT NULL REFERENCES qa.evaluations(id) ON DELETE CASCADE,
+    section_id      TEXT NOT NULL,
+    section_number  SMALLINT NOT NULL,
+    score_type      TEXT NOT NULL,
+    numeric_score   SMALLINT,
+    binary_value    TEXT,
+    score_source    TEXT NOT NULL,
+    -- Populated when score_source='ai' (per CHECK below); NULL otherwise.
+    ai_provider     TEXT,
+    -- Specific model identifier within the provider, e.g. gemini-2.5-flash
+    -- or gemma-4-27b-q4. NULL for non-AI sections.
+    model           TEXT,
+    confidence      TEXT,
+    reasoning       TEXT,
+    CONSTRAINT eval_sections_score_type_check
+        CHECK (score_type IN ('numeric', 'binary',
+                              'manual_numeric', 'manual_binary',
+                              'auto_value')),
+    CONSTRAINT eval_sections_score_source_check
+        CHECK (score_source IN ('ai', 'manual', 'auto_value', 'manual_default')),
+    CONSTRAINT eval_sections_numeric_range_check
+        CHECK (numeric_score IS NULL OR numeric_score BETWEEN 1 AND 5),
+    CONSTRAINT eval_sections_binary_value_check
+        CHECK (binary_value IS NULL OR binary_value IN ('Y', 'N', 'NA')),
+    -- "Exactly one of numeric_score/binary_value populated, matching score_type"
+    --   numeric / manual_numeric → numeric_score required, binary NULL
+    --   binary  / manual_binary  → binary_value required, numeric NULL
+    --   auto_value               → exactly one of the two populated
+    --                              (the section's underlying shape decides)
+    CONSTRAINT eval_sections_value_matches_type_check CHECK (
+        (score_type IN ('numeric', 'manual_numeric')
+            AND numeric_score IS NOT NULL AND binary_value IS NULL)
+        OR (score_type IN ('binary', 'manual_binary')
+            AND binary_value IS NOT NULL AND numeric_score IS NULL)
+        OR (score_type = 'auto_value'
+            AND ((numeric_score IS NOT NULL AND binary_value IS NULL)
+              OR (binary_value IS NOT NULL AND numeric_score IS NULL)))
+    ),
+    -- `ai_provider` iff `score_source='ai'`.
+    CONSTRAINT eval_sections_ai_provider_iff_ai CHECK (
+        (score_source = 'ai' AND ai_provider IS NOT NULL)
+        OR (score_source <> 'ai' AND ai_provider IS NULL)
+    ),
+    CONSTRAINT eval_sections_ai_provider_value_check
+        CHECK (ai_provider IS NULL OR ai_provider IN ('gemini', 'landgpt')),
+    CONSTRAINT uq_eval_sections_eval_section UNIQUE (evaluation_id, section_id)
+);
+
+
+-- ── qa.formula_compliance_sweeps (§3.13, new in v1.1) ───────────────────────
+-- Persistent record of every historic-compliance sweep run during Phase
+-- A.5. One row per (evaluation × swept formula version). Replaces v1's
+-- transient overall_score_parity_check_value column so iteration history
+-- is preserved across formula revisions.
+
+CREATE TABLE qa.formula_compliance_sweeps (
+    id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    evaluation_id           BIGINT NOT NULL REFERENCES qa.evaluations(id) ON DELETE CASCADE,
+    swept_formula_version   TEXT NOT NULL REFERENCES qa.formula_versions(formula_version),
+    recomputed_score        NUMERIC(5,1) NOT NULL,
+    original_score          NUMERIC(5,1) NOT NULL,
+    -- Signed delta — sign matters for pattern-spotting (new > sheet vs
+    -- new < sheet are different stories).
+    delta                   NUMERIC(6,2) GENERATED ALWAYS AS
+                            (recomputed_score - original_score) STORED,
+    -- ε pinned per sweep for reproducibility (default 0.05 per spec).
+    epsilon                 NUMERIC(4,2) NOT NULL DEFAULT 0.05,
+    -- ABS(delta) > epsilon, persisted at sweep time so iteration-rate
+    -- queries don't have to recompute.
+    flagged                 BOOLEAN NOT NULL,
+    swept_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Re-running the sweep for the same (eval, version) is a no-op via
+    -- ON CONFLICT DO NOTHING on this UNIQUE.
+    CONSTRAINT uq_sweeps_eval_version UNIQUE (evaluation_id, swept_formula_version)
+);
+
+
+-- ── qa.score_audit (§3.9) ───────────────────────────────────────────────────
+-- Action-level log. 1:1 with today's Sheets `Score_Audit` tab; the column
+-- list mirrors `backend/config/score_audit.py:COLUMNS`. Retention: 180
+-- days hot (daily cron MOVEs older rows to score_audit_archive).
+--
+-- v0.6 added `evaluation_orphaned` action when a qa.evaluations row is
+-- deleted (admin-only path).
+
+CREATE TABLE qa.score_audit (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    timestamp         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    api_key_role      TEXT NOT NULL,
+    evaluator_email   TEXT,
+    agent_email       TEXT,
+    agent_name        TEXT,
+    call_id           TEXT,
+    target_team       TEXT,
+    action            TEXT NOT NULL,
+    result_row        INTEGER,
+    notes             TEXT,
+    CONSTRAINT score_audit_action_check
+        CHECK (action IN ('scored', 'denied', 'approved', 'evaluation_orphaned'))
+);
+
+
+-- ── qa.score_audit_archive (§3.9) ───────────────────────────────────────────
+-- Same shape as score_audit; rows moved here by daily cron after 180d.
+-- Search endpoint UNIONs both tables.
+
+CREATE TABLE qa.score_audit_archive (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    -- Preserves the original score_audit.id for forensic continuity, but
+    -- not enforced as UNIQUE — the archive is append-only with rare
+    -- compaction.
+    original_id       BIGINT NOT NULL,
+    timestamp         TIMESTAMPTZ NOT NULL,
+    api_key_role      TEXT NOT NULL,
+    evaluator_email   TEXT,
+    agent_email       TEXT,
+    agent_name        TEXT,
+    call_id           TEXT,
+    target_team       TEXT,
+    action            TEXT NOT NULL,
+    result_row        INTEGER,
+    notes             TEXT,
+    archived_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT score_audit_archive_action_check
+        CHECK (action IN ('scored', 'denied', 'approved', 'evaluation_orphaned'))
+);
+
+
+-- ── qa.api_audit_log (§3.10) ────────────────────────────────────────────────
+-- Request-level audit + cost attribution. PERMANENT retention (changed
+-- in v0.5) — multi-year visibility for "what would model X have cost us
+-- last year?" comparisons. CC startup-replay tripwire lands here too
+-- with endpoint='cc.startup_replay', action='replay'.
+
+CREATE TABLE qa.api_audit_log (
+    id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    timestamp           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    team_id             TEXT,
+    endpoint            TEXT NOT NULL,
+    method              TEXT NOT NULL,
+    status_code         SMALLINT,
+    duration_ms         NUMERIC(10,1),
+    api_key_team        TEXT,
+    api_key_role        TEXT,
+    action              TEXT,
+    model               TEXT,
+    estimated_cost_usd  NUMERIC(8,4),
+    call_id             TEXT,
+    agent_name          TEXT,
+    error_detail        TEXT
+);
+
+
+-- ── qa.agent_stat_points (§9.2) ─────────────────────────────────────────────
+-- One row per evaluation finalize. team_stats.py keeps owning the math;
+-- what changes is it computes ONE point on each finalize. Consumers:
+-- CC Zone D sparklines, QA outlier chiclets, PDF assessment pipeline.
+--
+-- `coverage_regime` is hardcoded to 'manager_sample' today; per the
+-- [[project_predictive_groundwork]] memory it moves per-row at the Local
+-- AI cutover (~July 2026) so old manager-sampled rows and new full-
+-- coverage rows stay distinguishable downstream.
+
+CREATE TABLE qa.agent_stat_points (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id         TEXT NOT NULL REFERENCES public.teams(id),
+    agent_id        BIGINT NOT NULL REFERENCES qa.agents(id),
+    -- UNIQUE because each evaluation finalize produces at most one point.
+    evaluation_id   BIGINT NOT NULL UNIQUE REFERENCES qa.evaluations(id),
+    score           NUMERIC(5,1) NOT NULL,
+    ewma            NUMERIC(6,2) NOT NULL,
+    -- Pinned per point so historical series are reproducible even when
+    -- team_stats.py changes the default λ.
+    ewma_lambda     NUMERIC(4,3) NOT NULL,
+    spc_mean        NUMERIC(6,2),
+    spc_sigma       NUMERIC(6,3),
+    spc_flags       TEXT[],
+    coverage_regime TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/database/migrations/006_qa_tables_down.sql
+++ b/database/migrations/006_qa_tables_down.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- Migration 006 — DOWN
+--
+-- Drops in reverse FK-dependency order, no CASCADE. The FK from
+-- qa.evaluations.command_center_call_id → command_center.calls.id is
+-- declared on qa.evaluations side, so dropping qa.evaluations also
+-- drops that constraint cleanly without touching command_center.calls.
+-- ============================================================================
+
+DROP TABLE IF EXISTS qa.agent_stat_points;
+DROP TABLE IF EXISTS qa.api_audit_log;
+DROP TABLE IF EXISTS qa.score_audit_archive;
+DROP TABLE IF EXISTS qa.score_audit;
+DROP TABLE IF EXISTS qa.formula_compliance_sweeps;
+DROP TABLE IF EXISTS qa.evaluation_sections;
+DROP TABLE IF EXISTS qa.evaluations;
+DROP TABLE IF EXISTS qa.formula_versions;
+DROP TABLE IF EXISTS qa.agents;

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_006.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_006.py
@@ -1,0 +1,922 @@
+"""Tests for migration 006 — qa.* tables.
+
+Per SQLMigration.md §11.5 floor for every new table:
+  - ≥1 CHECK test per declared CHECK
+  - ≥1 UPSERT-idempotency test per UNIQUE conflict target
+
+Plus per §11.5 for state-machine columns and cross-schema FKs:
+  - qa.evaluations.state transitions (draft → approved → finalized)
+  - qa.evaluations.command_center_call_id FK referential integrity
+  - qa.evaluations.command_center_call_id NULL allowed (CC-outage path)
+
+Pydantic JSONB validator tests are deliberately out of scope per
+§7.5 (they ship in the "Pydantic models PR", a separate Wave-1 PR
+that lives under qa-automation/AI-Scoring/backend/models/). The DB
+columns are exercised here as raw JSONB.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from database import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
+UP_005 = (MIGRATIONS_DIR / "005_command_center_tables.sql").read_text()
+UP_006 = (MIGRATIONS_DIR / "006_qa_tables.sql").read_text()
+DOWN_006 = (MIGRATIONS_DIR / "006_qa_tables_down.sql").read_text()
+
+
+@pytest_asyncio.fixture
+async def pg_006(clean_pg: asyncpg.Connection) -> asyncpg.Connection:
+    """clean_pg + 004 + 005 + 006."""
+    await clean_pg.execute(UP_004)
+    await clean_pg.execute(UP_005)
+    await clean_pg.execute(UP_006)
+    return clean_pg
+
+
+# Shared canonical models_used JSON for evaluations writes.
+_MODELS = '{"text": {"provider": "gemini", "model": "gemini-2.5-flash"}}'
+
+
+# ---------------------------------------------------------------------------
+# qa.agents — UNIQUE (team_id, LOWER(name)) is case-insensitive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_unique_team_lower_name_blocks_case_insensitive_dupe(
+    pg_006: asyncpg.Connection,
+) -> None:
+    await pg_006.execute(
+        "INSERT INTO qa.agents (team_id, name, email) VALUES ('sales', 'Alpha Rep', 'a@l.com')"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.agents (team_id, name, email) "
+            "VALUES ('sales', 'alpha rep', 'a@l.com')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agents_same_name_different_team_ok(
+    pg_006: asyncpg.Connection,
+) -> None:
+    await pg_006.execute(
+        "INSERT INTO qa.agents (team_id, name, email) "
+        "VALUES ('sales', 'Alpha Rep', 'a@l.com'), "
+        "       ('member_support', 'Alpha Rep', 'a@l.com')"
+    )
+    assert await pg_006.fetchval("SELECT COUNT(*) FROM qa.agents") == 2
+
+
+# ---------------------------------------------------------------------------
+# qa.formula_versions — UNIQUE formula_version, FK target for evaluations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_formula_versions_formula_version_unique(
+    pg_006: asyncpg.Connection,
+) -> None:
+    await pg_006.execute(
+        "INSERT INTO qa.formula_versions "
+        "(formula_version, team_id, formula_json, effective_from) "
+        "VALUES ('sales_v1', 'sales', '{}'::jsonb, NOW())"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.formula_versions "
+            "(formula_version, team_id, formula_json, effective_from) "
+            "VALUES ('sales_v1', 'sales', '{}'::jsonb, NOW())"
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — CHECK constraints (§3.4.3 relaxed pre-cutover form)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluations_state_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations (team_id, agent_name_raw, state, source, models_used) "
+            "VALUES ('sales', 'A', 'unknown_state', 'ai', $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_source_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations (team_id, agent_name_raw, state, source, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'unknown_source', $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_relaxed_check_accepts_approved_with_null_score(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """Pre-cutover: Stage 2 writes evaluator_email + approved_at but
+    overall_score stays NULL until Stage 3 (ARRAYFORMULA readback).
+    The §3.4.3 relaxed CHECK MUST accept this — the v0.4 strict CHECK
+    would have rejected it."""
+    eval_id = await pg_006.fetchval(
+        """
+        INSERT INTO qa.evaluations
+            (team_id, agent_name_raw, state, source,
+             evaluator_email, approved_at, models_used)
+        VALUES ('sales', 'A', 'approved', 'ai', 'm@l.com', NOW(), $1::jsonb)
+        RETURNING id
+        """,
+        _MODELS,
+    )
+    assert eval_id is not None
+
+
+@pytest.mark.asyncio
+async def test_evaluations_finalized_without_score_rejected(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """state='finalized' MUST have overall_score (both pre- and post-cutover)."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            """
+            INSERT INTO qa.evaluations
+                (team_id, agent_name_raw, state, source,
+                 evaluator_email, approved_at, finalized_at, models_used)
+            VALUES ('sales', 'A', 'finalized', 'ai',
+                    'm@l.com', NOW(), NOW(), $1::jsonb)
+            """,
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_finalized_without_finalized_at_rejected(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            """
+            INSERT INTO qa.evaluations
+                (team_id, agent_name_raw, state, source,
+                 evaluator_email, approved_at, overall_score, models_used)
+            VALUES ('sales', 'A', 'finalized', 'ai',
+                    'm@l.com', NOW(), 88.5, $1::jsonb)
+            """,
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_approved_without_evaluator_email_rejected(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            """
+            INSERT INTO qa.evaluations
+                (team_id, agent_name_raw, state, source, approved_at, models_used)
+            VALUES ('sales', 'A', 'approved', 'ai', NOW(), $1::jsonb)
+            """,
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_scoring_status_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, scoring_status, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'bogus_status', $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluations_ai_provider_primary_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, ai_provider_primary, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'OpenAI', $1::jsonb)",
+            _MODELS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — state-machine transitions per §11.5
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_transition_draft_to_approved(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eval_id = await pg_006.fetchval(
+        "INSERT INTO qa.evaluations (team_id, agent_name_raw, state, source, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+    await pg_006.execute(
+        "UPDATE qa.evaluations SET state='approved', evaluator_email='m@l.com', "
+        "approved_at = NOW() WHERE id = $1",
+        eval_id,
+    )
+    state = await pg_006.fetchval("SELECT state FROM qa.evaluations WHERE id = $1", eval_id)
+    assert state == "approved"
+
+
+@pytest.mark.asyncio
+async def test_state_transition_approved_to_finalized(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eval_id = await pg_006.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, evaluator_email, approved_at, models_used) "
+        "VALUES ('sales', 'A', 'approved', 'ai', 'm@l.com', NOW(), $1::jsonb) "
+        "RETURNING id",
+        _MODELS,
+    )
+    await pg_006.execute(
+        "UPDATE qa.evaluations SET state='finalized', overall_score=88.5, "
+        "finalized_at = NOW() WHERE id = $1",
+        eval_id,
+    )
+    state = await pg_006.fetchval("SELECT state FROM qa.evaluations WHERE id = $1", eval_id)
+    assert state == "finalized"
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — §3.4.1 dual partial UNIQUEs (dialpad_call_id + dialpad_link)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_call_id_allows_multiple_nulls(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """Backfilled rows may share NULL dialpad_call_id — the partial
+    UNIQUE WHERE NOT NULL must allow that."""
+    for _ in range(3):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations (team_id, agent_name_raw, state, source, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', $1::jsonb)",
+            _MODELS,
+        )
+    assert await pg_006.fetchval("SELECT COUNT(*) FROM qa.evaluations") == 3
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_call_id_blocks_duplicate(
+    pg_006: asyncpg.Connection,
+) -> None:
+    await pg_006.execute(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, dialpad_call_id, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', 'c1', $1::jsonb)",
+        _MODELS,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, dialpad_call_id, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'c1', $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_link_blocks_duplicate(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """The second partial UNIQUE on `dialpad_link` is the transition-period
+    dedupe used by _find_row_by_dialpad_link (legacy Sheets path)."""
+    link = "https://dialpad.com/callhistory/callreview/abc"
+    await pg_006.execute(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, dialpad_link, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb)",
+        link, _MODELS,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, dialpad_link, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb)",
+            link, _MODELS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — cross-schema FK to command_center.calls per §11.5
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_command_center_call_id_fk_rejects_dangling_reference(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, command_center_call_id, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 999999, $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_center_call_id_nullable_for_cc_outage_path(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """§3.4: NULL on Phase B backfilled rows and on rows written during a
+    CC outage — QA writes must NEVER be blocked by CC unavailability."""
+    eid = await pg_006.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+    assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_command_center_call_id_accepts_valid_calls_row(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """End-to-end: insert a calls row, then an eval that points at it."""
+    call_id = await pg_006.fetchval(
+        "INSERT INTO command_center.calls (team_id, dialpad_call_id, seen_via) "
+        "VALUES ('sales', 'c1', 'webhook') RETURNING id"
+    )
+    eval_id = await pg_006.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, command_center_call_id, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+        call_id, _MODELS,
+    )
+    assert eval_id is not None
+
+
+@pytest.mark.asyncio
+async def test_formula_version_fk_rejects_unknown_version(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, formula_version, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'never_existed', $1::jsonb)",
+            _MODELS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluation_sections — CHECKs + UNIQUE + cascade
+# ---------------------------------------------------------------------------
+
+
+async def _make_eval(conn: asyncpg.Connection) -> int:
+    return await conn.fetchval(
+        "INSERT INTO qa.evaluations (team_id, agent_name_raw, state, source, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_score_type_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'greeting', 1, 'WAT', 4, 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_score_source_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source) "
+            "VALUES ($1, 'g', 1, 'manual_numeric', 4, 'WAT')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_numeric_range_check(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'g', 1, 'numeric', 6, 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_binary_value_check(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " binary_value, score_source, ai_provider) "
+            "VALUES ($1, 'id', 2, 'binary', 'maybe', 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_value_matches_type_numeric(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """score_type='numeric' requires numeric_score populated, binary NULL."""
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        # binary_value populated for a numeric section
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " binary_value, score_source, ai_provider) "
+            "VALUES ($1, 'g', 1, 'numeric', 'Y', 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_value_matches_type_binary(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        # numeric_score populated for a binary section
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'id', 2, 'binary', 3, 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_value_matches_type_auto_value_numeric(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """`auto_value` accepts either numeric or binary (matching the
+    underlying section's shape). A numeric auto_value row is valid."""
+    eid = await _make_eval(pg_006)
+    await pg_006.execute(
+        "INSERT INTO qa.evaluation_sections "
+        "(evaluation_id, section_id, section_number, score_type, "
+        " numeric_score, score_source) "
+        "VALUES ($1, 'auto_section', 9, 'auto_value', 5, 'auto_value')",
+        eid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_value_matches_type_auto_value_binary(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    await pg_006.execute(
+        "INSERT INTO qa.evaluation_sections "
+        "(evaluation_id, section_id, section_number, score_type, "
+        " binary_value, score_source) "
+        "VALUES ($1, 'auto_doc', 9, 'auto_value', 'Y', 'auto_value')",
+        eid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_ai_provider_required_when_ai(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source) "
+            "VALUES ($1, 'g', 1, 'numeric', 4, 'ai')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_ai_provider_null_for_manual(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        # ai_provider populated but score_source != 'ai' — invalid
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'g', 1, 'manual_numeric', 4, 'manual', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_ai_provider_value_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'g', 1, 'numeric', 4, 'ai', 'OpenAI')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_unique_evaluation_section(
+    pg_006: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_006)
+    await pg_006.execute(
+        "INSERT INTO qa.evaluation_sections "
+        "(evaluation_id, section_id, section_number, score_type, "
+        " numeric_score, score_source, ai_provider) "
+        "VALUES ($1, 'g', 1, 'numeric', 4, 'ai', 'gemini')",
+        eid,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.evaluation_sections "
+            "(evaluation_id, section_id, section_number, score_type, "
+            " numeric_score, score_source, ai_provider) "
+            "VALUES ($1, 'g', 1, 'numeric', 5, 'ai', 'gemini')",
+            eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_sections_cascade_on_eval_delete(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """ON DELETE CASCADE on evaluation_id — admin-deleted evaluations must
+    not leave orphan sections."""
+    eid = await _make_eval(pg_006)
+    await pg_006.execute(
+        "INSERT INTO qa.evaluation_sections "
+        "(evaluation_id, section_id, section_number, score_type, "
+        " numeric_score, score_source, ai_provider) "
+        "VALUES ($1, 'g', 1, 'numeric', 4, 'ai', 'gemini'), "
+        "       ($1, 'r', 2, 'numeric', 4, 'ai', 'gemini')",
+        eid,
+    )
+    await pg_006.execute("DELETE FROM qa.evaluations WHERE id = $1", eid)
+    assert (
+        await pg_006.fetchval(
+            "SELECT COUNT(*) FROM qa.evaluation_sections WHERE evaluation_id = $1",
+            eid,
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# qa.formula_compliance_sweeps — §3.13 new in v1.1
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def pg_with_formula(pg_006: asyncpg.Connection) -> asyncpg.Connection:
+    await pg_006.execute(
+        "INSERT INTO qa.formula_versions "
+        "(formula_version, team_id, formula_json, effective_from) "
+        "VALUES ('sales_v1', 'sales', '{}'::jsonb, NOW())"
+    )
+    return pg_006
+
+
+@pytest.mark.asyncio
+async def test_sweep_delta_is_generated_signed_correctly(
+    pg_with_formula: asyncpg.Connection,
+) -> None:
+    """`delta` is GENERATED ALWAYS AS (recomputed - original) STORED.
+    Sign matters: positive delta means new formula > sheet; negative
+    means new formula < sheet. The runbook (§7.7) uses both signs to
+    spot pattern direction."""
+    eid = await _make_eval(pg_with_formula)
+    await pg_with_formula.execute(
+        "INSERT INTO qa.formula_compliance_sweeps "
+        "(evaluation_id, swept_formula_version, recomputed_score, "
+        " original_score, flagged) "
+        "VALUES ($1, 'sales_v1', 82.0, 78.0, TRUE)",
+        eid,
+    )
+    delta = await pg_with_formula.fetchval(
+        "SELECT delta FROM qa.formula_compliance_sweeps WHERE evaluation_id = $1",
+        eid,
+    )
+    assert float(delta) == 4.0
+
+
+@pytest.mark.asyncio
+async def test_sweep_delta_negative_when_new_below_sheet(
+    pg_with_formula: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_with_formula)
+    await pg_with_formula.execute(
+        "INSERT INTO qa.formula_compliance_sweeps "
+        "(evaluation_id, swept_formula_version, recomputed_score, "
+        " original_score, flagged) "
+        "VALUES ($1, 'sales_v1', 70.0, 78.0, TRUE)",
+        eid,
+    )
+    delta = await pg_with_formula.fetchval(
+        "SELECT delta FROM qa.formula_compliance_sweeps WHERE evaluation_id = $1",
+        eid,
+    )
+    assert float(delta) == -8.0
+
+
+@pytest.mark.asyncio
+async def test_sweep_unique_eval_version_supports_on_conflict_do_nothing(
+    pg_with_formula: asyncpg.Connection,
+) -> None:
+    """§3.13 write path uses ON CONFLICT (evaluation_id, swept_formula_version)
+    DO NOTHING — re-running the sweep is idempotent."""
+    eid = await _make_eval(pg_with_formula)
+    for _ in range(2):
+        await pg_with_formula.execute(
+            "INSERT INTO qa.formula_compliance_sweeps "
+            "(evaluation_id, swept_formula_version, recomputed_score, "
+            " original_score, flagged) "
+            "VALUES ($1, 'sales_v1', 82.0, 78.0, TRUE) "
+            "ON CONFLICT (evaluation_id, swept_formula_version) DO NOTHING",
+            eid,
+        )
+    assert (
+        await pg_with_formula.fetchval(
+            "SELECT COUNT(*) FROM qa.formula_compliance_sweeps WHERE evaluation_id = $1",
+            eid,
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweep_multiple_versions_preserve_iteration_history(
+    pg_with_formula: asyncpg.Connection,
+) -> None:
+    """Two formula versions sweeping the same eval produce two rows —
+    that's what makes v2-vs-v1 flag-rate comparisons a single GROUP BY."""
+    eid = await _make_eval(pg_with_formula)
+    await pg_with_formula.execute(
+        "INSERT INTO qa.formula_versions "
+        "(formula_version, team_id, formula_json, effective_from) "
+        "VALUES ('sales_v2', 'sales', '{}'::jsonb, NOW())"
+    )
+    await pg_with_formula.execute(
+        "INSERT INTO qa.formula_compliance_sweeps "
+        "(evaluation_id, swept_formula_version, recomputed_score, "
+        " original_score, flagged) "
+        "VALUES ($1, 'sales_v1', 82.0, 78.0, TRUE), "
+        "       ($1, 'sales_v2', 79.0, 78.0, FALSE)",
+        eid,
+    )
+    rows = await pg_with_formula.fetch(
+        "SELECT swept_formula_version, flagged FROM qa.formula_compliance_sweeps "
+        "WHERE evaluation_id = $1 ORDER BY swept_formula_version",
+        eid,
+    )
+    assert [(r["swept_formula_version"], r["flagged"]) for r in rows] == [
+        ("sales_v1", True),
+        ("sales_v2", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sweep_cascade_on_eval_delete(
+    pg_with_formula: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_with_formula)
+    await pg_with_formula.execute(
+        "INSERT INTO qa.formula_compliance_sweeps "
+        "(evaluation_id, swept_formula_version, recomputed_score, "
+        " original_score, flagged) "
+        "VALUES ($1, 'sales_v1', 82.0, 78.0, TRUE)",
+        eid,
+    )
+    await pg_with_formula.execute("DELETE FROM qa.evaluations WHERE id = $1", eid)
+    assert (
+        await pg_with_formula.fetchval(
+            "SELECT COUNT(*) FROM qa.formula_compliance_sweeps WHERE evaluation_id = $1",
+            eid,
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# qa.score_audit + qa.score_audit_archive — action CHECKs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_score_audit_action_check_accepts_evaluation_orphaned(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """v0.6 added the `evaluation_orphaned` action when an evaluation row
+    is deleted (§3.9). Must be in the CHECK list."""
+    await pg_006.execute(
+        "INSERT INTO qa.score_audit (api_key_role, action, notes) "
+        "VALUES ('privileged', 'evaluation_orphaned', 'manual delete')"
+    )
+    row = await pg_006.fetchval(
+        "SELECT action FROM qa.score_audit ORDER BY id DESC LIMIT 1"
+    )
+    assert row == "evaluation_orphaned"
+
+
+@pytest.mark.asyncio
+async def test_score_audit_action_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.score_audit (api_key_role, action) "
+            "VALUES ('team', 'wat_is_this')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_score_audit_archive_accepts_same_action_set(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """The archive table mirrors score_audit's action vocabulary — cron-
+    moved rows must satisfy the same CHECK."""
+    await pg_006.execute(
+        "INSERT INTO qa.score_audit_archive "
+        "(original_id, timestamp, api_key_role, action) "
+        "VALUES (1, NOW(), 'team', 'scored')"
+    )
+    cnt = await pg_006.fetchval("SELECT COUNT(*) FROM qa.score_audit_archive")
+    assert cnt == 1
+
+
+@pytest.mark.asyncio
+async def test_score_audit_archive_action_check_rejects_unknown(
+    pg_006: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.score_audit_archive "
+            "(original_id, timestamp, api_key_role, action) "
+            "VALUES (1, NOW(), 'team', 'wat_is_this')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.agent_stat_points — UNIQUE evaluation_id, FK fan-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stat_points_unique_per_evaluation(
+    pg_006: asyncpg.Connection,
+) -> None:
+    """Each evaluation finalize produces at most one stat point — the
+    UNIQUE on evaluation_id prevents double-counting if a finalize is
+    retried after an in-flight crash."""
+    aid = await pg_006.fetchval(
+        "INSERT INTO qa.agents (team_id, name, email) "
+        "VALUES ('sales', 'A', 'a@l.com') RETURNING id"
+    )
+    eid = await _make_eval(pg_006)
+    await pg_006.execute(
+        "INSERT INTO qa.agent_stat_points "
+        "(team_id, agent_id, evaluation_id, score, ewma, ewma_lambda) "
+        "VALUES ('sales', $1, $2, 88.5, 88.2, 0.500)",
+        aid, eid,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_006.execute(
+            "INSERT INTO qa.agent_stat_points "
+            "(team_id, agent_id, evaluation_id, score, ewma, ewma_lambda) "
+            "VALUES ('sales', $1, $2, 90.0, 89.0, 0.500)",
+            aid, eid,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Down — drops every qa.* table cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_qa_tables(pg_006: asyncpg.Connection) -> None:
+    await pg_006.execute(DOWN_006)
+    rows = await pg_006.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'qa'"
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — 004 → 005 → 006 → down 006
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_applies_004_005_006_in_sequence(
+    clean_pg: asyncpg.Connection, tmp_path: Path
+) -> None:
+    import shutil
+    migdir = tmp_path / "migrations"
+    migdir.mkdir()
+    for name in [
+        "004_create_schemas_and_teams.sql",
+        "004_create_schemas_and_teams_down.sql",
+        "005_command_center_tables.sql",
+        "005_command_center_tables_down.sql",
+        "006_qa_tables.sql",
+        "006_qa_tables_down.sql",
+    ]:
+        shutil.copy(MIGRATIONS_DIR / name, migdir)
+
+    rc = await runner.cmd_up(clean_pg, migrations_dir=migdir)
+    assert rc == 0
+
+    applied = await clean_pg.fetch(
+        "SELECT version FROM public.schema_migrations ORDER BY version"
+    )
+    assert [r["version"] for r in applied] == [4, 5, 6]
+
+    # Cross-check we can write an eval that FKs to a CC call — proves
+    # the cross-schema FK was wired up correctly through the runner.
+    cid = await clean_pg.fetchval(
+        "INSERT INTO command_center.calls (team_id, dialpad_call_id, seen_via) "
+        "VALUES ('sales', 'c1', 'webhook') RETURNING id"
+    )
+    eid = await clean_pg.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, command_center_call_id, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+        cid, _MODELS,
+    )
+    assert eid is not None
+
+    # Down 006 only — qa.* gone, command_center.* + public.teams stay.
+    rc = await runner.cmd_down(clean_pg)
+    assert rc == 0
+    qa_tables = await clean_pg.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'qa'"
+    )
+    assert qa_tables == []
+    # 005 + 004 untouched.
+    assert (
+        await clean_pg.fetchval("SELECT COUNT(*) FROM command_center.calls") == 1
+    )
+    assert await clean_pg.fetchval("SELECT COUNT(*) FROM public.teams") == 2


### PR DESCRIPTION
## Summary
- Nine `qa.*` tables (§3) that replace the Sheets-as-DB QA pipeline: `agents`, `formula_versions` (§3.12), `evaluations` (FR-AI + Score destination + Analyst_History collapsed into one row across draft → approved → finalized), `evaluation_sections` (per-section ai_provider for Plan B), `formula_compliance_sweeps` (§3.13, v1.1 — preserves iteration history), `score_audit` + `score_audit_archive`, `api_audit_log` (permanent retention, §3.10), `agent_stat_points` (§9.2).
- 17 CHECKs in the §3.4.3 relaxed pre-cutover form — `state='approved'` allows NULL `overall_score` because Stage 3 (ARRAYFORMULA readback) fills it later. Migration 012 tightens per team after Phase C. Dual partial UNIQUE dedupe indexes ship per §3.4.1 (enforce invariants, not perf). Cross-schema nullable FK to `command_center.calls` so a CC outage never blocks a QA Stage 1 write.
- 45 tests at `tests/integration/test_migration_006.py`: every CHECK + UNIQUE, draft→approved→finalized state-machine transitions, dual partial UNIQUEs (NULL coexistence + dedupe), cross-schema FK referential integrity + nullable-for-CC-outage path, evaluation_sections value-shape × score_type interaction (numeric/binary/auto_value/manual_*), `ai_provider` iff `score_source='ai'`, sweep GENERATED `delta` sign correctness + iteration preservation, CASCADEs on eval delete, runner integration (004 → 005 → 006 → down 006).

## Reviewer note
`qa.evaluations.sop_used_document_id` is `BIGINT NULL` *without* FK — spec §7.6 requires 006/007 to be independent; the FK to `embeddings.sop_documents` lands when LandGPT v2 wires up the RAG consumer.

## Test plan
- [ ] `make test-integration` — 45 tests in test_migration_006.py should pass
- [ ] Confirm the relaxed CHECKs match §3.4.3 (migration 012 will tighten later)
- [ ] Spot-check: `formula_version` FK on evaluations references `qa.formula_versions(formula_version)` by string, not id

## Stacked on
[#53 — migration 005](https://github.com/mxg108/Landing-scripts/pull/53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)