### PR TITLE
feat(database): migration 008 — analytics + KNN indexes

### DIFF
--- a/database/migrations/008_indexes.sql
+++ b/database/migrations/008_indexes.sql
@@ -1,0 +1,117 @@
+-- ============================================================================
+-- Migration 008: analytics + KNN indexes
+-- Spec: database/SQLMigration.md §9.1, §9.2, §3.12, §3.13, §4.2, §4.1, §5.6
+--
+-- Indexes split out from 005/006/007 so that future re-indexing can use
+-- CREATE INDEX CONCURRENTLY (this initial-deploy migration creates them
+-- without CONCURRENTLY because the tables are empty — locking is a
+-- non-issue on empty tables and CONCURRENTLY can't run inside the
+-- runner's per-migration transaction).
+--
+-- Categories:
+--   §9.1 read-path indexes on qa.evaluations + qa.evaluation_sections
+--   §9.2 idx_stat_points_agent on qa.agent_stat_points
+--   §3.12 lookup index on qa.formula_versions
+--   §3.13 sweep indexes on qa.formula_compliance_sweeps
+--   §4.2 calls perf indexes (ratio, date-range, per-agent)
+--   §4.1 webhook_events replay-ordering index
+--   §4.5 frequent_callers_cache lookup index
+--   §5.6 HNSW KNN indexes per non-NULL dim column
+-- ============================================================================
+
+
+-- ── §9.1 read-path indexes on qa.evaluations ────────────────────────────────
+-- These three drive agent-history queries, team-stats, and category
+-- trend analysis. Partial WHERE state='finalized' keeps the indexes
+-- tight — draft/approved rows are write-heavy and don't get read on
+-- the analytical hot paths.
+
+CREATE INDEX idx_eval_team_time
+    ON qa.evaluations (team_id, finalized_at)
+    WHERE state = 'finalized';
+
+CREATE INDEX idx_eval_agent_time
+    ON qa.evaluations (agent_id, finalized_at)
+    WHERE state = 'finalized' AND agent_id IS NOT NULL;
+
+CREATE INDEX idx_sections_trend
+    ON qa.evaluation_sections (section_id, evaluation_id);
+
+
+-- ── §9.2 agent_stat_points lookup ───────────────────────────────────────────
+-- The CC sparkline path: "latest N points for this agent, in id order"
+-- (id is monotonic with finalize time within an agent).
+
+CREATE INDEX idx_stat_points_agent
+    ON qa.agent_stat_points (agent_id, id);
+
+
+-- ── §3.12 formula_versions per-team lookup ──────────────────────────────────
+-- "Which formula version was current at time T for team X" reads via
+-- this index ordered DESC by effective_from.
+
+CREATE INDEX idx_formula_versions_team_effective
+    ON qa.formula_versions (team_id, effective_from DESC);
+
+
+-- ── §3.13 formula_compliance_sweeps lookup indexes ──────────────────────────
+-- The flag-rate-per-formula-version query (the iteration-progress metric)
+-- joins on (swept_formula_version, flagged) and aggregates. The
+-- eval-id lookup serves "show me every sweep for this evaluation."
+
+CREATE INDEX idx_sweeps_formula_flagged
+    ON qa.formula_compliance_sweeps (swept_formula_version, flagged);
+
+CREATE INDEX idx_sweeps_eval
+    ON qa.formula_compliance_sweeps (evaluation_id);
+
+
+-- ── §4.2 command_center.calls perf indexes ──────────────────────────────────
+-- The ratio query (calls-received-vs-calls-scored) is leadership's
+-- single-most-asked metric — this index turns it into milliseconds.
+
+CREATE INDEX idx_calls_team_scored_connected
+    ON command_center.calls (team_id, scored, connected_at);
+
+-- Date-range queries (per-team daily volume, calls in window, etc.).
+CREATE INDEX idx_calls_team_connected
+    ON command_center.calls (team_id, connected_at DESC)
+    WHERE connected_at IS NOT NULL;
+
+-- Agent-level call volume queries (Zone D drill-down).
+CREATE INDEX idx_calls_agent
+    ON command_center.calls (team_id, dialpad_agent_id)
+    WHERE dialpad_agent_id IS NOT NULL;
+
+
+-- ── §4.1 webhook_events replay-ordering index ───────────────────────────────
+-- call_state.rebuild() reads `WHERE team_id = ? AND event_timestamp >=
+-- $today` ORDER BY event_timestamp, id. Perf budget per §4.1.2: p95 < 2s
+-- at 10k events.
+
+CREATE INDEX idx_webhook_replay
+    ON command_center.webhook_events (team_id, event_timestamp, id);
+
+
+-- ── §4.5 frequent_callers_cache per-team lookup ─────────────────────────────
+
+CREATE INDEX idx_frequent_callers_team_phone
+    ON command_center.frequent_callers_cache (team_id, caller_phone_e164);
+
+
+-- ── §5.6 KNN HNSW indexes on the embedding_* dim columns ────────────────────
+-- HNSW with default operator class `vector_cosine_ops` — cosine
+-- similarity matches the SOP-retrieval use case. Partial WHERE NOT NULL
+-- keeps each index focused on rows that actually carry that dim class
+-- (the exactly-one-dim CHECK guarantees a row populates exactly one of
+-- the two columns).
+
+CREATE INDEX idx_chunk_embeddings_hnsw_1536
+    ON embeddings.sop_chunk_embeddings
+    USING hnsw (embedding_1536 vector_cosine_ops)
+    WHERE embedding_1536 IS NOT NULL;
+
+CREATE INDEX idx_chunk_embeddings_hnsw_1024
+    ON embeddings.sop_chunk_embeddings
+    USING hnsw (embedding_1024 vector_cosine_ops)
+    WHERE embedding_1024 IS NOT NULL;

--- a/database/migrations/008_indexes_down.sql
+++ b/database/migrations/008_indexes_down.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- Migration 008 — DOWN
+--
+-- Drops every index this migration created. Order doesn't matter for
+-- DROP INDEX. Down is a no-op for query correctness but restores the
+-- "no analytics indexes" state for rerunning the index-tuning analysis.
+-- ============================================================================
+
+DROP INDEX IF EXISTS embeddings.idx_chunk_embeddings_hnsw_1024;
+DROP INDEX IF EXISTS embeddings.idx_chunk_embeddings_hnsw_1536;
+DROP INDEX IF EXISTS command_center.idx_frequent_callers_team_phone;
+DROP INDEX IF EXISTS command_center.idx_webhook_replay;
+DROP INDEX IF EXISTS command_center.idx_calls_agent;
+DROP INDEX IF EXISTS command_center.idx_calls_team_connected;
+DROP INDEX IF EXISTS command_center.idx_calls_team_scored_connected;
+DROP INDEX IF EXISTS qa.idx_sweeps_eval;
+DROP INDEX IF EXISTS qa.idx_sweeps_formula_flagged;
+DROP INDEX IF EXISTS qa.idx_formula_versions_team_effective;
+DROP INDEX IF EXISTS qa.idx_stat_points_agent;
+DROP INDEX IF EXISTS qa.idx_sections_trend;
+DROP INDEX IF EXISTS qa.idx_eval_agent_time;
+DROP INDEX IF EXISTS qa.idx_eval_team_time;

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_008.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_008.py
@@ -1,0 +1,364 @@
+"""Tests for migration 008 — analytics + KNN indexes.
+
+Per SQLMigration.md §11.5: "For every analytics index (§9.1): ≥1
+EXPLAIN-plan test asserting the index is used by the documented query
+shape." That requirement is also applied to the §9.2/§3.12/§3.13/§4.x
+indexes — every index in this PR gets one EXPLAIN test against the
+query shape its docstring names.
+
+`SET enable_seqscan = OFF` is used to keep the planner from preferring a
+sequential scan on the tiny ephemeral test tables — once tables have
+real volume the planner will pick the indexes naturally, but the
+correctness gate here is "the index is structurally compatible with the
+query," not "the planner would have picked it on 0 rows."
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
+UP_005 = (MIGRATIONS_DIR / "005_command_center_tables.sql").read_text()
+UP_006 = (MIGRATIONS_DIR / "006_qa_tables.sql").read_text()
+UP_007 = (MIGRATIONS_DIR / "007_embeddings_tables.sql").read_text()
+UP_008 = (MIGRATIONS_DIR / "008_indexes.sql").read_text()
+DOWN_008 = (MIGRATIONS_DIR / "008_indexes_down.sql").read_text()
+
+
+@pytest_asyncio.fixture
+async def pg_008(clean_pg: asyncpg.Connection) -> asyncpg.Connection:
+    await clean_pg.execute(UP_004)
+    await clean_pg.execute(UP_005)
+    await clean_pg.execute(UP_006)
+    await clean_pg.execute(UP_007)
+    await clean_pg.execute(UP_008)
+    # Force index consideration regardless of table-row counts.
+    await clean_pg.execute("SET enable_seqscan = OFF")
+    return clean_pg
+
+
+async def _plan(conn: asyncpg.Connection, sql: str, *args) -> str:
+    rows = await conn.fetch(f"EXPLAIN {sql}", *args)
+    return "\n".join(r["QUERY PLAN"] for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# §9.1 read-path indexes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_eval_team_time_used_by_team_finalized_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """Drives team-stats and dashboard date-range queries."""
+    plan = await _plan(
+        pg_008,
+        "SELECT id FROM qa.evaluations "
+        "WHERE state = 'finalized' AND team_id = 'sales' "
+        "ORDER BY finalized_at DESC LIMIT 50",
+    )
+    assert "idx_eval_team_time" in plan
+
+
+@pytest.mark.asyncio
+async def test_idx_eval_agent_time_used_by_agent_history_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """Drives agent-history reads (ProgressionCard, agent dashboard)."""
+    plan = await _plan(
+        pg_008,
+        "SELECT id FROM qa.evaluations "
+        "WHERE state = 'finalized' AND agent_id = 1 "
+        "ORDER BY finalized_at DESC LIMIT 50",
+    )
+    assert "idx_eval_agent_time" in plan
+
+
+@pytest.mark.asyncio
+async def test_idx_sections_trend_used_by_section_id_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """Drives per-category trend analysis across evaluations."""
+    plan = await _plan(
+        pg_008,
+        "SELECT evaluation_id, numeric_score FROM qa.evaluation_sections "
+        "WHERE section_id = 'greeting'",
+    )
+    assert "idx_sections_trend" in plan
+
+
+# ---------------------------------------------------------------------------
+# §9.2 agent_stat_points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_stat_points_agent_used_by_sparkline_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """CC Zone D sparkline read pattern: latest N stat points for an agent."""
+    plan = await _plan(
+        pg_008,
+        "SELECT score, ewma FROM qa.agent_stat_points "
+        "WHERE agent_id = 1 ORDER BY id DESC LIMIT 10",
+    )
+    assert "idx_stat_points_agent" in plan
+
+
+# ---------------------------------------------------------------------------
+# §3.12 formula_versions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_formula_versions_team_effective_used_by_history(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """'What formula was current at time T for team X' query."""
+    plan = await _plan(
+        pg_008,
+        "SELECT formula_version, formula_json FROM qa.formula_versions "
+        "WHERE team_id = 'sales' ORDER BY effective_from DESC LIMIT 5",
+    )
+    assert "idx_formula_versions_team_effective" in plan
+
+
+# ---------------------------------------------------------------------------
+# §3.13 formula_compliance_sweeps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_sweeps_formula_flagged_used_by_iteration_rate_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """The §7.7 runbook's flag-rate-per-version query: GROUP BY flagged
+    WHERE swept_formula_version = ?."""
+    plan = await _plan(
+        pg_008,
+        "SELECT flagged, COUNT(*) FROM qa.formula_compliance_sweeps "
+        "WHERE swept_formula_version = 'sales_v1' "
+        "GROUP BY flagged",
+    )
+    assert "idx_sweeps_formula_flagged" in plan
+
+
+@pytest.mark.asyncio
+async def test_idx_sweeps_eval_used_by_per_eval_history_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    plan = await _plan(
+        pg_008,
+        "SELECT swept_formula_version, recomputed_score "
+        "FROM qa.formula_compliance_sweeps WHERE evaluation_id = 1",
+    )
+    assert "idx_sweeps_eval" in plan
+
+
+# ---------------------------------------------------------------------------
+# §4.2 command_center.calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_calls_team_scored_connected_used_by_ratio_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """The single-most-asked leadership metric: calls-received-vs-scored."""
+    plan = await _plan(
+        pg_008,
+        "SELECT COUNT(*) FILTER (WHERE scored), COUNT(*) "
+        "FROM command_center.calls "
+        "WHERE team_id = 'sales' AND connected_at::date "
+        "BETWEEN '2026-01-01' AND '2026-12-31'",
+    )
+    assert "idx_calls_team_scored_connected" in plan
+
+
+@pytest.mark.asyncio
+async def test_idx_calls_team_connected_used_by_date_range_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    plan = await _plan(
+        pg_008,
+        "SELECT id FROM command_center.calls "
+        "WHERE team_id = 'sales' AND connected_at IS NOT NULL "
+        "ORDER BY connected_at DESC LIMIT 100",
+    )
+    assert "idx_calls_team_connected" in plan
+
+
+@pytest.mark.asyncio
+async def test_idx_calls_agent_used_by_per_agent_volume_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    plan = await _plan(
+        pg_008,
+        "SELECT COUNT(*) FROM command_center.calls "
+        "WHERE team_id = 'sales' AND dialpad_agent_id = 'a1'",
+    )
+    assert "idx_calls_agent" in plan
+
+
+# ---------------------------------------------------------------------------
+# §4.1 webhook_events replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_webhook_replay_used_by_rebuild_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """call_state.rebuild() reads in (team_id, event_timestamp, id) order."""
+    plan = await _plan(
+        pg_008,
+        "SELECT raw_payload FROM command_center.webhook_events "
+        "WHERE team_id = 'sales' AND event_timestamp >= '2026-06-23' "
+        "ORDER BY event_timestamp ASC, id ASC",
+    )
+    assert "idx_webhook_replay" in plan
+
+
+# ---------------------------------------------------------------------------
+# §4.5 frequent_callers_cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_frequent_callers_team_phone_used_by_lookup(
+    pg_008: asyncpg.Connection,
+) -> None:
+    plan = await _plan(
+        pg_008,
+        "SELECT * FROM command_center.frequent_callers_cache "
+        "WHERE team_id = 'sales' AND caller_phone_e164 = '+15551234567'",
+    )
+    assert "idx_frequent_callers_team_phone" in plan
+
+
+# ---------------------------------------------------------------------------
+# §5.6 HNSW KNN — pgvector
+# ---------------------------------------------------------------------------
+
+
+def _vec(n: int) -> str:
+    return "[" + ",".join("0.1" for _ in range(n)) + "]"
+
+
+@pytest.mark.asyncio
+async def test_hnsw_index_1536_used_by_cosine_knn_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    """Documented query pattern: ORDER BY embedding_1536 <=> $1 LIMIT N.
+    The pgvector planner picks the HNSW index for cosine-similarity KNN."""
+    plan = await _plan(
+        pg_008,
+        "SELECT id FROM embeddings.sop_chunk_embeddings "
+        f"WHERE embedding_1536 IS NOT NULL "
+        f"ORDER BY embedding_1536 <=> '{_vec(1536)}'::vector LIMIT 5",
+    )
+    assert "idx_chunk_embeddings_hnsw_1536" in plan
+
+
+@pytest.mark.asyncio
+async def test_hnsw_index_1024_used_by_cosine_knn_query(
+    pg_008: asyncpg.Connection,
+) -> None:
+    plan = await _plan(
+        pg_008,
+        "SELECT id FROM embeddings.sop_chunk_embeddings "
+        f"WHERE embedding_1024 IS NOT NULL "
+        f"ORDER BY embedding_1024 <=> '{_vec(1024)}'::vector LIMIT 5",
+    )
+    assert "idx_chunk_embeddings_hnsw_1024" in plan
+
+
+# ---------------------------------------------------------------------------
+# Down — all indexes gone, tables intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_008_indexes(pg_008: asyncpg.Connection) -> None:
+    await pg_008.execute(DOWN_008)
+
+    # The §11.5 EXPLAIN tests assert specific index names by string; if
+    # any 008 index survived the down, the planner would still mention
+    # it. Check that no 008 index appears in pg_indexes.
+    indexes_008 = [
+        "idx_eval_team_time", "idx_eval_agent_time", "idx_sections_trend",
+        "idx_stat_points_agent", "idx_formula_versions_team_effective",
+        "idx_sweeps_formula_flagged", "idx_sweeps_eval",
+        "idx_calls_team_scored_connected", "idx_calls_team_connected",
+        "idx_calls_agent", "idx_webhook_replay",
+        "idx_frequent_callers_team_phone",
+        "idx_chunk_embeddings_hnsw_1536", "idx_chunk_embeddings_hnsw_1024",
+    ]
+    rows = await pg_008.fetch(
+        "SELECT indexname FROM pg_indexes WHERE indexname = ANY($1::text[])",
+        indexes_008,
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — full Wave 1 (004 → 008)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_applies_entire_wave_1_then_rolls_back_indexes(
+    clean_pg: asyncpg.Connection, tmp_path: Path
+) -> None:
+    """End-to-end: every Wave-1 migration applies in order through the
+    runner, and `down` rolls back just 008's indexes (leaving tables
+    intact)."""
+    import shutil
+    from database import runner as _runner
+    migdir = tmp_path / "migrations"
+    migdir.mkdir()
+    for name in [
+        "004_create_schemas_and_teams.sql",
+        "004_create_schemas_and_teams_down.sql",
+        "005_command_center_tables.sql",
+        "005_command_center_tables_down.sql",
+        "006_qa_tables.sql",
+        "006_qa_tables_down.sql",
+        "007_embeddings_tables.sql",
+        "007_embeddings_tables_down.sql",
+        "008_indexes.sql",
+        "008_indexes_down.sql",
+    ]:
+        shutil.copy(MIGRATIONS_DIR / name, migdir)
+
+    rc = await _runner.cmd_up(clean_pg, migrations_dir=migdir)
+    assert rc == 0
+
+    applied = await clean_pg.fetch(
+        "SELECT version FROM public.schema_migrations ORDER BY version"
+    )
+    assert [r["version"] for r in applied] == [4, 5, 6, 7, 8]
+
+    # An 008 index exists
+    cnt = await clean_pg.fetchval(
+        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_eval_team_time'"
+    )
+    assert cnt == 1
+
+    # Down only 008 — qa.* tables still there, indexes gone.
+    rc = await _runner.cmd_down(clean_pg)
+    assert rc == 0
+    cnt = await clean_pg.fetchval(
+        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_eval_team_time'"
+    )
+    assert cnt == 0
+    # qa.evaluations table still exists.
+    assert await clean_pg.fetchval("SELECT to_regclass('qa.evaluations')") is not None


### PR DESCRIPTION
## Summary
- Splits 14 indexes out of 005/006/007 into their own migration so future re-indexing can use `CREATE INDEX CONCURRENTLY` without holding locks. This initial-deploy migration creates them without CONCURRENTLY (tables are empty; CONCURRENTLY can't run inside the runner's per-migration transaction).
- Indexes: §9.1 read-path (3 — eval team/agent/section trend, partial WHERE state='finalized'), §9.2 stat_points lookup, §3.12 formula_versions per-team, §3.13 sweep flag-rate + per-eval, §4.2 calls (3 — ratio query / date-range / per-agent), §4.1 webhook_events replay-ordering, §4.5 frequent_callers_cache, §5.6 HNSW per dim column with `vector_cosine_ops` (partial WHERE NOT NULL).
- 14 EXPLAIN-plan tests at `tests/integration/test_migration_008.py` — per §11.5 floor, one per index against its documented query shape. `SET enable_seqscan = OFF` keeps the planner from defaulting to seq scan on tiny ephemeral test tables (the gate is "structurally compatible," not "would be picked on 0 rows"). Down test asserts every 008 index disappears from `pg_indexes`. Runner integration covers the full Wave-1 chain (004 → 008).

## Test plan
- [ ] `make test-integration` — 14 EXPLAIN-plan tests should pass plus the runner full-chain test
- [ ] Confirm HNSW indexes use `vector_cosine_ops` (matches the SOP-retrieval use case)
- [ ] Post-deploy: monitor index sizes; the leadership ratio query (`idx_calls_team_scored_connected`) should answer in single-digit ms

## Stacked on
[#55 — migration 007](https://github.com/mxg108/Landing-scripts/pull/55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)