### PR TITLE
fix(database): bootstrap crashes with AttributeError on args.limit

### DIFF
--- a/database/runner.py
+++ b/database/runner.py
@@ -374,6 +374,30 @@ def _make_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _action_label(args: argparse.Namespace) -> str:
+    """Human-readable action label shown in the confirmation prompt.
+
+    Branches per subcommand so each path only references the args
+    attributes its own subparser declared. A dict literal here would
+    eagerly evaluate every entry (including ``args.limit`` on the
+    ``down`` entry), which crashed bootstrap — that subparser has no
+    ``--limit`` flag.
+    """
+    if args.command == "up":
+        return (
+            f"apply pending migrations (limit={args.limit})"
+            if args.limit is not None else "apply ALL pending migrations"
+        )
+    if args.command == "down":
+        return f"roll back the {args.limit} most-recent migration(s)"
+    if args.command == "bootstrap":
+        return (
+            "register pre-runner migrations as applied "
+            f"({', '.join(f'{v:03d}' for v in PREEXISTING_VERSIONS)})"
+        )
+    raise ValueError(f"unexpected mutating command: {args.command}")
+
+
 async def main_async(args: argparse.Namespace) -> int:
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
@@ -382,18 +406,8 @@ async def main_async(args: argparse.Namespace) -> int:
 
     # Mutating commands: show what we're about to do and prompt for y/N.
     if args.command in ("up", "down", "bootstrap"):
-        action = {
-            "up": (
-                f"apply pending migrations (limit={args.limit})"
-                if args.limit is not None else "apply ALL pending migrations"
-            ),
-            "down": f"roll back the {args.limit} most-recent migration(s)",
-            "bootstrap": (
-                "register pre-runner migrations as applied "
-                f"({', '.join(f'{v:03d}' for v in PREEXISTING_VERSIONS)})"
-            ),
-        }[args.command]
-        if not _confirm(action, dsn, yes=getattr(args, "yes", False)):
+        if not _confirm(_action_label(args), dsn,
+                        yes=getattr(args, "yes", False)):
             print("Aborted.", file=sys.stderr)
             return 1
 

--- a/qa-automation/AI-Scoring/tests/test_runner_confirm.py
+++ b/qa-automation/AI-Scoring/tests/test_runner_confirm.py
@@ -201,3 +201,67 @@ def test_status_does_not_carry_yes_flag() -> None:
     parser = runner._make_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["status", "--yes"])
+
+
+# ---------------------------------------------------------------------------
+# _action_label — per-subcommand label generation
+#
+# Regression layer for the bug shipped in the initial confirmation-prompt
+# PR: a dict literal in main_async eagerly evaluated args.limit for every
+# command, but the bootstrap subparser doesn't declare --limit. Computing
+# the label per command (if/elif) instead of via a dict keeps each branch
+# isolated. These tests instantiate args through the actual parser so we
+# catch any future drift between subparser flags and the label function.
+# ---------------------------------------------------------------------------
+
+
+def test_action_label_bootstrap_does_not_reference_limit() -> None:
+    """The regression. Bootstrap's args namespace has no `limit`; touching
+    it raises AttributeError. The label function MUST work with bare
+    bootstrap args."""
+    parser = runner._make_parser()
+    args = parser.parse_args(["bootstrap", "--yes"])
+    label = runner._action_label(args)
+    assert "register" in label
+    # Both pre-existing versions are mentioned in the label so the
+    # operator sees exactly what's about to be marked applied.
+    assert "001" in label
+    assert "002" in label
+
+
+def test_action_label_up_without_limit() -> None:
+    parser = runner._make_parser()
+    args = parser.parse_args(["up"])
+    assert runner._action_label(args) == "apply ALL pending migrations"
+
+
+def test_action_label_up_with_limit() -> None:
+    parser = runner._make_parser()
+    args = parser.parse_args(["up", "--limit", "2"])
+    label = runner._action_label(args)
+    assert "limit=2" in label
+
+
+def test_action_label_down_default_limit() -> None:
+    """`down` defaults --limit to 1. The label should reflect that."""
+    parser = runner._make_parser()
+    args = parser.parse_args(["down"])
+    label = runner._action_label(args)
+    assert "1 most-recent migration" in label
+
+
+def test_action_label_down_with_limit() -> None:
+    parser = runner._make_parser()
+    args = parser.parse_args(["down", "--limit", "3"])
+    label = runner._action_label(args)
+    assert "roll back the 3 most-recent" in label
+
+
+def test_action_label_rejects_status() -> None:
+    """`status` is read-only; the label function is only valid for
+    mutating commands. Defensive — caller (main_async) gates by command,
+    but tests of this invariant document the contract."""
+    import argparse
+    args = argparse.Namespace(command="status")
+    with pytest.raises(ValueError, match="unexpected mutating command"):
+        runner._action_label(args)


### PR DESCRIPTION
## Summary
Hotfix for a regression I shipped in PR #63. `make migrate-bootstrap` crashed with `AttributeError: 'Namespace' object has no attribute 'limit'` — the action-label dict in `main_async` eagerly evaluated `args.limit` for every key (including `down`), but the `bootstrap` subparser never declared `--limit`.

## Root cause
Python evaluates ALL dict literal values at construction. The dict:

```python
action = {
    "up":   f"...{args.limit}..." if args.limit is not None ...,
    "down": f"roll back the {args.limit} ...",
    "bootstrap": "register ...",
}[args.command]
```

…blows up on bootstrap because the `down` entry's f-string evaluates first.

## Fix
Extract per-command label into `_action_label(args)` using if/elif so each branch only touches the attributes its own subparser declared.

## Test gap closed
PR #63's unit tests covered argparse parsing and helpers in isolation but never exercised the `main_async` integration where the dict actually evaluates. Adding 6 regression tests at the unit level (no Docker):

- `test_action_label_bootstrap_does_not_reference_limit` ← the exact failure mode
- `test_action_label_up_without_limit` / `with_limit`
- `test_action_label_down_default_limit` / `with_limit`
- `test_action_label_rejects_status` ← documents that read-only commands shouldn't reach this path

**30/30 unit tests pass in ~0.09s.**

## Test plan
- [ ] `pytest qa-automation/AI-Scoring/tests/test_runner_confirm.py -v` — 30 tests in <1s
- [ ] After merge, `git pull` locally and re-run `make migrate-bootstrap` — should now show the y/N prompt instead of crashing

## Urgency
Blocking — this is what we hit live during Step 4 walkthrough. Once this lands, the Railway migration can resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)