### PR TITLE
Wave 2 Phase 1a — Pydantic models + MS Ops-signed config

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
@@ -1,0 +1,53 @@
+{
+  "formula_id": "member_support_v2",
+  "rubric_version": "member_support_v2",
+  "supersedes": "member_support_v1",
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "redistribute_per_rules"
+  },
+  "sections": [
+    { "key": "greeting",              "label": "Greeting",                      "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "caller_id",             "label": "Caller ID",                     "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "purpose",               "label": "Purpose of Call",               "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": "candidate" },
+    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": "active" },
+    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
+    { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
+    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
+    { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
+    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn",     "weight": 5.0,  "trigger": null }
+  ],
+  "rules": [
+    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
+    { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
+    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
+    { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
+    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.5 }, { "section": "call_resolution", "frac_lte": 0.5 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" } }
+  ],
+  "evaluation_order": [
+    "hard_zero",
+    "caller_id_na_transfer",
+    "frequent_caller_shift",
+    "hrr_na_spread",
+    "weighted_sum",
+    "caller_id_scale_half",
+    "escalation_flag"
+  ],
+  "triggers": {
+    "threshold": { "op": "lte", "frac": 0.5, "ratings": [1, 2, 3] },
+    "active": ["process_adherence", "call_resolution"],
+    "candidates": ["matching", "efficiency"],
+    "routes_to": "human_review_required"
+  },
+  "external_signals": {
+    "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
+  },
+  "human_review_triggers": [
+    { "section_id": "process_adherence", "max_score_to_trigger": 3 },
+    { "section_id": "call_resolution",   "max_score_to_trigger": 3 }
+  ]
+}

--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -1,13 +1,18 @@
 """Team configuration model and loader.
 
-Each team's rubric, column layout, and Gemini config live in a JSON file
-at backend/config/teams/{team_id}.json.
+Wave 2 Phase 1a: `RubricSection` (backend/models/formula.py) replaces the
+legacy `SectionDef` — same runtime surface, Ops-signed short section ids.
+The loader also assembles a `Rubric` from either the new nested shape (MS)
+or the legacy flat shape (Sales, until §10 sign-off closes).
 
-Schema v2.0 (Phase 2): Analyst_History and Form Responses AI column
-layouts are derived by formula from len(sections) — see
-backend.config.history_layout. Per-team config only declares tab names
-and the per-team `score_destination` block (the legacy form layouts
-that ARRAYFORMULAs and Apps Script flows depend on).
+Layout:
+
+    config/teams/{team}.json                  — runtime team config + rubric
+    config/scoring/{team}/overall_formula.json — Formula (Phase 3a lands v2 rows)
+
+MS ships in the new nested shape (rubric block, Ops-signed short ids).
+Sales keeps the flat shape (top-level sections/scoring_prompt/rubric_version)
+until Wave 2 Phase 3c closes the §10 sign-off; the loader detects and adapts.
 """
 
 from __future__ import annotations
@@ -15,15 +20,20 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from backend.config.history_layout import HistoryLayout
+from backend.models.formula import (
+    Rubric,
+    RubricSection,
+    ScoringPrompt,
+)
 
 
 # ---------------------------------------------------------------------------
-# Sub-models
+# Sub-models — Sheets/Gemini/Stats runtime config (unchanged from Wave 1)
 # ---------------------------------------------------------------------------
 
 class GeminiConfig(BaseModel):
@@ -45,24 +55,13 @@ class FormResponsesAIConfig(BaseModel):
 
 
 class AnalystHistoryConfig(BaseModel):
-    """Analyst_History tab — finalized evaluations.
-
-    Layout is derived from len(sections); only tab names are configured.
-    `tab_name_legacy` is set during the Phase 2 cutover so the migration
-    script knows where to read pre-refactor rows from. Sales has no
-    legacy tab → field stays null.
-    """
+    """Analyst_History tab — finalized evaluations."""
     tab_name: str
     tab_name_legacy: Optional[str] = None
 
 
 class WeightsReferenceConfig(BaseModel):
-    """Reference to a per-team weights tab used by the score formula.
-
-    Sheet-only — Python neither reads nor writes these. Recorded for
-    documentation and future tooling that may want to inspect or
-    rebalance weights from one place.
-    """
+    """Reference to a per-team weights tab used by the score formula."""
     tab_name: str
     range: str
     comment: Optional[str] = None
@@ -70,56 +69,13 @@ class WeightsReferenceConfig(BaseModel):
 
 class ScoreDestinationConfig(BaseModel):
     """Per-team score-destination tab where approved scores land and the
-    overall-score formula calculates.
-
-    The only place in the system with hardcoded column letters — mirrors
-    the legacy form layouts that pre-existing ARRAYFORMULAs and Apps
-    Script flows depend on. Pipeline Stage 2 writes section scores here;
-    Stage 3 reads back from `score_readback_col`.
-    """
+    overall-score formula calculates."""
     tab_name: str
-
     section_score_columns: dict[str, str]
-    """Map of column letter -> section_id, for the columns where each
-    section's score lives in the destination tab. The key set defines
-    which columns the writer touches; section_ids absent here are
-    skipped (e.g. MS skips no sections; Sales writes all 19)."""
-
     score_readback_col: str
-    """Column letter where the calculated overall score lives (typically
-    populated by an ARRAYFORMULA in the sheet itself)."""
-
     arrayformula_buffer_seconds: float = 4.0
-    """Max seconds to wait for the ARRAYFORMULA to evaluate after Stage 2
-    writes. Stage 3 polls the readback cell with bounded retries."""
-
     metadata_cols: dict[str, str]
-    """Map of metadata-field name -> column letter for non-section fields
-    on the destination tab. Field set varies per team:
-
-    - MS: timestamp, manager_email, agent_name, key_strengths,
-      opportunities, dialpad_link
-    - Sales: dialpad_link, timestamp, agent_name, evaluator_email,
-      feedback_combined (single cell, key_strengths + opportunities
-      concatenated)
-
-    Call-time initiative (PR-1) — see
-    references/CallTimeOnAnalystHistory.md: the ``timestamp`` field
-    now semantically holds the call's ``date_connected`` from Dialpad,
-    sourced via `fr_ai_row[COL_TIMESTAMP]` in Stage 2. The JSON column
-    letters didn't change — only the meaning. The Apps Script email
-    pipeline's "Evaluation Date" line consequently renders as the call
-    date going forward.
-    """
-
     metadata_cols_note: Optional[str] = None
-    """Free-form doc string for the per-team JSON to record any
-    team-specific semantic notes about ``metadata_cols``. Never read
-    by Python — purely a hint for reviewers who jump straight to the
-    JSON without opening this file. Mirrors the ``comment`` sibling
-    on :class:`WeightsReferenceConfig`.
-    """
-
     weights_reference: Optional[WeightsReferenceConfig] = None
 
 
@@ -131,74 +87,14 @@ class SheetsConfig(BaseModel):
     mails_tab: str
 
 
-class ScoringPromptConfig(BaseModel):
-    """Prompt-level settings for Gemini scoring."""
-    system_prompt_template: str
-    confidence_levels_note: str
-    sop_sections: list[int]                  # section_numbers that need SOP context
-    long_call_focus_sections: list[str] = Field(default_factory=list)
-    """section_id list that scoring_service.score_call uses to compose the
-    long-call attention note (calls over 25 minutes). Each id resolves to
-    the section's name + number for the prompt. MS focuses on
-    efficiency_call_handling; Sales focuses on hold_usage. Empty list
-    skips the attention note."""
-
-
 class StatsConfig(BaseModel):
-    """Per-team statistical thresholds.
-
-    Today every team uses the same defaults — these became magic numbers
-    when the engine was MS-only.  Lifted to config so a low-volume team
-    (e.g. Sales during ramp) can loosen sensitivity without forking code.
-
-    When 100% Local AI scoring goes live, these defaults will need to
-    change again (much higher N → tighter thresholds, longer EWMA spans).
-    Kept here so that change is one config edit, not a code release.
-    """
+    """Per-team statistical thresholds (unchanged from Wave 1)."""
     min_evals_for_outlier: int = 5
-    outlier_z_threshold: float = 3.5      # Modified-Z cutoff (MAD-based)
+    outlier_z_threshold: float = 3.5
     ewma_span: int = 5
     ewma_min_evals: int = 3
-    ewma_trend_delta: float = 3.0          # |Δ| to trigger improving/declining
-    spc_sigma_multiplier: float = 2.0      # Shewhart control limits
-
-
-class SectionDef(BaseModel):
-    """Definition of a single rubric section."""
-    id: str                                  # canonical scoring ID
-    history_id: str                          # dashboard/history ID (may differ)
-    name: str                                # display name
-    section_number: int
-    score_type: str                          # "numeric" (1-5 AI), "yn" (Y/N AI),
-                                             # "manual" (1-5 analyst input), or
-                                             # "manual_yn" (Y/N analyst input —
-                                             # AI cannot score, e.g. cases that
-                                             # require supervisor verification)
-    score_range: Optional[list[int]] = None  # e.g. [1, 5] for numeric
-    audio_dependent: bool = False
-    rubric_question: Optional[str] = None
-    score_descriptions: Optional[dict[str, str]] = None
-    na_applicable: bool = False
-    confidence_cap: Optional[str] = None
-    special_reasoning_instructions: Optional[str] = None
-
-    auto_value: Optional[str] = None
-    """When set, the section is never AI-scored: the prompt builder skips
-    it, the writer hardcodes this value at the score column, and
-    reasoning + confidence cells stay blank. Used for sections with a
-    fixed answer (e.g. Sales Q18 screen_recording = 'Yes' for outbound)."""
-
-    manual_default_value: Optional[str] = None
-    """Default value Stage 2 writes to the score destination if a manual
-    section has no analyst-entered value at approval time. MS sets this
-    to '1' for documentation (legacy behavior — the FR1 score formula
-    needs a value at L for the calculation to work). Sales leaves it
-    null for pb_creation / mc_call_notes (the formula treats blank as
-    N/A and excludes from the weighted average)."""
-
-    deprecated_at: Optional[str] = None
-    """ISO date. Section stays in the layout for historical row stability
-    but is excluded from new evaluations. Reserved — not used at launch."""
+    ewma_trend_delta: float = 3.0
+    spc_sigma_multiplier: float = 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -206,54 +102,70 @@ class SectionDef(BaseModel):
 # ---------------------------------------------------------------------------
 
 class TeamConfig(BaseModel):
-    """Full configuration for one team's QA scoring setup."""
+    """Full configuration for one team's QA scoring setup.
+
+    `rubric` (RubricSection[] + ScoringPrompt) replaces the legacy top-level
+    `sections` + `scoring_prompt` + `rubric_version` triplet. The properties
+    below preserve the SectionDef-era filtering surface — every downstream
+    consumer keeps the same `.numeric_sections`, `.yn_sections`, etc.
+    """
     team_id: str
     display_name: str
     company: str
-    rubric_version: str = "1.0"
     excluded_test_agents: list[str] = Field(
         default_factory=list,
         description="Canonical agent names to exclude from analytics (e.g. dev/test users).",
     )
     gemini: GeminiConfig
     sheets: SheetsConfig
-    sections: list[SectionDef]
-    scoring_prompt: ScoringPromptConfig
+    rubric: Rubric
     stats: StatsConfig = Field(default_factory=StatsConfig)
+
+    model_config = ConfigDict(extra="ignore")
+
+    # --- Rubric passthroughs (backward-compat surface) ----------------------
+
+    @property
+    def rubric_version(self) -> str:
+        return self.rubric.rubric_version
+
+    @property
+    def sections(self) -> list[RubricSection]:
+        return self.rubric.sections
+
+    @property
+    def scoring_prompt(self) -> ScoringPrompt:
+        return self.rubric.scoring_prompt
 
     # --- Section partitions --------------------------------------------------
 
     @property
-    def ai_scored_sections(self) -> list[SectionDef]:
-        """Sections actually sent to Gemini.
-
-        Excludes manual + manual_yn sections (analyst-only) and
-        `auto_value` sections (writer hardcodes them — Gemini never sees
-        the question).
-        """
+    def ai_scored_sections(self) -> list[RubricSection]:
+        """Sections sent to the AI scorer. Excludes manual/manual_yn (analyst-
+        filled) and `auto_value` sections (writer hardcodes them)."""
         return [
             s for s in self.sections
             if s.score_type not in ("manual", "manual_yn") and s.auto_value is None
         ]
 
     @property
-    def numeric_sections(self) -> list[SectionDef]:
+    def numeric_sections(self) -> list[RubricSection]:
         """Sections whose stored value is a 1-5 score (AI or manual)."""
         return [s for s in self.sections if s.score_type in ("numeric", "manual")]
 
     @property
-    def yn_sections(self) -> list[SectionDef]:
+    def yn_sections(self) -> list[RubricSection]:
         """Sections whose stored value is Y/N (AI or manual). Includes
         `auto_value` sections (still Y/N data for analytics)."""
         return [s for s in self.sections if s.score_type in ("yn", "manual_yn")]
 
     @property
-    def manual_sections(self) -> list[SectionDef]:
-        """Sections filled by the analyst, not Gemini — either shape."""
+    def manual_sections(self) -> list[RubricSection]:
+        """Sections filled by the analyst, not the AI scorer."""
         return [s for s in self.sections if s.score_type in ("manual", "manual_yn")]
 
     @property
-    def auto_value_sections(self) -> list[SectionDef]:
+    def auto_value_sections(self) -> list[RubricSection]:
         """Sections with a hardcoded value — never AI-scored, never analyst-edited."""
         return [s for s in self.sections if s.auto_value is not None]
 
@@ -266,11 +178,7 @@ class TeamConfig(BaseModel):
 
     @property
     def yn_section_labels(self) -> dict[str, str]:
-        """history_id -> display name for Y/N sections.
-
-        Used by the dashboard to title binary-stats KPI cards and
-        roster-table columns.
-        """
+        """history_id -> display name for Y/N sections."""
         return {s.history_id: s.name for s in self.yn_sections}
 
     @property
@@ -284,56 +192,92 @@ class TeamConfig(BaseModel):
         return {s.history_id: s.name for s in self.numeric_sections}
 
     @property
-    def progression_sections(self) -> list[SectionDef]:
-        """Sections included in progression assessments.
-
-        Excludes auto_value sections — there's no signal in tracking a
-        constant value over time.
-        """
+    def progression_sections(self) -> list[RubricSection]:
+        """Sections included in progression assessments. Excludes auto_value."""
         return [s for s in self.sections if s.auto_value is None]
 
     @property
     def section_name_to_history_id(self) -> dict[str, str]:
-        """Display name -> history_id for all sections.
-
-        Used by progression_service to resolve Gemini response keys.
-        """
+        """Display name -> history_id for all sections. Used by
+        progression_service to resolve Gemini response keys."""
         return {s.name: s.history_id for s in self.sections}
 
     @property
-    def scoring_id_to_section(self) -> dict[str, SectionDef]:
-        """Lookup section by canonical scoring ID."""
+    def scoring_id_to_section(self) -> dict[str, RubricSection]:
+        """Lookup section by canonical scoring ID (Ops-signed short key)."""
         return {s.id: s for s in self.sections}
 
     @property
-    def history_id_to_section(self) -> dict[str, SectionDef]:
-        """Lookup section by history ID."""
+    def history_id_to_section(self) -> dict[str, RubricSection]:
+        """Lookup section by history ID (legacy Sheets-column identifier)."""
         return {s.history_id: s for s in self.sections}
 
     @property
-    def sections_by_number(self) -> list[SectionDef]:
+    def sections_by_number(self) -> list[RubricSection]:
         """Sections sorted by section_number — the canonical order for the
-        derived history/FR-AI layout. section_number is the stable
-        identifier; once a team's rubric publishes it must never shift."""
+        derived history/FR-AI layout."""
         return sorted(self.sections, key=lambda s: s.section_number)
 
     # --- Derived layout ------------------------------------------------------
 
     @property
     def history_layout(self) -> HistoryLayout:
-        """Column layout for Analyst_History and Form Responses AI tabs.
-
-        Both tabs share this shape; section index follows section_number
-        order (use `sections_by_number` to walk in lockstep).
-        """
+        """Column layout for Analyst_History and Form Responses AI tabs."""
         return HistoryLayout(n_sections=len(self.sections))
 
 
 # ---------------------------------------------------------------------------
-# Loader
+# Loader — handles both the new nested shape (MS) and the legacy flat shape (Sales)
 # ---------------------------------------------------------------------------
 
 _CONFIG_DIR = Path(__file__).parent / "teams"
+
+
+def _normalize_scoring_prompt(raw_prompt: dict[str, Any], sections: list[dict]) -> dict[str, Any]:
+    """Convert legacy scoring_prompt fields to the new ScoringPrompt shape.
+
+    Legacy Sales JSON uses `sop_sections: list[int]` (section numbers).
+    New shape uses `sop_sections: list[str]` (section ids). We convert by
+    resolving section_number → id against the sections array.
+
+    Also adds `audio_dependent_sections` (§8.3a Plan B) by scanning the
+    sections' `audio_dependent` flag if the field is missing.
+    """
+    prompt = dict(raw_prompt)
+
+    number_to_id = {s["section_number"]: s["id"] for s in sections if "section_number" in s and "id" in s}
+
+    sop = prompt.get("sop_sections", [])
+    if sop and all(isinstance(v, int) for v in sop):
+        prompt["sop_sections"] = [number_to_id[n] for n in sop if n in number_to_id]
+
+    if "audio_dependent_sections" not in prompt:
+        prompt["audio_dependent_sections"] = [
+            s["id"] for s in sections if s.get("audio_dependent")
+        ]
+
+    return prompt
+
+
+def _assemble_rubric_block(raw: dict[str, Any]) -> dict[str, Any]:
+    """Extract a Rubric-shaped dict from either the new or legacy JSON layout.
+
+    New (MS): `raw["rubric"] = {"rubric_version": "...", "sections": [...], "scoring_prompt": {...}}`
+    Legacy (Sales): top-level `raw["rubric_version"]`, `raw["sections"]`, `raw["scoring_prompt"]`
+    """
+    if "rubric" in raw:
+        block = dict(raw["rubric"])
+    else:
+        block = {
+            "rubric_version": raw.get("rubric_version", f"{raw.get('team_id', 'unknown')}_v1"),
+            "sections": raw["sections"],
+            "scoring_prompt": raw["scoring_prompt"],
+        }
+
+    block["scoring_prompt"] = _normalize_scoring_prompt(
+        block["scoring_prompt"], block["sections"]
+    )
+    return block
 
 
 @lru_cache(maxsize=8)
@@ -347,6 +291,9 @@ def get_team_config(team_id: str = "member_support") -> TeamConfig:
     if not path.exists():
         raise FileNotFoundError(f"No config for team '{team_id}': {path}")
     raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["rubric"] = _assemble_rubric_block(raw)
+    for legacy_key in ("rubric_version", "sections", "scoring_prompt"):
+        raw.pop(legacy_key, None)
     return TeamConfig(**raw)
 
 

--- a/qa-automation/AI-Scoring/backend/config/teams/member_support.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/member_support.json
@@ -2,7 +2,6 @@
   "team_id": "member_support",
   "display_name": "Member Support",
   "company": "Landing Living LLC",
-  "rubric_version": "2.0",
 
   "excluded_test_agents": ["Maximiliano Perez"],
 
@@ -36,15 +35,15 @@
       "tab_name": "Form Responses 1",
       "section_score_columns": {
         "D": "greeting",
-        "E": "caller_identity_validation",
-        "F": "purpose_of_call",
-        "G": "matching_the_moment",
+        "E": "caller_id",
+        "F": "purpose",
+        "G": "matching",
         "H": "process_adherence",
         "I": "call_resolution",
-        "J": "communication",
-        "K": "efficiency_call_handling",
-        "L": "documentation",
-        "M": "customer_resolution_indicator"
+        "J": "comms",
+        "K": "efficiency",
+        "L": "human_review_required",
+        "M": "cri"
       },
       "score_readback_col": "Q",
       "arrayformula_buffer_seconds": 4,
@@ -56,197 +55,203 @@
         "opportunities": "O",
         "dialpad_link": "P"
       },
-      "metadata_cols_note": "Call-time initiative (PR-1): `timestamp` (col A) now semantically holds the call's date_connected from Dialpad, not the eval/approval clock. Sourced via fr_ai_row[COL_TIMESTAMP] in Stage 2 — the FR-AI tab's col C was repurposed by sheets_service.write_draft_to_fr_ai. The JSON value 'A' didn't change; only the meaning of what lands there did. See references/CallTimeOnAnalystHistory.md."
+      "metadata_cols_note": "Call-time initiative (PR-1): `timestamp` (col A) now semantically holds the call's date_connected from Dialpad, not the eval/approval clock. Sourced via fr_ai_row[COL_TIMESTAMP] in Stage 2 — the FR-AI tab's col C was repurposed by sheets_service.write_draft_to_fr_ai. The JSON value 'A' didn't change; only the meaning of what lands there did. See references/CallTimeOnAnalystHistory.md. Section keys updated 2026-06-30 to Ops-signed short ids per Wave2Plan.md §9; column letters unchanged — sheet ARRAYFORMULAs reference letters, not names."
     },
     "mails_tab": "Mails"
   },
 
-  "sections": [
-    {
-      "id": "greeting",
-      "history_id": "greeting",
-      "name": "Greeting",
-      "section_number": 1,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": "Did the agent use the institutional greeting, their name and answer immediately?",
-      "score_descriptions": {
-        "1": "Not ready, no script, noisy headset",
-        "2": "Used script but poor tone, didn't pick up promptly",
-        "3": "Used script, answered within 5 seconds",
-        "4": "Missed self-introduction but answered timely",
-        "5": "Used script, great opening tone, answered immediately"
+  "rubric": {
+    "rubric_version": "member_support_v2",
+    "sections": [
+      {
+        "id": "greeting",
+        "history_id": "greeting",
+        "name": "Greeting",
+        "section_number": 1,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": "Did the agent use the institutional greeting, their name and answer immediately?",
+        "score_descriptions": {
+          "1": "Not ready, no script, noisy headset",
+          "2": "Used script but poor tone, didn't pick up promptly",
+          "3": "Used script, answered within 5 seconds",
+          "4": "Missed self-introduction but answered timely",
+          "5": "Used script, great opening tone, answered immediately"
+        },
+        "na_applicable": false,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "caller_identity_validation",
-      "history_id": "identity_validation",
-      "name": "Caller Identity Validation",
-      "section_number": 2,
-      "score_type": "yn",
-      "audio_dependent": false,
-      "rubric_question": "Did the agent verify: full name AND DOB (OR last 4 digits of payment method OR last 4 of SSN)?",
-      "na_applicable": true,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "purpose_of_call",
-      "history_id": "purpose_of_call",
-      "name": "Purpose of the Call",
-      "section_number": 3,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": "Did the agent ask relevant questions to understand the issue?",
-      "score_descriptions": {
-        "1": "Immediate transfer, no probing",
-        "2": "Repeated the question or asked obvious questions",
-        "3": "Understood but didn't probe or questions were convoluted",
-        "4": "Probing questions to get to root cause",
-        "5": "Multiple probing questions, reinstated problem back to member"
+      {
+        "id": "caller_id",
+        "history_id": "identity_validation",
+        "name": "Caller ID",
+        "section_number": 2,
+        "score_type": "yn",
+        "audio_dependent": false,
+        "rubric_question": "Did the agent verify: full name AND DOB (OR last 4 digits of payment method OR last 4 of SSN)?",
+        "na_applicable": true,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "matching_the_moment",
-      "history_id": "matching_the_moment",
-      "name": "Matching the Moment",
-      "section_number": 4,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": true,
-      "rubric_question": "Was tone and pace appropriate to the context of the call?",
-      "score_descriptions": {
-        "1": "Contrary/sarcastic tone, interrupting the guest",
-        "2": "Disregarded sentiment, monotonous, not assertive",
-        "3": "Matched the tone",
-        "4": "2 of 3: Assurance of assistance, empathy, paraphrasing",
-        "5": "All 3: Assurance + empathy + paraphrasing reason for call"
+      {
+        "id": "purpose",
+        "history_id": "purpose_of_call",
+        "name": "Purpose of the Call",
+        "section_number": 3,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": "Did the agent ask relevant questions to understand the issue?",
+        "score_descriptions": {
+          "1": "Immediate transfer, no probing",
+          "2": "Repeated the question or asked obvious questions",
+          "3": "Understood but didn't probe or questions were convoluted",
+          "4": "Probing questions to get to root cause",
+          "5": "Multiple probing questions, reinstated problem back to member"
+        },
+        "na_applicable": false,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": "medium",
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "process_adherence",
-      "history_id": "process_adherence",
-      "name": "Process Adherence",
-      "section_number": 5,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": "Did the agent follow correct process and company policies?",
-      "score_descriptions": {
-        "1": "Misinformed member, no action, didn't follow process",
-        "2": "Missing steps, incomplete info, gray areas",
-        "3": "Right steps but missed something minor",
-        "4": "Completed right steps",
-        "5": "Above and beyond, steps followed completely"
+      {
+        "id": "matching",
+        "history_id": "matching_the_moment",
+        "name": "Matching the Moment",
+        "section_number": 4,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": true,
+        "rubric_question": "Was tone and pace appropriate to the context of the call?",
+        "score_descriptions": {
+          "1": "Contrary/sarcastic tone, interrupting the guest",
+          "2": "Disregarded sentiment, monotonous, not assertive",
+          "3": "Matched the tone",
+          "4": "2 of 3: Assurance of assistance, empathy, paraphrasing",
+          "5": "All 3: Assurance + empathy + paraphrasing reason for call"
+        },
+        "na_applicable": false,
+        "confidence_cap": "medium",
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "call_resolution",
-      "history_id": "call_resolution",
-      "name": "Call Resolution",
-      "section_number": 6,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": "Was the issue fully resolved or clear resolution path provided?",
-      "score_descriptions": {
-        "1": "No solution provided or no follow-up",
-        "2": "Incorrect solution or improper expectations",
-        "3": "Found solution but missed small details",
-        "4": "Handled call, provided resolution but missed next steps",
-        "5": "Solution found, educated member on process and next steps"
+      {
+        "id": "process_adherence",
+        "history_id": "process_adherence",
+        "name": "Process Adherence",
+        "section_number": 5,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": "Did the agent follow correct process and company policies?",
+        "score_descriptions": {
+          "1": "Misinformed member, no action, didn't follow process",
+          "2": "Missing steps, incomplete info, gray areas",
+          "3": "Right steps but missed something minor",
+          "4": "Completed right steps",
+          "5": "Above and beyond, steps followed completely"
+        },
+        "na_applicable": false,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "communication",
-      "history_id": "communication",
-      "name": "Communication",
-      "section_number": 7,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": "Clear, concise, helpful information?",
-      "score_descriptions": {
-        "1": "Confusing, unclear, inappropriate language",
-        "2": "Landing lingo, grammatical errors, rambling, inappropriate slang",
-        "3": "Good simple communication",
-        "4": "Appropriate communication",
-        "5": "Professional wording, clear/concise, engaging, built rapport"
+      {
+        "id": "call_resolution",
+        "history_id": "call_resolution",
+        "name": "Call Resolution",
+        "section_number": 6,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": "Was the issue fully resolved or clear resolution path provided?",
+        "score_descriptions": {
+          "1": "No solution provided or no follow-up",
+          "2": "Incorrect solution or improper expectations",
+          "3": "Found solution but missed small details",
+          "4": "Handled call, provided resolution but missed next steps",
+          "5": "Solution found, educated member on process and next steps"
+        },
+        "na_applicable": false,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
-    },
-    {
-      "id": "efficiency_call_handling",
-      "history_id": "efficiency",
-      "name": "Efficiency & Call Handling",
-      "section_number": 8,
-      "score_type": "numeric",
-      "score_range": [1, 5],
-      "audio_dependent": true,
-      "rubric_question": "Handled efficiently without unnecessary delays?",
-      "score_descriptions": {
-        "1": "Call avoidance, inefficient hold use, didn't announce hold",
-        "2": "Didn't refresh member timely, wasted time finding solution",
-        "3": "Assisted but didn't inform caller about time needed",
-        "4": "Assisted guest in timely manner",
-        "5": "No hold/dead air OR proper hold expectations set, confident throughout"
+      {
+        "id": "comms",
+        "history_id": "communication",
+        "name": "Communication",
+        "section_number": 7,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": "Clear, concise, helpful information?",
+        "score_descriptions": {
+          "1": "Confusing, unclear, inappropriate language",
+          "2": "Landing lingo, grammatical errors, rambling, inappropriate slang",
+          "3": "Good simple communication",
+          "4": "Appropriate communication",
+          "5": "Professional wording, clear/concise, engaging, built rapport"
+        },
+        "na_applicable": false,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
       },
-      "na_applicable": false,
-      "confidence_cap": "medium",
-      "special_reasoning_instructions": "ALWAYS include timestamps if holds longer than 3 minutes or significant dead air (longer than 30 seconds) were detected"
-    },
-    {
-      "id": "documentation",
-      "history_id": "documentation",
-      "name": "Documentation",
-      "section_number": 9,
-      "score_type": "manual",
-      "score_range": [1, 5],
-      "audio_dependent": false,
-      "rubric_question": null,
-      "score_descriptions": null,
-      "na_applicable": false,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null,
-      "manual_default_value": "1"
-    },
-    {
-      "id": "customer_resolution_indicator",
-      "history_id": "customer_resolution_indicator",
-      "name": "Customer Resolution Indicator",
-      "section_number": 10,
-      "score_type": "yn",
-      "audio_dependent": false,
-      "rubric_question": "Did agent summarize result/actions AND ask if there is anything else they can do?",
-      "na_applicable": true,
-      "confidence_cap": null,
-      "special_reasoning_instructions": null
+      {
+        "id": "efficiency",
+        "history_id": "efficiency",
+        "name": "Efficiency & Call Handling",
+        "section_number": 8,
+        "score_type": "numeric",
+        "score_range": [1, 5],
+        "audio_dependent": true,
+        "rubric_question": "Handled efficiently without unnecessary delays?",
+        "score_descriptions": {
+          "1": "Call avoidance, inefficient hold use, didn't announce hold",
+          "2": "Didn't refresh member timely, wasted time finding solution",
+          "3": "Assisted but didn't inform caller about time needed",
+          "4": "Assisted guest in timely manner",
+          "5": "No hold/dead air OR proper hold expectations set, confident throughout"
+        },
+        "na_applicable": false,
+        "confidence_cap": "medium",
+        "special_reasoning_instructions": "ALWAYS include timestamps if holds longer than 3 minutes or significant dead air (longer than 30 seconds) were detected"
+      },
+      {
+        "id": "human_review_required",
+        "history_id": "human_review_required",
+        "name": "Human Review Required",
+        "section_number": 9,
+        "score_type": "manual",
+        "score_range": [1, 5],
+        "audio_dependent": false,
+        "rubric_question": null,
+        "score_descriptions": {
+          "1": "Reviewer agrees with the AI flag — agent handled this interaction poorly.",
+          "5": "Reviewer disagrees — false flag; agent handled the call well."
+        },
+        "na_applicable": true,
+        "confidence_cap": null,
+        "special_reasoning_instructions": "Filled by a human reviewer only when the AI trigger fires (§3.14). Default state is NA — the auto-flow never fires this section.",
+        "manual_default_value": "1"
+      },
+      {
+        "id": "cri",
+        "history_id": "customer_resolution_indicator",
+        "name": "Customer Resolution Indicator",
+        "section_number": 10,
+        "score_type": "yn",
+        "audio_dependent": false,
+        "rubric_question": "Did agent summarize result/actions AND ask if there is anything else they can do?",
+        "na_applicable": true,
+        "confidence_cap": null,
+        "special_reasoning_instructions": null
+      }
+    ],
+    "scoring_prompt": {
+      "system_prompt_template": "You are a QA evaluator for a call center at {company}.\nYou will listen to a full call recording and score it using the rubric provided.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the agent in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone, DO NOT use the Third person (\"they/them\") anywhere in your outputs.",
+      "confidence_levels_note": "- \"high\": Clear evidence in audio, no ambiguity\n- \"medium\": Reasonable inference, some ambiguity or audio-dependent nuance\n- \"low\": Insufficient signal, heavy guessing required",
+      "sop_sections": ["process_adherence", "call_resolution"],
+      "long_call_focus_sections": ["efficiency"],
+      "audio_dependent_sections": ["matching", "efficiency"]
     }
-  ],
-
-  "scoring_prompt": {
-    "system_prompt_template": "You are a QA evaluator for a call center at {company}.\nYou will listen to a full call recording and score it using the rubric provided.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the agent in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone, DO NOT use the Third person (\"they/them\") anywhere in your outputs.",
-    "confidence_levels_note": "- \"high\": Clear evidence in audio, no ambiguity\n- \"medium\": Reasonable inference, some ambiguity or audio-dependent nuance\n- \"low\": Insufficient signal, heavy guessing required",
-    "sop_sections": [5, 6],
-    "long_call_focus_sections": ["efficiency_call_handling"]
   }
 }

--- a/qa-automation/AI-Scoring/backend/models/formula.py
+++ b/qa-automation/AI-Scoring/backend/models/formula.py
@@ -1,0 +1,826 @@
+"""Pydantic models for the Postgres-owned scoring engine.
+
+Wave 2 Phase 1a: the shared schema every downstream write validates against.
+Covers the Ops-signed formula/rubric shape (member_support_scoring_migration.md §8,
+sales_scoring_migration.md §8) plus the DB-side row shapes from SQLMigration.md
+§3.4 / §3.5 / §3.19 / §3.20 / §3.21 / §8.1 / §8.2.
+
+Model summary:
+
+    Formula ─── §8 canonical config (formula_id, scale, normalization,
+                sections, rules, evaluation_order, triggers, external_signals)
+    Rule    ─── discriminated union of 6 types (score_override, weight_transfer,
+                weight_redistribution, score_scale, flag, na_redistribution)
+    Rubric  ─── §3.19.1 (rubric_version + sections + scoring_prompt)
+    RubricSection ── the full runtime shape (replaces legacy SectionDef)
+    ScoringPrompt ── Gemini prompt config, archived with the rubric
+
+    EvaluationSection ── §3.5 per-section row shape
+    AssessmentSection ── §3.21 progression-assessment section snapshot
+    ModelsUsed / AnnotatedTranscript / RecordingUrls ── JSONB shapes on
+                qa.evaluations (§8.1, §8.2, §3.4.2)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+WEIGHT_SUM_TOLERANCE = 0.01  # weights are floats; permit rounding noise
+RATING_MIN = 1
+RATING_MAX = 5
+
+
+# ---------------------------------------------------------------------------
+# Formula scaffolding
+# ---------------------------------------------------------------------------
+
+class ScoreScale(BaseModel):
+    """Output range of the formula (0-100 for both teams today)."""
+    model_config = ConfigDict(extra="forbid")
+    min: float
+    max: float
+
+
+class RatingCurve(BaseModel):
+    """Linear rating→frac curve. Both teams use (rating-1)/4 as the assumed
+    curve; Sales §10 flags it for confirmation."""
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["linear"] = "linear"
+    input_min: int = RATING_MIN
+    input_max: int = RATING_MAX
+    output: list[float] = Field(default_factory=lambda: [0.0, 1.0])
+
+
+class BinaryMap(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    Y: float = 1.0
+    N: float = 0.0
+
+
+NaPolicy = Literal["redistribute_per_rules", "full_credit"]
+"""Per-formula NA switch (Wave 2 Plan §8 critical risk #3).
+
+    MS   → redistribute_per_rules  (rules move the NA weight elsewhere)
+    Sales → full_credit             (NA section keeps its weight at frac=1.0)
+"""
+
+
+class Normalization(BaseModel):
+    """Normalization block from Ops-signed §8. `na` is the load-bearing switch."""
+    model_config = ConfigDict(extra="forbid")
+    rating_1_5: RatingCurve = Field(default_factory=RatingCurve)
+    binary_yn: BinaryMap = Field(default_factory=BinaryMap)
+    na: NaPolicy
+
+
+# Ops-signed section score types. `_na` suffix = section may return NA.
+# The DB-side qa.evaluation_sections.score_type is a coarser projection
+# (numeric / binary / manual_numeric / manual_binary / auto_value — §3.5)
+# derived at write time.
+FormulaSectionScoreType = Literal[
+    "rating_1_5",
+    "rating_1_5_na",
+    "binary_yn",
+    "binary_yn_na",
+    "manual_yn",
+    "auto_value",
+]
+
+
+SectionTrigger = Literal["active", "candidate"]
+
+
+class FormulaSection(BaseModel):
+    """A section entry inside a Formula. Ops-signed §8 shape.
+
+    Redundant with Rubric.sections on purpose: Formula is archived in
+    qa.formula_versions independently of the Rubric archive (qa.rubric_versions)
+    so it must be standalone-loadable. Cross-consistency is enforced at eval time
+    by compute_overall_score() and by the §3.19.3 rubric-vs-active-formula check.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    """Ops-signed short section id — matches Rubric.sections[].id."""
+    label: str
+    score_type: FormulaSectionScoreType
+    weight: float
+    trigger: Optional[SectionTrigger] = None
+    category: Optional[str] = None
+    """Optional grouping label (Sales carries it from the source PDF)."""
+    binary_map: Optional[BinaryMap] = None
+    """Override for the normalization's binary_map on a per-section basis.
+    Currently unused; reserved per SQLMigration §3.8 point 3."""
+    na_default: bool = False
+    """Presentational hint (§3.8 point 7): writer sets binary_value='NA' on
+    Stage 1 creation. `human_review_required` is the only section with this
+    today."""
+
+
+# ---------------------------------------------------------------------------
+# Rule library (6 types via discriminated union on `type`)
+# ---------------------------------------------------------------------------
+
+class RuleWhenSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    section: str
+    equals: Optional[str] = None
+    frac_lte: Optional[float] = None
+    frac_gte: Optional[float] = None
+
+
+class RuleWhenSignal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    signal: str
+
+
+class RuleWhenAny(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    any: list[Union[RuleWhenSection, RuleWhenSignal]]
+
+
+class RuleWhenAll(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    all: list[Union[RuleWhenSection, RuleWhenSignal]]
+
+
+RuleWhen = Union[RuleWhenSection, RuleWhenSignal, RuleWhenAny, RuleWhenAll]
+
+
+class ScoreOverrideEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    set_score: float
+
+
+class ScoreOverrideRule(BaseModel):
+    """MS `hard_zero` — sets final score = 0 when `caller_id = N`.
+    Disabled for MS per §5; kept for other teams (collections/billing/legal)."""
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["score_override"]
+    enabled: bool
+    when: RuleWhen
+    effect: ScoreOverrideEffect
+    note: Optional[str] = None
+
+
+class WeightTransferEffect(BaseModel):
+    """`amount: "all"` moves the whole weight; `fraction: N.M` moves a share.
+    MS's `frequent_caller_shift` uses fraction=0.5."""
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    from_: str = Field(alias="from")
+    to: Union[str, dict[str, float]]
+    amount: Optional[Literal["all"]] = None
+    fraction: Optional[float] = None
+    target_configurable: bool = False
+
+    @model_validator(mode="after")
+    def _one_of_amount_or_fraction(self) -> "WeightTransferEffect":
+        if (self.amount is None) == (self.fraction is None):
+            raise ValueError(
+                "weight_transfer effect: exactly one of `amount` or `fraction` required"
+            )
+        if self.fraction is not None and not (0 < self.fraction <= 1):
+            raise ValueError(
+                f"weight_transfer fraction must be in (0, 1], got {self.fraction}"
+            )
+        return self
+
+
+class WeightTransferRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["weight_transfer"]
+    enabled: bool
+    when: RuleWhen
+    effect: WeightTransferEffect
+    note: Optional[str] = None
+
+
+WeightRedistributionMethod = Literal["equal_additive", "proportional"]
+
+
+class WeightRedistributionEffect(BaseModel):
+    """Ops-signed `hrr_na_spread` uses method=equal_additive, to=active_sections."""
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    method: WeightRedistributionMethod
+    from_: str = Field(alias="from")
+    to: Union[Literal["active_sections", "remaining"], list[str]]
+
+
+class WeightRedistributionRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["weight_redistribution"]
+    enabled: bool
+    when: RuleWhen
+    effect: WeightRedistributionEffect
+    note: Optional[str] = None
+
+
+class ScoreScaleEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    multiply: float
+
+
+class ScoreScaleRule(BaseModel):
+    """MS `caller_id_scale_half` — post-sum × 0.5 when caller_id=N."""
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["score_scale"]
+    enabled: bool
+    when: RuleWhen
+    effect: ScoreScaleEffect
+    note: Optional[str] = None
+
+
+class FlagEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    emit_event: str
+    route: Optional[str] = None
+
+
+class FlagRule(BaseModel):
+    """MS `escalation_flag` — emits event, does NOT touch the score."""
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["flag"]
+    enabled: bool
+    when: RuleWhen
+    effect: FlagEffect
+    note: Optional[str] = None
+
+
+class NaRedistributionRule(BaseModel):
+    """SQLMigration §3.8's proportional NA redistribution. Distinct from
+    weight_redistribution (equal_additive): here the missing weight is spread
+    across `targets` proportional to their existing weights."""
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    type: Literal["na_redistribution"]
+    enabled: bool
+    when: RuleWhen
+    mode: Literal["proportional"] = "proportional"
+    targets: Union[Literal["remaining"], list[str]] = "remaining"
+    note: Optional[str] = None
+
+
+Rule = Annotated[
+    Union[
+        ScoreOverrideRule,
+        WeightTransferRule,
+        WeightRedistributionRule,
+        ScoreScaleRule,
+        FlagRule,
+        NaRedistributionRule,
+    ],
+    Field(discriminator="type"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Triggers, signals, human review
+# ---------------------------------------------------------------------------
+
+class TriggerThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    op: Literal["lte", "lt"] = "lte"
+    frac: float = 0.5
+    ratings: Optional[list[int]] = None
+
+
+class TriggersConfig(BaseModel):
+    """Ops-signed shape for section-level escalation triggers.
+
+    Distinct from §3.14 `human_review_triggers` (score-threshold on a
+    section triggers the human-review queue); both surfaces can coexist —
+    `active` here identifies which sections are candidate-for-escalation,
+    §3.14 is the pipeline-level gate. Sales' triggers block is empty."""
+    model_config = ConfigDict(extra="forbid")
+    threshold: Optional[TriggerThreshold] = None
+    active: list[str] = Field(default_factory=list)
+    candidates: list[str] = Field(default_factory=list)
+    routes_to: Optional[str] = None
+
+
+class ExternalSignal(BaseModel):
+    """MS's `frequent_caller` signal (looker_snapshot via command_center).
+    Wave 2 wires signals as `false` by default until CC ships (Wave 3)."""
+    model_config = ConfigDict(extra="forbid")
+    source: str
+    via: Optional[str] = None
+
+
+class HumanReviewTrigger(BaseModel):
+    """§3.14 pipeline trigger. Distinct from TriggersConfig's active list —
+    this one gates the human-review queue by a numeric_score threshold."""
+    model_config = ConfigDict(extra="forbid")
+    section_id: str
+    max_score_to_trigger: int = Field(ge=RATING_MIN, le=RATING_MAX)
+
+
+# ---------------------------------------------------------------------------
+# Formula (top-level)
+# ---------------------------------------------------------------------------
+
+WEIGHTED_SUM = "weighted_sum"
+"""Sentinel token used in evaluation_order to mark where Σ(weight×frac) runs."""
+
+
+class Formula(BaseModel):
+    """Ops-signed §8 canonical config. Archived as qa.formula_versions.formula_json."""
+    model_config = ConfigDict(extra="forbid")
+
+    formula_id: str
+    rubric_version: str
+    supersedes: Optional[str] = None
+    scale: ScoreScale
+    normalization: Normalization
+    sections: list[FormulaSection]
+    rules: list[Rule] = Field(default_factory=list)
+    evaluation_order: list[str]
+    triggers: TriggersConfig = Field(default_factory=TriggersConfig)
+    external_signals: dict[str, ExternalSignal] = Field(default_factory=dict)
+    deprecated_sections: list[str] = Field(default_factory=list)
+    human_review_triggers: list[HumanReviewTrigger] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _weights_sum_to_scale_max(self) -> "Formula":
+        total = sum(s.weight for s in self.sections)
+        target = self.scale.max
+        if abs(total - target) > WEIGHT_SUM_TOLERANCE:
+            raise ValueError(
+                f"formula {self.formula_id!r}: section weights sum to {total} "
+                f"but scale.max is {target} (tolerance {WEIGHT_SUM_TOLERANCE})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _unique_section_keys(self) -> "Formula":
+        keys = [s.key for s in self.sections]
+        if len(set(keys)) != len(keys):
+            dupes = sorted({k for k in keys if keys.count(k) > 1})
+            raise ValueError(
+                f"formula {self.formula_id!r}: duplicate section keys {dupes}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _unique_rule_ids(self) -> "Formula":
+        ids = [r.id for r in self.rules]
+        if len(set(ids)) != len(ids):
+            dupes = sorted({i for i in ids if ids.count(i) > 1})
+            raise ValueError(
+                f"formula {self.formula_id!r}: duplicate rule ids {dupes}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _evaluation_order_matches_rules(self) -> "Formula":
+        rule_ids = {r.id for r in self.rules}
+        allowed = rule_ids | {WEIGHTED_SUM}
+        unknown = [t for t in self.evaluation_order if t not in allowed]
+        if unknown:
+            raise ValueError(
+                f"formula {self.formula_id!r}: evaluation_order references "
+                f"unknown tokens {unknown} (allowed: rule ids + {WEIGHTED_SUM!r})"
+            )
+        if WEIGHTED_SUM not in self.evaluation_order:
+            raise ValueError(
+                f"formula {self.formula_id!r}: evaluation_order must include "
+                f"the {WEIGHTED_SUM!r} sentinel"
+            )
+        listed_rules = [t for t in self.evaluation_order if t in rule_ids]
+        if len(set(listed_rules)) != len(listed_rules):
+            raise ValueError(
+                f"formula {self.formula_id!r}: evaluation_order lists a rule "
+                f"more than once"
+            )
+        missing = rule_ids - set(listed_rules)
+        if missing:
+            raise ValueError(
+                f"formula {self.formula_id!r}: rules {sorted(missing)} defined "
+                f"but not scheduled in evaluation_order"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _human_review_triggers_reference_existing_sections(self) -> "Formula":
+        keys = {s.key for s in self.sections}
+        bad = [t.section_id for t in self.human_review_triggers if t.section_id not in keys]
+        if bad:
+            raise ValueError(
+                f"formula {self.formula_id!r}: human_review_triggers reference "
+                f"unknown sections {bad}"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Rubric — the full runtime shape (replaces legacy SectionDef)
+# ---------------------------------------------------------------------------
+
+# Runtime score_type — matches the current app's expectations. The `_na`
+# distinction lives on `na_applicable`, not encoded in this enum, so
+# existing filters like `s.score_type in ("numeric", "manual")` keep working.
+RubricSectionScoreType = Literal[
+    "numeric",
+    "yn",
+    "manual",
+    "manual_yn",
+    "auto_value",
+]
+
+
+class RubricSection(BaseModel):
+    """A single rubric section. Replaces `SectionDef` in team_config.py.
+
+    Uses Ops-signed short `id` (Wave 2 Plan §9 remapping). Preserves the
+    runtime fields SectionDef carried (rubric_question, score_descriptions,
+    etc.) so the AI scoring pipeline continues to work unchanged.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    history_id: str
+    name: str
+    section_number: int
+    score_type: RubricSectionScoreType
+    score_range: Optional[list[int]] = None
+    audio_dependent: bool = False
+    rubric_question: Optional[str] = None
+    score_descriptions: Optional[dict[str, str]] = None
+    na_applicable: bool = False
+    confidence_cap: Optional[str] = None
+    special_reasoning_instructions: Optional[str] = None
+    auto_value: Optional[str] = None
+    manual_default_value: Optional[str] = None
+    deprecated_at: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _auto_value_score_type(self) -> "RubricSection":
+        if self.auto_value is not None and self.score_type != "auto_value":
+            # SectionDef's convention lets `auto_value` coexist with `yn`
+            # (Sales Q18 screen_recording is `yn` + auto_value="Yes"). Preserve
+            # that: only enforce the invariant that `score_type='auto_value'`
+            # implies `auto_value` is set.
+            pass
+        if self.score_type == "auto_value" and self.auto_value is None:
+            raise ValueError(
+                f"section {self.id!r}: score_type='auto_value' requires `auto_value` to be set"
+            )
+        return self
+
+
+class ScoringPrompt(BaseModel):
+    """Prompt-level settings for the AI scorer. Archived with the rubric per
+    §3.19.1 so the AI contract is versioned end-to-end alongside sections."""
+    model_config = ConfigDict(extra="forbid")
+
+    system_prompt_template: str
+    confidence_levels_note: str
+    sop_sections: list[str] = Field(default_factory=list)
+    """Section ids (not numbers) that need SOP context in the prompt.
+
+    §3.19.1 validation: every id must exist in Rubric.sections[].id.
+    Historical note: `team_config.ScoringPromptConfig` accepted
+    section_number ints; the archived rubric_json shape (§3.19.1) uses ids
+    for stability across renumbering.
+    """
+    long_call_focus_sections: list[str] = Field(default_factory=list)
+    audio_dependent_sections: list[str] = Field(default_factory=list)
+    """Plan B routing config (§8.3a). Sections whose scoring quality depends
+    on audio fidelity — LandGPT reroutes them to Gemini if all come back
+    uniform LOW confidence."""
+
+
+class Rubric(BaseModel):
+    """qa.rubric_versions.rubric_json — the archived rubric per §3.19.1."""
+    model_config = ConfigDict(extra="forbid")
+
+    rubric_version: str
+    sections: list[RubricSection]
+    scoring_prompt: ScoringPrompt
+
+    @model_validator(mode="after")
+    def _unique_section_ids(self) -> "Rubric":
+        ids = [s.id for s in self.sections]
+        if len(set(ids)) != len(ids):
+            dupes = sorted({i for i in ids if ids.count(i) > 1})
+            raise ValueError(
+                f"rubric {self.rubric_version!r}: duplicate section ids {dupes}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _scoring_prompt_section_ids_exist(self) -> "Rubric":
+        section_ids = {s.id for s in self.sections}
+        bad_sop = [i for i in self.scoring_prompt.sop_sections if i not in section_ids]
+        bad_long = [i for i in self.scoring_prompt.long_call_focus_sections if i not in section_ids]
+        bad_audio = [i for i in self.scoring_prompt.audio_dependent_sections if i not in section_ids]
+        errs = []
+        if bad_sop:
+            errs.append(f"sop_sections references unknown section ids {bad_sop}")
+        if bad_long:
+            errs.append(f"long_call_focus_sections references unknown section ids {bad_long}")
+        if bad_audio:
+            errs.append(f"audio_dependent_sections references unknown section ids {bad_audio}")
+        if errs:
+            raise ValueError(f"rubric {self.rubric_version!r}: " + "; ".join(errs))
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Evaluation + Assessment section rows
+# ---------------------------------------------------------------------------
+
+# DB-facing score_type on qa.evaluation_sections (§3.5). Coarser than the
+# rubric's runtime score_type — flattens manual/manual_yn/numeric/binary
+# into the persisted enum values.
+EvaluationSectionScoreType = Literal[
+    "numeric",
+    "binary",
+    "manual_numeric",
+    "manual_binary",
+    "auto_value",
+]
+
+EvaluationScoreSource = Literal["ai", "manual", "auto_value", "manual_default"]
+EvaluationAiProvider = Literal["gemini", "landgpt"]
+
+
+class EvaluationSection(BaseModel):
+    """One row of qa.evaluation_sections. §3.5 shape.
+
+    CHECKs enforced by DB: exactly one of numeric_score/binary_value populated
+    matching score_type; ai_provider populated iff score_source='ai'. Pydantic
+    mirrors those checks at the writer boundary so violations fail fast.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    evaluation_id: Optional[int] = None
+    section_id: str
+    section_number: int
+    score_type: EvaluationSectionScoreType
+    numeric_score: Optional[int] = Field(default=None, ge=RATING_MIN, le=RATING_MAX)
+    binary_value: Optional[Literal["Y", "N", "NA"]] = None
+    score_source: EvaluationScoreSource
+    ai_provider: Optional[EvaluationAiProvider] = None
+    model: Optional[str] = None
+    confidence: Optional[Literal["LOW", "MED", "HIGH"]] = None
+    reasoning: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _exactly_one_score_populated(self) -> "EvaluationSection":
+        is_numeric = self.score_type in ("numeric", "manual_numeric")
+        is_binary = self.score_type in ("binary", "manual_binary")
+        if is_numeric:
+            if self.numeric_score is None or self.binary_value is not None:
+                raise ValueError(
+                    f"section {self.section_id!r}: score_type={self.score_type!r} "
+                    "requires numeric_score set and binary_value NULL"
+                )
+        elif is_binary:
+            if self.binary_value is None or self.numeric_score is not None:
+                raise ValueError(
+                    f"section {self.section_id!r}: score_type={self.score_type!r} "
+                    "requires binary_value set and numeric_score NULL"
+                )
+        elif self.score_type == "auto_value":
+            if self.binary_value is None and self.numeric_score is None:
+                raise ValueError(
+                    f"section {self.section_id!r}: auto_value section must "
+                    "populate one of binary_value or numeric_score"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _ai_provider_iff_ai_source(self) -> "EvaluationSection":
+        if self.score_source == "ai":
+            if self.ai_provider is None:
+                raise ValueError(
+                    f"section {self.section_id!r}: score_source='ai' requires ai_provider"
+                )
+        else:
+            if self.ai_provider is not None:
+                raise ValueError(
+                    f"section {self.section_id!r}: ai_provider only valid when "
+                    "score_source='ai'"
+                )
+        return self
+
+
+AssessmentTrend = Literal["improving", "stable", "declining"]
+
+
+class AssessmentSection(BaseModel):
+    """qa.assessment_sections row — §3.21 shape. Snapshots section identity
+    at generation time so historical assessments render correctly after the
+    rubric is reshaped."""
+    model_config = ConfigDict(extra="forbid")
+
+    assessment_id: Optional[int] = None
+    section_id: str
+    section_name: str
+    section_number: int
+    trend: AssessmentTrend
+    summary: str
+    coaching_tip: str
+
+
+# ---------------------------------------------------------------------------
+# JSONB shapes on qa.evaluations
+# ---------------------------------------------------------------------------
+
+class ModelInfo(BaseModel):
+    """One leg of the audio/text cascade in `models_used`."""
+    model_config = ConfigDict(extra="forbid")
+    provider: str
+    model: str
+    version: Optional[str] = None
+
+
+class FallbackInfo(BaseModel):
+    """Plan B activation record — which sections rerouted and why. §8.3a."""
+    model_config = ConfigDict(extra="forbid")
+    provider: str
+    sections: list[str]
+    reason: str
+
+
+class ModelsUsed(BaseModel):
+    """qa.evaluations.models_used JSONB — §8.1 shape.
+
+    Pre-LandGPT runs: `audio` NULL/omitted, `text = gemini-2.5-flash`.
+    Post-LandGPT: both legs populated, `fallback` records Plan B if fired.
+    """
+    model_config = ConfigDict(extra="forbid")
+    audio: Optional[ModelInfo] = None
+    text: Optional[ModelInfo] = None
+    fallback: Optional[FallbackInfo] = None
+
+
+class TranscriptTurn(BaseModel):
+    """One turn in AnnotatedTranscript.turns. Qwen2-Audio output per §8.2."""
+    model_config = ConfigDict(extra="forbid")
+    speaker: Literal["agent", "caller", "system", "other"]
+    text: str
+    emotion: Optional[str] = None
+    paraphrase_intent: Optional[str] = None
+    pace_marker: Optional[str] = None
+    interruption: Optional[bool] = None
+    start_ms: Optional[int] = None
+    end_ms: Optional[int] = None
+
+
+class AnnotatedTranscript(BaseModel):
+    """qa.evaluations.annotated_transcript JSONB — §8.2 shape.
+
+    NULL for Gemini-scored evaluations (pre-LandGPT / Plan-B-only routes).
+    Always populated when models_used.audio.provider == 'landgpt'.
+    """
+    model_config = ConfigDict(extra="forbid")
+    schema_version: str
+    language_detected: Optional[str] = None
+    turns: list[TranscriptTurn]
+
+
+class RecordingUrls(BaseModel):
+    """qa.evaluations.recording_urls JSONB — §3.4.2 shape. Raw dialpad
+    recording_details (ids, durations, start_time) stay in dialpad_call_metadata."""
+    model_config = ConfigDict(extra="forbid")
+    audio: list[str] = Field(default_factory=list)
+    screen: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Cross-artifact consistency (§3.19.3)
+# ---------------------------------------------------------------------------
+
+def validate_formula_against_rubric(formula: Formula, rubric: Rubric) -> None:
+    """§3.19.3 hard-fail check — every section the formula references must
+    exist in the rubric. Called at API boundaries where formula/rubric are
+    loaded together (e.g. compute_overall_score, POST /rubric edit path).
+    """
+    rubric_ids = {s.id for s in rubric.sections}
+    formula_ids = {s.key for s in formula.sections}
+
+    # Rules and evaluation_order can reference sections via when/effect.
+    rule_referenced: set[str] = set()
+    for rule in formula.rules:
+        rule_referenced |= _sections_in_when(rule.when)
+        rule_referenced |= _sections_in_effect(rule)
+
+    missing = (formula_ids | rule_referenced) - rubric_ids
+    if missing:
+        raise FormulaRubricMismatchError(sorted(missing), formula.formula_id, rubric.rubric_version)
+
+
+def _sections_in_when(when: RuleWhen) -> set[str]:
+    if isinstance(when, RuleWhenSection):
+        return {when.section}
+    if isinstance(when, RuleWhenSignal):
+        return set()
+    if isinstance(when, (RuleWhenAny, RuleWhenAll)):
+        clauses = when.any if isinstance(when, RuleWhenAny) else when.all
+        out: set[str] = set()
+        for c in clauses:
+            if isinstance(c, RuleWhenSection):
+                out.add(c.section)
+        return out
+    return set()
+
+
+def _sections_in_effect(rule: Rule) -> set[str]:
+    out: set[str] = set()
+    effect = getattr(rule, "effect", None)
+    if effect is None:
+        return out
+    src = getattr(effect, "from_", None)
+    if isinstance(src, str):
+        out.add(src)
+    dst = getattr(effect, "to", None)
+    if isinstance(dst, str) and dst not in ("active_sections", "remaining"):
+        out.add(dst)
+    elif isinstance(dst, list):
+        out.update(dst)
+    elif isinstance(dst, dict):
+        out.update(dst.keys())
+    return out
+
+
+class FormulaRubricMismatchError(ValueError):
+    """§3.19.3: rubric drops/renames a section the active formula references."""
+
+    def __init__(self, missing: list[str], formula_id: str, rubric_version: str) -> None:
+        self.missing = missing
+        self.formula_id = formula_id
+        self.rubric_version = rubric_version
+        super().__init__(
+            f"formula {formula_id!r} references sections not in rubric "
+            f"{rubric_version!r}: {missing}"
+        )
+
+
+__all__ = [
+    # Formula
+    "Formula",
+    "FormulaSection",
+    "FormulaSectionScoreType",
+    "ScoreScale",
+    "Normalization",
+    "RatingCurve",
+    "BinaryMap",
+    "NaPolicy",
+    "SectionTrigger",
+    "TriggersConfig",
+    "TriggerThreshold",
+    "ExternalSignal",
+    "HumanReviewTrigger",
+    "WEIGHTED_SUM",
+    # Rules
+    "Rule",
+    "ScoreOverrideRule",
+    "ScoreOverrideEffect",
+    "WeightTransferRule",
+    "WeightTransferEffect",
+    "WeightRedistributionRule",
+    "WeightRedistributionEffect",
+    "WeightRedistributionMethod",
+    "ScoreScaleRule",
+    "ScoreScaleEffect",
+    "FlagRule",
+    "FlagEffect",
+    "NaRedistributionRule",
+    "RuleWhen",
+    "RuleWhenSection",
+    "RuleWhenSignal",
+    "RuleWhenAny",
+    "RuleWhenAll",
+    # Rubric
+    "Rubric",
+    "RubricSection",
+    "RubricSectionScoreType",
+    "ScoringPrompt",
+    # DB row shapes
+    "EvaluationSection",
+    "EvaluationSectionScoreType",
+    "EvaluationScoreSource",
+    "EvaluationAiProvider",
+    "AssessmentSection",
+    "AssessmentTrend",
+    # JSONB shapes
+    "ModelsUsed",
+    "ModelInfo",
+    "FallbackInfo",
+    "AnnotatedTranscript",
+    "TranscriptTurn",
+    "RecordingUrls",
+    # Cross-checks
+    "validate_formula_against_rubric",
+    "FormulaRubricMismatchError",
+]

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -44,7 +44,8 @@ from backend.config.history_layout import col_index_to_letter, col_letter_to_ind
 from backend.models.scorecard import ScorecardWithMeta
 
 if TYPE_CHECKING:
-    from backend.config.team_config import SectionDef, TeamConfig
+    from backend.config.team_config import TeamConfig
+    from backend.models.formula import RubricSection
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
@@ -124,7 +125,7 @@ def _format_call_started(call_started_at_utc) -> str:
     return call_started_at_utc.strftime("%m/%d/%Y %H:%M:%S")
 
 
-def _format_ai_score(sec_def: SectionDef, ai_section: dict) -> str:
+def _format_ai_score(sec_def: RubricSection, ai_section: dict) -> str:
     """Convert AI-output section dict to a score-cell string.
 
     Explicit N/A wins regardless of score_type: when ``yn_value == "NA"``,

--- a/qa-automation/AI-Scoring/tests/conftest.py
+++ b/qa-automation/AI-Scoring/tests/conftest.py
@@ -28,7 +28,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from backend.config import history_layout  # noqa: E402
-from backend.config.team_config import TeamConfig  # noqa: E402
+from backend.config.team_config import TeamConfig, _assemble_rubric_block  # noqa: E402
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "teams"
 _PROD_CONFIG_DIR = _REPO_ROOT / "backend" / "config" / "teams"
@@ -47,14 +47,17 @@ def load_test_config(name: str) -> TeamConfig:
     fixture_path = _FIXTURE_DIR / f"{name}.json"
     if fixture_path.exists():
         raw = json.loads(fixture_path.read_text(encoding="utf-8"))
-        return TeamConfig(**raw)
-    prod_path = _PROD_CONFIG_DIR / f"{name}.json"
-    if prod_path.exists():
+    else:
+        prod_path = _PROD_CONFIG_DIR / f"{name}.json"
+        if not prod_path.exists():
+            raise FileNotFoundError(
+                f"No config '{name}' under {_FIXTURE_DIR} or {_PROD_CONFIG_DIR}"
+            )
         raw = json.loads(prod_path.read_text(encoding="utf-8"))
-        return TeamConfig(**raw)
-    raise FileNotFoundError(
-        f"No config '{name}' under {_FIXTURE_DIR} or {_PROD_CONFIG_DIR}"
-    )
+    raw["rubric"] = _assemble_rubric_block(raw)
+    for legacy_key in ("rubric_version", "sections", "scoring_prompt"):
+        raw.pop(legacy_key, None)
+    return TeamConfig(**raw)
 
 
 @pytest.fixture(params=TEST_CONFIG_NAMES)

--- a/qa-automation/AI-Scoring/tests/test_formula_models.py
+++ b/qa-automation/AI-Scoring/tests/test_formula_models.py
@@ -1,0 +1,548 @@
+"""Pydantic model tests for the Postgres-owned scoring engine.
+
+Locks the Formula/Rubric/Rule shapes ahead of Wave 2 Phase 2 (rule engine +
+compute_overall_score). Uses the shipped MS overall_formula.json + team.json
+as the canonical happy-path fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from backend.models.formula import (
+    AnnotatedTranscript,
+    AssessmentSection,
+    EvaluationSection,
+    FallbackInfo,
+    Formula,
+    FormulaRubricMismatchError,
+    ModelsUsed,
+    RecordingUrls,
+    Rubric,
+    RubricSection,
+    WEIGHTED_SUM,
+    validate_formula_against_rubric,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MS_TEAM_JSON = _REPO_ROOT / "backend" / "config" / "teams" / "member_support.json"
+_MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
+
+
+@pytest.fixture(scope="module")
+def ms_formula_raw() -> dict:
+    return json.loads(_MS_FORMULA_JSON.read_text())
+
+
+@pytest.fixture(scope="module")
+def ms_team_raw() -> dict:
+    return json.loads(_MS_TEAM_JSON.read_text())
+
+
+@pytest.fixture(scope="module")
+def ms_formula(ms_formula_raw) -> Formula:
+    return Formula.model_validate(ms_formula_raw)
+
+
+@pytest.fixture(scope="module")
+def ms_rubric(ms_team_raw) -> Rubric:
+    return Rubric.model_validate(ms_team_raw["rubric"])
+
+
+# ---------------------------------------------------------------------------
+# Happy-path — ships-with-repo configs load
+# ---------------------------------------------------------------------------
+
+class TestMemberSupportShippedConfig:
+    """The MS files in the repo must load. If these break, downstream is blocked."""
+
+    def test_formula_loads(self, ms_formula):
+        assert ms_formula.formula_id == "member_support_v2"
+        assert len(ms_formula.sections) == 10
+        assert len(ms_formula.rules) == 6
+
+    def test_rubric_loads(self, ms_rubric):
+        assert ms_rubric.rubric_version == "member_support_v2"
+        assert len(ms_rubric.sections) == 10
+
+    def test_version_link_matches(self, ms_formula, ms_rubric):
+        assert ms_formula.rubric_version == ms_rubric.rubric_version
+
+    def test_cross_validation_passes(self, ms_formula, ms_rubric):
+        validate_formula_against_rubric(ms_formula, ms_rubric)
+
+    def test_weight_sum_equals_scale_max(self, ms_formula):
+        total = sum(s.weight for s in ms_formula.sections)
+        assert total == pytest.approx(ms_formula.scale.max)
+
+    def test_ms_na_policy_is_redistribute(self, ms_formula):
+        assert ms_formula.normalization.na == "redistribute_per_rules"
+
+    def test_ms_has_human_review_triggers(self, ms_formula):
+        keys = {t.section_id for t in ms_formula.human_review_triggers}
+        assert keys == {"process_adherence", "call_resolution"}
+
+    def test_ms_formula_round_trips(self, ms_formula_raw, ms_formula):
+        # Preserve alias-keyed dict (`from` → `from_`) via by_alias=True.
+        dumped = ms_formula.model_dump(by_alias=True)
+        Formula.model_validate(dumped)
+
+
+class TestSalesCanonicalConfig:
+    """Sales §8 canonical config parses cleanly even though the JSON file
+    hasn't been regenerated yet (blocked on §10 sign-off)."""
+
+    @pytest.fixture(scope="class")
+    def sales_formula(self) -> Formula:
+        return Formula.model_validate({
+            "formula_id": "sales_v1",
+            "rubric_version": "sales_v1",
+            "supersedes": None,
+            "scale": {"min": 0, "max": 100},
+            "normalization": {
+                "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+                "binary_yn": {"Y": 1.0, "N": 0.0},
+                "na": "full_credit",
+            },
+            "sections": [
+                {"key": "greeting",           "label": "Greeting",              "category": "Opening",     "score_type": "binary_yn_na",  "weight": 5.0},
+                {"key": "stay_type",          "label": "Personal or COHO Stay", "category": "Opening",     "score_type": "binary_yn_na",  "weight": 4.0},
+                {"key": "move_reason",        "label": "Move Reason",           "category": "Discovery",   "score_type": "rating_1_5_na", "weight": 15.0},
+                {"key": "landing_intro",      "label": "Landing Intro",         "category": "Discovery",   "score_type": "binary_yn_na",  "weight": 6.0},
+                {"key": "timeline_housing",   "label": "Timeline & Housing",    "category": "Discovery",   "score_type": "rating_1_5_na", "weight": 8.0},
+                {"key": "landing_guarantee",  "label": "Landing Guarantee",     "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 6.0},
+                {"key": "pricing",            "label": "Pricing Breakdown",     "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 8.0},
+                {"key": "fit_confirmation",   "label": "Confirmation of Fit",   "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 5.0},
+                {"key": "objection_handling", "label": "Objection Handling",    "category": "Objections",  "score_type": "rating_1_5_na", "weight": 8.0},
+                {"key": "urgency",            "label": "Urgency",               "category": "Objections",  "score_type": "binary_yn_na",  "weight": 5.0},
+                {"key": "follow_up",          "label": "Follow-up",             "category": "Objections",  "score_type": "binary_yn_na",  "weight": 6.0},
+                {"key": "potential_booking",  "label": "Potential Booking",     "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 4.0},
+                {"key": "notes_mc",           "label": "Detailed Notes in MC",  "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 5.0},
+                {"key": "contact_shared",     "label": "Contact Shared",        "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 5.0},
+                {"key": "client_experience",  "label": "Client Experience",     "category": "Post-Call",   "score_type": "rating_1_5_na", "weight": 10.0},
+            ],
+            "rules": [],
+            "evaluation_order": [WEIGHTED_SUM],
+            "triggers": {},
+            "external_signals": {},
+            "deprecated_sections": [],
+        })
+
+    def test_loads_fifteen_sections(self, sales_formula):
+        assert len(sales_formula.sections) == 15
+
+    def test_full_credit_na_policy(self, sales_formula):
+        assert sales_formula.normalization.na == "full_credit"
+
+    def test_no_rules_no_triggers(self, sales_formula):
+        assert sales_formula.rules == []
+        assert sales_formula.human_review_triggers == []
+
+    def test_evaluation_order_is_just_weighted_sum(self, sales_formula):
+        assert sales_formula.evaluation_order == [WEIGHTED_SUM]
+
+    def test_weights_sum_to_hundred(self, sales_formula):
+        assert sum(s.weight for s in sales_formula.sections) == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# Validator guardrails (Wave 2 Plan §8 delivery risks)
+# ---------------------------------------------------------------------------
+
+def _minimal_formula() -> dict:
+    """Smallest passing formula — used as a base to mutate for negative tests."""
+    return {
+        "formula_id": "test_v1",
+        "rubric_version": "test_v1",
+        "scale": {"min": 0, "max": 100},
+        "normalization": {
+            "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+            "binary_yn": {"Y": 1.0, "N": 0.0},
+            "na": "full_credit",
+        },
+        "sections": [
+            {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 60.0},
+            {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+        ],
+        "rules": [],
+        "evaluation_order": [WEIGHTED_SUM],
+        "triggers": {},
+        "external_signals": {},
+    }
+
+
+class TestFormulaValidators:
+
+    def test_weight_sum_wrong_raises(self):
+        raw = _minimal_formula()
+        raw["sections"][0]["weight"] = 50.0  # sum becomes 90
+        with pytest.raises(ValidationError, match="section weights sum to"):
+            Formula.model_validate(raw)
+
+    def test_missing_na_policy_raises(self):
+        raw = _minimal_formula()
+        del raw["normalization"]["na"]
+        with pytest.raises(ValidationError):
+            Formula.model_validate(raw)
+
+    def test_bad_na_policy_raises(self):
+        raw = _minimal_formula()
+        raw["normalization"]["na"] = "silent_lose"
+        with pytest.raises(ValidationError):
+            Formula.model_validate(raw)
+
+    def test_evaluation_order_missing_weighted_sum_raises(self):
+        raw = _minimal_formula()
+        raw["evaluation_order"] = []
+        with pytest.raises(ValidationError, match="weighted_sum"):
+            Formula.model_validate(raw)
+
+    def test_evaluation_order_unknown_rule_raises(self):
+        raw = _minimal_formula()
+        raw["evaluation_order"] = [WEIGHTED_SUM, "nonexistent_rule"]
+        with pytest.raises(ValidationError, match="unknown tokens"):
+            Formula.model_validate(raw)
+
+    def test_evaluation_order_missing_rule_raises(self):
+        raw = _minimal_formula()
+        raw["rules"] = [{
+            "id": "r1", "type": "score_scale", "enabled": True,
+            "when": {"section": "a", "equals": "N"},
+            "effect": {"multiply": 0.5},
+        }]
+        raw["evaluation_order"] = [WEIGHTED_SUM]  # r1 defined but not scheduled
+        with pytest.raises(ValidationError, match="defined but not scheduled"):
+            Formula.model_validate(raw)
+
+    def test_duplicate_section_keys_raise(self):
+        raw = _minimal_formula()
+        raw["sections"] = [
+            {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 50.0},
+            {"key": "a", "label": "A dup", "score_type": "rating_1_5", "weight": 50.0},
+        ]
+        with pytest.raises(ValidationError, match="duplicate section keys"):
+            Formula.model_validate(raw)
+
+    def test_duplicate_rule_ids_raise(self):
+        raw = _minimal_formula()
+        rule = {
+            "id": "same", "type": "score_scale", "enabled": True,
+            "when": {"section": "a", "equals": "N"},
+            "effect": {"multiply": 0.5},
+        }
+        raw["rules"] = [rule, dict(rule)]
+        raw["evaluation_order"] = ["same", WEIGHTED_SUM]
+        with pytest.raises(ValidationError, match="duplicate rule ids"):
+            Formula.model_validate(raw)
+
+    def test_human_review_trigger_unknown_section_raises(self):
+        raw = _minimal_formula()
+        raw["human_review_triggers"] = [{"section_id": "nope", "max_score_to_trigger": 3}]
+        with pytest.raises(ValidationError, match="unknown sections"):
+            Formula.model_validate(raw)
+
+
+class TestRuleTypes:
+    """One test per rule type — confirms discriminated union routes correctly."""
+
+    def _wrap(self, rule: dict) -> Formula:
+        raw = _minimal_formula()
+        raw["rules"] = [rule]
+        raw["evaluation_order"] = [rule["id"], WEIGHTED_SUM]
+        return Formula.model_validate(raw)
+
+    def test_score_override(self):
+        f = self._wrap({
+            "id": "hz", "type": "score_override", "enabled": False,
+            "when": {"section": "a", "equals": "N"},
+            "effect": {"set_score": 0},
+        })
+        assert f.rules[0].type == "score_override"
+
+    def test_weight_transfer_with_amount(self):
+        f = self._wrap({
+            "id": "wt", "type": "weight_transfer", "enabled": True,
+            "when": {"section": "a", "equals": "NA"},
+            "effect": {"from": "a", "to": "b", "amount": "all"},
+        })
+        assert f.rules[0].effect.amount == "all"
+        assert f.rules[0].effect.from_ == "a"
+
+    def test_weight_transfer_with_fraction(self):
+        f = self._wrap({
+            "id": "wt", "type": "weight_transfer", "enabled": True,
+            "when": {"signal": "some_signal"},
+            "effect": {"from": "a", "to": "b", "fraction": 0.5},
+        })
+        assert f.rules[0].effect.fraction == 0.5
+
+    def test_weight_transfer_needs_exactly_one_of_amount_or_fraction(self):
+        with pytest.raises(ValidationError, match="exactly one of `amount` or `fraction`"):
+            self._wrap({
+                "id": "wt", "type": "weight_transfer", "enabled": True,
+                "when": {"section": "a", "equals": "NA"},
+                "effect": {"from": "a", "to": "b"},  # neither
+            })
+
+    def test_weight_redistribution(self):
+        f = self._wrap({
+            "id": "wr", "type": "weight_redistribution", "enabled": True,
+            "when": {"section": "a", "equals": "NA"},
+            "effect": {"method": "equal_additive", "from": "a", "to": "active_sections"},
+        })
+        assert f.rules[0].effect.method == "equal_additive"
+
+    def test_score_scale(self):
+        f = self._wrap({
+            "id": "ss", "type": "score_scale", "enabled": True,
+            "when": {"section": "a", "equals": "N"},
+            "effect": {"multiply": 0.5},
+        })
+        assert f.rules[0].effect.multiply == 0.5
+
+    def test_flag(self):
+        f = self._wrap({
+            "id": "fg", "type": "flag", "enabled": True,
+            "when": {"any": [{"section": "a", "frac_lte": 0.5}]},
+            "effect": {"emit_event": "review", "route": "supervisor"},
+        })
+        assert f.rules[0].effect.emit_event == "review"
+
+    def test_na_redistribution(self):
+        f = self._wrap({
+            "id": "nr", "type": "na_redistribution", "enabled": True,
+            "when": {"section": "a", "equals": "NA"},
+            "targets": "remaining",
+        })
+        assert f.rules[0].mode == "proportional"
+        assert f.rules[0].targets == "remaining"
+
+
+# ---------------------------------------------------------------------------
+# Rubric — cross-reference guardrails (§3.19)
+# ---------------------------------------------------------------------------
+
+class TestRubricValidators:
+
+    def _minimal_rubric(self) -> dict:
+        return {
+            "rubric_version": "rt_v1",
+            "sections": [
+                {"id": "a", "history_id": "a", "name": "A", "section_number": 1, "score_type": "numeric"},
+                {"id": "b", "history_id": "b", "name": "B", "section_number": 2, "score_type": "yn"},
+            ],
+            "scoring_prompt": {
+                "system_prompt_template": "prompt",
+                "confidence_levels_note": "notes",
+                "sop_sections": [],
+                "long_call_focus_sections": [],
+                "audio_dependent_sections": [],
+            },
+        }
+
+    def test_scoring_prompt_references_unknown_section_raises(self):
+        raw = self._minimal_rubric()
+        raw["scoring_prompt"]["sop_sections"] = ["nonexistent"]
+        with pytest.raises(ValidationError, match="sop_sections references unknown"):
+            Rubric.model_validate(raw)
+
+    def test_duplicate_section_ids_raise(self):
+        raw = self._minimal_rubric()
+        raw["sections"][1]["id"] = "a"
+        with pytest.raises(ValidationError, match="duplicate section ids"):
+            Rubric.model_validate(raw)
+
+    def test_auto_value_requires_auto_value_score_type(self):
+        # `score_type='auto_value'` requires `auto_value` set — inverse of below.
+        with pytest.raises(ValidationError, match="requires `auto_value`"):
+            RubricSection.model_validate({
+                "id": "sr", "history_id": "sr", "name": "screen_recording",
+                "section_number": 1, "score_type": "auto_value",
+            })
+
+
+class TestFormulaRubricCrossValidation:
+    """§3.19.3 hard-fail check — the invariant that makes reproducibility work."""
+
+    def _minimal_rubric(self, ids: list[str]) -> dict:
+        return {
+            "rubric_version": "cross_v1",
+            "sections": [
+                {"id": i, "history_id": i, "name": i, "section_number": n, "score_type": "numeric"}
+                for n, i in enumerate(ids, start=1)
+            ],
+            "scoring_prompt": {
+                "system_prompt_template": "p", "confidence_levels_note": "n",
+                "sop_sections": [], "long_call_focus_sections": [], "audio_dependent_sections": [],
+            },
+        }
+
+    def test_missing_section_in_rubric_raises(self):
+        rubric = Rubric.model_validate(self._minimal_rubric(["a"]))
+        formula = Formula.model_validate({
+            **_minimal_formula(),
+            "sections": [
+                {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 100.0},
+            ],
+        })
+        # Now the rubric drops "b" — formula still fine, but if we swap a
+        # formula that references "b" the check fails.
+        formula2 = Formula.model_validate({
+            **_minimal_formula(),
+            "sections": [
+                {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 50.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 50.0},
+            ],
+        })
+        validate_formula_against_rubric(formula, rubric)  # OK
+        with pytest.raises(FormulaRubricMismatchError) as exc_info:
+            validate_formula_against_rubric(formula2, rubric)
+        assert exc_info.value.missing == ["b"]
+
+    def test_rule_referenced_section_missing_raises(self):
+        rubric = Rubric.model_validate(self._minimal_rubric(["a"]))
+        formula = Formula.model_validate({
+            **_minimal_formula(),
+            "sections": [
+                {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 100.0},
+            ],
+            "rules": [{
+                "id": "wt", "type": "weight_transfer", "enabled": True,
+                "when": {"section": "phantom", "equals": "NA"},
+                "effect": {"from": "phantom", "to": "a", "amount": "all"},
+            }],
+            "evaluation_order": ["wt", WEIGHTED_SUM],
+        })
+        with pytest.raises(FormulaRubricMismatchError):
+            validate_formula_against_rubric(formula, rubric)
+
+
+# ---------------------------------------------------------------------------
+# EvaluationSection — §3.5 DB row constraints
+# ---------------------------------------------------------------------------
+
+class TestEvaluationSectionValidators:
+
+    def test_numeric_requires_numeric_score(self):
+        with pytest.raises(ValidationError, match="requires numeric_score"):
+            EvaluationSection.model_validate({
+                "section_id": "greeting", "section_number": 1,
+                "score_type": "numeric", "score_source": "ai",
+                "ai_provider": "gemini",
+                "binary_value": "Y",  # wrong shape
+            })
+
+    def test_binary_requires_binary_value(self):
+        with pytest.raises(ValidationError, match="requires binary_value"):
+            EvaluationSection.model_validate({
+                "section_id": "cri", "section_number": 10,
+                "score_type": "binary", "score_source": "ai",
+                "ai_provider": "gemini",
+                "numeric_score": 5,  # wrong shape
+            })
+
+    def test_ai_source_requires_ai_provider(self):
+        with pytest.raises(ValidationError, match="score_source='ai' requires ai_provider"):
+            EvaluationSection.model_validate({
+                "section_id": "greeting", "section_number": 1,
+                "score_type": "numeric", "score_source": "ai",
+                "numeric_score": 4,
+            })
+
+    def test_non_ai_source_forbids_ai_provider(self):
+        with pytest.raises(ValidationError, match="only valid when score_source='ai'"):
+            EvaluationSection.model_validate({
+                "section_id": "greeting", "section_number": 1,
+                "score_type": "manual_numeric", "score_source": "manual",
+                "ai_provider": "gemini",
+                "numeric_score": 4,
+            })
+
+    def test_numeric_score_bounds(self):
+        with pytest.raises(ValidationError):
+            EvaluationSection.model_validate({
+                "section_id": "greeting", "section_number": 1,
+                "score_type": "numeric", "score_source": "ai",
+                "ai_provider": "gemini",
+                "numeric_score": 6,  # > 5
+            })
+
+
+# ---------------------------------------------------------------------------
+# AssessmentSection, ModelsUsed, AnnotatedTranscript, RecordingUrls
+# ---------------------------------------------------------------------------
+
+class TestAssessmentSection:
+
+    def test_valid_trend(self):
+        s = AssessmentSection.model_validate({
+            "section_id": "greeting", "section_name": "Greeting", "section_number": 1,
+            "trend": "improving", "summary": "up", "coaching_tip": "keep going",
+        })
+        assert s.trend == "improving"
+
+    def test_invalid_trend_raises(self):
+        with pytest.raises(ValidationError):
+            AssessmentSection.model_validate({
+                "section_id": "greeting", "section_name": "Greeting", "section_number": 1,
+                "trend": "flat", "summary": "x", "coaching_tip": "y",
+            })
+
+
+class TestModelsUsed:
+
+    def test_gemini_only_cascade(self):
+        m = ModelsUsed.model_validate({
+            "text": {"provider": "gemini", "model": "gemini-2.5-flash"},
+        })
+        assert m.text.model == "gemini-2.5-flash"
+        assert m.audio is None
+        assert m.fallback is None
+
+    def test_landgpt_cascade_with_fallback(self):
+        m = ModelsUsed.model_validate({
+            "audio": {"provider": "landgpt", "model": "qwen2-audio-v1"},
+            "text": {"provider": "landgpt", "model": "gemma-4-27b-q4"},
+            "fallback": {"provider": "gemini", "sections": ["matching"], "reason": "audio_dep_low"},
+        })
+        assert m.fallback.sections == ["matching"]
+
+
+class TestAnnotatedTranscript:
+
+    def test_loads(self):
+        t = AnnotatedTranscript.model_validate({
+            "schema_version": "qwen2_audio_v1",
+            "language_detected": "en",
+            "turns": [
+                {"speaker": "agent", "text": "hello", "start_ms": 0, "end_ms": 1000},
+                {"speaker": "caller", "text": "hi"},
+            ],
+        })
+        assert len(t.turns) == 2
+
+    def test_bad_speaker_raises(self):
+        with pytest.raises(ValidationError):
+            AnnotatedTranscript.model_validate({
+                "schema_version": "v1",
+                "turns": [{"speaker": "narrator", "text": "..."}],
+            })
+
+
+class TestRecordingUrls:
+
+    def test_defaults_to_empty_lists(self):
+        r = RecordingUrls.model_validate({})
+        assert r.audio == []
+        assert r.screen == []
+
+    def test_populated(self):
+        r = RecordingUrls.model_validate({
+            "audio": ["https://x/a.mp3"],
+            "screen": ["https://x/s.mp4"],
+        })
+        assert r.audio[0].endswith("a.mp3")


### PR DESCRIPTION
## Summary

Wave 2 Phase 1a per `qa-automation/AI-Scoring/references/Wave2Plan.md` §6.

- New `backend/models/formula.py` — the Pydantic model surface Wave 2 downstream writes validate against: `Formula` (Ops-signed §8 shape), 6-type discriminated `Rule` union (score_override / weight_transfer / weight_redistribution / score_scale / flag / na_redistribution), `Rubric` + `RubricSection` (replaces `SectionDef`), `ScoringPrompt`, `EvaluationSection` (§3.5), `AssessmentSection` (§3.21), and the JSONB shapes (`ModelsUsed` §8.1, `AnnotatedTranscript` §8.2, `RecordingUrls` §3.4.2).
- Regenerated Member Support config under the new shape:
  - `backend/config/teams/member_support.json` — Ops-signed short section ids (Wave2Plan §9 remapping table); rubric block nested; `history_id` preserved on legacy values except `documentation → human_review_required` (semantic rename per §3.5 v1.2).
  - `backend/config/scoring/member_support/overall_formula.json` — new `member_support_v2` Formula ready for Phase 3a to archive into `qa.formula_versions`.
- Sales config unchanged (stays on legacy flat shape until §10 sign-off closes). The loader auto-derives `sop_sections` (int→id) and `audio_dependent_sections` (from section flags) so Sales' runtime is unaffected.

Validators enforced at Pydantic load per Wave2Plan §8 delivery risks: weight sum ≈ scale.max, unique section keys, unique rule ids, `evaluation_order` covers exactly the defined rules + `weighted_sum` sentinel, `na_policy` required (redistribute_per_rules vs full_credit), rubric ↔ formula cross-check (§3.19.3 hard-fail invariant).

## Test plan

- [x] `pytest tests/ --ignore=tests/integration` — 294 passed / 6 skipped / 3 xfailed (48 new formula-model tests + 246 unchanged)
- [x] MS `overall_formula.json` + `teams/member_support.json` round-trip through `Formula.model_validate` / `Rubric.model_validate` and cross-check via `validate_formula_against_rubric`
- [x] Sales `sales.json` (legacy flat shape) still loads via the compat path; `sop_sections` int-list converted to id-list; `audio_dependent_sections` auto-derived from `audio_dependent: true` flags
- [ ] Manual smoke: dashboard/team routes render for both teams (deferred — no dev-server access from this branch; verify locally before merge)

## Out of scope / follow-ups

- **Sales JSON migration** — blocked on the 7 §10 sign-off items (rating→points curve, NA policy, section reconciliation, etc.). Placeholder tracked in tasks.
- **`db_provider.py` schema name** — still queries `qa_scoring` while SQLMigration.md uses `qa`. Separate PR.
- **Phase 2** (rule engine + `compute_overall_score()`) now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)