### PR TITLE
feat(database): runner confirmation prompt + _down naming convention doc

### DIFF
--- a/database/runner.py
+++ b/database/runner.py
@@ -8,13 +8,27 @@ time, so rollback survives later deletion of the ``_down.sql`` file.
 CLI::
 
     python -m database.runner status
-    python -m database.runner up [--limit N]
-    python -m database.runner down [--limit N]    # default 1
-    python -m database.runner bootstrap
+    python -m database.runner up [--limit N] [--yes]
+    python -m database.runner down [--limit N] [--yes]    # default --limit 1
+    python -m database.runner bootstrap [--yes]
 
 ``DATABASE_URL`` env var carries the connection string. The ``bootstrap``
 command registers migrations that were applied via raw psql before this
 runner existed (currently 001 and 002 — the mass_notifications schema).
+
+Mutating commands (``up`` / ``down`` / ``bootstrap``) prompt for
+confirmation before doing work, showing the redacted target DSN.
+``--yes`` (or ``-y``) skips the prompt for scripted / CI use. If stdin
+is not a TTY and ``--yes`` wasn't passed, the runner refuses without
+prompting — protects against piped or cron contexts silently mutating
+the production database.
+
+Naming convention
+-----------------
+The ``_down`` suffix is reserved by the down-file convention. A migration
+file named e.g. ``104_callback_down.sql`` is ambiguous — the parser will
+treat it as the down companion of a non-existent ``104_callback.sql`` and
+the migration won't be applied. Pick names that don't end in ``_down``.
 """
 
 from __future__ import annotations
@@ -269,6 +283,46 @@ async def cmd_bootstrap(conn: asyncpg.Connection) -> int:
 # ---------------------------------------------------------------------------
 
 
+# Matches the password portion of `postgresql://user:pass@host/db` etc.
+_DSN_PASSWORD_RE = re.compile(r"(://[^:/@]+:)[^@]*(@)")
+
+
+def _redact_dsn(dsn: str) -> str:
+    """Replace the password in postgres://user:pass@host/db with ``***``.
+
+    Leaves user, host, port, and database visible so the operator can
+    verify they're targeting the right database before confirming a
+    mutating command.
+    """
+    return _DSN_PASSWORD_RE.sub(r"\1***\2", dsn)
+
+
+def _confirm(action: str, dsn: str, *, yes: bool) -> bool:
+    """Ask the operator to confirm a state-mutating action.
+
+    Returns True iff the operator typed ``y`` / ``yes`` (case-insensitive)
+    or ``yes=True`` was passed (i.e. ``--yes`` on the CLI). If stdin is
+    not a TTY and ``yes=False``, refuses without prompting so we don't
+    silently proceed under cron / CI.
+    """
+    if yes:
+        return True
+    print(f"About to: {action}", file=sys.stderr)
+    print(f"Target:   {_redact_dsn(dsn)}", file=sys.stderr)
+    if not sys.stdin.isatty():
+        print(
+            "ERROR: stdin is not a TTY; pass --yes (or -y) to confirm.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        response = input("Continue? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.", file=sys.stderr)
+        return False
+    return response in ("y", "yes")
+
+
 def _make_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="database.runner",
@@ -288,6 +342,11 @@ def _make_parser() -> argparse.ArgumentParser:
         default=None,
         help="Apply at most N pending migrations.",
     )
+    up.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
 
     down = sub.add_parser("down", help="Roll back the most-recent migration(s).")
     down.add_argument(
@@ -296,10 +355,20 @@ def _make_parser() -> argparse.ArgumentParser:
         default=1,
         help="Roll back N migrations (default 1).",
     )
+    down.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
 
-    sub.add_parser(
+    boot = sub.add_parser(
         "bootstrap",
         help="Register pre-runner migrations (001, 002) as applied without running them.",
+    )
+    boot.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip the confirmation prompt.",
     )
 
     return p
@@ -310,6 +379,23 @@ async def main_async(args: argparse.Namespace) -> int:
     if not dsn:
         print("ERROR: DATABASE_URL not set in environment.", file=sys.stderr)
         return 1
+
+    # Mutating commands: show what we're about to do and prompt for y/N.
+    if args.command in ("up", "down", "bootstrap"):
+        action = {
+            "up": (
+                f"apply pending migrations (limit={args.limit})"
+                if args.limit is not None else "apply ALL pending migrations"
+            ),
+            "down": f"roll back the {args.limit} most-recent migration(s)",
+            "bootstrap": (
+                "register pre-runner migrations as applied "
+                f"({', '.join(f'{v:03d}' for v in PREEXISTING_VERSIONS)})"
+            ),
+        }[args.command]
+        if not _confirm(action, dsn, yes=getattr(args, "yes", False)):
+            print("Aborted.", file=sys.stderr)
+            return 1
 
     conn = await asyncpg.connect(dsn)
     try:

--- a/qa-automation/AI-Scoring/tests/test_runner_confirm.py
+++ b/qa-automation/AI-Scoring/tests/test_runner_confirm.py
@@ -1,0 +1,203 @@
+"""Unit tests for ``database/runner.py`` confirmation prompt + DSN
+redaction. These don't need Docker — they exercise the pure-function
+helpers and argparse plumbing directly.
+
+The full integration suite at ``tests/integration/`` tests the runner's
+DB behavior end-to-end; this file targets the operator-facing safety
+gate added in the follow-up PR.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Make ``database.runner`` importable. Walk up to the repo root via the
+# database/migrations/ ancestor — robust against tree restructuring.
+def _find_repo_root() -> Path:
+    p = Path(__file__).resolve()
+    while p.parent != p:
+        if (p / "database" / "migrations").is_dir():
+            return p
+        p = p.parent
+    raise RuntimeError("Could not locate repo root (no database/migrations/ ancestor)")
+
+
+_REPO_ROOT = _find_repo_root()
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+from database import runner  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _redact_dsn — strip the password but leave everything else readable
+# ---------------------------------------------------------------------------
+
+
+def test_redact_dsn_replaces_password() -> None:
+    dsn = "postgresql://user:supersecret@host.railway.app:5432/railway"
+    redacted = runner._redact_dsn(dsn)
+    assert redacted == "postgresql://user:***@host.railway.app:5432/railway"
+
+
+def test_redact_dsn_handles_no_password() -> None:
+    """A DSN without a `:password@` segment should pass through unchanged."""
+    dsn = "postgresql://localhost:5432/db"
+    assert runner._redact_dsn(dsn) == dsn
+
+
+def test_redact_dsn_handles_complex_password() -> None:
+    """Passwords with URL-encoded special chars (but no `@`) should still
+    be redacted cleanly."""
+    dsn = "postgresql://admin:p%40ss%21word@host:5432/db"
+    redacted = runner._redact_dsn(dsn)
+    assert "p%40ss" not in redacted
+    assert "***" in redacted
+    assert "admin" in redacted
+    assert "host:5432/db" in redacted
+
+
+def test_redact_dsn_does_not_leak_password_in_logs() -> None:
+    """The contract: never include the literal password in the redacted
+    string. Defense-in-depth assertion for the "show DSN in prompt"
+    code path."""
+    dsn = "postgres://u:my_uniq_secret_4242@h/d"
+    assert "my_uniq_secret_4242" not in runner._redact_dsn(dsn)
+
+
+# ---------------------------------------------------------------------------
+# _confirm — yes flag, TTY check, y/N parsing
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_returns_true_when_yes_flag_set() -> None:
+    """`--yes` bypasses the prompt entirely. No TTY check, no stdin read."""
+    assert runner._confirm("apply migrations", "postgres://u:p@h/d", yes=True) is True
+
+
+def test_confirm_returns_false_when_not_tty_and_no_yes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """In a non-TTY (pipe / cron / CI), refuse without prompting.
+    Prevents silent mutations when the operator didn't pass --yes."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    rc = runner._confirm("apply migrations", "postgres://u:p@h/d", yes=False)
+    assert rc is False
+    captured = capsys.readouterr()
+    assert "TTY" in captured.err or "tty" in captured.err.lower()
+
+
+def test_confirm_accepts_lowercase_y(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is True
+
+
+def test_confirm_accepts_yes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "YES")
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is True
+
+
+def test_confirm_rejects_n(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is False
+
+
+def test_confirm_rejects_empty_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty (just Enter) is treated as N. The prompt says [y/N] — N
+    is the default."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is False
+
+
+def test_confirm_rejects_anything_other_than_y_or_yes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "go")
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is False
+
+
+def test_confirm_handles_keyboard_interrupt_as_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_prompt: str) -> str:
+        raise KeyboardInterrupt
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", _raise)
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is False
+
+
+def test_confirm_handles_eof_as_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_prompt: str) -> str:
+        raise EOFError
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", _raise)
+    assert runner._confirm("X", "postgres://u:p@h/d", yes=False) is False
+
+
+def test_confirm_prompt_shows_redacted_dsn(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """The whole point — operators see the target DB but not the password."""
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    runner._confirm("apply migrations",
+                    "postgresql://u:supersecret@prod.railway.app:5432/db",
+                    yes=False)
+    captured = capsys.readouterr()
+    assert "***" in captured.err
+    assert "prod.railway.app" in captured.err
+    assert "supersecret" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# argparse — --yes / -y are accepted on every mutating subcommand
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["up", "--yes"],
+        ["up", "-y"],
+        ["up", "--limit", "2", "-y"],
+        ["down", "--yes"],
+        ["down", "-y"],
+        ["down", "--limit", "3", "--yes"],
+        ["bootstrap", "--yes"],
+        ["bootstrap", "-y"],
+    ],
+)
+def test_parser_accepts_yes_on_mutating_subcommands(argv: list[str]) -> None:
+    parser = runner._make_parser()
+    args = parser.parse_args(argv)
+    assert getattr(args, "yes", False) is True
+
+
+def test_parser_yes_defaults_false_when_unspecified() -> None:
+    parser = runner._make_parser()
+    args = parser.parse_args(["up"])
+    assert getattr(args, "yes", False) is False
+
+
+def test_status_does_not_carry_yes_flag() -> None:
+    """``status`` is read-only — no confirmation needed, no --yes flag.
+    Passing --yes to status should be a parse error."""
+    parser = runner._make_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["status", "--yes"])


### PR DESCRIPTION
## Summary
Adds a y/N confirmation prompt to mutating runner commands. Pre-Step-4 safety upgrade — operators see what they're about to do and which database they're targeting before any DDL lands.

- **Prompt shape:** Action label (e.g. *"apply ALL pending migrations"*) + redacted DSN (*"postgresql://user:***@host.railway.app:5432/db"*) + `Continue? [y/N]`. Accepts `y` / `yes` (case-insensitive); anything else aborts.
- **`--yes` / `-y` bypasses** for scripted / CI use. Added to `up`, `down`, `bootstrap`. `status` stays read-only — passing `--yes` to status is a parse error by design.
- **Non-TTY hard-fail:** when stdin is not a TTY and `--yes` wasn't passed, the runner refuses without prompting. Protects against piped / cron contexts silently mutating production.
- **DSN redaction:** strips the password between `://user:` and `@host`. Defense-in-depth test asserts the literal password is never substring-included in the redacted output.
- **`_down` suffix docstring:** documents that the suffix is reserved by the down-file naming convention. A file like `104_callback_down.sql` would be ambiguous and silently skipped — the note steers future operators away from that footgun.

## What stays unchanged
- `cmd_up` / `cmd_down` / `cmd_bootstrap` signatures — the prompt lives at the CLI boundary (`main_async`), so existing integration tests calling them directly aren't affected.
- The `status` command — read-only, no prompt.
- The schema_migrations table format.

## Tests
24 unit tests at `qa-automation/AI-Scoring/tests/test_runner_confirm.py` — **no Docker required**. Runs in ~0.04s. Covers:

- Password redaction (3 cases) + literal-leak defense-in-depth assertion
- `--yes` bypass
- Non-TTY refusal with stderr message
- `y` / `yes` / empty / `n` / arbitrary answer parsing
- `KeyboardInterrupt` and `EOFError` as abort
- End-to-end prompt-shows-redacted-DSN (not the password)
- Argparse: `--yes` / `-y` accepted on every mutating subcommand, rejected on `status`

## Test plan
- [ ] `pytest qa-automation/AI-Scoring/tests/test_runner_confirm.py -v` — 24 tests in <1s
- [ ] Manual smoke: `make migrate-status` (no prompt — read-only)
- [ ] Manual smoke: `make migrate` against a sandbox DB — prompt appears, redacted DSN visible, password not visible

## Sequencing
Independent of PR #62 (migration 009). Either order is fine for merging. Both wanted before Step 4 (Railway apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)