### PR TITLE
feat(database): migration 009 — VP review additions

### DIFF
--- a/database/migrations/009_vp_review_additions.sql
+++ b/database/migrations/009_vp_review_additions.sql
@@ -1,0 +1,218 @@
+-- ============================================================================
+-- Migration 009: VP review additions (2026-06-24 Ops VP review)
+-- Spec: database/SQLMigration.md §3.4 (column additions),
+--       §3.14 (pipeline trigger), §3.15–§3.18 (tags + coachings tables),
+--       §7.6 (migration ordering), §8.6 (auto-tagging forward path)
+--
+-- Three coupled concerns:
+--
+--   1) Coaching workflow — qa.coachings (one row per session) + M:N
+--      qa.coaching_evaluations. Escalation pattern TL → Manager → HR can
+--      revisit the same eval; one session can cover multiple evals.
+--
+--   2) Tag taxonomy — qa.tags (slug + category) + qa.evaluation_tags
+--      (M:N with source provenance). Seeds 4 human-review-focus tags.
+--      Forward-compatible with LandGPT v2 auto-tagging (source='ai').
+--
+--   3) Pipeline trigger — new 'flagged_human_review' value on
+--      qa.evaluations.scoring_status + paired timestamps. The trigger
+--      condition lives in per-team overall_formula.json
+--      (human_review_triggers array), not the schema.
+--
+-- All ALTERs and CREATEs are reversible via the companion _down.sql.
+-- This migration depends on 006 (qa.* base tables) being applied.
+-- ============================================================================
+
+
+-- ── (a) ALTER qa.evaluations — new columns + extended CHECK ─────────────────
+
+ALTER TABLE qa.evaluations
+    ADD COLUMN needs_coaching             TEXT,
+    ADD COLUMN action_plan                TEXT,
+    ADD COLUMN human_review_required_at   TIMESTAMPTZ,
+    ADD COLUMN human_review_completed_at  TIMESTAMPTZ;
+
+-- needs_coaching is Y/N or NULL (NULL = manager hasn't decided / not asked).
+ALTER TABLE qa.evaluations
+    ADD CONSTRAINT evaluations_needs_coaching_check
+    CHECK (needs_coaching IS NULL OR needs_coaching IN ('Y', 'N'));
+
+-- Pair invariant: you can't complete a review that was never required.
+ALTER TABLE qa.evaluations
+    ADD CONSTRAINT evaluations_human_review_pair_check
+    CHECK (human_review_completed_at IS NULL
+           OR human_review_required_at IS NOT NULL);
+
+-- Extend scoring_status to admit the new 'flagged_human_review' value.
+-- The existing constraint must be dropped and re-added since CHECK
+-- definitions are not mutable in place. Any row with the new value gets
+-- rejected by the OLD constraint, so this DDL is safe: no row can yet
+-- carry the new value at apply time.
+ALTER TABLE qa.evaluations
+    DROP CONSTRAINT evaluations_scoring_status_check;
+
+ALTER TABLE qa.evaluations
+    ADD CONSTRAINT evaluations_scoring_status_check
+    CHECK (scoring_status IN ('complete', 'flagged_long_call', 'errored',
+                              'landgpt_unavailable_routed_to_gemini',
+                              'flagged_human_review'));
+
+
+-- ── (b) qa.tags — controlled tag vocabulary (§3.15) ─────────────────────────
+
+CREATE TABLE qa.tags (
+    id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    slug        TEXT NOT NULL UNIQUE,
+    -- Drives WHERE category = ... analytics. Initial human_review_focus
+    -- namespace + future categories (compliance, soft_skills, operational,
+    -- product, outcome) ship as rows, not migrations. No CHECK on the
+    -- value space — keeping it open so adding 'product' next quarter is
+    -- a row insert, not a migration.
+    category    TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    description TEXT,
+    -- Soft-delete: managers can stop seeing a tag in dropdowns without
+    -- losing historical references on qa.evaluation_tags.
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed: 4 initial human-review-focus tags per §3.15. ON CONFLICT keeps
+-- the seed idempotent under re-run (the migration runner's transaction
+-- wrapping makes this redundant, but matches 004's pattern).
+INSERT INTO qa.tags (slug, category, label, description) VALUES
+    ('sop',          'human_review_focus', 'SOP',
+     'Standard operating procedure / process compliance'),
+    ('soft_skills',  'human_review_focus', 'Soft Skills',
+     'Communication, empathy, tone, customer experience'),
+    ('hard_skills',  'human_review_focus', 'Hard Skills',
+     'Product knowledge, tool usage, technical execution'),
+    ('efficiency',   'human_review_focus', 'Efficiency',
+     'Call structure, hold time use, escalation appropriateness, resource leverage')
+ON CONFLICT (slug) DO NOTHING;
+
+
+-- ── (c) qa.evaluation_tags — M:N join with provenance (§3.16) ───────────────
+
+CREATE TABLE qa.evaluation_tags (
+    id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    evaluation_id  BIGINT NOT NULL REFERENCES qa.evaluations(id) ON DELETE CASCADE,
+    tag_id         BIGINT NOT NULL REFERENCES qa.tags(id),
+    -- 'manager' is the only source today; 'ai' lands with LandGPT v2's
+    -- annotated-transcript path; 'auto' reserved for rule-based tagging
+    -- (e.g. profanity detector → compliance.profanity_agent).
+    source         TEXT NOT NULL,
+    -- Email when source='manager'; NULL for ai/auto.
+    created_by     TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT evaluation_tags_source_check
+        CHECK (source IN ('manager', 'ai', 'auto')),
+    -- The same tag from manager + ai coexist as distinct rows: agreement
+    -- between the two is information ("AI saw this and manager confirmed").
+    CONSTRAINT uq_evaluation_tags_eval_tag_source
+        UNIQUE (evaluation_id, tag_id, source)
+);
+
+
+-- ── (d) qa.coachings — coaching session records (§3.17) ─────────────────────
+
+CREATE TABLE qa.coachings (
+    id                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    agent_id              BIGINT NOT NULL REFERENCES qa.agents(id),
+    team_id               TEXT NOT NULL REFERENCES public.teams(id),
+    -- Escalation level derived from the role enum.
+    conducted_by_role     TEXT NOT NULL,
+    -- Free text email — not FK'd to a roles table (no roles table exists).
+    conducted_by_email    TEXT,
+    status                TEXT NOT NULL DEFAULT 'pending',
+    -- The plan agreed in this session; supersedes qa.evaluations.action_plan
+    -- (the evaluator's initial proposal) once agreed.
+    action_plan           TEXT,
+    action_plan_deadline  TIMESTAMPTZ,
+    -- What was actually discussed; required at completion.
+    coaching_summary      TEXT,
+    agent_attitude        TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- When the session is set to happen — often populated at create time.
+    scheduled_at          TIMESTAMPTZ,
+    completed_at          TIMESTAMPTZ,
+    completed_by          TEXT,
+    CONSTRAINT coachings_conducted_by_role_check
+        CHECK (conducted_by_role IN ('team_lead', 'manager', 'hr', 'external')),
+    CONSTRAINT coachings_status_check
+        CHECK (status IN ('pending', 'completed', 'cancelled')),
+    CONSTRAINT coachings_agent_attitude_check
+        CHECK (agent_attitude IS NULL OR agent_attitude IN
+               ('receptive', 'engaged', 'neutral',
+                'defensive', 'dismissive', 'mixed')),
+    -- Completion pair: status='completed' MUST carry summary +
+    -- completed_at + completed_by.
+    CONSTRAINT coachings_completion_pair_check CHECK (
+        status <> 'completed'
+        OR (coaching_summary IS NOT NULL
+            AND completed_at IS NOT NULL
+            AND completed_by IS NOT NULL)
+    )
+);
+
+
+-- ── (e) qa.coaching_evaluations — M:N coachings ↔ evaluations (§3.18) ──────
+
+CREATE TABLE qa.coaching_evaluations (
+    id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    -- Parent: deleting a coaching wipes its links to evals.
+    coaching_id             BIGINT NOT NULL
+                            REFERENCES qa.coachings(id) ON DELETE CASCADE,
+    -- Child: deleting an eval should NOT silently strip it from
+    -- historical coaching records. FK without CASCADE means an eval
+    -- delete fails loudly if any coaching still references it; admin
+    -- delete path explicitly handles the cleanup.
+    evaluation_id           BIGINT NOT NULL REFERENCES qa.evaluations(id),
+    opportunities_snapshot  TEXT,
+    per_eval_note           TEXT,
+    linked_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_coaching_evals_coaching_eval
+        UNIQUE (coaching_id, evaluation_id)
+);
+
+
+-- ── (f) Indexes — partial + analytical lookups ─────────────────────────────
+-- Per §3.14, §3.15, §3.16, §3.17, §3.18 + spec convention that "structural"
+-- indexes ship with their tables (analytics indexes are in 008's scope but
+-- for this incremental migration the analytics ones live here too — there
+-- is no "010_indexes.sql" to split into).
+
+-- Human-review queue: surfaces evals that flagged at Stage 1 (or Stage 1.5
+-- re-evaluation) and await a reviewer. Partial — only draft + flagged rows
+-- matter.
+CREATE INDEX idx_eval_human_review_queue
+    ON qa.evaluations (team_id, human_review_required_at)
+    WHERE state = 'draft'
+      AND scoring_status = 'flagged_human_review';
+
+-- Tag analytics + dropdown lookups.
+CREATE INDEX idx_tags_category_active
+    ON qa.tags (category)
+    WHERE active = TRUE;
+
+-- "What tags does this eval have" — the most common read pattern.
+CREATE INDEX idx_evaluation_tags_eval
+    ON qa.evaluation_tags (evaluation_id);
+
+-- "Which evals got tagged X by which source" — drives the future LandGPT-
+-- vs-manager agreement analytics.
+CREATE INDEX idx_evaluation_tags_tag_source
+    ON qa.evaluation_tags (tag_id, source);
+
+-- Coachings pending overdue-deadline surface.
+CREATE INDEX idx_coachings_pending
+    ON qa.coachings (team_id, action_plan_deadline)
+    WHERE status = 'pending';
+
+-- Per-agent coaching history view.
+CREATE INDEX idx_coachings_agent_status
+    ON qa.coachings (agent_id, status, created_at DESC);
+
+-- "This call has been coached on N times" badge per §3.18.
+CREATE INDEX idx_coaching_evals_eval
+    ON qa.coaching_evaluations (evaluation_id);

--- a/database/migrations/009_vp_review_additions_down.sql
+++ b/database/migrations/009_vp_review_additions_down.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- Migration 009 — DOWN
+--
+-- Drops every artifact 009's UP created, in reverse dependency order:
+--   1) Drop new tables (coaching_evaluations first — FK to coachings).
+--   2) Drop new indexes on qa.evaluations (the partial human-review queue).
+--   3) Reverse the ALTER TABLE qa.evaluations changes:
+--      - Drop the new columns + their CHECKs (CHECKs drop with the columns).
+--      - Restore the original scoring_status CHECK (without 'flagged_human_review').
+--
+-- WARNING: if any qa.evaluations row has scoring_status='flagged_human_review',
+-- the down will fail when re-adding the original CHECK constraint — rows
+-- violating the old enum block the constraint validation. That's by design;
+-- the operator must manually decide what to do with those rows (mark them
+-- 'complete', delete them, or stop the rollback) before re-running down.
+-- ============================================================================
+
+-- Tables — coaching_evaluations FKs to coachings, drop in order
+DROP TABLE IF EXISTS qa.coaching_evaluations;
+DROP TABLE IF EXISTS qa.coachings;
+DROP TABLE IF EXISTS qa.evaluation_tags;
+DROP TABLE IF EXISTS qa.tags;
+
+-- Partial index on qa.evaluations — drops cleanly even if rows exist.
+DROP INDEX IF EXISTS qa.idx_eval_human_review_queue;
+
+-- Reverse the ALTER TABLE qa.evaluations changes.
+-- Restore scoring_status CHECK to its pre-009 form. If any rows hold
+-- 'flagged_human_review', this ADD CONSTRAINT will fail at validation time.
+ALTER TABLE qa.evaluations
+    DROP CONSTRAINT IF EXISTS evaluations_scoring_status_check;
+
+ALTER TABLE qa.evaluations
+    ADD CONSTRAINT evaluations_scoring_status_check
+    CHECK (scoring_status IN ('complete', 'flagged_long_call', 'errored',
+                              'landgpt_unavailable_routed_to_gemini'));
+
+-- Drop the v1.2 CHECK constraints (DROP COLUMN drops them anyway, but
+-- being explicit makes the intent clear and survives partial down).
+ALTER TABLE qa.evaluations
+    DROP CONSTRAINT IF EXISTS evaluations_human_review_pair_check,
+    DROP CONSTRAINT IF EXISTS evaluations_needs_coaching_check;
+
+-- Drop the v1.2 columns.
+ALTER TABLE qa.evaluations
+    DROP COLUMN IF EXISTS human_review_completed_at,
+    DROP COLUMN IF EXISTS human_review_required_at,
+    DROP COLUMN IF EXISTS action_plan,
+    DROP COLUMN IF EXISTS needs_coaching;

--- a/qa-automation/AI-Scoring/tests/integration/conftest.py
+++ b/qa-automation/AI-Scoring/tests/integration/conftest.py
@@ -38,8 +38,19 @@ import pytest
 import pytest_asyncio
 from testcontainers.postgres import PostgresContainer
 
-# Make ``database.runner`` importable without an install step.
-_REPO_ROOT = Path(__file__).resolve().parents[3]
+# Make ``database.runner`` importable without an install step. Walk up
+# from this file until we find ``database/migrations/`` — robust against
+# anyone restructuring the test tree (parents[N] miscounts otherwise).
+def _find_repo_root() -> Path:
+    p = Path(__file__).resolve()
+    while p.parent != p:
+        if (p / "database" / "migrations").is_dir():
+            return p
+        p = p.parent
+    raise RuntimeError("Could not locate repo root (no database/migrations/ ancestor)")
+
+
+_REPO_ROOT = _find_repo_root()
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_004.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_004.py
@@ -18,7 +18,7 @@ import pytest
 
 from database import runner
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
 UP_SQL = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
 DOWN_SQL = (MIGRATIONS_DIR / "004_create_schemas_and_teams_down.sql").read_text()

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_005.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_005.py
@@ -11,6 +11,7 @@ rolls back to confirm the down script leaves the database in the state
 
 from __future__ import annotations
 
+import datetime
 import json
 from pathlib import Path
 
@@ -20,7 +21,7 @@ import pytest_asyncio
 
 from database import runner
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
 
 UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
@@ -114,7 +115,7 @@ async def test_webhook_events_partial_unique_dedupes_call_kind(
     """The (dialpad_call_id, state, event_timestamp) UNIQUE applies only
     to event_kind='call' — a replayed call payload with the same triple
     must collide."""
-    ts = "2026-06-23T10:00:00Z"
+    ts = datetime.datetime(2026, 6, 23, 10, 0, 0, tzinfo=datetime.timezone.utc)
     await pg_005.execute(
         """
         INSERT INTO command_center.webhook_events
@@ -140,7 +141,7 @@ async def test_webhook_events_partial_unique_dedupes_call_kind(
 async def test_webhook_events_partial_unique_dedupes_agent_status(
     pg_005: asyncpg.Connection,
 ) -> None:
-    ts = "2026-06-23T10:00:00Z"
+    ts = datetime.datetime(2026, 6, 23, 10, 0, 0, tzinfo=datetime.timezone.utc)
     await pg_005.execute(
         """
         INSERT INTO command_center.webhook_events
@@ -168,7 +169,7 @@ async def test_webhook_events_different_kinds_same_timestamp_both_ok(
 ) -> None:
     """Two partial UNIQUEs are independent — a call event and an
     agent_status event with the same timestamp do NOT collide."""
-    ts = "2026-06-23T10:00:00Z"
+    ts = datetime.datetime(2026, 6, 23, 10, 0, 0, tzinfo=datetime.timezone.utc)
     await pg_005.execute(
         """
         INSERT INTO command_center.webhook_events

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_006.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_006.py
@@ -26,7 +26,7 @@ import pytest_asyncio
 
 from database import runner
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
 
 UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_007.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_007.py
@@ -20,7 +20,7 @@ import pytest_asyncio
 
 from database import runner
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
 
 UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
@@ -188,18 +188,24 @@ async def test_sop_documents_one_current_per_team_language(
     pg_007: asyncpg.Connection,
 ) -> None:
     """Partial UNIQUE on (team_id, language) WHERE is_current=TRUE —
-    cross-language `is_current` rows for the same team coexist."""
+    cross-language `is_current` rows for the same team coexist.
+
+    Note version_tags differ per row: the full UNIQUE on
+    (team_id, version_tag) means EN and ES can't share a tag even with
+    different languages — that's a separate invariant; this test
+    exercises only the language-partial UNIQUE.
+    """
     await pg_007.execute(
         "INSERT INTO embeddings.sop_documents "
         "(team_id, title, version_tag, language, is_current) "
-        "VALUES ('sales', 'EN', 'v1', 'en', TRUE), "
-        "       ('sales', 'ES', 'v1', 'es', TRUE)"
+        "VALUES ('sales', 'EN', 'v1-en', 'en', TRUE), "
+        "       ('sales', 'ES', 'v1-es', 'es', TRUE)"
     )
     with pytest.raises(asyncpg.exceptions.UniqueViolationError):
         await pg_007.execute(
             "INSERT INTO embeddings.sop_documents "
             "(team_id, title, version_tag, language, is_current) "
-            "VALUES ('sales', 'EN-v2', 'v2', 'en', TRUE)"
+            "VALUES ('sales', 'EN-v2', 'v2-en', 'en', TRUE)"
         )
 
 

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_008.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_008.py
@@ -21,7 +21,7 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
 
 UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
@@ -169,16 +169,36 @@ async def test_idx_sweeps_eval_used_by_per_eval_history_query(
 
 
 @pytest.mark.asyncio
-async def test_idx_calls_team_scored_connected_used_by_ratio_query(
+async def test_idx_calls_team_scored_connected_used_by_filtered_query(
     pg_008: asyncpg.Connection,
 ) -> None:
-    """The single-most-asked leadership metric: calls-received-vs-scored."""
+    """The (team_id, scored, connected_at) composite shines when the
+    query filters on team+scored AND orders/ranges on connected_at —
+    that's the "list scored calls in this window" pattern (CC drill-
+    down, ratio query when materialized as paginated listings).
+
+    Needs real row-count statistics: on an empty table the planner
+    can't tell whether the (team_id, connected_at) partial index or
+    this composite is cheaper, and may pick uq_calls_team_call_id
+    instead because its prefix is also team_id. Populating + ANALYZE
+    gives it the stats to choose."""
+    await pg_008.execute(
+        "INSERT INTO command_center.calls "
+        "(team_id, dialpad_call_id, seen_via, scored, scored_at, connected_at) "
+        "SELECT 'sales', 'call_' || g::text, 'webhook', "
+        "       (g % 3 = 0), "
+        "       CASE WHEN g % 3 = 0 THEN NOW() ELSE NULL END, "
+        "       NOW() - (g || ' minutes')::interval "
+        "FROM generate_series(1, 200) g"
+    )
+    await pg_008.execute("ANALYZE command_center.calls")
+
     plan = await _plan(
         pg_008,
-        "SELECT COUNT(*) FILTER (WHERE scored), COUNT(*) "
-        "FROM command_center.calls "
-        "WHERE team_id = 'sales' AND connected_at::date "
-        "BETWEEN '2026-01-01' AND '2026-12-31'",
+        "SELECT id, connected_at FROM command_center.calls "
+        "WHERE team_id = 'sales' AND scored = TRUE "
+        "AND connected_at > NOW() - INTERVAL '2 hours' "
+        "ORDER BY connected_at DESC LIMIT 20",
     )
     assert "idx_calls_team_scored_connected" in plan
 

--- a/qa-automation/AI-Scoring/tests/integration/test_migration_009.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_migration_009.py
@@ -1,0 +1,929 @@
+"""Tests for migration 009 — VP review additions (2026-06-24).
+
+Per SQLMigration.md §11.5 floor:
+  - ≥1 CHECK test per declared CHECK
+  - ≥1 UPSERT-idempotency test per UNIQUE conflict target
+  - State-machine transitions for `qa.coachings.status` and the
+    `scoring_status` extension on `qa.evaluations`
+  - CHECK pair-invariant tests (§3.4.3 v1.2 + §3.17 completion pair)
+  - M:N cardinality tests (one coaching → many evals; one eval → many coachings)
+  - EXPLAIN-plan for the new partial index
+
+Plus a migration-mechanism test that asserts the down script restores
+the original `scoring_status` CHECK constraint (§3.14 — failing loud
+when a flagged_human_review row would block the rollback is the
+correct behavior).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from database import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+UP_004 = (MIGRATIONS_DIR / "004_create_schemas_and_teams.sql").read_text()
+UP_005 = (MIGRATIONS_DIR / "005_command_center_tables.sql").read_text()
+UP_006 = (MIGRATIONS_DIR / "006_qa_tables.sql").read_text()
+UP_009 = (MIGRATIONS_DIR / "009_vp_review_additions.sql").read_text()
+DOWN_009 = (MIGRATIONS_DIR / "009_vp_review_additions_down.sql").read_text()
+
+
+@pytest_asyncio.fixture
+async def pg_009(clean_pg: asyncpg.Connection) -> asyncpg.Connection:
+    """clean_pg + 004 + 005 + 006 + 009. Skips 007/008 — independent."""
+    await clean_pg.execute(UP_004)
+    await clean_pg.execute(UP_005)
+    await clean_pg.execute(UP_006)
+    await clean_pg.execute(UP_009)
+    return clean_pg
+
+
+_MODELS = '{"text": {"provider": "gemini", "model": "gemini-2.5-flash"}}'
+
+
+async def _make_eval(conn: asyncpg.Connection, dialpad_call_id: str | None = None) -> int:
+    """Insert a draft evaluation; return its id. Optional unique id to
+    avoid the (team_id, dialpad_call_id) partial UNIQUE colliding when
+    a test needs more than one eval."""
+    if dialpad_call_id is None:
+        return await conn.fetchval(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', $1::jsonb) RETURNING id",
+            _MODELS,
+        )
+    return await conn.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, dialpad_call_id, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+        dialpad_call_id, _MODELS,
+    )
+
+
+async def _make_agent(conn: asyncpg.Connection, name: str = "Alpha Rep") -> int:
+    return await conn.fetchval(
+        "INSERT INTO qa.agents (team_id, name, email) "
+        "VALUES ('sales', $1, 'a@l.com') RETURNING id",
+        name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — v1.2 column ALTERs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_coaching_accepts_y_n_null(pg_009: asyncpg.Connection) -> None:
+    """All three valid values pass."""
+    for val in ("Y", "N", None):
+        eid = await pg_009.fetchval(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, needs_coaching, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+            val, _MODELS,
+        )
+        assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_needs_coaching_rejects_other(pg_009: asyncpg.Connection) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, needs_coaching, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'maybe', $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_action_plan_accepts_text_and_null(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await pg_009.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, action_plan, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+        "Practice greeting cadence; review SOP step 3.", _MODELS,
+    )
+    assert eid is not None
+    val = await pg_009.fetchval(
+        "SELECT action_plan FROM qa.evaluations WHERE id = $1", eid
+    )
+    assert "SOP step 3" in val
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — human_review pair invariant (§3.4.3 v1.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_review_pair_blocks_completed_without_required(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Setting `human_review_completed_at` without `human_review_required_at`
+    is nonsensical (you can't complete a review that was never started)."""
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, "
+            " human_review_completed_at, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', NOW(), $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_human_review_pair_allows_required_alone(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """A flagged eval awaiting review has required_at but no completed_at."""
+    eid = await pg_009.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, scoring_status, "
+        " human_review_required_at, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', 'flagged_human_review', "
+        " NOW(), $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+    assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_human_review_pair_allows_both_set(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """After a human reviewer finishes, both timestamps are populated."""
+    eid = await pg_009.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, scoring_status, "
+        " human_review_required_at, human_review_completed_at, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', 'complete', "
+        " NOW() - INTERVAL '10 minutes', NOW(), $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+    assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_human_review_pair_allows_both_null(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """The trigger never fired — both timestamps stay NULL."""
+    eid = await _make_eval(pg_009)
+    pair = await pg_009.fetchrow(
+        "SELECT human_review_required_at, human_review_completed_at "
+        "FROM qa.evaluations WHERE id = $1", eid
+    )
+    assert pair["human_review_required_at"] is None
+    assert pair["human_review_completed_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluations — extended scoring_status CHECK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scoring_status_accepts_flagged_human_review(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await pg_009.fetchval(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, scoring_status, "
+        " human_review_required_at, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', 'flagged_human_review', "
+        " NOW(), $1::jsonb) RETURNING id",
+        _MODELS,
+    )
+    assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_scoring_status_accepts_all_pre_v1_2_values(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Re-asserting the extended CHECK didn't accidentally drop any
+    pre-existing value."""
+    for val in ('complete', 'flagged_long_call', 'errored',
+                'landgpt_unavailable_routed_to_gemini'):
+        eid = await pg_009.fetchval(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, scoring_status, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', $1, $2::jsonb) RETURNING id",
+            val, _MODELS,
+        )
+        assert eid is not None
+
+
+@pytest.mark.asyncio
+async def test_scoring_status_check_still_rejects_unknown(
+    pg_009: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, scoring_status, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'wat_is_this', $1::jsonb)",
+            _MODELS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.tags — UNIQUE slug + seed + active default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tags_slug_unique(pg_009: asyncpg.Connection) -> None:
+    """Seed already inserted `sop`; re-inserting must collide."""
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.tags (slug, category, label) "
+            "VALUES ('sop', 'human_review_focus', 'SOP Duplicate')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tags_seed_has_four_human_review_focus_tags(
+    pg_009: asyncpg.Connection,
+) -> None:
+    rows = await pg_009.fetch(
+        "SELECT slug, label FROM qa.tags "
+        "WHERE category = 'human_review_focus' ORDER BY slug"
+    )
+    slugs = [(r["slug"], r["label"]) for r in rows]
+    assert slugs == [
+        ("efficiency", "Efficiency"),
+        ("hard_skills", "Hard Skills"),
+        ("soft_skills", "Soft Skills"),
+        ("sop", "SOP"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tags_active_defaults_true(pg_009: asyncpg.Connection) -> None:
+    """The seed didn't specify `active`; the column default kicks in."""
+    rows = await pg_009.fetch(
+        "SELECT active FROM qa.tags WHERE category = 'human_review_focus'"
+    )
+    assert all(r["active"] is True for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_tags_seed_idempotent_on_conflict(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """ON CONFLICT (slug) DO NOTHING — re-applying the seed line doesn't
+    duplicate or error."""
+    await pg_009.execute(
+        "INSERT INTO qa.tags (slug, category, label) VALUES "
+        "    ('sop',          'human_review_focus', 'SOP-redup'), "
+        "    ('soft_skills',  'human_review_focus', 'Soft-redup'), "
+        "    ('hard_skills',  'human_review_focus', 'Hard-redup'), "
+        "    ('efficiency',   'human_review_focus', 'Eff-redup') "
+        "ON CONFLICT (slug) DO NOTHING"
+    )
+    # Still exactly the 4 original seed rows.
+    n = await pg_009.fetchval(
+        "SELECT COUNT(*) FROM qa.tags WHERE category = 'human_review_focus'"
+    )
+    assert n == 4
+    # Original label preserved (DO NOTHING didn't overwrite).
+    sop_label = await pg_009.fetchval(
+        "SELECT label FROM qa.tags WHERE slug = 'sop'"
+    )
+    assert sop_label == "SOP"
+
+
+# ---------------------------------------------------------------------------
+# qa.evaluation_tags — CHECKs + UNIQUE + provenance coexistence
+# ---------------------------------------------------------------------------
+
+
+async def _tag_id(conn: asyncpg.Connection, slug: str) -> int:
+    return await conn.fetchval(
+        "SELECT id FROM qa.tags WHERE slug = $1", slug
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_source_check_rejects_unknown(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_009)
+    tid = await _tag_id(pg_009, "sop")
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluation_tags "
+            "(evaluation_id, tag_id, source) VALUES ($1, $2, 'bogus_source')",
+            eid, tid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_source_check_accepts_all_three(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_009)
+    tid = await _tag_id(pg_009, "sop")
+    for source in ("manager", "ai", "auto"):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluation_tags "
+            "(evaluation_id, tag_id, source) VALUES ($1, $2, $3)",
+            eid, tid, source,
+        )
+    assert (
+        await pg_009.fetchval(
+            "SELECT COUNT(*) FROM qa.evaluation_tags WHERE evaluation_id = $1",
+            eid,
+        )
+        == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_unique_per_eval_tag_source(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Same (eval, tag, source) triple → conflict. Different source → OK."""
+    eid = await _make_eval(pg_009)
+    tid = await _tag_id(pg_009, "sop")
+    await pg_009.execute(
+        "INSERT INTO qa.evaluation_tags (evaluation_id, tag_id, source, created_by) "
+        "VALUES ($1, $2, 'manager', 'm@l.com')",
+        eid, tid,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluation_tags (evaluation_id, tag_id, source) "
+            "VALUES ($1, $2, 'manager')",
+            eid, tid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_same_tag_different_sources_coexist(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Manager + AI both tag the same eval with the same tag — both rows
+    persist (agreement is information). Forward-compatible with §8.6."""
+    eid = await _make_eval(pg_009)
+    tid = await _tag_id(pg_009, "soft_skills")
+    await pg_009.execute(
+        "INSERT INTO qa.evaluation_tags (evaluation_id, tag_id, source, created_by) "
+        "VALUES ($1, $2, 'manager', 'm@l.com'), "
+        "       ($1, $2, 'ai',      NULL)",
+        eid, tid,
+    )
+    rows = await pg_009.fetch(
+        "SELECT source FROM qa.evaluation_tags WHERE evaluation_id = $1 "
+        "ORDER BY source",
+        eid,
+    )
+    assert [r["source"] for r in rows] == ["ai", "manager"]
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_cascade_on_eval_delete(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_009)
+    tid = await _tag_id(pg_009, "sop")
+    await pg_009.execute(
+        "INSERT INTO qa.evaluation_tags (evaluation_id, tag_id, source) "
+        "VALUES ($1, $2, 'manager')",
+        eid, tid,
+    )
+    await pg_009.execute("DELETE FROM qa.evaluations WHERE id = $1", eid)
+    assert (
+        await pg_009.fetchval(
+            "SELECT COUNT(*) FROM qa.evaluation_tags WHERE evaluation_id = $1",
+            eid,
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_tags_fk_blocks_unknown_tag(
+    pg_009: asyncpg.Connection,
+) -> None:
+    eid = await _make_eval(pg_009)
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluation_tags (evaluation_id, tag_id, source) "
+            "VALUES ($1, 999999, 'manager')",
+            eid,
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.coachings — CHECKs + completion pair invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coachings_conducted_by_role_rejects_unknown(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+            "VALUES ($1, 'sales', 'ceo')",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_conducted_by_role_accepts_all_four(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    for role in ("team_lead", "manager", "hr", "external"):
+        cid = await pg_009.fetchval(
+            "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+            "VALUES ($1, 'sales', $2) RETURNING id",
+            aid, role,
+        )
+        assert cid is not None
+
+
+@pytest.mark.asyncio
+async def test_coachings_status_check(pg_009: asyncpg.Connection) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings "
+            "(agent_id, team_id, conducted_by_role, status) "
+            "VALUES ($1, 'sales', 'manager', 'archived')",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_agent_attitude_rejects_unknown(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings "
+            "(agent_id, team_id, conducted_by_role, agent_attitude) "
+            "VALUES ($1, 'sales', 'manager', 'angry')",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_agent_attitude_accepts_all_six(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    for attitude in ("receptive", "engaged", "neutral",
+                     "defensive", "dismissive", "mixed"):
+        cid = await pg_009.fetchval(
+            "INSERT INTO qa.coachings "
+            "(agent_id, team_id, conducted_by_role, agent_attitude) "
+            "VALUES ($1, 'sales', 'manager', $2) RETURNING id",
+            aid, attitude,
+        )
+        assert cid is not None
+
+
+@pytest.mark.asyncio
+async def test_coachings_attitude_allows_null(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Pending coachings don't have an attitude yet."""
+    aid = await _make_agent(pg_009)
+    cid = await pg_009.fetchval(
+        "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+        "VALUES ($1, 'sales', 'manager') RETURNING id",
+        aid,
+    )
+    attitude = await pg_009.fetchval(
+        "SELECT agent_attitude FROM qa.coachings WHERE id = $1", cid
+    )
+    assert attitude is None
+
+
+@pytest.mark.asyncio
+async def test_coachings_completion_pair_blocks_completed_without_summary(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings "
+            "(agent_id, team_id, conducted_by_role, status, "
+            " completed_at, completed_by) "
+            "VALUES ($1, 'sales', 'manager', 'completed', NOW(), 'm@l.com')",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_completion_pair_blocks_completed_without_completed_by(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings "
+            "(agent_id, team_id, conducted_by_role, status, "
+            " coaching_summary, completed_at) "
+            "VALUES ($1, 'sales', 'manager', 'completed', "
+            " 'discussed SOP step 3', NOW())",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_completed_with_all_three_succeeds(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    cid = await pg_009.fetchval(
+        "INSERT INTO qa.coachings "
+        "(agent_id, team_id, conducted_by_role, status, "
+        " coaching_summary, completed_at, completed_by, agent_attitude) "
+        "VALUES ($1, 'sales', 'manager', 'completed', "
+        " 'discussed SOP step 3; agent receptive', NOW(), 'm@l.com', 'receptive') "
+        "RETURNING id",
+        aid,
+    )
+    assert cid is not None
+
+
+@pytest.mark.asyncio
+async def test_coachings_pending_allows_null_summary(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """A pending coaching is created BEFORE the session; summary is NULL."""
+    aid = await _make_agent(pg_009)
+    cid = await pg_009.fetchval(
+        "INSERT INTO qa.coachings "
+        "(agent_id, team_id, conducted_by_role, action_plan, "
+        " action_plan_deadline) "
+        "VALUES ($1, 'sales', 'team_lead', "
+        " 'Listen to 3 model calls; demo SOP step 3', "
+        " NOW() + INTERVAL '7 days') RETURNING id",
+        aid,
+    )
+    assert cid is not None
+    row = await pg_009.fetchrow(
+        "SELECT status, coaching_summary, completed_at "
+        "FROM qa.coachings WHERE id = $1", cid,
+    )
+    assert row["status"] == "pending"
+    assert row["coaching_summary"] is None
+    assert row["completed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_coachings_team_id_fk_enforced(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+            "VALUES ($1, 'phantom_team', 'manager')",
+            aid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coachings_agent_id_fk_enforced(
+    pg_009: asyncpg.Connection,
+) -> None:
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+            "VALUES (999999, 'sales', 'manager')",
+        )
+
+
+# ---------------------------------------------------------------------------
+# qa.coachings — status state-machine transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coaching_pending_to_completed_transition(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    cid = await pg_009.fetchval(
+        "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+        "VALUES ($1, 'sales', 'manager') RETURNING id",
+        aid,
+    )
+    await pg_009.execute(
+        "UPDATE qa.coachings SET status='completed', "
+        " coaching_summary='went well', completed_at=NOW(), "
+        " completed_by='m@l.com' WHERE id = $1",
+        cid,
+    )
+    status = await pg_009.fetchval(
+        "SELECT status FROM qa.coachings WHERE id = $1", cid
+    )
+    assert status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_coaching_pending_to_cancelled_transition(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Cancellation doesn't require summary/completed_at — completion pair
+    CHECK only fires for status='completed'."""
+    aid = await _make_agent(pg_009)
+    cid = await pg_009.fetchval(
+        "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+        "VALUES ($1, 'sales', 'team_lead') RETURNING id",
+        aid,
+    )
+    await pg_009.execute(
+        "UPDATE qa.coachings SET status='cancelled' WHERE id = $1", cid,
+    )
+    status = await pg_009.fetchval(
+        "SELECT status FROM qa.coachings WHERE id = $1", cid
+    )
+    assert status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# qa.coaching_evaluations — M:N semantics + cascade boundaries
+# ---------------------------------------------------------------------------
+
+
+async def _make_coaching(
+    conn: asyncpg.Connection, agent_id: int, role: str = "manager"
+) -> int:
+    return await conn.fetchval(
+        "INSERT INTO qa.coachings (agent_id, team_id, conducted_by_role) "
+        "VALUES ($1, 'sales', $2) RETURNING id",
+        agent_id, role,
+    )
+
+
+@pytest.mark.asyncio
+async def test_coaching_evals_unique_pair(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    cid = await _make_coaching(pg_009, aid)
+    eid = await _make_eval(pg_009)
+    await pg_009.execute(
+        "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+        "VALUES ($1, $2)",
+        cid, eid,
+    )
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+            "VALUES ($1, $2)",
+            cid, eid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_coaching_evals_cascade_on_coaching_delete(
+    pg_009: asyncpg.Connection,
+) -> None:
+    aid = await _make_agent(pg_009)
+    cid = await _make_coaching(pg_009, aid)
+    eid = await _make_eval(pg_009)
+    await pg_009.execute(
+        "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+        "VALUES ($1, $2)",
+        cid, eid,
+    )
+    await pg_009.execute("DELETE FROM qa.coachings WHERE id = $1", cid)
+    assert (
+        await pg_009.fetchval(
+            "SELECT COUNT(*) FROM qa.coaching_evaluations "
+            "WHERE coaching_id = $1", cid,
+        )
+        == 0
+    )
+    # The evaluation itself is untouched.
+    assert (
+        await pg_009.fetchval(
+            "SELECT COUNT(*) FROM qa.evaluations WHERE id = $1", eid
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_coaching_evals_fk_blocks_evaluation_delete(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """No CASCADE on evaluation_id — deleting an eval that's still linked
+    to a coaching must fail loudly (admin path explicitly handles)."""
+    aid = await _make_agent(pg_009)
+    cid = await _make_coaching(pg_009, aid)
+    eid = await _make_eval(pg_009)
+    await pg_009.execute(
+        "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+        "VALUES ($1, $2)",
+        cid, eid,
+    )
+    with pytest.raises(asyncpg.exceptions.ForeignKeyViolationError):
+        await pg_009.execute("DELETE FROM qa.evaluations WHERE id = $1", eid)
+
+
+@pytest.mark.asyncio
+async def test_one_coaching_covers_multiple_evals(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Manager reviews 3 calls in one sit-down — one coaching, three
+    join rows."""
+    aid = await _make_agent(pg_009)
+    cid = await _make_coaching(pg_009, aid)
+    eids = [await _make_eval(pg_009, f"call-{i}") for i in range(3)]
+    for eid in eids:
+        await pg_009.execute(
+            "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+            "VALUES ($1, $2)",
+            cid, eid,
+        )
+    assert (
+        await pg_009.fetchval(
+            "SELECT COUNT(*) FROM qa.coaching_evaluations WHERE coaching_id = $1",
+            cid,
+        )
+        == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_eval_appears_in_multiple_coachings(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """Escalation: TL → Manager → HR all coach on the same call. Three
+    coaching rows, three join rows on the same eval."""
+    aid = await _make_agent(pg_009)
+    cid_tl = await _make_coaching(pg_009, aid, "team_lead")
+    cid_mgr = await _make_coaching(pg_009, aid, "manager")
+    cid_hr = await _make_coaching(pg_009, aid, "hr")
+    eid = await _make_eval(pg_009)
+    for cid in (cid_tl, cid_mgr, cid_hr):
+        await pg_009.execute(
+            "INSERT INTO qa.coaching_evaluations (coaching_id, evaluation_id) "
+            "VALUES ($1, $2)",
+            cid, eid,
+        )
+    rows = await pg_009.fetch(
+        "SELECT c.conducted_by_role FROM qa.coaching_evaluations ce "
+        "JOIN qa.coachings c ON c.id = ce.coaching_id "
+        "WHERE ce.evaluation_id = $1 ORDER BY c.conducted_by_role",
+        eid,
+    )
+    assert [r["conducted_by_role"] for r in rows] == ["hr", "manager", "team_lead"]
+
+
+# ---------------------------------------------------------------------------
+# EXPLAIN-plan — partial human-review queue index
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idx_eval_human_review_queue_used_by_queue_read(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """The queue read: "evals waiting for human review, by team, oldest
+    first" — should use the partial index."""
+    await pg_009.execute("SET enable_seqscan = OFF")
+    rows = await pg_009.fetch(
+        "EXPLAIN SELECT id, human_review_required_at FROM qa.evaluations "
+        "WHERE state = 'draft' AND scoring_status = 'flagged_human_review' "
+        "AND team_id = 'sales' ORDER BY human_review_required_at"
+    )
+    plan = "\n".join(r["QUERY PLAN"] for r in rows)
+    assert "idx_eval_human_review_queue" in plan
+
+
+# ---------------------------------------------------------------------------
+# Down — drops every v1.2 artifact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_v1_2_tables(
+    pg_009: asyncpg.Connection,
+) -> None:
+    await pg_009.execute(DOWN_009)
+    for table in ("qa.tags", "qa.evaluation_tags",
+                  "qa.coachings", "qa.coaching_evaluations"):
+        assert await pg_009.fetchval(f"SELECT to_regclass('{table}')") is None
+
+
+@pytest.mark.asyncio
+async def test_down_removes_v1_2_columns_on_evaluations(
+    pg_009: asyncpg.Connection,
+) -> None:
+    await pg_009.execute(DOWN_009)
+    cols = await pg_009.fetch(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = 'qa' AND table_name = 'evaluations' "
+        "AND column_name IN ('needs_coaching', 'action_plan', "
+        " 'human_review_required_at', 'human_review_completed_at')"
+    )
+    assert cols == []
+
+
+@pytest.mark.asyncio
+async def test_down_restores_original_scoring_status_check(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """After down, the original (pre-v1.2) scoring_status CHECK is back —
+    so 'flagged_human_review' is no longer accepted."""
+    await pg_009.execute(DOWN_009)
+    with pytest.raises(asyncpg.exceptions.CheckViolationError):
+        await pg_009.execute(
+            "INSERT INTO qa.evaluations "
+            "(team_id, agent_name_raw, state, source, scoring_status, models_used) "
+            "VALUES ('sales', 'A', 'draft', 'ai', 'flagged_human_review', "
+            " $1::jsonb)",
+            _MODELS,
+        )
+
+
+@pytest.mark.asyncio
+async def test_down_fails_when_flagged_human_review_rows_exist(
+    pg_009: asyncpg.Connection,
+) -> None:
+    """If any row still carries the new scoring_status value when down
+    runs, the ADD CONSTRAINT validation fails. By design — the operator
+    must clear or migrate those rows manually before rolling back."""
+    await pg_009.execute(
+        "INSERT INTO qa.evaluations "
+        "(team_id, agent_name_raw, state, source, scoring_status, "
+        " human_review_required_at, models_used) "
+        "VALUES ('sales', 'A', 'draft', 'ai', 'flagged_human_review', "
+        " NOW(), $1::jsonb)",
+        _MODELS,
+    )
+    with pytest.raises(asyncpg.PostgresError):
+        await pg_009.execute(DOWN_009)
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — full chain 004 → 009
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_applies_004_005_006_009_in_sequence(
+    clean_pg: asyncpg.Connection, tmp_path: Path
+) -> None:
+    import shutil
+    migdir = tmp_path / "migrations"
+    migdir.mkdir()
+    for name in [
+        "004_create_schemas_and_teams.sql",
+        "004_create_schemas_and_teams_down.sql",
+        "005_command_center_tables.sql",
+        "005_command_center_tables_down.sql",
+        "006_qa_tables.sql",
+        "006_qa_tables_down.sql",
+        "009_vp_review_additions.sql",
+        "009_vp_review_additions_down.sql",
+    ]:
+        shutil.copy(MIGRATIONS_DIR / name, migdir)
+
+    rc = await runner.cmd_up(clean_pg, migrations_dir=migdir)
+    assert rc == 0
+    applied = await clean_pg.fetch(
+        "SELECT version FROM public.schema_migrations ORDER BY version"
+    )
+    assert [r["version"] for r in applied] == [4, 5, 6, 9]
+
+    # Smoke: the seed tags exist + new evaluations column is queryable.
+    n_tags = await clean_pg.fetchval(
+        "SELECT COUNT(*) FROM qa.tags WHERE category = 'human_review_focus'"
+    )
+    assert n_tags == 4
+    needs_coaching = await clean_pg.fetchval(
+        "SELECT needs_coaching FROM qa.evaluations LIMIT 1"
+    )
+    assert needs_coaching is None  # no rows yet — column accessible
+
+    # Down only 009 — qa.tags/coachings gone, qa.evaluations stays.
+    rc = await runner.cmd_down(clean_pg)
+    assert rc == 0
+    assert await clean_pg.fetchval("SELECT to_regclass('qa.tags')") is None
+    assert await clean_pg.fetchval("SELECT to_regclass('qa.evaluations')") is not None

--- a/qa-automation/AI-Scoring/tests/integration/test_runner.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_runner.py
@@ -184,8 +184,10 @@ async def test_down_refuses_irreversible_migration(
 ) -> None:
     migdir = tmp_path / "migrations"
     migdir.mkdir()
-    (migdir / "100_no_down.sql").write_text("CREATE TABLE public.x (id INT);")
-    # No _down.sql — irreversible.
+    # NOTE: do NOT name this `100_no_down.sql` — the `_down` suffix is
+    # reserved by the down-file convention and the runner's parser would
+    # treat it as the down companion of a non-existent `100_no.sql`.
+    (migdir / "100_irreversible.sql").write_text("CREATE TABLE public.x (id INT);")
 
     await runner.cmd_up(clean_pg, migrations_dir=migdir)
     rc = await runner.cmd_down(clean_pg)

--- a/qa-automation/AI-Scoring/tests/integration/test_scaffolding.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_scaffolding.py
@@ -11,10 +11,20 @@ the fixture isolation is caught at PR time.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import asyncpg
 import pytest
 
-from conftest import EPSILON, load_overall_formula
+# conftest.py is loaded by pytest but not importable by name. Add this
+# directory to sys.path so we can `import conftest` like a regular module.
+_INTEGRATION_DIR = Path(__file__).resolve().parent
+if str(_INTEGRATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_INTEGRATION_DIR))
+
+import conftest as _conftest  # noqa: E402
+from conftest import EPSILON, load_overall_formula  # noqa: E402
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements SQLMigration v1.2 schema additions per the 2026-06-24 Ops VP review.

- **ALTER `qa.evaluations`**: + `needs_coaching` ('Y'/'N'/NULL CHECK), + `action_plan` (evaluator's initial proposal), + `human_review_required_at` / `human_review_completed_at` (pair invariant — can't complete without required), extends `scoring_status` CHECK to include `'flagged_human_review'`.
- **`qa.tags`** + **`qa.evaluation_tags`**: seeds 4 human-review-focus tags (`sop`, `soft_skills`, `hard_skills`, `efficiency`). M:N with source provenance (`manager`/`ai`/`auto`). `UNIQUE (evaluation_id, tag_id, source)` so manager+AI tagging the same eval coexist as distinct rows — agreement is information for §8.6.
- **`qa.coachings`**: `conducted_by_role` enum (team_lead/manager/hr/external), `status` enum, `agent_attitude` 6-value enum, completion pair CHECK.
- **`qa.coaching_evaluations`**: M:N with opportunities_snapshot. CASCADE on coaching_id; FK without CASCADE on evaluation_id (admin-delete must handle orphans explicitly).
- **7 new indexes**: human-review queue partial (drives §3.14), per-tag-source lookup (for §8.6 agreement analytics), coachings pending queue, per-agent coaching history, per-eval "coached N times" badge, etc.

## Tests
45 new tests at `tests/integration/test_migration_009.py`. Coverage per §11.5:

- ≥1 CHECK test per declared CHECK (positive + negative): needs_coaching, conducted_by_role, status, agent_attitude, source, scoring_status extension.
- ≥1 UNIQUE-conflict test per UNIQUE: tags.slug, evaluation_tags triple, coaching_evals pair.
- Pair invariants: human_review pair (4 cases — NULL, required-alone, both-set, completed-without-required), coachings completion pair (blocks completion without summary OR without completed_by).
- State-machine transitions: pending → completed and pending → cancelled on coachings; flagged_human_review extension on evaluations.
- M:N cardinality: one coaching covers multiple evals; one eval appears in multiple coachings (TL→Manager→HR escalation).
- Cascade boundaries: CASCADE on coaching delete; FK violation on eval delete with active links.
- EXPLAIN-plan: idx_eval_human_review_queue used by the queue-read query shape.
- Down tests: drops all v1.2 artifacts; restores original scoring_status CHECK; **fails loud when flagged_human_review rows still exist** (by design — see SQL comment).
- Runner integration: 004 → 005 → 006 → 009 in sequence; partial rollback of 009 leaves 006 intact.

**181/181** integration tests pass locally in ~12s.

## Bonus: test-scaffolding fixes folded in
The integration suite was broken on `main` (`parents[3]` returned `qa-automation/`, so `from database import runner` failed). My fixes from PR #57 didn't reach main during merge — I re-applied them here as part of 009's test-validation pass:

- `conftest.py`: `_find_repo_root()` walker instead of fragile `parents[3]`
- `test_migration_004-008.py`: `parents[3]` → `parents[4]`
- `test_migration_005.py`: datetime objects, not string timestamps
- `test_migration_007.py`: distinct version_tags per language
- `test_migration_008.py`: populated EXPLAIN data + unambiguous query shape
- `test_runner.py`: `100_irreversible.sql` (`_down` suffix is reserved)
- `test_scaffolding.py`: `sys.path` add for `import conftest`

## Test plan
- [ ] `make test-integration` — 181 tests should pass in ~12s
- [ ] Confirm seed list matches Q5b lock (sop / soft_skills / hard_skills / efficiency)
- [ ] Spot-check that `idx_eval_human_review_queue` partial WHERE matches the queue endpoint's WHERE
- [ ] Spec doc v1.2 lives at `database/SQLMigration.md` §3.14–§3.18 + §8.6

## What's next
After this merges, we resume Step 4 — apply 004 → 009 to Railway:
1. `make migrate-status` — read-only sanity (the runner already added the y/N prompt for mutating commands; needs `--yes` to bypass)
2. `make migrate-bootstrap` — register 001/002 as applied
3. `make migrate` — apply 004 → 009 (each prompts y/N; backup already taken)
4. Decommission `qa_scoring` (the original 003 stub schema) separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)