### PR TITLE
feat(qa-automation): Wave 2 Phase 2a — pure formula rule engine

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/rule_engine.py
+++ b/qa-automation/AI-Scoring/backend/services/rule_engine.py
@@ -1,0 +1,542 @@
+"""Pure formula rule engine — Wave 2 Phase 2a.
+
+Table-driven scorer for the Ops-signed formula shape (backend/models/formula.py).
+One engine, both teams: everything team-specific lives in the `Formula` —
+rules, `evaluation_order`, and the per-formula `normalization.na` policy
+(member_support_scoring_migration.md §4-§6, sales_scoring_migration.md §4-§6).
+
+NO DB access, NO clock, NO randomness. `qa.compute_overall_score()` (Phase 2b)
+is the DB-touching wrapper that loads the archived formula/rubric and calls
+`evaluate_formula()`.
+
+Semantics locked here (each traces to a spec line):
+
+- **Normalization** (MS §4 / Sales §4): rating → linear curve; binary → Y/N
+  map (per-section `binary_map` overrides the formula-level one). NA depends
+  on `normalization.na`:
+    * `full_credit` — NA scores frac 1.0 on its own slot; weights never move
+      (Sales §4: "NA behaves exactly like a perfect score").
+    * `redistribute_per_rules` — the section goes *inactive* (frac None,
+      contributes 0) and its weight must be moved off by a rule. Any inactive
+      section still holding weight at `weighted_sum` time raises
+      `UnhandledNaWeightError` — MS §4: "never silently lost".
+- **Evaluation order** (MS §6): tokens run exactly as listed. Weight-moving
+  rules operate on *current* effective weights, so transfer→shift ordering
+  compounds deliberately (caller_id_na_transfer feeds frequent_caller_shift).
+  Static misconfigurations fail before any data is read
+  (`FormulaOrderError`): a weight-moving rule scheduled after `weighted_sum`,
+  a `score_scale` scheduled before it, or a duplicated `weighted_sum` token.
+- **`when` conditions**: `equals` compares against the raw answer rendered as
+  a string ("Y"/"N"/"NA"/"1".."5"); `frac_lte`/`frac_gte` compare against the
+  section's *normalized* frac — raw ratings, pre-redistribution, so weight
+  moves never change whether a call escalates (MS §6 step 7). Conditions on
+  one clause AND together. An inactive (NA) section has no frac: numeric
+  conditions are False, only `equals: "NA"` can match it. Signals default
+  False when absent (frequent_caller is false-by-default until Command
+  Center ships — Wave 3).
+- **score_override** (MS §5 hard_zero): when fired, the final score IS
+  `effect.set_score`. Evaluation continues so the trace, raw score, and flag
+  events stay observable, but later `score_scale` steps do not touch the
+  overridden value.
+- **Answers are strict**: every formula section must be answered, unknown
+  keys raise, NA is only legal where the section's score_type allows it.
+  Key-mismatch bugs (the Wave2Plan §9 remapping risk) must fail loudly, not
+  score wrong.
+
+Answer encoding: ratings are ints (1-5), binary is "Y"/"N", not-applicable is
+"NA". Sales' 0/1 labels are presentation only — callers map them to N/Y
+before invoking (Sales §4: "identical to the shared binary_yn normalization").
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from backend.models.formula import (
+    WEIGHTED_SUM,
+    FlagRule,
+    Formula,
+    FormulaSection,
+    NaRedistributionRule,
+    Rule,
+    RuleWhen,
+    RuleWhenAll,
+    RuleWhenAny,
+    RuleWhenSection,
+    RuleWhenSignal,
+    ScoreOverrideRule,
+    ScoreScaleRule,
+    WeightRedistributionRule,
+    WeightTransferRule,
+)
+
+SectionAnswer = Union[int, str]
+"""int 1-5 for ratings; "Y"/"N" for binary; "NA" where the section allows it."""
+
+_EPS = 1e-9
+
+# score_type → (kind, na_allowed). manual_yn is analyst-filled Y/N whose
+# default state is NA; auto_value is a hardcoded Y — both normalize as binary.
+_SCORE_TYPE_TRAITS: dict[str, tuple[str, bool]] = {
+    "rating_1_5": ("rating", False),
+    "rating_1_5_na": ("rating", True),
+    "binary_yn": ("binary", False),
+    "binary_yn_na": ("binary", True),
+    "manual_yn": ("binary", True),
+    "auto_value": ("binary", False),
+}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class RuleEngineError(ValueError):
+    """Base for every deterministic engine failure."""
+
+
+class FormulaOrderError(RuleEngineError):
+    """evaluation_order is statically misconfigured (checked before any data)."""
+
+
+class AnswerValidationError(RuleEngineError):
+    """Answers don't match the formula's sections/score types."""
+
+
+class UnhandledNaWeightError(RuleEngineError):
+    """Under redistribute_per_rules, an NA section's weight was never moved
+    off by a rule — MS §4 forbids silently losing it."""
+
+    def __init__(self, formula_id: str, stranded: dict[str, float]) -> None:
+        self.stranded = stranded
+        super().__init__(
+            f"formula {formula_id!r}: NA sections still hold weight at "
+            f"weighted_sum time: {stranded} — no rule redistributed them"
+        )
+
+
+class RuleApplicationError(RuleEngineError):
+    """A rule fired but its effect can't be applied deterministically."""
+
+
+# ---------------------------------------------------------------------------
+# Result shapes
+# ---------------------------------------------------------------------------
+
+class EmittedEvent(BaseModel):
+    """One flag-rule emission (MS §5 escalation_flag). Score-neutral."""
+    model_config = ConfigDict(extra="forbid")
+    rule_id: str
+    event: str
+    route: Optional[str] = None
+
+
+class RuleTrace(BaseModel):
+    """Per-token evaluation record — the audit trail Phase 2c parity checks
+    read when a golden fixture disagrees."""
+    model_config = ConfigDict(extra="forbid")
+    rule_id: str
+    rule_type: str
+    fired: bool
+    note: Optional[str] = None
+
+
+class ScoreResult(BaseModel):
+    """Everything evaluate_formula() decided, not just the number."""
+    model_config = ConfigDict(extra="forbid")
+
+    formula_id: str
+    rubric_version: str
+    final_score: float
+    raw_score: float
+    """Σ(weight × frac) before post-sum scaling and before any override."""
+    overridden: bool = False
+    effective_weights: dict[str, float]
+    """Weights after all weight-moving rules — MS's derived "automated"
+    weights land here (computed, not stored — MS §9)."""
+    fracs: dict[str, Optional[float]]
+    """Normalized frac per section; None = inactive (NA under redistribute)."""
+    contributions: dict[str, float]
+    na_sections: list[str] = Field(default_factory=list)
+    events: list[EmittedEvent] = Field(default_factory=list)
+    trace: list[RuleTrace] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def evaluate_formula(
+    formula: Formula,
+    answers: dict[str, SectionAnswer],
+    signals: Optional[dict[str, bool]] = None,
+) -> ScoreResult:
+    """Score one evaluation against an Ops-signed formula. Pure function."""
+    signals = signals or {}
+    _check_static_order(formula)
+
+    fracs, na_sections = _normalize_answers(formula, answers)
+    weights = {s.key: s.weight for s in formula.sections}
+
+    rules_by_id = {r.id: r for r in formula.rules}
+    trace: list[RuleTrace] = []
+    events: list[EmittedEvent] = []
+    override_score: Optional[float] = None
+    raw_score: Optional[float] = None
+    running_score: Optional[float] = None
+
+    for token in formula.evaluation_order:
+        if token == WEIGHTED_SUM:
+            _assert_na_weight_handled(formula, weights, fracs)
+            raw_score = sum(
+                weights[key] * frac
+                for key, frac in fracs.items()
+                if frac is not None
+            )
+            running_score = raw_score
+            continue
+
+        rule = rules_by_id[token]
+        if not rule.enabled:
+            trace.append(RuleTrace(rule_id=rule.id, rule_type=rule.type, fired=False, note="disabled"))
+            continue
+
+        fired = _when_matches(rule.when, answers, fracs, signals)
+        if not fired:
+            trace.append(RuleTrace(rule_id=rule.id, rule_type=rule.type, fired=False))
+            continue
+
+        note: Optional[str] = None
+        if isinstance(rule, ScoreOverrideRule):
+            override_score = rule.effect.set_score
+            note = f"final score overridden to {override_score}"
+        elif isinstance(rule, WeightTransferRule):
+            note = _apply_weight_transfer(rule, weights)
+        elif isinstance(rule, WeightRedistributionRule):
+            note = _apply_weight_redistribution(rule, weights, fracs)
+        elif isinstance(rule, NaRedistributionRule):
+            note = _apply_na_redistribution(rule, weights, fracs)
+        elif isinstance(rule, ScoreScaleRule):
+            if override_score is not None:
+                note = "skipped: score already overridden"
+            else:
+                assert running_score is not None  # static order check guarantees post-sum
+                running_score *= rule.effect.multiply
+                note = f"score × {rule.effect.multiply}"
+        elif isinstance(rule, FlagRule):
+            events.append(EmittedEvent(rule_id=rule.id, event=rule.effect.emit_event, route=rule.effect.route))
+            note = f"emitted {rule.effect.emit_event!r}"
+
+        trace.append(RuleTrace(rule_id=rule.id, rule_type=rule.type, fired=True, note=note))
+
+    assert raw_score is not None and running_score is not None  # model requires the sentinel
+    final = override_score if override_score is not None else running_score
+    final = min(max(final, formula.scale.min), formula.scale.max)
+
+    return ScoreResult(
+        formula_id=formula.formula_id,
+        rubric_version=formula.rubric_version,
+        final_score=final,
+        raw_score=raw_score,
+        overridden=override_score is not None,
+        effective_weights=weights,
+        fracs=fracs,
+        contributions={
+            key: (weights[key] * frac if frac is not None else 0.0)
+            for key, frac in fracs.items()
+        },
+        na_sections=na_sections,
+        events=events,
+        trace=trace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static order checks — fail before reading any answer
+# ---------------------------------------------------------------------------
+
+_PRE_SUM_ONLY = ("weight_transfer", "weight_redistribution", "na_redistribution")
+_POST_SUM_ONLY = ("score_scale",)
+
+
+def _check_static_order(formula: Formula) -> None:
+    order = formula.evaluation_order
+    if order.count(WEIGHTED_SUM) != 1:
+        raise FormulaOrderError(
+            f"formula {formula.formula_id!r}: evaluation_order must contain "
+            f"exactly one {WEIGHTED_SUM!r} token"
+        )
+    sum_at = order.index(WEIGHTED_SUM)
+    rules_by_id = {r.id: r for r in formula.rules}
+    for pos, token in enumerate(order):
+        if token == WEIGHTED_SUM:
+            continue
+        rtype = rules_by_id[token].type
+        if rtype in _PRE_SUM_ONLY and pos > sum_at:
+            raise FormulaOrderError(
+                f"formula {formula.formula_id!r}: {rtype} rule {token!r} is "
+                f"scheduled after {WEIGHTED_SUM!r} — weight moves would be lost"
+            )
+        if rtype in _POST_SUM_ONLY and pos < sum_at:
+            raise FormulaOrderError(
+                f"formula {formula.formula_id!r}: {rtype} rule {token!r} is "
+                f"scheduled before {WEIGHTED_SUM!r} — there is no score to scale yet"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Normalization (MS §4 / Sales §4)
+# ---------------------------------------------------------------------------
+
+def _normalize_answers(
+    formula: Formula, answers: dict[str, SectionAnswer]
+) -> tuple[dict[str, Optional[float]], list[str]]:
+    section_keys = {s.key for s in formula.sections}
+    unknown = sorted(set(answers) - section_keys)
+    if unknown:
+        raise AnswerValidationError(
+            f"formula {formula.formula_id!r}: answers for unknown sections "
+            f"{unknown} — section-key mismatch (Wave2Plan §9)?"
+        )
+    missing = sorted(section_keys - set(answers))
+    if missing:
+        raise AnswerValidationError(
+            f"formula {formula.formula_id!r}: missing answers for {missing}"
+        )
+
+    fracs: dict[str, Optional[float]] = {}
+    na_sections: list[str] = []
+    for section in formula.sections:
+        answer = answers[section.key]
+        kind, na_allowed = _SCORE_TYPE_TRAITS[section.score_type]
+
+        if answer == "NA":
+            if not na_allowed:
+                raise AnswerValidationError(
+                    f"section {section.key!r}: NA not allowed for "
+                    f"score_type={section.score_type!r}"
+                )
+            na_sections.append(section.key)
+            if formula.normalization.na == "full_credit":
+                fracs[section.key] = 1.0  # Sales §4: full points on-slot
+            else:
+                fracs[section.key] = None  # inactive; a rule must move its weight
+            continue
+
+        if kind == "rating":
+            fracs[section.key] = _rating_frac(formula, section, answer)
+        else:
+            fracs[section.key] = _binary_frac(formula, section, answer)
+
+    return fracs, na_sections
+
+
+def _rating_frac(formula: Formula, section: FormulaSection, answer: SectionAnswer) -> float:
+    curve = formula.normalization.rating_1_5
+    if not isinstance(answer, int) or isinstance(answer, bool) or not (
+        curve.input_min <= answer <= curve.input_max
+    ):
+        raise AnswerValidationError(
+            f"section {section.key!r}: expected int rating "
+            f"{curve.input_min}-{curve.input_max}, got {answer!r}"
+        )
+    out_lo, out_hi = curve.output
+    span = curve.input_max - curve.input_min
+    return out_lo + (answer - curve.input_min) / span * (out_hi - out_lo)
+
+
+def _binary_frac(formula: Formula, section: FormulaSection, answer: SectionAnswer) -> float:
+    binary_map = section.binary_map or formula.normalization.binary_yn
+    if answer == "Y":
+        return binary_map.Y
+    if answer == "N":
+        return binary_map.N
+    raise AnswerValidationError(
+        f"section {section.key!r}: expected 'Y'/'N'"
+        f"{'/NA' if _SCORE_TYPE_TRAITS[section.score_type][1] else ''}, got {answer!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `when` evaluation
+# ---------------------------------------------------------------------------
+
+def _when_matches(
+    when: RuleWhen,
+    answers: dict[str, SectionAnswer],
+    fracs: dict[str, Optional[float]],
+    signals: dict[str, bool],
+) -> bool:
+    if isinstance(when, RuleWhenSignal):
+        return signals.get(when.signal, False)
+    if isinstance(when, RuleWhenAny):
+        return any(_when_matches(c, answers, fracs, signals) for c in when.any)
+    if isinstance(when, RuleWhenAll):
+        return all(_when_matches(c, answers, fracs, signals) for c in when.all)
+
+    # RuleWhenSection — AND every condition present on the clause.
+    conditions = [when.equals is not None, when.frac_lte is not None, when.frac_gte is not None]
+    if not any(conditions):
+        raise RuleApplicationError(
+            f"when-clause on section {when.section!r} has no condition "
+            f"(one of equals/frac_lte/frac_gte required)"
+        )
+    if when.section not in fracs:
+        raise RuleApplicationError(
+            f"when-clause references unknown section {when.section!r}"
+        )
+    if when.equals is not None and str(answers[when.section]) != when.equals:
+        return False
+    frac = fracs[when.section]
+    if when.frac_lte is not None and (frac is None or frac > when.frac_lte):
+        return False
+    if when.frac_gte is not None and (frac is None or frac < when.frac_gte):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Weight-moving effects (all pre-sum; operate on current effective weights)
+# ---------------------------------------------------------------------------
+
+def _apply_weight_transfer(rule: WeightTransferRule, weights: dict[str, float]) -> str:
+    effect = rule.effect
+    source = effect.from_
+    moved = weights[source] if effect.amount == "all" else weights[source] * (effect.fraction or 0.0)
+    weights[source] -= moved
+
+    if isinstance(effect.to, str):
+        weights[effect.to] += moved
+        return f"moved {moved:g} from {source!r} to {effect.to!r}"
+
+    share_sum = sum(effect.to.values())
+    if abs(share_sum - 1.0) > 1e-6:
+        raise RuleApplicationError(
+            f"rule {rule.id!r}: transfer target shares sum to {share_sum}, expected 1.0"
+        )
+    for target, share in effect.to.items():
+        weights[target] += moved * share
+    return f"moved {moved:g} from {source!r} split across {sorted(effect.to)}"
+
+
+def _redistribution_targets(
+    selector: Union[str, list[str]],
+    exclude: set[str],
+    weights: dict[str, float],
+    fracs: dict[str, Optional[float]],
+    rule_id: str,
+) -> list[str]:
+    """Resolve a to/targets selector to *active* sections (frac is not None).
+    "active_sections" and "remaining" are aliases: every scored section except
+    the sources — MS §3 footnote: the spread is recomputed over the sections
+    that remain active."""
+    if isinstance(selector, str):
+        pool = [k for k in weights if k not in exclude and fracs.get(k) is not None]
+    else:
+        pool = [k for k in selector if k not in exclude and fracs.get(k) is not None]
+    if not pool:
+        raise RuleApplicationError(
+            f"rule {rule_id!r}: no active target sections to redistribute to"
+        )
+    return pool
+
+
+def _apply_weight_redistribution(
+    rule: WeightRedistributionRule,
+    weights: dict[str, float],
+    fracs: dict[str, Optional[float]],
+) -> str:
+    effect = rule.effect
+    pool_weight = weights[effect.from_]
+    if pool_weight <= _EPS:
+        return f"no-op: {effect.from_!r} holds no weight"
+    targets = _redistribution_targets(effect.to, {effect.from_}, weights, fracs, rule.id)
+
+    if effect.method == "equal_additive":
+        per_target = pool_weight / len(targets)
+        for key in targets:
+            weights[key] += per_target
+        detail = f"+{per_target:g} each to {len(targets)} active sections"
+    else:  # proportional
+        base = sum(weights[k] for k in targets)
+        if base <= _EPS:
+            raise RuleApplicationError(
+                f"rule {rule.id!r}: proportional redistribution but targets hold no weight"
+            )
+        for key in targets:
+            weights[key] += pool_weight * weights[key] / base
+        detail = f"proportional across {len(targets)} active sections"
+
+    weights[effect.from_] = 0.0
+    return f"spread {pool_weight:g} from {effect.from_!r}: {detail}"
+
+
+def _apply_na_redistribution(
+    rule: NaRedistributionRule,
+    weights: dict[str, float],
+    fracs: dict[str, Optional[float]],
+) -> str:
+    """SQLMigration §3.8 proportional NA spread. Sources are the when-clause
+    sections that are actually inactive (NA) and still hold weight."""
+    sources = [
+        key for key in sorted(_sections_in_when(rule.when))
+        if fracs.get(key) is None and weights.get(key, 0.0) > _EPS
+    ]
+    if not sources:
+        return "no-op: no NA sections with weight in when-clause"
+
+    targets = _redistribution_targets(rule.targets, set(sources), weights, fracs, rule.id)
+    base = sum(weights[k] for k in targets)
+    if base <= _EPS:
+        raise RuleApplicationError(
+            f"rule {rule.id!r}: proportional redistribution but targets hold no weight"
+        )
+    total = sum(weights[k] for k in sources)
+    for key in targets:
+        weights[key] += total * weights[key] / base
+    for key in sources:
+        weights[key] = 0.0
+    return f"spread {total:g} from {sources} proportionally across {len(targets)} sections"
+
+
+def _sections_in_when(when: RuleWhen) -> set[str]:
+    if isinstance(when, RuleWhenSection):
+        return {when.section}
+    if isinstance(when, (RuleWhenAny, RuleWhenAll)):
+        clauses = when.any if isinstance(when, RuleWhenAny) else when.all
+        return {c.section for c in clauses if isinstance(c, RuleWhenSection)}
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# NA safety net — MS §4: NA weight is "never silently lost"
+# ---------------------------------------------------------------------------
+
+def _assert_na_weight_handled(
+    formula: Formula,
+    weights: dict[str, float],
+    fracs: dict[str, Optional[float]],
+) -> None:
+    stranded = {
+        key: weights[key]
+        for key, frac in fracs.items()
+        if frac is None and weights[key] > _EPS
+    }
+    if stranded:
+        raise UnhandledNaWeightError(formula.formula_id, stranded)
+
+
+__all__ = [
+    "SectionAnswer",
+    "evaluate_formula",
+    "ScoreResult",
+    "EmittedEvent",
+    "RuleTrace",
+    "RuleEngineError",
+    "FormulaOrderError",
+    "AnswerValidationError",
+    "UnhandledNaWeightError",
+    "RuleApplicationError",
+]

--- a/qa-automation/AI-Scoring/tests/test_rule_engine.py
+++ b/qa-automation/AI-Scoring/tests/test_rule_engine.py
@@ -1,0 +1,531 @@
+"""Rule engine tests — Wave 2 Phase 2a.
+
+Exercises evaluate_formula() against the shipped MS overall_formula.json and
+the Sales §8 canonical config. The Sales §11 worked example (expected 75.00)
+is the only spec-guaranteed vector — Phase 2c adds sheet-parity golden
+fixtures on top.
+
+Hand-computed MS expectations reference member_support_scoring_migration.md:
+the §3 "automated" weight column (+10/9 per active section when
+human_review_required = NA) and the §6 evaluation order.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.models.formula import WEIGHTED_SUM, Formula
+from backend.services.rule_engine import (
+    AnswerValidationError,
+    FormulaOrderError,
+    RuleApplicationError,
+    UnhandledNaWeightError,
+    evaluate_formula,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def ms_formula() -> Formula:
+    return Formula.model_validate(json.loads(_MS_FORMULA_JSON.read_text(encoding="utf-8")))
+
+
+def ms_answers(**overrides):
+    """Perfect call: all 5s / Y, human_review_required at its NA default."""
+    base = {
+        "greeting": 5,
+        "caller_id": "Y",
+        "purpose": 5,
+        "matching": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "comms": 5,
+        "efficiency": 5,
+        "human_review_required": "NA",
+        "cri": "Y",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(scope="module")
+def sales_formula() -> Formula:
+    """Sales §8 canonical config (inline until §10 sign-off ships the file)."""
+    return Formula.model_validate({
+        "formula_id": "sales_v1",
+        "rubric_version": "sales_v1",
+        "supersedes": None,
+        "scale": {"min": 0, "max": 100},
+        "normalization": {
+            "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+            "binary_yn": {"Y": 1.0, "N": 0.0},
+            "na": "full_credit",
+        },
+        "sections": [
+            {"key": "greeting",           "label": "Greeting",              "score_type": "binary_yn_na",  "weight": 5.0},
+            {"key": "stay_type",          "label": "Personal or COHO Stay", "score_type": "binary_yn_na",  "weight": 4.0},
+            {"key": "move_reason",        "label": "Move Reason",           "score_type": "rating_1_5_na", "weight": 15.0},
+            {"key": "landing_intro",      "label": "Landing Intro",         "score_type": "binary_yn_na",  "weight": 6.0},
+            {"key": "timeline_housing",   "label": "Timeline & Housing",    "score_type": "rating_1_5_na", "weight": 8.0},
+            {"key": "landing_guarantee",  "label": "Landing Guarantee",     "score_type": "rating_1_5_na", "weight": 6.0},
+            {"key": "pricing",            "label": "Pricing Breakdown",     "score_type": "rating_1_5_na", "weight": 8.0},
+            {"key": "fit_confirmation",   "label": "Confirmation of Fit",   "score_type": "rating_1_5_na", "weight": 5.0},
+            {"key": "objection_handling", "label": "Objection Handling",    "score_type": "rating_1_5_na", "weight": 8.0},
+            {"key": "urgency",            "label": "Urgency",               "score_type": "binary_yn_na",  "weight": 5.0},
+            {"key": "follow_up",          "label": "Follow-up",             "score_type": "binary_yn_na",  "weight": 6.0},
+            {"key": "potential_booking",  "label": "Potential Booking",     "score_type": "binary_yn_na",  "weight": 4.0},
+            {"key": "notes_mc",           "label": "Detailed Notes in MC",  "score_type": "binary_yn_na",  "weight": 5.0},
+            {"key": "contact_shared",     "label": "Contact Shared",        "score_type": "binary_yn_na",  "weight": 5.0},
+            {"key": "client_experience",  "label": "Client Experience",     "score_type": "rating_1_5_na", "weight": 10.0},
+        ],
+        "rules": [],
+        "evaluation_order": [WEIGHTED_SUM],
+        "triggers": {},
+        "external_signals": {},
+        "deprecated_sections": [],
+    })
+
+
+def _formula(**overrides) -> Formula:
+    """Minimal two-section formula, mutated per test."""
+    base = {
+        "formula_id": "test_v1",
+        "rubric_version": "test_v1",
+        "scale": {"min": 0, "max": 100},
+        "normalization": {
+            "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+            "binary_yn": {"Y": 1.0, "N": 0.0},
+            "na": "full_credit",
+        },
+        "sections": [
+            {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 60.0},
+            {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+        ],
+        "rules": [],
+        "evaluation_order": [WEIGHTED_SUM],
+        "triggers": {},
+        "external_signals": {},
+    }
+    base.update(overrides)
+    return Formula.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# Sales — full_credit NA, no rules (spec §4/§6/§11)
+# ---------------------------------------------------------------------------
+
+class TestSalesFullCredit:
+
+    # Spec §11 answers, with the PDF's 0/1 binary labels mapped to N/Y.
+    SALES_S11_ANSWERS = {
+        "greeting": "Y",
+        "stay_type": "N",
+        "move_reason": 4,
+        "landing_intro": "Y",
+        "timeline_housing": "NA",
+        "landing_guarantee": 3,
+        "pricing": 5,
+        "fit_confirmation": 2,
+        "objection_handling": 4,
+        "urgency": "Y",
+        "follow_up": "N",
+        "potential_booking": "Y",
+        "notes_mc": "Y",
+        "contact_shared": "NA",
+        "client_experience": 4,
+    }
+
+    def test_spec_s11_worked_example_is_75(self, sales_formula):
+        result = evaluate_formula(sales_formula, self.SALES_S11_ANSWERS)
+        assert result.final_score == pytest.approx(75.00, abs=1e-9)
+        assert result.raw_score == pytest.approx(75.00, abs=1e-9)
+
+    def test_na_sections_contribute_full_weight(self, sales_formula):
+        result = evaluate_formula(sales_formula, self.SALES_S11_ANSWERS)
+        assert result.contributions["timeline_housing"] == pytest.approx(8.0)
+        assert result.contributions["contact_shared"] == pytest.approx(5.0)
+        assert result.fracs["timeline_housing"] == 1.0
+
+    def test_weights_are_static_under_full_credit(self, sales_formula):
+        result = evaluate_formula(sales_formula, self.SALES_S11_ANSWERS)
+        assert result.effective_weights == {s.key: s.weight for s in sales_formula.sections}
+
+    def test_all_na_scores_100(self, sales_formula):
+        answers = {s.key: "NA" for s in sales_formula.sections}
+        result = evaluate_formula(sales_formula, answers)
+        assert result.final_score == pytest.approx(100.0)
+
+    def test_no_events_no_trace(self, sales_formula):
+        result = evaluate_formula(sales_formula, self.SALES_S11_ANSWERS)
+        assert result.events == []
+        assert result.trace == []
+
+
+# ---------------------------------------------------------------------------
+# Member Support — redistribute_per_rules (spec §3-§6)
+# ---------------------------------------------------------------------------
+
+class TestMemberSupportEngine:
+
+    def test_perfect_call_hrr_na_scores_100(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers())
+        assert result.final_score == pytest.approx(100.0)
+        assert result.na_sections == ["human_review_required"]
+
+    def test_hrr_na_spread_matches_spec_automated_weights(self, ms_formula):
+        """§3 automated column: 9 active sections gain +10/9 ≈ 1.11 each."""
+        result = evaluate_formula(ms_formula, ms_answers())
+        w = result.effective_weights
+        assert w["human_review_required"] == pytest.approx(0.0)
+        assert w["greeting"] == pytest.approx(5 + 10 / 9)     # 6.11%
+        assert w["process_adherence"] == pytest.approx(25 + 10 / 9)  # 26.11%
+        assert w["call_resolution"] == pytest.approx(20 + 10 / 9)    # 21.11%
+        assert sum(w.values()) == pytest.approx(100.0)
+
+    def test_all_fours_standard_automated_case(self, ms_formula):
+        answers = ms_answers(
+            greeting=4, purpose=4, matching=4, process_adherence=4,
+            call_resolution=4, comms=4, efficiency=4,
+        )
+        result = evaluate_formula(ms_formula, answers)
+        # ratings 0.75 × (80 + 7·10/9) + binary 1.0 × (10 + 2·10/9)
+        assert result.final_score == pytest.approx(0.75 * (80 + 70 / 9) + (10 + 20 / 9))
+
+    def test_caller_id_na_transfers_weight_to_call_resolution(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(caller_id="NA"))
+        w = result.effective_weights
+        assert w["caller_id"] == pytest.approx(0.0)
+        # 20 + 5 transferred + 10/8 from the hrr spread over 8 active sections
+        assert w["call_resolution"] == pytest.approx(25 + 10 / 8)
+        assert result.final_score == pytest.approx(100.0)
+        assert result.na_sections == ["caller_id", "human_review_required"]
+
+    def test_caller_id_n_scales_final_by_half(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(caller_id="N"))
+        # caller_id stays active (frac 0, weight 5 + 10/9); raw loses only its slot
+        assert result.raw_score == pytest.approx(100 - (5 + 10 / 9))
+        assert result.final_score == pytest.approx((100 - (5 + 10 / 9)) * 0.5)
+        assert not result.overridden
+
+    def test_hard_zero_disabled_never_fires(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(caller_id="N"))
+        hard_zero = next(t for t in result.trace if t.rule_id == "hard_zero")
+        assert not hard_zero.fired
+        assert hard_zero.note == "disabled"
+
+    def test_frequent_caller_shift_moves_half_of_current_resolution_weight(self, ms_formula):
+        result = evaluate_formula(
+            ms_formula, ms_answers(), signals={"frequent_caller": True}
+        )
+        w = result.effective_weights
+        # 0.5 × 20 moves resolution → process, then the hrr spread adds 10/9 each
+        assert w["process_adherence"] == pytest.approx(35 + 10 / 9)
+        assert w["call_resolution"] == pytest.approx(10 + 10 / 9)
+
+    def test_transfer_then_shift_compound_in_evaluation_order(self, ms_formula):
+        """caller_id_na_transfer runs first (§6), so the shift moves half of
+        the *boosted* call_resolution weight (25, not 20)."""
+        result = evaluate_formula(
+            ms_formula, ms_answers(caller_id="NA"), signals={"frequent_caller": True}
+        )
+        w = result.effective_weights
+        assert w["process_adherence"] == pytest.approx(25 + 12.5 + 10 / 8)
+        assert w["call_resolution"] == pytest.approx(12.5 + 10 / 8)
+
+    def test_signal_absent_means_false(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers())
+        shift = next(t for t in result.trace if t.rule_id == "frequent_caller_shift")
+        assert not shift.fired
+
+    def test_escalation_flag_fires_at_rating_3_and_below(self, ms_formula):
+        for rating, should_fire in [(1, True), (2, True), (3, True), (4, False), (5, False)]:
+            result = evaluate_formula(ms_formula, ms_answers(process_adherence=rating))
+            fired = any(e.rule_id == "escalation_flag" for e in result.events)
+            assert fired is should_fire, f"rating {rating}"
+
+    def test_escalation_event_shape_and_score_neutrality(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(call_resolution=1))
+        event = next(e for e in result.events if e.rule_id == "escalation_flag")
+        assert event.event == "human_review_required"
+        assert event.route == "supervisor_review"
+        # flag never touches the score: only resolution's own slot is lost
+        assert result.final_score == pytest.approx(100 - (20 + 10 / 9))
+
+    def test_hrr_scored_by_supervisor_keeps_base_weights(self, ms_formula):
+        """When human review actually happened (HRR = 1), nothing is NA and
+        base weights apply unchanged."""
+        result = evaluate_formula(ms_formula, ms_answers(human_review_required=1))
+        assert result.effective_weights == {s.key: s.weight for s in ms_formula.sections}
+        # HRR frac 0 → loses its 10 points
+        assert result.final_score == pytest.approx(90.0)
+        assert result.na_sections == []
+
+
+class TestScoreOverride:
+
+    def _hard_zero_enabled(self, ms_formula) -> Formula:
+        raw = ms_formula.model_dump(by_alias=True)
+        rule = next(r for r in raw["rules"] if r["id"] == "hard_zero")
+        rule["enabled"] = True
+        return Formula.model_validate(raw)
+
+    def test_hard_zero_enabled_overrides_final_score(self, ms_formula):
+        formula = self._hard_zero_enabled(ms_formula)
+        result = evaluate_formula(formula, ms_answers(caller_id="N"))
+        assert result.final_score == 0.0
+        assert result.overridden
+        # raw score stays observable for the trace/parity checks
+        assert result.raw_score == pytest.approx(100 - (5 + 10 / 9))
+
+    def test_override_skips_later_score_scale(self, ms_formula):
+        formula = self._hard_zero_enabled(ms_formula)
+        result = evaluate_formula(formula, ms_answers(caller_id="N"))
+        scale = next(t for t in result.trace if t.rule_id == "caller_id_scale_half")
+        assert scale.fired
+        assert "skipped" in (scale.note or "")
+
+    def test_override_does_not_suppress_flags(self, ms_formula):
+        formula = self._hard_zero_enabled(ms_formula)
+        result = evaluate_formula(
+            formula, ms_answers(caller_id="N", process_adherence=1)
+        )
+        assert result.overridden
+        assert any(e.rule_id == "escalation_flag" for e in result.events)
+
+
+# ---------------------------------------------------------------------------
+# NA safety net — MS §4 "never silently lost"
+# ---------------------------------------------------------------------------
+
+class TestUnhandledNaWeight:
+
+    def test_na_with_no_rule_raises_under_redistribute(self):
+        formula = _formula(
+            normalization={
+                "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+                "binary_yn": {"Y": 1.0, "N": 0.0},
+                "na": "redistribute_per_rules",
+            },
+            sections=[
+                {"key": "a", "label": "A", "score_type": "rating_1_5_na", "weight": 60.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+            ],
+        )
+        with pytest.raises(UnhandledNaWeightError) as exc:
+            evaluate_formula(formula, {"a": "NA", "b": 5})
+        assert exc.value.stranded == {"a": 60.0}
+
+    def test_same_shape_is_fine_under_full_credit(self):
+        formula = _formula(
+            sections=[
+                {"key": "a", "label": "A", "score_type": "rating_1_5_na", "weight": 60.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+            ],
+        )
+        result = evaluate_formula(formula, {"a": "NA", "b": 5})
+        assert result.final_score == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# Generic rule mechanics (beyond the two shipped formulas)
+# ---------------------------------------------------------------------------
+
+class TestRuleMechanics:
+
+    def test_na_redistribution_rule_is_proportional(self):
+        """SQLMigration §3.8: 'a' NA → its 20 spreads 60:20 across b/c."""
+        formula = _formula(
+            normalization={
+                "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
+                "binary_yn": {"Y": 1.0, "N": 0.0},
+                "na": "redistribute_per_rules",
+            },
+            sections=[
+                {"key": "a", "label": "A", "score_type": "rating_1_5_na", "weight": 20.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 60.0},
+                {"key": "c", "label": "C", "score_type": "rating_1_5", "weight": 20.0},
+            ],
+            rules=[{
+                "id": "a_na", "type": "na_redistribution", "enabled": True,
+                "when": {"section": "a", "equals": "NA"},
+                "mode": "proportional", "targets": "remaining",
+            }],
+            evaluation_order=["a_na", WEIGHTED_SUM],
+        )
+        result = evaluate_formula(formula, {"a": "NA", "b": 5, "c": 1})
+        assert result.effective_weights["b"] == pytest.approx(75.0)  # 60 + 20·(60/80)
+        assert result.effective_weights["c"] == pytest.approx(25.0)  # 20 + 20·(20/80)
+        assert result.final_score == pytest.approx(75.0)
+
+    def test_weight_transfer_split_targets(self):
+        formula = _formula(
+            sections=[
+                {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 20.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+                {"key": "c", "label": "C", "score_type": "rating_1_5", "weight": 40.0},
+            ],
+            rules=[{
+                "id": "split", "type": "weight_transfer", "enabled": True,
+                "when": {"section": "a", "frac_lte": 1.0},
+                "effect": {"from": "a", "to": {"b": 0.75, "c": 0.25}, "amount": "all"},
+            }],
+            evaluation_order=["split", WEIGHTED_SUM],
+        )
+        result = evaluate_formula(formula, {"a": 5, "b": 5, "c": 5})
+        assert result.effective_weights == pytest.approx({"a": 0.0, "b": 55.0, "c": 45.0})
+
+    def test_weight_transfer_bad_shares_raise(self):
+        formula = _formula(
+            sections=[
+                {"key": "a", "label": "A", "score_type": "rating_1_5", "weight": 20.0},
+                {"key": "b", "label": "B", "score_type": "rating_1_5", "weight": 40.0},
+                {"key": "c", "label": "C", "score_type": "rating_1_5", "weight": 40.0},
+            ],
+            rules=[{
+                "id": "split", "type": "weight_transfer", "enabled": True,
+                "when": {"section": "a", "frac_lte": 1.0},
+                "effect": {"from": "a", "to": {"b": 0.5, "c": 0.25}, "amount": "all"},
+            }],
+            evaluation_order=["split", WEIGHTED_SUM],
+        )
+        with pytest.raises(RuleApplicationError, match="shares sum"):
+            evaluate_formula(formula, {"a": 5, "b": 5, "c": 5})
+
+    def test_frac_gte_condition(self):
+        formula = _formula(
+            rules=[{
+                "id": "high_a", "type": "flag", "enabled": True,
+                "when": {"section": "a", "frac_gte": 0.75},
+                "effect": {"emit_event": "kudos"},
+            }],
+            evaluation_order=["high_a", WEIGHTED_SUM],
+        )
+        fired = evaluate_formula(formula, {"a": 4, "b": 3})
+        assert any(e.event == "kudos" for e in fired.events)
+        not_fired = evaluate_formula(formula, {"a": 3, "b": 3})
+        assert not_fired.events == []
+
+    def test_equals_matches_rating_answers_as_strings(self):
+        formula = _formula(
+            rules=[{
+                "id": "exact_three", "type": "flag", "enabled": True,
+                "when": {"section": "a", "equals": "3"},
+                "effect": {"emit_event": "mid"},
+            }],
+            evaluation_order=["exact_three", WEIGHTED_SUM],
+        )
+        assert evaluate_formula(formula, {"a": 3, "b": 5}).events != []
+        assert evaluate_formula(formula, {"a": 4, "b": 5}).events == []
+
+    def test_when_clause_without_condition_raises(self):
+        formula = _formula(
+            rules=[{
+                "id": "vacuous", "type": "flag", "enabled": True,
+                "when": {"section": "a"},
+                "effect": {"emit_event": "noop"},
+            }],
+            evaluation_order=["vacuous", WEIGHTED_SUM],
+        )
+        with pytest.raises(RuleApplicationError, match="no condition"):
+            evaluate_formula(formula, {"a": 5, "b": 5})
+
+    def test_stacked_score_scales_multiply(self):
+        formula = _formula(
+            rules=[
+                {"id": "s1", "type": "score_scale", "enabled": True,
+                 "when": {"section": "a", "frac_lte": 1.0}, "effect": {"multiply": 0.5}},
+                {"id": "s2", "type": "score_scale", "enabled": True,
+                 "when": {"section": "a", "frac_lte": 1.0}, "effect": {"multiply": 0.9}},
+            ],
+            evaluation_order=[WEIGHTED_SUM, "s1", "s2"],
+        )
+        result = evaluate_formula(formula, {"a": 5, "b": 5})
+        assert result.final_score == pytest.approx(45.0)
+        assert result.raw_score == pytest.approx(100.0)
+
+
+# ---------------------------------------------------------------------------
+# Static evaluation_order misconfigurations
+# ---------------------------------------------------------------------------
+
+class TestStaticOrderChecks:
+
+    def test_weight_rule_after_weighted_sum_raises(self):
+        formula = _formula(
+            rules=[{
+                "id": "late_move", "type": "weight_transfer", "enabled": True,
+                "when": {"section": "a", "frac_lte": 1.0},
+                "effect": {"from": "a", "to": "b", "amount": "all"},
+            }],
+            evaluation_order=[WEIGHTED_SUM, "late_move"],
+        )
+        with pytest.raises(FormulaOrderError, match="after"):
+            evaluate_formula(formula, {"a": 5, "b": 5})
+
+    def test_score_scale_before_weighted_sum_raises(self):
+        formula = _formula(
+            rules=[{
+                "id": "early_scale", "type": "score_scale", "enabled": True,
+                "when": {"section": "a", "frac_lte": 1.0}, "effect": {"multiply": 0.5},
+            }],
+            evaluation_order=["early_scale", WEIGHTED_SUM],
+        )
+        with pytest.raises(FormulaOrderError, match="before"):
+            evaluate_formula(formula, {"a": 5, "b": 5})
+
+    def test_duplicate_weighted_sum_raises(self):
+        formula = _formula(evaluation_order=[WEIGHTED_SUM, WEIGHTED_SUM])
+        with pytest.raises(FormulaOrderError, match="exactly one"):
+            evaluate_formula(formula, {"a": 5, "b": 5})
+
+    def test_static_checks_run_before_answer_validation(self):
+        """Misconfigured order fails even with garbage answers — the check is
+        data-independent."""
+        formula = _formula(evaluation_order=[WEIGHTED_SUM, WEIGHTED_SUM])
+        with pytest.raises(FormulaOrderError):
+            evaluate_formula(formula, {})
+
+
+# ---------------------------------------------------------------------------
+# Strict answer validation (Wave2Plan §9 remapping risk)
+# ---------------------------------------------------------------------------
+
+class TestAnswerValidation:
+
+    def test_missing_answer_raises(self, ms_formula):
+        answers = ms_answers()
+        del answers["cri"]
+        with pytest.raises(AnswerValidationError, match="missing answers.*cri"):
+            evaluate_formula(ms_formula, answers)
+
+    def test_unknown_section_key_raises(self, ms_formula):
+        """Legacy history_id keys must not silently score — §9 remapping."""
+        answers = ms_answers()
+        answers["identity_validation"] = answers.pop("caller_id")
+        with pytest.raises(AnswerValidationError, match="unknown sections"):
+            evaluate_formula(ms_formula, answers)
+
+    def test_na_on_non_na_section_raises(self, ms_formula):
+        with pytest.raises(AnswerValidationError, match="NA not allowed"):
+            evaluate_formula(ms_formula, ms_answers(greeting="NA"))
+
+    @pytest.mark.parametrize("bad", [0, 6, "5", 4.5, True, None])
+    def test_bad_rating_values_raise(self, ms_formula, bad):
+        with pytest.raises(AnswerValidationError):
+            evaluate_formula(ms_formula, ms_answers(greeting=bad))
+
+    @pytest.mark.parametrize("bad", ["y", "yes", 1, "1", None])
+    def test_bad_binary_values_raise(self, ms_formula, bad):
+        """Sales' 0/1 labels are NOT accepted — callers map to Y/N first
+        (int 1 would be ambiguous with rating 1)."""
+        with pytest.raises(AnswerValidationError):
+            evaluate_formula(ms_formula, ms_answers(cri=bad))


### PR DESCRIPTION
## Summary

Phase 2a of [Wave2Plan.md](qa-automation/AI-Scoring/references/Wave2Plan.md): the table-driven rule engine. `evaluate_formula(formula, answers, signals)` is a **pure function** (no DB, no clock) that produces the final score plus a full audit trail; the Phase 2b `qa.compute_overall_score()` wrapper will load archived formula/rubric versions and call it.

One engine, both teams — everything team-specific lives in the `Formula`:
- **Normalization** — linear rating curve, Y/N binary map (per-section `binary_map` override honored), and the per-formula `normalization.na` switch: `full_credit` (Sales — NA scores frac 1.0 on-slot) vs `redistribute_per_rules` (MS — section goes inactive, rules move its weight).
- **All 6 rule types** — score_override, weight_transfer (amount/fraction, single or split targets), weight_redistribution (equal_additive + proportional), score_scale, flag, na_redistribution (§3.8 proportional).
- **`evaluation_order` sequencing** — weight moves operate on *current* weights, so `caller_id_na_transfer` → `frequent_caller_shift` compounds exactly as MS §6 specifies.

## Deliberate semantics (each traces to a spec line)

- **NA weight is never silently lost** (MS §4): under `redistribute_per_rules`, an inactive section still holding weight at `weighted_sum` time raises `UnhandledNaWeightError`.
- **Flags are score-neutral and read normalized fracs** (MS §6 step 7) — redistribution never changes whether a call escalates.
- **`score_override` wins**: later `score_scale` steps are skipped (traced), but flag events still emit.
- **Static order checks fail before reading data**: weight rule scheduled after `weighted_sum`, `score_scale` before it, or a duplicated sentinel → `FormulaOrderError`.
- **Strict answers**: unknown keys, missing sections, illegal NA, malformed ratings/binaries all raise — the Wave2Plan §9 section-key remapping risk fails loudly instead of scoring wrong. Sales' 0/1 labels are mapped to N/Y by callers (int `1` would be ambiguous with rating 1).

## Test plan

- [x] 47 new tests in `tests/test_rule_engine.py`, including:
  - **Sales §11 worked example = 75.00 exactly** — the spec-guaranteed vector (NA full-credit on a scaled and a binary section).
  - **MS §3 derived "automated" weights** — `hrr_na_spread` +10/9 per active section (6.11% / 26.11% / 21.11%), recomputed over 8 sections when `caller_id` is also NA.
  - caller_id N → ×0.5 post-sum scale; hard_zero disabled no-op + enabled override behavior; escalation threshold at ratings 1–3 only; frequent_caller signal default-false.
  - Every error path (`UnhandledNaWeightError`, `FormulaOrderError`, `AnswerValidationError`, `RuleApplicationError`).
- [x] Full suite: **340 passed, 6 skipped, 3 xfailed**, 1 failed — the failure is `test_analytics.py::test_monthly_summary_buckets_in_project_local_time`, a **pre-existing calendar-dependent test** (hardcodes May-2026 timestamps against now-relative month buckets; broke on the July rollover, fails on main too). Fix belongs in a separate PR.

## Out of scope / follow-ups

- **Phase 2b**: `qa.compute_overall_score(evaluation_id)` — DB wrapper over this engine.
- **Phase 2c**: golden fixtures at `tests/fixtures/overall_formula/{team}.json` (§11 vector already asserted here).
- **Known pre-existing failure**: the date-sensitive analytics test above — will fail CI all July until fixed.
- Sales formula JSON still inline-only, blocked on Sales §10 sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)