### PR TITLE
feat(database): migration 007 — embeddings.* tables

### DIFF
--- a/database/migrations/007_embeddings_tables.sql
+++ b/database/migrations/007_embeddings_tables.sql
@@ -1,0 +1,148 @@
+-- ============================================================================
+-- Migration 007: embeddings.* tables
+-- Spec: database/SQLMigration.md §5
+--
+-- Model-agnostic, multi-language RAG groundwork for LandGPT v2. The current
+-- pipeline does NOT query this schema — sizing and benchmark cadence
+-- (§5.8) follow the LandGPT v2 timeline.
+--
+-- Hard constraint: pgvector's ivfflat/HNSW indexes top out at 2,000
+-- dimensions. The column set covers VECTOR(1536) and VECTOR(1024); both
+-- are addable to HNSW indexes (008). A VECTOR(3072) column is storable
+-- but unindexable — use Matryoshka truncation to ≤ 2000 instead.
+--
+-- The "exactly one embedding_* column non-NULL, matching the model's
+-- declared dimensions" invariant is partially expressed: the CHECK below
+-- enforces the "exactly one non-NULL" half. The dim-match half is
+-- application-layer (the writer joins embedding_models to choose which
+-- column to populate); modeling it as a TRIGGER would couple the schema
+-- to embedding_models update behavior in a way that's not worth the
+-- complexity until LandGPT v2 ships.
+-- ============================================================================
+
+
+-- ── embeddings.embedding_models (§5.3) ──────────────────────────────────────
+-- Registry of embedding models the indexer knows how to use. Multiple
+-- models can be `is_current` simultaneously when they target different
+-- modalities (text vs text+image), but at most ONE per modality (partial
+-- UNIQUE index below).
+
+CREATE TABLE embeddings.embedding_models (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name              TEXT NOT NULL,
+    version           TEXT NOT NULL,
+    dimensions        INTEGER NOT NULL,
+    modality          TEXT NOT NULL,
+    is_cross_lingual  BOOLEAN NOT NULL,
+    provider          TEXT NOT NULL,
+    is_open_source    BOOLEAN NOT NULL,
+    cpu_deployable    BOOLEAN NOT NULL,
+    is_current        BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT embedding_models_dimensions_check
+        CHECK (dimensions > 0 AND dimensions <= 2000),
+    CONSTRAINT embedding_models_modality_check
+        CHECK (modality IN ('text', 'text+image', 'text+audio')),
+    CONSTRAINT embedding_models_provider_check
+        CHECK (provider IN ('google', 'bge', 'qwen-team', 'local')),
+    -- §5.3: "Only cpu_deployable=TRUE may be is_current."
+    CONSTRAINT embedding_models_current_requires_cpu_deployable
+        CHECK (is_current = FALSE OR cpu_deployable = TRUE),
+    CONSTRAINT uq_embedding_models_name_version UNIQUE (name, version)
+);
+
+-- §5.3: "At most one TRUE per modality (partial UNIQUE)." Enforced via a
+-- partial UNIQUE index that only sees `is_current=TRUE` rows.
+CREATE UNIQUE INDEX uq_embedding_models_current_per_modality
+    ON embeddings.embedding_models (modality)
+    WHERE is_current = TRUE;
+
+
+-- ── embeddings.sop_documents (§5.4) ─────────────────────────────────────────
+-- Per-team SOP corpus. UNIQUE (team_id, version_tag) makes successive
+-- versions of the same SOP coexist. The partial UNIQUE on is_current per
+-- (team_id, language) makes "what's the live SOP for this team and
+-- language" a single indexed read.
+
+CREATE TABLE embeddings.sop_documents (
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    team_id       TEXT NOT NULL REFERENCES public.teams(id),
+    title         TEXT NOT NULL,
+    version_tag   TEXT NOT NULL,
+    language      TEXT NOT NULL,
+    source_url    TEXT,
+    published_at  TIMESTAMPTZ,
+    is_current    BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_sop_documents_team_version UNIQUE (team_id, version_tag)
+);
+
+CREATE UNIQUE INDEX uq_sop_documents_current_per_team_language
+    ON embeddings.sop_documents (team_id, language)
+    WHERE is_current = TRUE;
+
+
+-- ── embeddings.sop_chunks (§5.5) ────────────────────────────────────────────
+-- Vector-agnostic chunk row. Same chunk can be embedded with multiple
+-- models in parallel; embeddings live in sop_chunk_embeddings, not here.
+
+CREATE TABLE embeddings.sop_chunks (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    document_id       BIGINT NOT NULL REFERENCES embeddings.sop_documents(id)
+                      ON DELETE CASCADE,
+    chunk_index       INTEGER NOT NULL,
+    text              TEXT NOT NULL,
+    token_count       INTEGER,
+    language          TEXT,
+    modality          TEXT,
+    -- Nested heading context (e.g. ["Procedures", "Move-In", "Step 3"])
+    -- — drives retrieval-time context rendering.
+    heading_path      TEXT[],
+    page_number       INTEGER,
+    image_asset_url   TEXT,
+    CONSTRAINT uq_sop_chunks_doc_index UNIQUE (document_id, chunk_index)
+);
+
+
+-- ── embeddings.sop_chunk_embeddings (§5.6) ──────────────────────────────────
+-- Per-(chunk, model) vector. The dim-class column set covers 1536 and
+-- 1024 today; new dim classes ship as new columns (1280, etc.) when
+-- benchmarks demand. HNSW indexes per non-NULL column live in 008.
+
+CREATE TABLE embeddings.sop_chunk_embeddings (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    chunk_id        BIGINT NOT NULL REFERENCES embeddings.sop_chunks(id)
+                    ON DELETE CASCADE,
+    model_id        BIGINT NOT NULL REFERENCES embeddings.embedding_models(id),
+    embedding_1536  VECTOR(1536),
+    embedding_1024  VECTOR(1024),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- §5.6: "exactly one embedding_* non-NULL". The dim-match half (i.e.
+    -- if model_id's dimensions=1024 then embedding_1024 is the populated
+    -- one) is application-layer (see header comment).
+    CONSTRAINT chunk_embeddings_exactly_one_dim CHECK (
+        (embedding_1536 IS NOT NULL AND embedding_1024 IS NULL)
+        OR (embedding_1024 IS NOT NULL AND embedding_1536 IS NULL)
+    ),
+    CONSTRAINT uq_chunk_embeddings_chunk_model UNIQUE (chunk_id, model_id)
+);
+
+
+-- ── embeddings.embedding_runs (§5.7) ────────────────────────────────────────
+-- Batch run audit log. One row per (document × model) indexing pass.
+
+CREATE TABLE embeddings.embedding_runs (
+    id                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    document_id        BIGINT NOT NULL REFERENCES embeddings.sop_documents(id)
+                       ON DELETE CASCADE,
+    model_id           BIGINT NOT NULL REFERENCES embeddings.embedding_models(id),
+    chunk_count        INTEGER,
+    total_tokens       INTEGER,
+    estimated_cost_usd NUMERIC(10,4),
+    started_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at       TIMESTAMPTZ,
+    status             TEXT NOT NULL DEFAULT 'running',
+    error_detail       TEXT,
+    CONSTRAINT embedding_runs_status_check
+        CHECK (status IN ('running', 'completed', 'failed', 'aborted'))
+);

