### PR TITLE
docs(qa-automation): Wave 2 plan + team scoring migration specs

### DIFF
--- a/database/member_support_scoring_migration.md
+++ b/database/member_support_scoring_migration.md
@@ -1,0 +1,202 @@
+# Member Support — QA Scoring Migration Spec
+
+> Canonical specification for the `member_support_v1` scoring formula.
+> **Purpose:** decouple the QA scoring pipeline from Google Sheets-as-database and make the
+> **PostgreSQL engine the single owner of score production**. Scope is deliberately limited to the
+> agreed rubric sections, their initial weights, the scoring formula/rules, and triggers.
+
+| | |
+|---|---|
+| **Status** | Finalized (Ops VP sign-off) |
+| **Formula ID** | `member_support_v1` |
+| **Rubric version** | `v1` |
+| **Score scale** | 0–100 |
+| **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
+| **Last updated** | 2026-06-30 |
+
+---
+
+## 1. Purpose & Scope
+
+**In scope**
+- The 10 agreed rubric sections and their score types.
+- Initial/base weights and how weight is redistributed at runtime.
+- The scoring formula: normalization, the rule library, and deterministic evaluation order.
+- Escalation triggers.
+
+**Out of scope** (owned by other docs)
+- Ingestion / transport (Dialpad → pipeline), Command Center event wiring, dashboards.
+- Prompt engineering for the AI scorer.
+- Supervisor-review UI and scorecard fields.
+
+**Migration intent**
+Today scores are computed against Google Sheets acting as both config and store. This spec defines the
+formula precisely enough that the PostgreSQL engine can own score production end-to-end; Sheets becomes,
+at most, a read-only mirror.
+
+---
+
+## 2. Formula Metadata
+
+| Field | Value |
+|---|---|
+| `formula_id` | `member_support_v1` |
+| `rubric_version` | `v1` |
+| `scale` | 0–100 |
+| weight basis | percentage points summing to 100 |
+| team rule set | Member Support (scale ×0.5; hard-zero disabled) |
+
+---
+
+## 3. Rubric Sections
+
+Base weight is **canonical** (stored). The **Automated** weight is *derived at runtime* when
+`human_review_required = NA` (rule `hrr_na_spread`) and is shown for reference only — it is not stored.
+
+| # | key | Label | Score type | Weight (base) | Weight (automated)* | Trigger |
+|---|---|---|---|---|---|---|
+| 1 | `greeting` | Greeting | rating 1–5 | 5% | 6.11% | — |
+| 2 | `caller_id` | Caller ID (identity validation) | Y / N / NA | 5% | 6.11% | — |
+| 3 | `purpose` | Purpose of Call | rating 1–5 | 5% | 6.11% | — |
+| 4 | `matching` | Matching the Moment | rating 1–5 | 5% | 6.11% | candidate |
+| 5 | `process_adherence` | Process Adherence | rating 1–5 | 25% | 26.11% | **active** |
+| 6 | `call_resolution` | Call Resolution | rating 1–5 | 20% | 21.11% | **active** |
+| 7 | `comms` | Communication | rating 1–5 | 10% | 11.11% | — |
+| 8 | `efficiency` | Efficiency | rating 1–5 | 10% | 11.11% | candidate |
+| 9 | `human_review_required` | Human Review Required *(was "Documentation")* | rating 1–5 / NA | 10% | 0% *(NA default)* | — |
+| 10 | `cri` | Customer Resolution Indicator | Y / N | 5% | 6.11% | — |
+| | | **Total** | | **100%** | **100%** | |
+
+\* Automated column assumes the standard automated case (only `human_review_required = NA` → 9 active
+sections, +1.11 pts each). It differs when additional sections are NA (the spread is recomputed over the
+sections that remain active).
+
+---
+
+## 4. Score Normalization
+
+- **Rating (1–5):** `frac = (rating − 1) / 4` → `1 = 0.00, 2 = 0.25, 3 = 0.50, 4 = 0.75, 5 = 1.00`.
+- **Binary (Y/N):** `Y = 1.0`, `N = 0.0`.
+- **NA:** the section is not scored; its weight is redistributed by the applicable rule (never silently lost).
+- **Section contribution:** `weight_i × frac_i`.
+- **Raw score:** `Σ contributions` over active sections → 0–100, *before* any score-level scaling.
+
+---
+
+## 5. Formula Rules (Rule Library)
+
+Rules belong to a shared engine and are gated per team. For `member_support_v1`:
+
+| id | type | enabled | Condition | Effect |
+|---|---|---|---|---|
+| `hard_zero` | score_override | **false** | `caller_id = N` | Set final score = 0. *Retained for collections / billing / legal; OFF for Member Support.* |
+| `caller_id_na_transfer` | weight_transfer | true | `caller_id = NA` | Move all `caller_id` weight → `call_resolution`. |
+| `frequent_caller_shift` | weight_transfer | true | `frequent_caller` signal | Move a configurable share (**default 0.5**) of `call_resolution` weight → `process_adherence` (target selectable). Also biases `caller_id` scoring toward NA (prompt-level). |
+| `hrr_na_spread` | weight_redistribution | true | `human_review_required = NA` | Split its weight **equally (additive)** across the active scored sections: `+weight / N` each. |
+| `caller_id_scale_half` | score_scale | true | `caller_id = N` | Multiply final score × **0.5**. (Section also contributes 0 on its own slot.) |
+| `escalation_flag` | flag | true | `process_adherence` frac ≤ 0.5 **OR** `call_resolution` frac ≤ 0.5 | Emit `human_review_required` event; route to supervisor review. |
+
+**Notes**
+- `cri = N` needs **no rule**: binary normalization already gives it `0`, so it simply forfeits its weight. *(The former ×0.9 score-wide multiplier is deprecated.)*
+- `caller_id = N` and `caller_id = NA` are mutually exclusive branches.
+- The `frequent_caller` signal originates from a **Looker snapshot delivered via Command Center** (external dependency; see §8 `external_signals`).
+
+---
+
+## 6. Rule Evaluation Order (deterministic)
+
+The engine always applies steps in this order:
+
+1. `hard_zero` check — team-gated; no-op for Member Support
+2. `caller_id_na_transfer` — weight → resolution
+3. `frequent_caller_shift` — resolution → process
+4. `hrr_na_spread` — equal-additive spread
+5. **weighted sum** — `Σ(weight × frac)`
+6. `caller_id_scale_half` — × 0.5
+7. `escalation_flag` check — reads *raw* process/resolution ratings; independent of redistribution
+
+Weight-moving rules (2–4) reshape the rubric **before** the sum; the ×0.5 (6) applies **after** it; the
+flag (7) reads raw ratings, so redistribution never changes whether a call escalates.
+
+---
+
+## 7. Triggers
+
+- **Threshold:** a trigger section scoring **1–3** (`frac ≤ 0.50`, inclusive) escalates the call.
+- **Active triggers:** `process_adherence`, `call_resolution`.
+- **Candidate triggers** (under review, **not live**): `matching`, `efficiency`.
+- **Routes to:** `human_review_required` — the supervisor scores that section on review.
+
+---
+
+## 8. Canonical Config (machine-readable)
+
+```json
+{
+  "formula_id": "member_support_v1",
+  "rubric_version": "v1",
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "redistribute_per_rules"
+  },
+  "sections": [
+    { "key": "greeting",              "label": "Greeting",                      "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "caller_id",             "label": "Caller ID",                     "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "purpose",               "label": "Purpose of Call",               "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": "candidate" },
+    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": "active" },
+    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
+    { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
+    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
+    { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "default": "NA" },
+    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn",     "weight": 5.0,  "trigger": null }
+  ],
+  "rules": [
+    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; off for member_support_v1" },
+    { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
+    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true } },
+    { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
+    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.5 }, { "section": "call_resolution", "frac_lte": 0.5 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" } }
+  ],
+  "evaluation_order": [
+    "hard_zero",
+    "caller_id_na_transfer",
+    "frequent_caller_shift",
+    "hrr_na_spread",
+    "weighted_sum",
+    "caller_id_scale_half",
+    "escalation_flag"
+  ],
+  "triggers": {
+    "threshold": { "op": "lte", "frac": 0.5, "ratings": [1, 2, 3] },
+    "active": ["process_adherence", "call_resolution"],
+    "candidates": ["matching", "efficiency"],
+    "routes_to": "human_review_required"
+  },
+  "external_signals": {
+    "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
+  }
+}
+```
+
+---
+
+## 9. Migration Notes (Sheets → PostgreSQL)
+
+- Base weights and rule config move into PostgreSQL (suggested: `qa.formula`, `qa.formula_section`,
+  `qa.formula_rule`), versioned by `formula_id`.
+- Automated weights are **computed, not stored** (derived by `hrr_na_spread`).
+- The engine **emits** `human_review_required` events rather than writing review state back to Sheets.
+- Sheets is demoted to a read-only mirror (or retired) once score parity is verified against a hold-out set.
+
+---
+
+## 10. Open Decisions
+
+- [ ] Confirm whether `matching` / `efficiency` become **active** triggers or stay candidates.
+- [ ] Confirm `frequent_caller_shift` default fraction (0.5) and default target (`process_adherence`).
+- [ ] Confirm hard-zero stays globally available (enabled per team) vs. removed outright for Member Support.
+- [ ] Confirm the NA-spread behavior when **multiple** sections are NA (current: recompute equal-additive over remaining active sections).

