### PR TITLE
test(database): pg_tx SAVEPOINT fixture + golden-fixture loader

### DIFF
--- a/qa-automation/AI-Scoring/tests/integration/conftest.py
+++ b/qa-automation/AI-Scoring/tests/integration/conftest.py
@@ -1,27 +1,35 @@
 """Postgres testcontainers fixtures for the integration suite.
 
-Per SQLMigration.md §11.0, one fresh container per test session, with each
-test running against an already-started Postgres+pgvector image. We use
-``pgvector/pgvector:pg16`` so the same fixture serves the runner tests
-(no extensions needed) and the future ``embeddings`` schema tests
+Per SQLMigration.md §11.0, one fresh container per test session, with
+each test running against an already-started Postgres+pgvector image. We
+use ``pgvector/pgvector:pg16`` so the same fixture serves the runner
+tests (no extensions needed) and the ``embeddings`` schema tests
 (VECTOR columns).
 
-Two fixtures are exposed:
+Three fixtures are exposed:
 
 - ``pg_dsn`` — session-scoped, the asyncpg-compatible connection string.
+
 - ``clean_pg`` — per-test asyncpg connection that drops every schema the
   runner could create *before yielding*, so each test starts from a
-  guaranteed-empty database. Use this for runner / migration tests.
+  guaranteed-empty database. **Use for runner / migration tests** —
+  those mutate DDL (CREATE TABLE inside a migration's own transaction)
+  that SAVEPOINTs cannot un-do.
 
-Per-table tests added in later phases will introduce a third fixture
-(``pg_tx``) that wraps each test in a SAVEPOINT-rolled-back transaction;
-keeping that out of Phase 0 since runner tests mutate DDL (CREATE TABLE
-inside a migration's own transaction) that SAVEPOINTs cannot un-do
-without dropping the schemas.
+- ``pg_tx`` — per-test asyncpg connection inside a transaction that
+  rolls back at test exit. Uses the session-scoped ``pg_migrated``
+  fixture as the schema baseline. **Use for application-layer tests**
+  that INSERT/UPDATE/DELETE against an already-migrated schema. Faster
+  than ``clean_pg`` because the migrations aren't re-applied per test.
+
+Golden-fixture helpers (loader at ``tests/fixtures/overall_formula/``)
+live alongside the fixtures themselves; see ``load_overall_formula``.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -34,6 +42,27 @@ from testcontainers.postgres import PostgresContainer
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+# Where canonical fixtures live (per SQLMigration.md §11.0).
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+_FORMULA_FIXTURES_DIR = _FIXTURES_DIR / "overall_formula"
+
+# Migrations applied at session start by ``pg_migrated``. Keep in
+# numeric order — the SQL files DDL-depend on each other.
+_WAVE_1_MIGRATIONS = (
+    "004_create_schemas_and_teams.sql",
+    "005_command_center_tables.sql",
+    "006_qa_tables.sql",
+    "007_embeddings_tables.sql",
+    "008_indexes.sql",
+)
+
+_MIGRATIONS_DIR = _REPO_ROOT / "database" / "migrations"
+
+# Acceptance threshold for compute_overall_score fixture tests
+# (§3.6 + §11.3.2). Centralized so per-team fixture loaders all use
+# the same value.
+EPSILON: float = 0.05
 
 
 @pytest.fixture(scope="session")
@@ -55,6 +84,12 @@ async def clean_pg(pg_dsn):
     previous test. Yields the live connection so the test can both invoke
     the runner (which opens its own connection via ``DATABASE_URL``) and
     introspect state directly.
+
+    NOTE: when this fixture is used in the same session as ``pg_tx`` /
+    ``pg_migrated``, the next test that depends on ``pg_migrated`` will
+    re-apply the migrations because the schemas were just dropped. That
+    self-healing is intentional — it keeps the two fixture families
+    composable.
     """
     conn = await asyncpg.connect(pg_dsn)
     # Order matters only because of FKs; CASCADE removes dependents.