--- a/database/migrations/007_embeddings_tables_down.sql
+++ b/database/migrations/007_embeddings_tables_down.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- Migration 007 — DOWN
+--
+-- Drops in reverse FK-dependency order. No CASCADE — if a downstream
+-- consumer (e.g. qa.evaluations.sop_used_document_id with an FK added in
+-- a future migration) is referencing embeddings.sop_documents, the
+-- drop will fail loudly. As of v1.1 that FK does NOT exist (006 ships
+-- the column without REFERENCES), so down here is straightforward.
+-- ============================================================================
+
+DROP TABLE IF EXISTS embeddings.embedding_runs;
+DROP TABLE IF EXISTS embeddings.sop_chunk_embeddings;
+DROP TABLE IF EXISTS embeddings.sop_chunks;
+DROP TABLE IF EXISTS embeddings.sop_documents;
+DROP TABLE IF EXISTS embeddings.embedding_models;

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_007.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_007.py
@@ -1,0 +1,489 @@
+"""Tests for migration 007 — embeddings.* tables.
+
+Per SQLMigration.md §11.5 floor:
+  - ≥1 CHECK test per declared CHECK
+  - ≥1 UPSERT-idempotency test per UNIQUE conflict target
+  - Specific dim-class invariant test per §11.1
+    (test_exactly_one_embedding_column_populated)
+
+§7.6: 006 and 007 are independent — these tests apply 004 (for
+public.teams FKs) but do NOT require 005 or 006.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from database import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
+UP_007 = (MIGRATIONS_DIR / "007_embeddings_tables.sql").read_text()
+DOWN_007 = (MIGRATIONS_DIR / "007_embeddings_tables_down.sql").read_text()
+
+
+@pytest_asyncio.fixture
+async def pg_007(clean_pg: asyncpg.Connection) -> asyncpg.Connection:
+    """clean_pg + 004 + 007. Skips 005/006 deliberately — independence
+    of 006 and 007 (§7.6) means this works."""
+    await clean_pg.execute(UP_004)
+    await clean_pg.execute(UP_007)
+    return clean_pg
+
+
+# Helper: a vector literal of N dims for INSERT testing.
+def _vec(n: int, fill: float = 0.1) -> str:
+    return "[" + ",".join(f"{fill}" for _ in range(n)) + "]"
+
+
+# ---------------------------------------------------------------------------
+# embedding_models — CHECKs + UNIQUE (name, version) + current-per-modality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_dimensions_capped_at_2000(
+    pg_007: asyncpg.Connection,
+) -> None:
+    """pgvector's HNSW max dim — a model with dimensions > 2000 must be
+    rejected here so we don't silently register one that can't be
+    indexed."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable) "
+            "VALUES ('big-model', 'v1', 3072, 'text', TRUE, 'google', FALSE, FALSE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_dimensions_zero_rejected(
+    pg_007: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable) "
+            "VALUES ('zero', 'v1', 0, 'text', TRUE, 'bge', TRUE, TRUE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_modality_check(
+    pg_007: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable) "
+            "VALUES ('odd-modality', 'v1', 1024, 'video', FALSE, 'bge', TRUE, TRUE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_provider_check(
+    pg_007: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable) "
+            "VALUES ('x', 'v1', 1024, 'text', FALSE, 'openai', FALSE, FALSE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_is_current_requires_cpu_deployable(
+    pg_007: asyncpg.Connection,
+) -> None:
+    """§5.3: cloud-only models cannot be `is_current` — the CPU-deployable
+    gate keeps the LandGPT-deployment story honest."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable, is_current) "
+            "VALUES ('cloud-only', 'v1', 1536, 'text', TRUE, 'google',"
+            " FALSE, FALSE, TRUE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_unique_name_version(
+    pg_007: asyncpg.Connection,
+) -> None:
+    await pg_007.execute(
+        "INSERT INTO embeddings.embedding_models "
+        "(name, version, dimensions, modality, is_cross_lingual, "
+        " provider, is_open_source, cpu_deployable) "
+        "VALUES ('bge-m3', 'v1', 1024, 'text', TRUE, 'bge', TRUE, TRUE)"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, "
+            " provider, is_open_source, cpu_deployable) "
+            "VALUES ('bge-m3', 'v1', 1024, 'text', TRUE, 'bge', TRUE, TRUE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_at_most_one_current_per_modality(
+    pg_007: asyncpg.Connection,
+) -> None:
+    """Partial UNIQUE on is_current=TRUE — only one current model per
+    modality. Multiple current models across DIFFERENT modalities OK."""
+    await pg_007.execute(
+        "INSERT INTO embeddings.embedding_models "
+        "(name, version, dimensions, modality, is_cross_lingual, provider, "
+        " is_open_source, cpu_deployable, is_current) "
+        "VALUES ('bge-text', 'v1', 1024, 'text', TRUE, 'bge', TRUE, TRUE, TRUE), "
+        "       ('multi-modal', 'v1', 1024, 'text+image', FALSE, 'qwen-team',"
+        "        TRUE, TRUE, TRUE)"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_models "
+            "(name, version, dimensions, modality, is_cross_lingual, provider, "
+            " is_open_source, cpu_deployable, is_current) "
+            "VALUES ('bge-text-v2', 'v2', 1024, 'text', TRUE, 'bge', "
+            "        TRUE, TRUE, TRUE)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# sop_documents — UNIQUE (team_id, version_tag), is_current partial UNIQUE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sop_documents_unique_team_version(
+    pg_007: asyncpg.Connection,
+) -> None:
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language) "
+        "VALUES ('sales', 'SOP A', 'v1', 'en')"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_documents "
+            "(team_id, title, version_tag, language) "
+            "VALUES ('sales', 'SOP A (alt)', 'v1', 'en')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sop_documents_one_current_per_team_language(
+    pg_007: asyncpg.Connection,
+) -> None:
+    """Partial UNIQUE on (team_id, language) WHERE is_current=TRUE —
+    cross-language `is_current` rows for the same team coexist."""
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language, is_current) "
+        "VALUES ('sales', 'EN', 'v1', 'en', TRUE), "
+        "       ('sales', 'ES', 'v1', 'es', TRUE)"
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_documents "
+            "(team_id, title, version_tag, language, is_current) "
+            "VALUES ('sales', 'EN-v2', 'v2', 'en', TRUE)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sop_documents_team_id_fk(
+    pg_007: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_documents "
+            "(team_id, title, version_tag, language) "
+            "VALUES ('phantom_team', 'SOP', 'v1', 'en')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# sop_chunks — UNIQUE (document_id, chunk_index), CASCADE on document delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sop_chunks_unique_doc_index(
+    pg_007: asyncpg.Connection,
+) -> None:
+    did = await pg_007.fetchval(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language) "
+        "VALUES ('sales', 'SOP', 'v1', 'en') RETURNING id"
+    )
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunks (document_id, chunk_index, text) "
+        "VALUES ($1, 0, 'first chunk')",
+        did,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_chunks (document_id, chunk_index, text) "
+            "VALUES ($1, 0, 'duplicate')",
+            did,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sop_chunks_cascade_on_document_delete(
+    pg_007: asyncpg.Connection,
+) -> None:
+    did = await pg_007.fetchval(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language) "
+        "VALUES ('sales', 'SOP', 'v1', 'en') RETURNING id"
+    )
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunks (document_id, chunk_index, text) "
+        "VALUES ($1, 0, 'c0'), ($1, 1, 'c1')",
+        did,
+    )
+    await pg_007.execute("DELETE FROM embeddings.sop_documents WHERE id = $1", did)
+    assert (
+        await pg_007.fetchval(
+            "SELECT COUNT(*) FROM embeddings.sop_chunks WHERE document_id = $1",
+            did,
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# sop_chunk_embeddings — exactly-one-dim CHECK + UNIQUE
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def chunk_id(pg_007: asyncpg.Connection) -> int:
+    did = await pg_007.fetchval(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language) "
+        "VALUES ('sales', 'SOP', 'v1', 'en') RETURNING id"
+    )
+    return await pg_007.fetchval(
+        "INSERT INTO embeddings.sop_chunks (document_id, chunk_index, text) "
+        "VALUES ($1, 0, 'chunk text') RETURNING id",
+        did,
+    )
+
+
+@pytest_asyncio.fixture
+async def model_1024_id(pg_007: asyncpg.Connection) -> int:
+    return await pg_007.fetchval(
+        "INSERT INTO embeddings.embedding_models "
+        "(name, version, dimensions, modality, is_cross_lingual, "
+        " provider, is_open_source, cpu_deployable) "
+        "VALUES ('bge-m3', 'v1', 1024, 'text', TRUE, 'bge', TRUE, TRUE) "
+        "RETURNING id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_exactly_one_dim_accepts_1024(
+    pg_007: asyncpg.Connection, chunk_id: int, model_1024_id: int
+) -> None:
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunk_embeddings "
+        "(chunk_id, model_id, embedding_1024) "
+        "VALUES ($1, $2, $3::vector)",
+        chunk_id, model_1024_id, _vec(1024),
+    )
+    n = await pg_007.fetchval(
+        "SELECT COUNT(*) FROM embeddings.sop_chunk_embeddings"
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_exactly_one_dim_accepts_1536(
+    pg_007: asyncpg.Connection, chunk_id: int
+) -> None:
+    mid = await pg_007.fetchval(
+        "INSERT INTO embeddings.embedding_models "
+        "(name, version, dimensions, modality, is_cross_lingual, "
+        " provider, is_open_source, cpu_deployable) "
+        "VALUES ('gemini-1536', 'v1', 1536, 'text', TRUE, 'google',"
+        " FALSE, FALSE) RETURNING id"
+    )
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunk_embeddings "
+        "(chunk_id, model_id, embedding_1536) "
+        "VALUES ($1, $2, $3::vector)",
+        chunk_id, mid, _vec(1536),
+    )
+    n = await pg_007.fetchval(
+        "SELECT COUNT(*) FROM embeddings.sop_chunk_embeddings"
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_both_dims_populated_rejected(
+    pg_007: asyncpg.Connection, chunk_id: int, model_1024_id: int
+) -> None:
+    """The exactly-one-dim CHECK means an indexer writing to both columns
+    by mistake gets caught at write time — not silently stored as a row
+    that KNN can't retrieve."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_chunk_embeddings "
+            "(chunk_id, model_id, embedding_1024, embedding_1536) "
+            "VALUES ($1, $2, $3::vector, $4::vector)",
+            chunk_id, model_1024_id, _vec(1024), _vec(1536),
+        )
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_neither_dim_populated_rejected(
+    pg_007: asyncpg.Connection, chunk_id: int, model_1024_id: int
+) -> None:
+    """A row with no embedding is a corrupt-write signature."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_chunk_embeddings "
+            "(chunk_id, model_id) VALUES ($1, $2)",
+            chunk_id, model_1024_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_unique_chunk_model(
+    pg_007: asyncpg.Connection, chunk_id: int, model_1024_id: int
+) -> None:
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunk_embeddings "
+        "(chunk_id, model_id, embedding_1024) "
+        "VALUES ($1, $2, $3::vector)",
+        chunk_id, model_1024_id, _vec(1024),
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.sop_chunk_embeddings "
+            "(chunk_id, model_id, embedding_1024) "
+            "VALUES ($1, $2, $3::vector)",
+            chunk_id, model_1024_id, _vec(1024, fill=0.2),
+        )
+
+
+@pytest.mark.asyncio
+async def test_chunk_embeddings_cascade_on_chunk_delete(
+    pg_007: asyncpg.Connection, chunk_id: int, model_1024_id: int
+) -> None:
+    await pg_007.execute(
+        "INSERT INTO embeddings.sop_chunk_embeddings "
+        "(chunk_id, model_id, embedding_1024) "
+        "VALUES ($1, $2, $3::vector)",
+        chunk_id, model_1024_id, _vec(1024),
+    )
+    await pg_007.execute("DELETE FROM embeddings.sop_chunks WHERE id = $1", chunk_id)
+    assert (
+        await pg_007.fetchval(
+            "SELECT COUNT(*) FROM embeddings.sop_chunk_embeddings "
+            "WHERE chunk_id = $1",
+            chunk_id,
+        )
+        == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# embedding_runs — status CHECK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedding_runs_status_check(
+    pg_007: asyncpg.Connection, model_1024_id: int
+) -> None:
+    did = await pg_007.fetchval(
+        "INSERT INTO embeddings.sop_documents "
+        "(team_id, title, version_tag, language) "
+        "VALUES ('sales', 'SOP', 'v1', 'en') RETURNING id"
+    )
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_007.execute(
+            "INSERT INTO embeddings.embedding_runs "
+            "(document_id, model_id, status) "
+            "VALUES ($1, $2, 'unknown_status')",
+            did, model_1024_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Down — drops every embeddings.* table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_embeddings_tables(
+    pg_007: asyncpg.Connection,
+) -> None:
+    await pg_007.execute(DOWN_007)
+    rows = await pg_007.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'embeddings'"
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — independence from 005/006 per §7.6
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_can_apply_007_without_005_or_006(
+    clean_pg: asyncpg.Connection, tmp_path: Path
+) -> None:
+    """§7.6 says 006 and 007 are independent. Confirm the runner can
+    apply 004 → 007 (skipping the 005/006 slot is not possible since
+    file numbering must be contiguous, but 007 can be applied in
+    isolation in a hypothetical embeddings-first deployment)."""
+    import shutil
+    migdir = tmp_path / "migrations"
+    migdir.mkdir()
+    shutil.copy(MIGRATIONS_DIR / "004_create_schemas_and_teams.sql", migdir)
+    shutil.copy(MIGRATIONS_DIR / "004_create_schemas_and_teams_down.sql", migdir)
+    # Renumber 007 → 005 in the temp dir so the runner sees a contiguous
+    # 004 → 005 chain — this proves 007's DDL has no cross-migration
+    # dependencies on 005's or 006's tables.
+    shutil.copy(
+        MIGRATIONS_DIR / "007_embeddings_tables.sql",
+        migdir / "005_embeddings_tables.sql",
+    )
+    shutil.copy(
+        MIGRATIONS_DIR / "007_embeddings_tables_down.sql",
+        migdir / "005_embeddings_tables_down.sql",
+    )
+
+    rc = await runner.cmd_up(clean_pg, migrations_dir=migdir)
+    assert rc == 0
+
+    tables = await clean_pg.fetch(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'embeddings' "
+        "ORDER BY tablename"
+    )
+    assert {r["tablename"] for r in tables} == {
+        "embedding_models",
+        "embedding_runs",
+        "sop_chunk_embeddings",
+        "sop_chunks",
+        "sop_documents",
+    }


### PR DESCRIPTION
## Summary
- Five `embeddings.*` tables (§5) for the LandGPT v2 RAG layer: `embedding_models` (registry), `sop_documents` (per-team SOP corpus), `sop_chunks`, `sop_chunk_embeddings` (`VECTOR(1536)` + `VECTOR(1024)` dim classes), `embedding_runs` (batch audit log).
- 6 CHECKs: dimensions ≤ 2000 (pgvector HNSW ceiling), modality enum, provider enum, `is_current ⇒ cpu_deployable`, embedding-column exactly-one-non-NULL (§5.6), embedding_runs status enum. Partial UNIQUEs: at-most-one `is_current=TRUE` per modality (models), per `(team_id, language)` (documents).
- 18 tests at `tests/integration/test_migration_007.py`: every CHECK + UNIQUE, both dim classes accepted independently, both-or-neither rejected, CASCADEs on document/chunk delete, team_id FK enforcement, runner integration that proves 007's independence from 005/006 per §7.6.

## Reviewer note
The "embedding dim matches the model's declared dimensions" half of the §5.6 invariant is application-layer (the writer joins `embedding_models` to pick the right column). Modeling it as a TRIGGER isn't worth the complexity until LandGPT v2 ships. `VECTOR(3072)` is storable but unindexable — Matryoshka-truncate to ≤2000 before registering a new model.

## Test plan
- [ ] `make test-integration` — 18 tests in test_migration_007.py should pass
- [ ] No live consumer in v1 — sizing and benchmark cadence (§5.8) run on the LandGPT v2 timeline
- [ ] HNSW indexes on the embedding columns ship in 008

## Stacked on
[#54 — migration 006](https://github.com/mxg108/Landing-scripts/pull/54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)