--- a/database/sales_scoring_migration.md
+++ b/database/sales_scoring_migration.md
@@ -1,0 +1,283 @@
+# Sales — QA Scoring Migration Spec
+
+> Canonical specification for the Sales scoring formula. **Same purpose and format as the Member Support
+> spec** (`member_support_scoring_migration.md`): make the PostgreSQL engine the owner of score production.
+>
+> **Populated from `QA_Scoring_Guide.pdf`** (Sales QA — Revised 15-Point Matrix). Structure matches Member
+> Support 1:1. Two modeling decisions inherited from the PDF differ from Member Support and are flagged
+> throughout — read these before locking `sales_v1`:
+>
+> 1. **N/A awards full credit on-slot** (frac 1.0), *not* redistribution — the single biggest behavioral
+>    difference from Member Support. See §4.
+> 2. **The rating→points curve is assumed** `(rating − 1) / 4`. The PDF gives point values but not the
+>    curve; this reading is the one consistent with the binary "0 or full points" anchors. See §4 / §10.
+
+| | |
+|---|---|
+| **Status** | Rubric finalized (Sales QA — Revised 15-Point Matrix); spec **populated from source PDF**, pending confirmation on the §10 flagged items |
+| **Formula ID** | `sales_v1` *(proposed — confirm)* |
+| **Rubric version** | `v1` *(proposed)* |
+| **Score scale** | 0–100 (15 questions, 100 points) |
+| **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
+| **Last updated** | 2026-06-30 |
+
+---
+
+## 1. Purpose & Scope
+
+**In scope**
+- The 15 agreed rubric sections and their score types.
+- Base weights (point values, which double as percentage weights).
+- The scoring formula: normalization and deterministic evaluation order — *currently a plain weighted sum, no rules.*
+
+**Out of scope** (owned by other docs / sources)
+- Ingestion / transport (Dialpad → pipeline), Command Center event wiring, dashboards.
+- Prompt engineering for the AI scorer.
+- Supervisor-review UI and scorecard fields.
+- **Section descriptor prose** (the 0/1 and 1–5 level definitions) — owned by `QA_Scoring_Guide.pdf`, not duplicated here.
+
+**Migration intent** — identical to Member Support: define the formula precisely enough for the
+PostgreSQL engine to own score production end-to-end; retire Sheets-as-DB.
+
+> **Version note:** the source is labeled a *revised* matrix, which implies a prior Sales rubric. If a
+> prior **engine-owned** version exists, this is a rubric version change (sections added/deprecated), and
+> the migration must preserve the mapping between historical scores and the version that produced them.
+> The add/deprecate diff (§3a / §3b) **cannot be derived from the new PDF alone** — it needs the prior
+> rubric. If `sales_v1` is the first engine-owned version, §3a / §3b are simply empty.
+
+---
+
+## 2. Formula Metadata
+
+| Field | Value |
+|---|---|
+| `formula_id` | `sales_v1` &nbsp; *(proposed — confirm)* |
+| `rubric_version` | `v1` &nbsp; *(proposed)* |
+| `supersedes` | `null` &nbsp; *(confirm — see §10)* |
+| `scale` | 0–100 (15 questions, 100 points) |
+| weight basis | points ≡ percentage points; sum = 100 |
+| **NA policy** | **full credit on-slot** (frac 1.0, **no redistribution**) — differs from Member Support |
+| special rules | **none** — reserved for future |
+
+---
+
+## 3. Rubric Sections
+
+15 sections. Weight = the PDF's point value; since points sum to 100, **points ≡ percentage weight**.
+**Every section accepts N/A, which awards full credit** (frac 1.0 — see §4). Weights are **static** (no
+runtime redistribution), so unlike Member Support there is no derived "automated" weight column.
+
+Score-type display: `0/1/NA` = binary (`binary_yn_na`), `1–5/NA` = rating (`rating_1_5_na`).
+
+| # | key | Label | Category | Score type | Weight | Trigger |
+|---|---|---|---|---|---|---|
+| 1 | `greeting` | Greeting | Opening & Professionalism | 0 / 1 / NA | 5% | — |
+| 2 | `stay_type` | Personal or COHO Stay | Opening & Professionalism | 0 / 1 / NA | 4% | — |
+| 3 | `move_reason` | Discover & Personalize the Move Reason | Discovery | 1–5 / NA | 15% | — |
+| 4 | `landing_intro` | First Time Hearing About Landing | Discovery | 0 / 1 / NA | 6% | — |
+| 5 | `timeline_housing` | Timeline & Housing Needs | Discovery | 1–5 / NA | 8% | — |
+| 6 | `landing_guarantee` | Landing Guarantee (Tour Objection) | Pitch & Value Selling | 1–5 / NA | 6% | — |
+| 7 | `pricing` | Pricing Breakdown | Pitch & Value Selling | 1–5 / NA | 8% | — |
+| 8 | `fit_confirmation` | Confirmation of Fit | Pitch & Value Selling | 1–5 / NA | 5% | — |
+| 9 | `objection_handling` | Objection Handling | Objections & Closing | 1–5 / NA | 8% | — |
+| 10 | `urgency` | Urgency | Objections & Closing | 0 / 1 / NA | 5% | — |
+| 11 | `follow_up` | Follow-up | Objections & Closing | 0 / 1 / NA | 6% | — |
+| 12 | `potential_booking` | Potential Booking (PB) | Post-Call & Documentation | 0 / 1 / NA | 4% | — |
+| 13 | `notes_mc` | Detailed Notes in MC | Post-Call & Documentation | 0 / 1 / NA | 5% | — |
+| 14 | `contact_shared` | Contact Information Shared | Post-Call & Documentation | 0 / 1 / NA | 5% | — |
+| 15 | `client_experience` | Client Experience | Post-Call & Documentation | 1–5 / NA | 10% | — |
+| | | **Total** | | | **100%** | |
+
+**Sanity check:** 7 scaled sections (60 pts) + 8 binary sections (40 pts) = 15 sections / 100 pts.
+
+> **Note on `client_experience`:** the PDF files it under *Post-Call & Documentation*. It reads as a
+> call-wide measure, so its category placement is transcribed faithfully but flagged in §10 for
+> confirmation.
+
+### 3a. Deprecated sections (removed vs. the prior Sales version)
+
+**Blocked — requires the prior Sales rubric.** The PDF is the *revised* matrix (new state) only; the
+section add/deprecate diff cannot be derived from it. Provide the previous rubric to populate this.
+*(If `sales_v1` is the first engine-owned version, this section is empty.)*
+
+- `<old_section_key>` — *reason / replaced by* &nbsp; **TODO (needs prior rubric)**
+
+### 3b. New sections (added vs. the prior Sales version)
+
+**Blocked — same reason as §3a.**
+
+- `<new_section_key>` — *definition* &nbsp; **TODO (needs prior rubric)**
+
+---
+
+## 4. Score Normalization
+
+- **Rating (1–5):** `frac = (rating − 1) / 4` → `1 = 0.00, 2 = 0.25, 3 = 0.50, 4 = 0.75, 5 = 1.00`.
+  ⚠️ **Assumed.** The PDF states point values but not the rating→points curve. This mapping is the one
+  consistent with the binary **"0 or full points"** anchors (worst rating = 0 pts, best = full pts).
+  **Confirm before locking** — the alternative `rating / 5` would give rating 1 = 20% instead of 0%,
+  changing every scaled section's score.
+- **Binary (0/1):** met (`1`) = `1.0`, not-met (`0`) = `0.0`. Identical to the shared `binary_yn`
+  normalization (`Y = 1.0 / N = 0.0`); Sales just labels the two branches `0` / `1`.
+- **N/A = full credit (frac = 1.0).** ⚠️ **Opposite of Member Support.** Per the source PDF footer, when a
+  criterion was not applicable the section is awarded **full points on its own slot**. There is **no
+  weight redistribution** — the section keeps its weight and contributes it in full, so NA behaves exactly
+  like a perfect score. *(In Member Support, NA removes the section and spreads its weight elsewhere.)*
+- **Section contribution:** `weight_i × frac_i`.
+- **Raw score:** `Σ contributions` across all 15 sections → 0–100. **No score-level scaling.**
+
+Because NA awards full credit in place (never moves weight), **all weights are static** — there is no
+"automated"/derived weight column as in Member Support.
+
+---
+
+## 5. Formula Rules (Rule Library)
+
+**Empty for `sales_v1`.** The Sales rubric has no score overrides, weight transfers, redistributions, or
+scaling rules. NA handling is a **normalization convention** (full credit, §4) that applies uniformly to
+every section, so it needs no rule-library entry.
+
+| id | type | enabled | Condition | Effect |
+|---|---|---|---|---|
+| *(none)* | | | | |
+
+> When Sales Management add rules later, mirror the Member Support rule schema (`id`, `type`, `enabled`,
+> `when`, `effect`) so both formulas run on the same engine. Do **not** implement any rules today — none
+> exist in the source.
+
+---
+
+## 6. Rule Evaluation Order (deterministic)
+
+1. **normalize** — map each section's answer to `frac` (rating curve, binary, or `NA → 1.0`).
+2. **weighted sum** — `Σ(weight × frac)` → 0–100.
+
+No pre-sum weight moves and no post-sum scaling exist in this version. NA is resolved during normalization
+(step 1), so it never reshapes the rubric.
+
+---
+
+## 7. Triggers
+
+**None.** No Sales section escalates or routes to review in this version. (Member Support's
+`escalation_flag` + threshold logic have no Sales equivalent yet.)
+
+---
+
+## 8. Canonical Config (machine-readable)
+
+```json
+{
+  "formula_id": "sales_v1",
+  "rubric_version": "v1",
+  "supersedes": null,
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "full_credit"
+  },
+  "sections": [
+    { "key": "greeting",           "label": "Greeting",                               "category": "Opening & Professionalism", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "stay_type",          "label": "Personal or COHO Stay",                  "category": "Opening & Professionalism", "score_type": "binary_yn_na",  "weight": 4.0,  "trigger": null },
+    { "key": "move_reason",        "label": "Discover & Personalize the Move Reason", "category": "Discovery",                  "score_type": "rating_1_5_na", "weight": 15.0, "trigger": null },
+    { "key": "landing_intro",      "label": "First Time Hearing About Landing",       "category": "Discovery",                  "score_type": "binary_yn_na",  "weight": 6.0,  "trigger": null },
+    { "key": "timeline_housing",   "label": "Timeline & Housing Needs",               "category": "Discovery",                  "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "landing_guarantee",  "label": "Landing Guarantee (Tour Objection)",     "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 6.0,  "trigger": null },
+    { "key": "pricing",            "label": "Pricing Breakdown",                      "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "fit_confirmation",   "label": "Confirmation of Fit",                    "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 5.0,  "trigger": null },
+    { "key": "objection_handling", "label": "Objection Handling",                     "category": "Objections & Closing",       "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "urgency",            "label": "Urgency",                                "category": "Objections & Closing",       "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "follow_up",          "label": "Follow-up",                              "category": "Objections & Closing",       "score_type": "binary_yn_na",  "weight": 6.0,  "trigger": null },
+    { "key": "potential_booking",  "label": "Potential Booking (PB)",                 "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 4.0,  "trigger": null },
+    { "key": "notes_mc",           "label": "Detailed Notes in MC",                   "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "contact_shared",     "label": "Contact Information Shared",             "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "client_experience",  "label": "Client Experience",                      "category": "Post-Call & Documentation",  "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null }
+  ],
+  "deprecated_sections": [],
+  "rules": [],
+  "evaluation_order": ["weighted_sum"],
+  "triggers": {},
+  "external_signals": {}
+}
+```
+
+**Schema notes vs. Member Support config**
+- `normalization` block is structurally identical **except** `na`: `"full_credit"` here vs.
+  `"redistribute_per_rules"` in Member Support. This is the switch the engine keys off for NA handling.
+- `binary_yn` keeps `Y`/`N` for engine consistency; the Sales rubric labels these branches `1`/`0`.
+- `category` is an **added** field (nullable, PDF-sourced) not present in Member Support; the engine can
+  ignore it. Confirm whether you want it persisted (§10).
+- `rules`, `triggers`, `external_signals`, `deprecated_sections` are all empty by design for this version.
+
+---
+
+## 9. Migration Notes (Sheets → PostgreSQL)
+
+- **Source of truth for section text:** `QA_Scoring_Guide.pdf` (Sales QA — Revised 15-Point Matrix).
+  Descriptor prose is **not duplicated** here — this spec owns the formula, weights, and normalization
+  only (same scope split as Member Support).
+- **Same schema as Member Support:** reuse `qa.formula`, `qa.formula_section`, `qa.formula_rule`, keyed by
+  `formula_id`. Sales rows carry an **empty `rules` set** and, if you keep `category`, one extra nullable
+  column on `qa.formula_section`.
+- **NA semantics differ and must be encoded, not assumed:** Sales NA = full credit on-slot (frac 1.0);
+  Member Support NA = redistribute. If the engine hard-codes NA→redistribute, add a **per-formula NA
+  policy** (`na: "full_credit"` vs `na: "redistribute_per_rules"`).
+- **Weights are static** — nothing to compute at score time beyond normalization + weighted sum.
+- **Version lineage:** persist `formula_id` / `rubric_version` on every stored score. If a prior
+  engine-owned Sales version exists, set `supersedes` and record the §3a / §3b diff so historical rows
+  stay interpretable.
+- Sheets demoted to read-only mirror (or retired) once score parity is verified against a hold-out set —
+  same cutover as Member Support. Use the §11 vector as a first parity/unit test.
+
+---
+
+## 10. Open Items — confirm before locking `sales_v1`
+
+- [ ] **Scaled 1–5 → points curve.** Assumed `(rating − 1) / 4` (worst = 0, best = full; consistent with
+      the binary "0 or full points" anchors). Confirm vs. `rating / 5`. *Materially changes every scaled
+      section's score.*
+- [ ] **NA = full credit.** Confirm the PDF footer ("N/A = full points when not applicable") applies to
+      **all 15 sections** and means full-credit-on-slot with **no redistribution** (opposite of Member
+      Support).
+- [ ] **Version number & lineage.** Confirm `formula_id = sales_v1` and whether it supersedes a prior
+      engine-owned version. If so, **provide the prior rubric** so §3a / §3b can be populated — the diff
+      can't be produced from the new PDF alone.
+- [ ] **Section keys.** Proposed keys are mine; confirm/rename to match existing column names in the
+      codebase.
+- [ ] **`category` field.** Confirm you want the PDF's category grouping persisted on `qa.formula_section`
+      (engine can ignore it; useful for reporting).
+- [ ] **`client_experience` placement.** The PDF files it under *Post-Call & Documentation*; confirm
+      that's intended (it reads as a call-wide measure).
+- [ ] **No rules / no triggers.** Confirmed absent in the PDF. Confirm none are planned for v1 before
+      engineering builds against an empty rule set.
+
+---
+
+## 11. Worked Example (test vector)
+
+*Not part of the 1:1 structure — added as a concrete parity/unit test for the engine. It exercises binary
+met/not-met, scaled ratings across the range, and NA-full-credit on both a scaled (`timeline_housing`) and
+a binary (`contact_shared`) section.*
+
+| key | answer | frac | weight | contribution |
+|---|---|---|---|---|
+| `greeting` | 1 | 1.00 | 5 | 5.00 |
+| `stay_type` | 0 | 0.00 | 4 | 0.00 |
+| `move_reason` | 4 | 0.75 | 15 | 11.25 |
+| `landing_intro` | 1 | 1.00 | 6 | 6.00 |
+| `timeline_housing` | **NA** | **1.00** | 8 | **8.00** |
+| `landing_guarantee` | 3 | 0.50 | 6 | 3.00 |
+| `pricing` | 5 | 1.00 | 8 | 8.00 |
+| `fit_confirmation` | 2 | 0.25 | 5 | 1.25 |
+| `objection_handling` | 4 | 0.75 | 8 | 6.00 |
+| `urgency` | 1 | 1.00 | 5 | 5.00 |
+| `follow_up` | 0 | 0.00 | 6 | 0.00 |
+| `potential_booking` | 1 | 1.00 | 4 | 4.00 |
+| `notes_mc` | 1 | 1.00 | 5 | 5.00 |
+| `contact_shared` | **NA** | **1.00** | 5 | **5.00** |
+| `client_experience` | 4 | 0.75 | 10 | 7.50 |
+| | | | **Σ** | **75.00** |
+
+Expected final score = **75.00**. Note the two NA sections each contribute their **full weight** (8.00 and
+5.00) — this is the behavior to assert against, since it's where Sales diverges from Member Support.

