### PR TITLE
feat(qa-automation): Wave 2 Phase 2c — golden fixtures + archived v0_sheet formula

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/v0_sheet.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/v0_sheet.json
@@ -1,0 +1,35 @@
+{
+  "formula_id": "member_support_v0_sheet",
+  "rubric_version": "member_support_v1",
+  "supersedes": null,
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.2, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "redistribute_per_rules"
+  },
+  "sections": [
+    { "key": "greeting",                      "label": "Greeting",                      "score_type": "rating_1_5",   "weight": 0.0,                "trigger": null },
+    { "key": "identity_validation",           "label": "Caller Identity Validation",    "score_type": "binary_yn_na", "weight": 0.0,                "trigger": null },
+    { "key": "purpose_of_call",               "label": "Purpose of the Call",           "score_type": "rating_1_5",   "weight": 8.333333333333334,  "trigger": null },
+    { "key": "matching_the_moment",           "label": "Matching the Moment",           "score_type": "rating_1_5",   "weight": 0.0,                "trigger": null },
+    { "key": "process_adherence",             "label": "Process Adherence",             "score_type": "rating_1_5",   "weight": 0.0,                "trigger": null },
+    { "key": "call_resolution",               "label": "Call Resolution",               "score_type": "rating_1_5",   "weight": 33.333333333333336, "trigger": null },
+    { "key": "communication",                 "label": "Communication",                 "score_type": "rating_1_5",   "weight": 16.666666666666668, "trigger": null },
+    { "key": "efficiency",                    "label": "Efficiency & Call Handling",    "score_type": "rating_1_5",   "weight": 16.666666666666668, "trigger": null },
+    { "key": "documentation",                 "label": "Documentation",                 "score_type": "rating_1_5",   "weight": 16.666666666666668, "trigger": null },
+    { "key": "customer_resolution_indicator", "label": "Customer Resolution Indicator", "score_type": "binary_yn_na", "weight": 8.333333333333334,  "trigger": null }
+  ],
+  "rules": [
+    { "id": "civ_na_redistribute", "type": "na_redistribution", "enabled": true, "when": { "section": "identity_validation", "equals": "NA" },           "mode": "proportional", "targets": "remaining", "note": "no-op today (weight 0) — kept so the archived formula states NA policy for every NA-able section" },
+    { "id": "cri_na_redistribute", "type": "na_redistribution", "enabled": true, "when": { "section": "customer_resolution_indicator", "equals": "NA" }, "mode": "proportional", "targets": "remaining" }
+  ],
+  "evaluation_order": [
+    "civ_na_redistribute",
+    "cri_na_redistribute",
+    "weighted_sum"
+  ],
+  "triggers": {},
+  "external_signals": {},
+  "deprecated_sections": []
+}