@@ -73,3 +108,96 @@ async def clean_pg(pg_dsn):
         yield conn
     finally:
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# pg_migrated / pg_tx — application-layer test scaffolding (§11.0)
+# ---------------------------------------------------------------------------
+
+
+async def _apply_wave_1(dsn: str) -> None:
+    """Apply 004 → 008 in order against the given DSN. Each migration
+    runs in its own implicit transaction (single ``execute`` call)."""
+    conn = await asyncpg.connect(dsn)
+    try:
+        # Self-heal: if a clean_pg test ran earlier in the session and
+        # tore down our schemas, we re-apply. If pg_migrated already ran,
+        # the migrations IF NOT EXISTS clauses (004) and table presence
+        # checks make the re-apply a no-op for 004 only — but 005-008
+        # would error on CREATE TABLE for existing tables. So we check
+        # explicitly.
+        already = await conn.fetchval(
+            "SELECT to_regclass('qa.evaluations')"
+        )
+        if already is not None:
+            return
+        for name in _WAVE_1_MIGRATIONS:
+            sql = (_MIGRATIONS_DIR / name).read_text(encoding="utf-8")
+            await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture
+async def pg_migrated(pg_dsn):
+    """Returns a DSN against a database with all Wave-1 migrations
+    applied. Self-heals if a ``clean_pg``-using test in the same session
+    dropped the schemas first.
+
+    The fixture is function-scoped (not session-scoped) so the self-heal
+    can run on every test — but ``_apply_wave_1`` short-circuits when
+    ``qa.evaluations`` already exists, so the cost is one round-trip
+    per test in the steady state. Worth the simplicity over an
+    invalidation dance with session-scoped state.
+    """
+    await _apply_wave_1(pg_dsn)
+    return pg_dsn
+
+
+@pytest_asyncio.fixture
+async def pg_tx(pg_migrated):
+    """Per-test asyncpg connection inside a transaction that rolls back
+    on test exit.
+
+    Use for application-layer tests that INSERT/UPDATE/DELETE against
+    the already-migrated schema; do NOT use for tests that CREATE/DROP
+    tables or schemas — those commits land outside the rollback envelope
+    and bleed across tests. Use ``clean_pg`` for DDL-mutating tests.
+    """
+    conn = await asyncpg.connect(pg_migrated)
+    tx = conn.transaction()
+    await tx.start()
+    try:
+        yield conn
+    finally:
+        try:
+            await tx.rollback()
+        finally:
+            await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Golden-fixture loader (§11.0 / §11.3.2)
+# ---------------------------------------------------------------------------
+
+
+def load_overall_formula(team: str) -> list[dict]:
+    """Load golden Analyst_History rows + sheet-computed scores for the
+    Phase A.5 compute_overall_score loop (§3.6 + §11.3.2).
+
+    Returns the JSON file's ``rows`` list. Returns ``[]`` if no fixture
+    file exists for the team yet — placeholder behavior so tests can be
+    parametrized via ``pytest.mark.parametrize`` without exploding when
+    fixtures haven't been authored.
+
+    Per spec §3.8, each row is shape::
+
+        {"evaluation_id": 12345,
+         "sections": [{"section_id": "...", "numeric_score": 4, ...}, ...],
+         "expected_score": 87.4}
+    """
+    fpath = _FORMULA_FIXTURES_DIR / f"{team}.json"
+    if not fpath.exists():
+        return []
+    data = json.loads(fpath.read_text(encoding="utf-8"))
+    return data.get("rows", [])