--- a/qa-automation/AI-Scoring/references/Wave2Plan.md
+++ b/qa-automation/AI-Scoring/references/Wave2Plan.md
@@ -1,0 +1,342 @@
+# Wave 2 Plan — QA Pipeline Automation for Agent Bonus Metrics
+
+> **Owning document for the 2026-07 push.** A fresh session should be able to open only this file plus the two team scoring specs and execute against the plan.
+>
+> **Ordered by silent-failure impact per [[feedback_silent_failure_ordering]]:** Phase 3 (formula sign-off) sits ahead of Phase 5 (backfill) because a locked-but-wrong formula silently produces wrong bonus numbers for every agent every month, while a delayed backfill loudly excludes rows that never got dual-written.
+
+| | |
+|---|---|
+| **Status** | v1 (2026-06-30, authoritative post-v1.4 schema) |
+| **Objective** | Postgres-backed monthly agent bonus metrics live by **2026-07-31** |
+| **Deadline** | 31 calendar days from today |
+| **Owner** | AI-Scoring backend + QA leadership (sign-off gate) |
+| **Superseded** | prior "Wave 2 inventory" laid out in chat — this doc is the reference going forward |
+
+---
+
+## 1. Objective — what "bonus-ready" means
+
+By month-end we can produce, for each active agent, a **defensible monthly QA score** that Landing HR can use as a bonus input. Concretely:
+
+- `GET /api/{team_id}/bonus_metrics?month=2026-07` returns per-agent:
+  - `overall_score` — from `qa.compute_overall_score()` running against a **locked** `formula_version` + `rubric_version`
+  - `evaluations_included` — count of finalized evals in the month
+  - `sections_summary` — per-section rollup for defensibility during appeals
+- The number is **reproducible** — feed the same eval row + the two archived versions, get the same score forever
+- QA leadership has **signed off** on both:
+  1. The formula/rubric that's live (per team, see §3)
+  2. The historic-compliance sweep result (per team, §7.7 of `SQLMigration.md`)
+
+That's the finish line. Nothing else needs to ship for that outcome.
+
+---
+
+## 2. Sources of truth for the formula and rubric
+
+**These files are AUTHORITATIVE:**
+
+| File | Team | Status |
+|---|---|---|
+| `database/member_support_scoring_migration.md` | Member Support | ✅ **Finalized** — Ops VP sign-off. 4 minor items in §10 still to confirm (see §5 below). |
+| `database/sales_scoring_migration.md` | Sales | ⚠️ **Populated from source PDF, PENDING sign-off** — 7 open items in its §10. Blocks Sales bonus math. |
+
+**These files DEFINE THE SCHEMA that the specs load into:**
+
+- `database/SQLMigration.md` — the QA-schema design (versions v1.0 → v1.4 shipped). Read §3.6 (compute_overall_score), §3.8 (formula rules pipeline), §3.12 (formula_versions), §3.14 (human-review trigger), §3.19 (rubric_versions).
+
+**These files are the LEGACY (partial, being superseded):**
+
+- `qa-automation/AI-Scoring/backend/config/teams/{sales,member_support}.json` — current JSON files that the app reads. Section IDs and weights **differ** from the Ops-signed specs. Section-key remapping in §9 is REQUIRED to reconcile.
+
+**Precedence when they disagree:** team scoring migration `.md` > SQLMigration.md > team JSON files. Any mismatch is resolved by treating the `.md` as the target and generating both the DB seed AND the (soon-to-be-generated) JSON file from it.
+
+---
+
+## 3. Delta from what's already shipped
+
+**What's on Railway prod as of 2026-06-30** (through migration 011, PR #68 applied):
+
+- `public.teams` seeded with `member_support` + `sales` (v1.3 operational columns filled)
+- `qa.evaluations` + `qa.evaluation_sections` (schema, empty)
+- `qa.agents` (schema, empty)
+- `qa.rubric_versions` seeded with `sales_v1` + `member_support_v1` **BUT sourced from the legacy JSON files, NOT the Ops-signed specs**
+- `qa.formula_versions` (schema, empty)
+- `qa.formula_compliance_sweeps` (schema, empty)
+- `qa.assessments` + `qa.assessment_sections` (schema, empty)
+- `qa.tags` seeded with 4 human-review-focus tags
+- `qa.coachings` + `qa.coaching_evaluations` (schema, empty)
+- `qa.agent_stat_points` (schema, empty)
+- `qa.score_audit` / `qa.api_audit_log` / `qa.evaluation_tags` (schema, empty)
+
+**What is NOT yet on Railway** (deferred to Wave 3, do not touch during Wave 2):
+
+- `command_center.*` — the whole schema is deployed but no writer wired up
+- `embeddings.*` — schema deployed, no consumer
+
+**The critical delta between what's seeded and what's authoritative:**
+
+The `member_support_v1` and `sales_v1` rows already in `qa.rubric_versions` (from migration 010's seed) reference the **legacy JSON section keys** — they DO NOT match the Ops-signed specs. When Wave 2 kicks off:
+
+1. New `member_support_v2` row lands in `qa.rubric_versions` with the Ops-signed content; the current `_v1` gets `effective_until = NOW()`
+2. First-ever `member_support_v2` row lands in `qa.formula_versions` with the Ops-signed formula
+3. Same pair for Sales — but only AFTER Sales management signs off on the 7 open items
+
+**Do NOT edit the migration 010 seed to fix this.** Ship the new versions as new rows. Ranks with `[[project_predictive_groundwork]]` — versioning is exactly for this case.
+
+---
+
+## 4. Formula engine — what needs to be built
+
+The Ops-signed specs use a **richer formula shape** than `SQLMigration.md §3.8` currently describes. `qa.compute_overall_score()` and the Pydantic `Formula` model must expand to support the full spec shape. Deltas from §3.8:
+
+| Field / concept | §3.8 today | Ops-signed spec (§8 of each team file) |
+|---|---|---|
+| Formula shape | `sections + rules + scale` | `formula_id + rubric_version + scale + normalization + sections + rules + evaluation_order + triggers + external_signals` |
+| Rule schema | `type + if + fields per type` | `id + type + enabled + when + effect + note` — every rule now has a stable ID and enabled flag |
+| NA policy | implicit in rule pipeline | **explicit per-formula** — MS `redistribute_per_rules`, Sales `full_credit` |
+| Evaluation order | implicit array order | **explicit** array of rule IDs + `weighted_sum` sentinel |
+| Rule types | `hard_zero`, `na_redistribution`, `weight_transfer` | + `weight_redistribution` (equal-additive), + `score_scale` (post-sum multiplier), + `flag` (emits event, doesn't affect score) |
+| Weight transfer amount | "all" or fraction | `amount: "all"` OR `fraction: N.M` — MS uses fraction for `frequent_caller_shift` |
+| Triggers | `human_review_triggers` (§3.8) | `triggers.active` + `triggers.candidates` + `triggers.threshold` + `triggers.routes_to` — same idea, richer shape |
+| External signals | not modeled | `external_signals.frequent_caller` — MS's `frequent_caller_shift` rule reads a signal delivered via Command Center Looker snapshot |
+
+**Two schema updates queue behind this:**
+
+- **Spec `SQLMigration.md` §3.8 needs to grow to match the Ops-signed shape.** File a v1.5 spec update (not urgent, doc only).
+- **Pydantic `Formula` model** (Wave 2a #1 below) implements the richer shape from day 1.
+
+**External signals — how to handle without Command Center.** MS's `frequent_caller_shift` rule reads `signals.frequent_caller` from a Looker snapshot delivered via CC. CC is postponed. Ship rule the with `enabled: true` in the formula JSON; wire `frequent_caller` as **`false` by default at evaluation time** in `compute_overall_score()`. When CC ships later, the signal starts firing without a formula change. Zero impact on bonus math meanwhile — the rule stays a no-op.
+
+---
+
+## 5. Open items blocking the plan
+
+**Member Support (§10 of the MS scoring spec):**
+
+- [ ] Confirm `matching` / `efficiency` become **active** triggers or stay candidates (currently only `process_adherence` + `call_resolution` fire escalation)
+- [ ] Confirm `frequent_caller_shift` default fraction (0.5) and default target (`process_adherence`)
+- [ ] Confirm hard-zero stays globally available (enabled per team) vs. removed outright for MS
+- [ ] Confirm NA-spread behavior when **multiple** sections are NA (current: recompute equal-additive over remaining active sections)
+
+**Sales (§10 of the Sales scoring spec):**
+
+- [ ] Confirm rating→points curve (`(rating − 1) / 4` vs `rating / 5`) — **materially changes every scaled section's score**
+- [ ] Confirm NA = full credit on-slot **for all 15 sections** with no redistribution
+- [ ] Confirm `formula_id = sales_v1` and version lineage
+- [ ] Confirm section keys (the spec's proposed keys)
+- [ ] Confirm whether to persist the PDF's `category` grouping on `qa.formula_section`
+- [ ] Confirm `client_experience` placement under *Post-Call & Documentation*
+- [ ] Confirm no rules / no triggers planned for `sales_v1`
+
+**Nothing else can start on Sales bonus math until §10 is closed.** MS can start now.
+
+**Q — should we get all sign-offs before writing any code?** No — Phase 1 and 2 (Foundation + Compute Engine) are entirely internal, agnostic to which sections/weights end up locked. Formula sign-off gates Phase 3 (ship the versions) onward, not the engine itself.
+
+---
+
+## 6. Phased plan (31 days, 2026-06-30 → 2026-07-31)
+
+Phases 1–2 are internal engineering. Phases 3–6 depend on QA leadership signoffs.
+
+### Phase 1 — Foundation (Days 1–5)
+
+**Goal:** Every downstream write validates against the same Pydantic contract; `team_config` reads from DB with a file fallback.
+
+| # | PR | Notes |
+|---|---|---|
+| 1a | Pydantic models — `Formula`, `Rule` (all 6 types), `Rubric`, `RubricSection`, `ScoringPrompt`, `EvaluationSection`, `AssessmentSection`, `ModelsUsed`, `AnnotatedTranscript`, `RecordingUrls` | Uses the **Ops-signed formula shape** — richer than §3.8. Read the two team `.md` files first. |
+| 1b | `team_config.py` DB-refactor + `backend.config.export_team` CLI | Q1.b dual-source (DB primary, JSON fallback), Q2.c cache-bust-on-write. Export script writes JSON from DB state — the "Save" button's future backend. |
+
+**Deliverable:** every `.json` shape is now Pydantic-validated at load; runtime reads from DB when available. Local dev still works without DB.
+
+### Phase 2 — Compute engine (Days 4–12)
+
+**Goal:** `qa.compute_overall_score(evaluation_id)` produces a deterministic, versioned score from row + archived formula + archived rubric.
+
+| # | PR | Notes |
+|---|---|---|
+| 2a | Rule engine — 6 rule types (hard_zero, weight_transfer, weight_redistribution, score_scale, flag, score_override), `evaluation_order` sequencing, `normalization` block with `na_policy` switch (redistribute vs full_credit) | Pure function, no DB access. Table-driven per `Formula` — one engine, both teams' rules. |
+| 2b | `qa.compute_overall_score(evaluation_id)` — the DB-touching wrapper | Loads formula + rubric from `qa.formula_versions` / `qa.rubric_versions`; calls the rule engine; returns `NUMERIC(5,1)`. |
+| 2c | Golden fixtures — per team, ~30-50 real Analyst_History rows with their sheet-computed scores → JSON fixtures at `tests/fixtures/overall_formula/{team}.json` | Sales' spec §11 gives the **first test vector** (75.00 with the sample answers) — use it. MS parity is the harder gate. |
+
+**Deliverable:** given a filled-in `qa.evaluations` row + `qa.evaluation_sections` rows, `compute_overall_score()` returns the correct score under any formula version.
+
+### Phase 3 — Formula sign-off + version ship (Days 8–15)
+
+**Goal:** Both teams have their new formula_version + rubric_version live in the DB, effective from a specific timestamp forward.
+
+| # | PR | Notes |
+|---|---|---|
+| 3a | Ship `member_support_v2` — new row in `qa.rubric_versions` + first row in `qa.formula_versions` | Mark existing MS `_v1` row `effective_until = NOW()`. Content from the finalized MS scoring spec §8. |
+| 3b | Close MS §10 open items with Ops VP | Fixes the 4 lingering ambiguities before ship. |
+| 3c | Coordinate with Sales management to close §10 open items | 7 items. Independent of MS ship. |
+| 3d | Ship `sales_v1_ops` — new rubric_version + first formula_version | Post Sales sign-off. Existing `sales_v1` gets `effective_until = NOW()`. |
+
+**Deliverable:** for both teams, `qa.rubric_versions WHERE effective_until IS NULL` and `qa.formula_versions WHERE effective_until IS NULL` return the Ops-signed content.
+
+### Phase 4 — Dual-write from sheets_service.py (Days 12–20)
+
+**Goal:** Every new eval from the current pre-filled scorecard workflow lands in Postgres alongside Sheets.
+
+| # | PR | Notes |
+|---|---|---|
+| 4a | `sheets_service.py` Stage 1 dual-write | Writes `qa.evaluations` (`state='draft'`) + `qa.evaluation_sections` at write_draft_to_fr_ai time. Postgres failures **swallowed** (§7.3 Phase A semantics). |
+| 4b | `sheets_service.py` Stage 2 dual-write | State transitions `draft → approved`, sets `evaluator_email` + `approved_at`. Post-Phase-C this is when `compute_overall_score` fires; pre-cutover we still take the Sheet's ARRAYFORMULA result via Stage 3 readback. |
+| 4c | `sheets_service.py` Stage 4 dual-write + `qa.agent_stat_points` seed on finalize | `state → finalized`, resolves `agent_id` via `qa.agents`. One new stat point per finalize (§9.2). |
+| 4d | Section-key remapping layer (§9 below) | Legacy JSON section keys → Ops-signed spec keys, per team. Applied at write path so `evaluation_sections.section_id` uses the Ops-signed key from day one. |
+| 4e | §3.14 human-review trigger fires at Stage 1 / Stage 1.5 | Reads formula's `triggers` block (MS has active triggers; Sales has none). Sets `scoring_status='flagged_human_review'` + `human_review_required_at`. |
+
+**Deliverable:** any eval flowing through the current scorecard workflow after this cutover is fully replicated in Postgres.
+
+### Phase 5 — Backfill Phase B (Days 15–25)
+
+**Goal:** All historical evals from Analyst_History are in `qa.evaluations` so "current month's metric" isn't a 2-week slice.
+
+| # | Script | Notes |
+|---|---|---|
+| 5a | `scripts/backfill_phase_b.py` — read Analyst_History per team → INSERT into `qa.evaluations` (`state='finalized'`) + `qa.evaluation_sections` | Uses section-key remapping (§9). Preserves `eval_approved_at` on the eval. Rate-limited to gspread-safe pace. |
+| 5b | `qa.agent_stat_points` seeding — replay per team ordered by **`eval_approved_at`** (not `finalized_at`) | §7.1 clarification — `finalized_at` is the backfill clock, not history. |
+| 5c | Stub `command_center.calls` rows with `seen_via='qa_backfill'` per backfilled eval | Needed so `qa.evaluations.command_center_call_id` FK is populated. Enrichment via `get_call_details()` runs in background (5 req/min); NOT required for bonus. |
+
+**Deliverable:** every finalized Analyst_History row appears as a `qa.evaluations` row with `state='finalized'`. `agent_stat_points` series is complete in historical order.
+
+### Phase 6 — Phase A.5 historic compliance sweep (Days 20–28)
+
+**Goal:** Recompute every backfilled row's `overall_score` under the new formula, surface flagged patterns, iterate until QA leadership accepts.
+
+| # | Item | Notes |
+|---|---|---|
+| 6a | Sweep script — for each backfilled row, `compute_overall_score()` under the new formula_version, persist to `qa.formula_compliance_sweeps` | §3.13 spec, ε = 0.05. Per-team run. |
+| 6b | Flag distribution report per team | §7.7 runbook. Feeds QA leadership review. |
+| 6c | Iterate formula versions if patterns warrant | Each iteration = new formula_version row + fresh sweep. Loop terminates when QA leadership signs the flagged set. |
+
+**Deliverable:** locked `formula_version` per team, backed by explicit QA leadership sign-off on the flagged-row set.
+
+### Phase 7 — Cutover + bonus surface (Days 25–31)
+
+**Goal:** Postgres is truth; monthly bonus metric surface answers HR's question.
+
+| # | PR | Notes |
+|---|---|---|
+| 7a | Phase C truth-flip per team | Reads move from Sheets to Postgres for agent history, team stats, dashboards, `Score_Audit` search. Sheets ARRAYFORMULA continues but its output is no longer authoritative. |
+| 7b | `GET /api/{team_id}/bonus_metrics?month=YYYY-MM` — per-agent monthly rollup | SQL view or on-the-fly aggregate. Returns `{agent, overall_score, evaluations_included, sections_summary}`. |
+| 7c | Frontend: bonus dashboard reads from the new endpoint | Small — replace the current stats source. |
+
+**Deliverable:** HR can pull the July 2026 bonus number for every active agent, defensibly, from a versioned formula they can review the sign-off history of.
+
+---
+
+## 7. Explicit deferrals (do NOT touch during Wave 2)
+
+The scope is disciplined. These items are OUT until Wave 3 (post-2026-07-31):
+
+- **Command Center** — the entire `command_center.*` schema and its writer. `qa.evaluations.command_center_call_id` stays NULL for backfilled rows (§4.2 allows this). Live CC development kicks off in August.
+- **Rubric editor UI** — managers keep editing team `.md` specs + the export script writes new versions. No web editor in July.
+- **Formula editor UI** — same.
+- **Assessment writer/reader** — `qa.assessments` sits empty. The current 1h in-memory TTL persists for July.
+- **Coaching workflow UI + tag apply/remove APIs** — DB tables exist; no writer or UI in July.
+- **LandGPT v2 integration** — Gemini continues producing scores. No cascade in July.
+- **Embeddings live ingestion** — schema is ready; consumer waits for LandGPT v2.
+- **Sheets Phase D retirement** — Sheets stays as a redundant sink through Wave 3.
+
+If it's not in §6, it's not this cycle.
+
+---
+
+## 8. Delivery risks and how they surface silently
+
+Ranked by silent-failure impact per [[feedback_silent_failure_ordering]]:
+
+**Critical — silent wrong numbers:**
+
+1. **Formula lock happens before sign-off closes.** If Sales §10 items don't get answered but we ship anyway, every Sales bonus is computed under a guessed rating curve. Discovery is post-payroll — very expensive.
+   → **Mitigation:** Sales version ships only after §10 is closed in writing (spec update marking each item resolved).
+
+2. **Section-key remapping is wrong.** A silent misalignment between Analyst_History column and spec section key means one section is scored as "0" for every backfilled eval, invisibly deflating everyone's score.
+   → **Mitigation:** Migration script asserts `evaluations_included × sections_per_eval == inserted_section_rows`. Any per-team sanity fails loud.
+
+3. **NA policy mismatch.** If Sales runs under MS's redistribute-NA instead of full-credit, or vice versa, every eval with an NA on any section produces a different score.
+   → **Mitigation:** `Formula.na_policy` is a required field with a CHECK; loading a formula without one raises. Test: run the §11 Sales worked example (expected 75.00) — assert exact.
+
+**High — wrong numbers with clear symptoms:**
+
+4. Weight sum ≠ 100 in a shipped formula → assertion at Pydantic load fails loud.
+5. Formula references section_id absent from active rubric → hard-fail validator (§3.19.3) blocks ship.
+
+**Medium — reversible:**
+
+6. Backfill misses rows (parse errors on Analyst_History edge cases) → row-count mismatch surfaces during Phase A.5 sweep.
+7. `qa.agent_stat_points` order wrong (seeded by `finalized_at` not `eval_approved_at`) → EWMA lookbacks compute under wrong history; PR-review-catchable.
+
+**Low:**
+
+8. Cost attribution missing on assessment writes → not blocking; can backfill from `api_audit_log`.
+
+---
+
+## 9. Section-key remapping table (mandatory reference for Phase B + dual-write)
+
+The legacy JSON section keys don't match the Ops-signed spec keys. Wave 2 code must translate at write time (§4d) AND at backfill time (§5a).
+
+**Member Support:**
+
+| Legacy JSON key | Ops-signed spec key | Notes |
+|---|---|---|
+| `greeting` | `greeting` | unchanged |
+| `caller_identity_validation` | `caller_id` | shortened |
+| `purpose_of_call` | `purpose` | shortened |
+| `matching_the_moment` | `matching` | shortened |
+| `process_adherence` | `process_adherence` | unchanged |
+| `call_resolution` | `call_resolution` | unchanged |
+| `communication` | `comms` | shortened |
+| `efficiency_call_handling` | `efficiency` | shortened |
+| `documentation` | `human_review_required` | **renamed + repurposed** — see SQLMigration.md §3.5 v1.2 deprecation note; legacy rows in `qa.evaluation_sections` stay with `section_id='documentation'`, new rows use `human_review_required` |
+| `customer_resolution_indicator` | `cri` | shortened |
+
+**Sales:** the Ops-signed matrix is 15 sections, but the legacy JSON has 19 with substantially different keys. The remapping table cannot be finalized until **Sales §10 is closed** — several current sections are being dropped and new ones introduced. Placeholder mapping to be authored during Phase 3c and reviewed with Sales management.
+
+| Legacy JSON key | Ops-signed spec key | Status |
+|---|---|---|
+| `greeting` | `greeting` | mapped |
+| `pb_creation` | `potential_booking` | mapped (renamed) |
+| `mc_call_notes` | `notes_mc` | mapped (renamed) |
+| … remaining 15 sections | | **PENDING §10 close** |
+
+---
+
+## 10. Reference commands + status checks
+
+**Verify Railway state matches this doc's Phase-3 preconditions:**
+
+```sql
+-- Should show: sales_v1 + member_support_v1 (from migration 010's seed).
+-- After Phase 3 you'll see additional rows.
+SELECT rubric_version, team_id, effective_from, effective_until
+FROM qa.rubric_versions ORDER BY team_id, effective_from;
+
+-- Should be EMPTY until Phase 3 lands the Ops-signed formulas.
+SELECT formula_version, team_id, effective_from FROM qa.formula_versions;
+
+-- Should return NULL for now; becomes non-NULL after Phase 4 dual-write starts.
+SELECT rubric_version, formula_version FROM qa.evaluations WHERE id = (SELECT MAX(id) FROM qa.evaluations);
+```
+
+**Golden-fixture parity check (Phase 2c):**
+
+Load Sales's §11 worked example into a test → `compute_overall_score(evaluation_id)` MUST return `75.00`. That's the only single-test spec-guaranteed value we have as of 2026-06-30.
+
+---
+
+## 11. Handoff notes for a fresh session
+
+If you're picking this up in a new conversation:
+
+1. **Read this doc top to bottom.**
+2. **Read `database/member_support_scoring_migration.md` and `database/sales_scoring_migration.md`** — these are the formula/rubric authorities.
+3. **Confirm the current state of Railway matches §3 "already shipped".** If not, find out what changed.
+4. **Confirm the current state of Sales §10 sign-offs.** If any of the 7 items are still open, do NOT ship `sales_v1_ops` yet.
+5. **Start with Phase 1a** (Pydantic models) unless someone tells you otherwise. It blocks nothing else and unblocks everything.
+6. **Never edit the two `_scoring_migration.md` specs unilaterally.** They're Ops VP / Sales Management sign-off surfaces.
+7. **Never write to `qa.assessments` / `qa.coachings` / `qa.evaluation_tags` / `command_center.*` — those are out of scope for Wave 2.**
+
+Questions this doc doesn't answer belong in the chat that produced it. Cross-reference `[[SQLMigration.md]]` for schema-level detail (§3.6 compute_overall_score, §3.19 rubric write path, §7.6 migration ordering).


### PR DESCRIPTION
## Summary
Establishes the authoritative reference for the Wave 2 push: **Postgres-backed monthly agent bonus metrics live by 2026-07-31**.

Three files land together:

- **`database/member_support_scoring_migration.md`** — Ops VP-signed rubric + formula for Member Support. 10 sections, 6 rules including the CC-dependent `frequent_caller_shift` and escalation flag on `process_adherence` / `call_resolution`. NA policy: redistribute.
- **`database/sales_scoring_migration.md`** — populated from the Sales QA Revised 15-Point Matrix PDF. 15 sections, no rules, NA = full-credit on-slot (opposite of MS). **PENDING sign-off** on 7 open items in §10.
- **`qa-automation/AI-Scoring/references/Wave2Plan.md`** — the reconciliation + 31-day phased plan. Self-contained for fresh-session pickup.

## Key reconciliations

The Wave2Plan surfaces a few important truths:

1. **The `_v1` rubric rows already seeded by migration 010 are stale.** They came from the legacy JSON files, not the Ops-signed specs. Phase 3 ships new versions (`member_support_v2` / `sales_v1_ops`); the current `_v1` gets `effective_until = NOW()`. **Do NOT edit the 010 seed** — versioning is exactly for this case.

2. **`qa.formula_versions` is currently empty.** First-ever rows land in Phase 3.

3. **The Ops-signed formula shape is richer than `SQLMigration.md §3.8` describes** — `id + enabled` on rules, explicit `evaluation_order`, per-formula `na_policy`, `external_signals` block. A v1.5 spec update is queued to bring §3.8 in line.

4. **MS's `frequent_caller_shift` rule reads a signal from Command Center Looker snapshots.** CC is postponed. The rule ships enabled but the signal defaults to false at evaluation time; when CC lands later, the signal starts firing without a formula change. Zero impact on bonus math meanwhile.

5. **Section-key remapping** between legacy JSON keys and Ops-signed keys is required for both dual-write and Phase B backfill. §9 has the MS mapping (complete); Sales mapping is blocked until §10 closes.

## What's deferred (per Ops VP direction)

Command Center, editor UIs, assessment writer/reader, LandGPT v2, embeddings live ingestion. Everything not directly on the critical path to bonus metrics.

## Test plan
- [ ] Review §1 (objective) and §2 (sources of truth) — confirm the precedence order matches your intent
- [ ] Review §6 (phased plan) — confirm the 31-day breakdown is realistic
- [ ] Confirm the deferrals in §7 are what you had in mind
- [ ] Once merged, a fresh session picking up Wave 2 reads only this doc + the two scoring specs

## What's next
Once #69 merges, Phase 1a starts — Pydantic models covering the richer Ops-signed formula shape + all v1.4 JSONB columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)