--- a/qa-automation/AI-Scoring/scripts/extract_golden_fixtures.py
+++ b/qa-automation/AI-Scoring/scripts/extract_golden_fixtures.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Extract golden score fixtures from a raw Analyst_History export.
+
+Wave 2 Phase 2c (BackfillPlan.md §6). Reads the gitignored seed CSV, runs the
+archived legacy formula over EVERY row as a parity check, then writes a
+stratified, anonymized sample to tests/fixtures/overall_formula/<team>.json.
+
+The fixtures carry only section answers + the sheet-computed overall — no
+agent/caller names, links, or timestamps (era + year-month only).
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python scripts/extract_golden_fixtures.py [--team member_support] [--sample 40]
+
+Exclusions mirror BackfillPlan.md §4/§8: all-zero test rows and manual
+hard-zero overrides (D5) are dropped; hand-edited rows (sheet overall
+inconsistent with the reconstructed formula) are KEPT and marked
+expect_exact=false — they document the anomaly.
+
+Sales note: the loader is column-shape-generic, but the section map below is
+per-team; add a SALES block when its export lands (same CSV shape per
+BackfillPlan.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from decimal import ROUND_HALF_UP, Decimal
+from pathlib import Path
+
+import pandas as pd
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_AI_SCORING))
+
+from backend.models.formula import Formula  # noqa: E402
+from backend.services.rule_engine import evaluate_formula  # noqa: E402
+
+_REPO_ROOT = _AI_SCORING.parent.parent
+
+# CSV column -> legacy section_id (the v0_sheet formula keys / v1 rubric ids).
+MS_SECTIONS = {
+    "Greeting": "greeting",
+    "Caller Identity Validation": "identity_validation",
+    "Purpose of the Call": "purpose_of_call",
+    "Matching the Moment": "matching_the_moment",
+    "Process Adherence": "process_adherence",
+    "Call Resolution": "call_resolution",
+    "Communication": "communication",
+    "Efficiency & Call Handling": "efficiency",
+    "Documentation": "documentation",
+    "Customer Resolution Indicator": "customer_resolution_indicator",
+}
+MS_BINARY = {"identity_validation", "customer_resolution_indicator"}
+
+BINARY_VOCAB = {"Y": "Y", "Yes": "Y", "N": "N", "No": "N", "Not Applicable": "NA", "NA": "NA"}
+
+TEAMS = {
+    "member_support": {
+        "csv": _REPO_ROOT / "database" / "analyst_history_member_support.csv",
+        "formula": _AI_SCORING / "backend" / "config" / "scoring" / "member_support" / "v0_sheet.json",
+        "sections": MS_SECTIONS,
+        "binary": MS_BINARY,
+    },
+}
+
+
+def load_rows(cfg) -> list[dict]:
+    df = pd.read_csv(cfg["csv"])
+    df.columns = [c.strip() for c in df.columns]
+    rows = []
+    for idx, r in df.iterrows():
+        answers: dict = {}
+        ok = True
+        for col, sid in cfg["sections"].items():
+            raw = str(r[col]).strip()
+            if sid in cfg["binary"]:
+                val = BINARY_VOCAB.get(raw)
+                if val is None:
+                    ok = False
+                    break
+                answers[sid] = val
+            else:
+                if not raw.isdigit() or not (1 <= int(raw) <= 5):
+                    ok = False  # '0' rows are the test artifacts
+                    break
+                answers[sid] = int(raw)
+        if not ok:
+            continue
+        ts = pd.to_datetime(r["Timestamp"], errors="coerce")
+        rows.append({
+            "row": int(idx) + 2,  # 1-based + header, for traceability against the sheet
+            "answers": answers,
+            "sheet_overall": int(r["Overall Score"]),
+            "era": "ai" if str(r.get("Source", "")).strip() == "ai" else "manual",
+            "year_month": ts.strftime("%Y-%m") if pd.notna(ts) else None,
+        })
+    return rows
+
+
+def engine_score(formula: Formula, answers: dict) -> int:
+    result = evaluate_formula(formula, answers)
+    return int(Decimal(str(result.final_score)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--team", default="member_support", choices=sorted(TEAMS))
+    ap.add_argument("--sample", type=int, default=40)
+    args = ap.parse_args()
+    cfg = TEAMS[args.team]
+
+    formula = Formula.model_validate(json.loads(cfg["formula"].read_text()))
+    rows = load_rows(cfg)
+    print(f"loaded {len(rows)} scoreable rows (test artifacts already dropped)")
+
+    matched, hard_zero, hand_edit = [], [], []
+    for row in rows:
+        row["engine_overall"] = engine_score(formula, row["answers"])
+        delta = abs(row["engine_overall"] - row["sheet_overall"])
+        if delta == 0:
+            matched.append(row)
+        elif row["sheet_overall"] == 0:
+            hard_zero.append(row)  # D5: manual hard-zero override — excluded
+        else:
+            hand_edit.append(row)
+
+    total = len(rows)
+    print(f"exact parity under {formula.formula_id}: {len(matched)}/{total} "
+          f"({len(matched) / total:.1%}) | hard-zero excluded: {len(hard_zero)} "
+          f"| hand-edits kept as expected-mismatch: {len(hand_edit)}")
+
+    # Stratified sample: era x score band x NA presence, deterministic.
+    rng = random.Random(42)
+    strata: dict = {}
+    for row in matched:
+        has_na = any(v == "NA" for v in row["answers"].values())
+        key = (row["era"], row["sheet_overall"] // 20, has_na)
+        strata.setdefault(key, []).append(row)
+    sample: list = []
+    keys = sorted(strata, key=str)
+    while len(sample) < min(args.sample, len(matched)) and keys:
+        for key in list(keys):
+            pool = strata[key]
+            if not pool:
+                keys.remove(key)
+                continue
+            sample.append(pool.pop(rng.randrange(len(pool))))
+            if len(sample) >= min(args.sample, len(matched)):
+                break
+
+    fixtures = []
+    for n, row in enumerate(sorted(sample, key=lambda r: r["row"]), 1):
+        fixtures.append({
+            "label": f"{args.team[:2]}-{n:04d}",
+            "era": row["era"],
+            "year_month": row["year_month"],
+            "answers": row["answers"],
+            "sheet_overall": row["sheet_overall"],
+            "expect_exact": True,
+        })
+    for n, row in enumerate(sorted(hand_edit, key=lambda r: r["row"]), 1):
+        fixtures.append({
+            "label": f"{args.team[:2]}-edit-{n:02d}",
+            "era": row["era"],
+            "year_month": row["year_month"],
+            "answers": row["answers"],
+            "sheet_overall": row["sheet_overall"],
+            "engine_overall": row["engine_overall"],
+            "expect_exact": False,
+            "note": "sheet overall hand-edited — inconsistent with the reconstructed formula (BackfillPlan.md §4)",
+        })
+
+    out = _AI_SCORING / "tests" / "fixtures" / "overall_formula" / f"{args.team}.json"
+    out.write_text(json.dumps({
+        "formula_id": formula.formula_id,
+        "source": "Analyst_History export (BackfillPlan.md §6); anonymized",
+        "fixtures": fixtures,
+    }, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {len(fixtures)} fixtures -> {out.relative_to(_AI_SCORING)}")
+
+    na_count = sum(1 for f in fixtures if any(v == "NA" for v in f["answers"].values()))
+    print(f"sample spread: {sum(1 for f in fixtures if f['era'] == 'ai')} ai / "
+          f"{sum(1 for f in fixtures if f['era'] == 'manual')} manual | {na_count} with NA")
+
+
+if __name__ == "__main__":
+    main()

--- a/qa-automation/AI-Scoring/tests/fixtures/overall_formula/member_support.json
+++ b/qa-automation/AI-Scoring/tests/fixtures/overall_formula/member_support.json
@@ -1,0 +1,829 @@
+{
+  "formula_id": "member_support_v0_sheet",
+  "source": "Analyst_History export (BackfillPlan.md \u00a76); anonymized",
+  "fixtures": [
+    {
+      "label": "me-0001",
+      "era": "manual",
+      "year_month": "2025-02",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 3,
+        "matching_the_moment": 3,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 4,
+        "efficiency": 2,
+        "documentation": 3,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 77,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0002",
+      "era": "manual",
+      "year_month": "2025-02",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "N",
+        "purpose_of_call": 1,
+        "matching_the_moment": 3,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 1,
+        "efficiency": 1,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 18,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0003",
+      "era": "manual",
+      "year_month": "2025-02",
+      "answers": {
+        "greeting": 4,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 3,
+        "process_adherence": 2,
+        "call_resolution": 2,
+        "communication": 3,
+        "efficiency": 4,
+        "documentation": 2,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 58,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0004",
+      "era": "manual",
+      "year_month": "2025-02",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 2,
+        "matching_the_moment": 1,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 1,
+        "efficiency": 1,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 20,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0005",
+      "era": "manual",
+      "year_month": "2025-04",
+      "answers": {
+        "greeting": 4,
+        "identity_validation": "Y",
+        "purpose_of_call": 3,
+        "matching_the_moment": 2,
+        "process_adherence": 4,
+        "call_resolution": 5,
+        "communication": 3,
+        "efficiency": 5,
+        "documentation": 1,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 77,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0006",
+      "era": "manual",
+      "year_month": "2025-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 4,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 82,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0007",
+      "era": "manual",
+      "year_month": "2025-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 3,
+        "matching_the_moment": 1,
+        "process_adherence": 3,
+        "call_resolution": 1,
+        "communication": 1,
+        "efficiency": 2,
+        "documentation": 2,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 28,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0008",
+      "era": "manual",
+      "year_month": "2025-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 4,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 97,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0009",
+      "era": "manual",
+      "year_month": "2025-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0010",
+      "era": "manual",
+      "year_month": "2025-11",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0011",
+      "era": "manual",
+      "year_month": "2026-03",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "N",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 1,
+        "efficiency": 1,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 52,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0012",
+      "era": "ai",
+      "year_month": "2026-03",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 2,
+        "matching_the_moment": 3,
+        "process_adherence": 3,
+        "call_resolution": 3,
+        "communication": 4,
+        "efficiency": 5,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 57,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0013",
+      "era": "ai",
+      "year_month": "2026-03",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 4,
+        "process_adherence": 3,
+        "call_resolution": 3,
+        "communication": 4,
+        "efficiency": 2,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 50,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0014",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0015",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0016",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 3,
+        "documentation": 4,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 80,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0017",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 3,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 4,
+        "efficiency": 4,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 78,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0018",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 3,
+        "matching_the_moment": 2,
+        "process_adherence": 2,
+        "call_resolution": 1,
+        "communication": 2,
+        "efficiency": 1,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 25,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0019",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 4,
+        "identity_validation": "N",
+        "purpose_of_call": 4,
+        "matching_the_moment": 3,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 2,
+        "efficiency": 2,
+        "documentation": 3,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 37,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0020",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 4,
+        "efficiency": 2,
+        "documentation": 3,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 65,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0021",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0022",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 92,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0023",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 5,
+        "efficiency": 2,
+        "documentation": 1,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 50,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0024",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 2,
+        "matching_the_moment": 2,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 1,
+        "efficiency": 3,
+        "documentation": 2,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 30,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0025",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 3,
+        "identity_validation": "Y",
+        "purpose_of_call": 3,
+        "matching_the_moment": 4,
+        "process_adherence": 4,
+        "call_resolution": 3,
+        "communication": 4,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "NA"
+      },
+      "sheet_overall": 78,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0026",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 4,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 92,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0027",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 4,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 88,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0028",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 4,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 2,
+        "process_adherence": 1,
+        "call_resolution": 1,
+        "communication": 2,
+        "efficiency": 2,
+        "documentation": 3,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 38,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0029",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 3,
+        "matching_the_moment": 3,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 3,
+        "efficiency": 2,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 52,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0030",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 93,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0031",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 2,
+        "call_resolution": 1,
+        "communication": 5,
+        "efficiency": 1,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 38,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0032",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 4,
+        "matching_the_moment": 3,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 4,
+        "efficiency": 3,
+        "documentation": 2,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 63,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0033",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 3,
+        "matching_the_moment": 4,
+        "process_adherence": 4,
+        "call_resolution": 3,
+        "communication": 4,
+        "efficiency": 3,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 52,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0034",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0035",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 2,
+        "matching_the_moment": 2,
+        "process_adherence": 2,
+        "call_resolution": 1,
+        "communication": 2,
+        "efficiency": 2,
+        "documentation": 3,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 33,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0036",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 3,
+        "identity_validation": "N",
+        "purpose_of_call": 4,
+        "matching_the_moment": 4,
+        "process_adherence": 5,
+        "call_resolution": 4,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "NA"
+      },
+      "sheet_overall": 91,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0037",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 2,
+        "call_resolution": 2,
+        "communication": 5,
+        "efficiency": 4,
+        "documentation": 1,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 63,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0038",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "NA",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 5,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "Y"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0039",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 3,
+        "identity_validation": "N",
+        "purpose_of_call": 4,
+        "matching_the_moment": 3,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 3,
+        "efficiency": 4,
+        "documentation": 1,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 60,
+      "expect_exact": true
+    },
+    {
+      "label": "me-0040",
+      "era": "ai",
+      "year_month": "2026-06",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "N",
+        "purpose_of_call": 5,
+        "matching_the_moment": 5,
+        "process_adherence": 4,
+        "call_resolution": 5,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "NA"
+      },
+      "sheet_overall": 100,
+      "expect_exact": true
+    },
+    {
+      "label": "me-edit-01",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 4,
+        "process_adherence": 5,
+        "call_resolution": 4,
+        "communication": 4,
+        "efficiency": 3,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 82,
+      "engine_overall": 73,
+      "expect_exact": false,
+      "note": "sheet overall hand-edited \u2014 inconsistent with the reconstructed formula (BackfillPlan.md \u00a74)"
+    },
+    {
+      "label": "me-edit-02",
+      "era": "ai",
+      "year_month": "2026-04",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "Y",
+        "purpose_of_call": 4,
+        "matching_the_moment": 3,
+        "process_adherence": 3,
+        "call_resolution": 3,
+        "communication": 4,
+        "efficiency": 4,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 76,
+      "engine_overall": 70,
+      "expect_exact": false,
+      "note": "sheet overall hand-edited \u2014 inconsistent with the reconstructed formula (BackfillPlan.md \u00a74)"
+    },
+    {
+      "label": "me-edit-03",
+      "era": "ai",
+      "year_month": "2026-05",
+      "answers": {
+        "greeting": 5,
+        "identity_validation": "N",
+        "purpose_of_call": 5,
+        "matching_the_moment": 4,
+        "process_adherence": 4,
+        "call_resolution": 4,
+        "communication": 5,
+        "efficiency": 5,
+        "documentation": 5,
+        "customer_resolution_indicator": "N"
+      },
+      "sheet_overall": 93,
+      "engine_overall": 85,
+      "expect_exact": false,
+      "note": "sheet overall hand-edited \u2014 inconsistent with the reconstructed formula (BackfillPlan.md \u00a74)"
+    }
+  ]
+}

--- a/qa-automation/AI-Scoring/tests/test_golden_fixtures.py
+++ b/qa-automation/AI-Scoring/tests/test_golden_fixtures.py
@@ -1,0 +1,120 @@
+"""Golden fixture tests — Wave 2 Phase 2c (BackfillPlan.md §6).
+
+Real Analyst_History rows (anonymized) with their sheet-computed overall
+scores, asserted against the engine under the archived legacy formula
+member_support_v0_sheet. This is exact-parity regression armor: if the
+engine's normalization, NA redistribution, or rounding drifts, these fail.
+
+Fixture provenance: scripts/extract_golden_fixtures.py over the (gitignored)
+seed CSV — 1,668/1,676 scoreable rows matched exactly at extraction time;
+the sampled 40 + the 3 hand-edited anomaly rows live here.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import ROUND_HALF_UP, Decimal
+from pathlib import Path
+
+import pytest
+
+from backend.models.formula import WEIGHTED_SUM, Formula
+from backend.services.rule_engine import evaluate_formula
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_V0_FORMULA = _AI_SCORING / "backend" / "config" / "scoring" / "member_support" / "v0_sheet.json"
+_FIXTURES = _AI_SCORING / "tests" / "fixtures" / "overall_formula" / "member_support.json"
+
+
+@pytest.fixture(scope="module")
+def v0_formula() -> Formula:
+    return Formula.model_validate(json.loads(_V0_FORMULA.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="module")
+def fixture_doc() -> dict:
+    return json.loads(_FIXTURES.read_text(encoding="utf-8"))
+
+
+def _sheet_round(score: float) -> int:
+    """The sheet displays integer scores; half-up matches its ROUND()."""
+    return int(Decimal(str(score)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+class TestV0SheetFormula:
+    """The archived legacy formula itself (BackfillPlan.md §2)."""
+
+    def test_validates_and_weights_sum_to_100(self, v0_formula):
+        assert v0_formula.formula_id == "member_support_v0_sheet"
+        assert sum(s.weight for s in v0_formula.sections) == pytest.approx(100.0)
+
+    def test_four_sections_carry_zero_weight(self, v0_formula):
+        zeros = {s.key for s in v0_formula.sections if s.weight == 0.0}
+        assert zeros == {
+            "greeting", "identity_validation",
+            "matching_the_moment", "process_adherence",
+        }
+
+    def test_twelfth_weights(self, v0_formula):
+        w = {s.key: s.weight for s in v0_formula.sections}
+        assert w["call_resolution"] == pytest.approx(400 / 12)
+        assert w["documentation"] == pytest.approx(200 / 12)
+        assert w["purpose_of_call"] == pytest.approx(100 / 12)
+
+    def test_r_over_5_curve(self, v0_formula):
+        """output [0.2, 1.0] == the sheet's rating/5 (rating 1 → 20%, not 0%)."""
+        assert v0_formula.normalization.rating_1_5.output == [0.2, 1.0]
+
+    def test_na_redistributes_per_rules(self, v0_formula):
+        assert v0_formula.normalization.na == "redistribute_per_rules"
+        assert [t for t in v0_formula.evaluation_order if t != WEIGHTED_SUM] == [
+            "civ_na_redistribute", "cri_na_redistribute",
+        ]
+
+
+class TestGoldenFixtures:
+
+    def test_fixture_inventory(self, fixture_doc):
+        fixtures = fixture_doc["fixtures"]
+        exact = [f for f in fixtures if f["expect_exact"]]
+        anomalies = [f for f in fixtures if not f["expect_exact"]]
+        assert len(exact) == 40
+        assert len(anomalies) == 3
+        assert {f["era"] for f in exact} == {"ai", "manual"}
+        assert any("NA" in f["answers"].values() for f in exact), \
+            "sample must exercise the NA-redistribute path"
+
+    def test_exact_parity_with_sheet(self, v0_formula, fixture_doc):
+        failures = []
+        for f in fixture_doc["fixtures"]:
+            if not f["expect_exact"]:
+                continue
+            result = evaluate_formula(v0_formula, f["answers"])
+            got = _sheet_round(result.final_score)
+            if got != f["sheet_overall"]:
+                failures.append(f"{f['label']}: engine {got} != sheet {f['sheet_overall']}")
+        assert not failures, "\n".join(failures)
+
+    def test_hand_edited_rows_stay_anomalous(self, v0_formula, fixture_doc):
+        """The 3 hand-edits document real sheet edits — if the engine ever
+        'matches' one, the formula was changed to chase an anomaly."""
+        for f in fixture_doc["fixtures"]:
+            if f["expect_exact"]:
+                continue
+            result = evaluate_formula(v0_formula, f["answers"])
+            assert _sheet_round(result.final_score) != f["sheet_overall"], f["label"]
+            assert _sheet_round(result.final_score) == f["engine_overall"], f["label"]
+
+    def test_na_fixtures_redistribute_not_full_credit(self, v0_formula, fixture_doc):
+        """On NA rows the CRI weight must spread over active sections —
+        full-credit would inflate the score (BackfillPlan.md §2 evidence)."""
+        na_fixtures = [
+            f for f in fixture_doc["fixtures"]
+            if f["expect_exact"] and f["answers"]["customer_resolution_indicator"] == "NA"
+        ]
+        assert na_fixtures, "sample must include a CRI=NA fixture"
+        for f in na_fixtures:
+            result = evaluate_formula(v0_formula, f["answers"])
+            assert result.effective_weights["customer_resolution_indicator"] == 0.0
+            assert sum(result.effective_weights.values()) == pytest.approx(100.0)
+            assert _sheet_round(result.final_score) == f["sheet_overall"]


### PR DESCRIPTION
## Summary

Phase 2c of [Wave2Plan.md](qa-automation/AI-Scoring/references/Wave2Plan.md), built on the [BackfillPlan.md](database/BackfillPlan.md) findings (#73):

- **`backend/config/scoring/member_support/v0_sheet.json`** — the reverse-engineered legacy sheet formula, encoded in the standard `Formula` shape: `r/5` rating curve (`output: [0.2, 1.0]`), twelfth-weights (resolution 4/12, comms/efficiency/documentation 2/12, purpose/cri 1/12, **zero weight** on greeting/identity_validation/matching/process_adherence), NA handled by proportional `na_redistribution` rules. This is the JSON that backfill B1 inserts into `qa.formula_versions` (decision D3) — every historic row becomes version-stamped and reproducible through `compute_overall_score()`.
- **`scripts/extract_golden_fixtures.py`** — team-parameterized extractor. Runs the engine over the entire seed as a parity gate, then writes a stratified anonymized sample. Extraction run: **1,668/1,676 scoreable rows match the sheet exactly (99.5%)**; 5 manual hard-zeros excluded (D5); 3 hand-edits kept as documented anomalies. Re-runnable for Sales when its export lands (same CSV shape).
- **`tests/fixtures/overall_formula/member_support.json`** — 43 fixtures (40 exact + 3 anomalies), both eras, 14 NA cases. Answers + sheet score + era/month only — no agent/caller names, links, or timestamps.
- **`tests/test_golden_fixtures.py`** — 9 tests: exact parity on all clean fixtures, hand-edits asserted to *stay* anomalous (so nobody chases them with formula tweaks), NA-redistribute behavior pinned against full-credit inflation, and the v0 formula's structural facts locked.

## Test plan

- [x] `pytest tests/test_golden_fixtures.py` — 9 passed.
- [x] Full suite: **370 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected; fails on main).
- [x] Fixture file audited for PII — labels/answers/era/month only.

## Notes

- Raw seed CSV stays gitignored; the extraction script is the reproducible bridge.
- The v2-vs-historic delta quantification belongs to the Phase 6 ε sweep (it needs the §9 key-remap layer); these fixtures pin *legacy* behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)