--- a/qa-automation/AI-Scoring/tests/integration/test_scaffolding.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_scaffolding.py
@@ -1,0 +1,116 @@
+"""Tests for the test scaffolding itself (§11.0 fixtures).
+
+Verifies the ``pg_tx`` SAVEPOINT-rolled-back pattern actually isolates
+writes across tests, and that the golden-fixture loader returns the
+right shape for both present and missing fixture files.
+
+These are tests-of-tests, so they don't carry per-§11.5 floor coverage
+(no migration to validate). They exist so a future contributor breaking
+the fixture isolation is caught at PR time.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from conftest import EPSILON, load_overall_formula
+
+
+# ---------------------------------------------------------------------------
+# pg_tx isolation — writes in one test must not be visible to the next
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pg_tx_writes_visible_within_same_test(
+    pg_tx: asyncpg.Connection,
+) -> None:
+    """Inside one test, writes ARE visible (the rollback only happens at
+    test exit). This is the baseline — without it the SAVEPOINT pattern
+    wouldn't work for any test that needs to observe its own state."""
+    await pg_tx.execute(
+        "INSERT INTO qa.agents (team_id, name, email) "
+        "VALUES ('sales', 'Tx Probe Alpha', 'p@l.com')"
+    )
+    n = await pg_tx.fetchval(
+        "SELECT COUNT(*) FROM qa.agents WHERE name = 'Tx Probe Alpha'"
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_pg_tx_isolation_part_1_writes_probe_row(
+    pg_tx: asyncpg.Connection,
+) -> None:
+    """Part 1 of an isolation pair: write a row. The test passes; on
+    exit the transaction rolls back. Part 2 (below) must then see no
+    such row — proving the isolation works across tests."""
+    await pg_tx.execute(
+        "INSERT INTO qa.agents (team_id, name, email) "
+        "VALUES ('sales', 'Tx Isolation Probe', 'p@l.com')"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pg_tx_isolation_part_2_does_not_see_part_1(
+    pg_tx: asyncpg.Connection,
+) -> None:
+    """Part 2 of the isolation pair. If pg_tx is truly SAVEPOINT-rolled-
+    back, this test starts in the migrated-but-empty state — the row
+    inserted in part 1 must not be visible."""
+    n = await pg_tx.fetchval(
+        "SELECT COUNT(*) FROM qa.agents WHERE name = 'Tx Isolation Probe'"
+    )
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_pg_tx_inherits_seed_rows_from_004(
+    pg_tx: asyncpg.Connection,
+) -> None:
+    """The session-baseline includes 004's seed (member_support, sales).
+    pg_tx tests can rely on those rows being present without inserting
+    them."""
+    rows = await pg_tx.fetch("SELECT id FROM public.teams ORDER BY id")
+    assert [r["id"] for r in rows] == ["member_support", "sales"]
+
+
+# ---------------------------------------------------------------------------
+# load_overall_formula — present + missing fixture behavior
+# ---------------------------------------------------------------------------
+
+
+def test_load_overall_formula_missing_returns_empty() -> None:
+    """No fixture file exists yet for either team. The loader returns
+    an empty list rather than raising — that lets parametrized golden-
+    fixture tests stay registerable before fixtures are authored."""
+    assert load_overall_formula("member_support") == []
+    assert load_overall_formula("sales") == []
+
+
+def test_load_overall_formula_present_returns_rows(tmp_path, monkeypatch) -> None:
+    """Authoring a fixture: drop a JSON with the expected ``rows``
+    array, the loader returns it. Future Wave-2 PRs that add real
+    fixtures rely on this shape contract."""
+    import conftest
+    fixtures_dir = tmp_path / "overall_formula"
+    fixtures_dir.mkdir()
+    payload = {
+        "rows": [
+            {"evaluation_id": 1, "sections": [], "expected_score": 87.5},
+            {"evaluation_id": 2, "sections": [], "expected_score": 92.1},
+        ],
+    }
+    (fixtures_dir / "sales.json").write_text(__import__("json").dumps(payload))
+    monkeypatch.setattr(conftest, "_FORMULA_FIXTURES_DIR", fixtures_dir)
+    rows = conftest.load_overall_formula("sales")
+    assert len(rows) == 2
+    assert rows[0]["expected_score"] == 87.5
+
+
+def test_epsilon_pinned_at_005() -> None:
+    """The Phase A.5 acceptance threshold (§3.6) is exactly 0.05 — pin
+    it here so accidental changes show up as a failing test, not a
+    silently shifted compliance gate."""
+    assert EPSILON == 0.05


### PR DESCRIPTION
## Summary
- `pg_migrated` fixture: applies 004 → 008 once per session against the testcontainers Postgres, self-heals if a clean_pg-using test earlier in the session tore down the schemas. Short-circuits when `qa.evaluations` already exists.
- `pg_tx` fixture: per-test asyncpg connection inside a `BEGIN ... ROLLBACK` envelope. Use for application-layer tests that INSERT/UPDATE/DELETE against an already-migrated schema; DDL-mutating tests still use `clean_pg`.
- `load_overall_formula(team)` returns rows from `tests/fixtures/overall_formula/<team>.json` or `[]` if no fixture exists (lets parametrized tests register before fixtures are authored). `EPSILON = 0.05` pinned per §3.6 / §11.3.2.
- 6 scaffolding tests at `tests/integration/test_scaffolding.py`: pg_tx within-test write visibility, cross-test isolation (two paired tests where part 2 must not see part 1's row), seed-row inheritance, fixture-loader present/absent shape, EPSILON pin.

## Reviewer note
`pg_tx` uses asyncpg's `conn.transaction()` (BEGIN/ROLLBACK), not a nested SAVEPOINT — tests using `pg_tx` must NOT open their own outer transactions (would commit prematurely).

## Test plan
- [ ] `make test-integration` — 6 scaffolding tests should pass
- [ ] Spot-check `tests/fixtures/overall_formula/` directory exists (only `.gitkeep` so far)
- [ ] Future Wave-2 PRs (compute_overall_score, dual-write integration, backfill scripts) build on these fixtures

## Stacked on
[#56 — migration 008](https://github.com/mxg108/Landing-scripts/pull/56). Last PR in the Wave-1 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)