### PR TITLE
feat(qa-automation): Wave 2 Phase 4a — Stage 1 dual-write to Postgres

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -35,6 +35,9 @@ async def _lifespan(app: FastAPI):
         strict=os.environ.get("QA_VERSION_SHIP_STRICT", "") == "1",
     )
     yield
+    # Wave 2 Phase 4a: dual-write pool (lazy-created on first Stage 1 write).
+    from backend.services.eval_store import close_pool
+    await close_pool()
 
 
 app = FastAPI(

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -27,6 +27,7 @@ from backend.services.history_service import (
     agent_name_for_email,
     email_in_team_mails,
 )
+from backend.services.eval_store import record_draft_evaluation
 from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
@@ -301,8 +302,12 @@ async def score_single_call(
                     call_details=call_details,
                 )
             row_num = write_draft_to_fr_ai(scorecard, config)
+            # Stage 1 dual-write (Wave 2 Phase 4a) — §7.3 Phase A: never
+            # raises; Postgres failures are logged and swallowed.
+            evaluation_id = await record_draft_evaluation(scorecard, config)
             _jobs[key]["status"] = "complete"
             _jobs[key]["sheets_row"] = row_num
+            _jobs[key]["evaluation_id"] = evaluation_id
             _jobs[key]["scorecard"] = scorecard.model_dump()
         except Exception as e:
             _jobs[key]["status"] = "error"
@@ -414,8 +419,10 @@ async def score_batch(
                         duration_ms=dur,
                     )
                 row_num = write_draft_to_fr_ai(scorecard, config)
+                evaluation_id = await record_draft_evaluation(scorecard, config)
                 _jobs[k]["status"] = "complete"
                 _jobs[k]["sheets_row"] = row_num
+                _jobs[k]["evaluation_id"] = evaluation_id
                 _jobs[k]["scorecard"] = scorecard.model_dump()
             except Exception as e:
                 _jobs[k]["status"] = "error"

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -1,0 +1,252 @@
+"""Postgres dual-write for the scoring pipeline — Wave 2 Phase 4a.
+
+Stage 1 (SQLMigration §3.2): when `write_draft_to_fr_ai` lands a draft
+scorecard on the sheet, `record_draft_evaluation()` lands the same content
+as one `qa.evaluations` row (state='draft') + bulk `qa.evaluation_sections`.
+
+Failure semantics are §7.3 Phase A: **the Sheets path is truth and must
+never notice Postgres**. Every DB failure here is logged and swallowed —
+`record_draft_evaluation()` returns None instead of raising. Phase C flips
+this to hard errors; that flip is a deliberate future edit, not a flag.
+
+Idempotency mirrors the sheet: Stage 1 re-scores overwrite by dialpad_link
+(§3.4.1 partial UNIQUE (team_id, dialpad_link)), so an existing draft row is
+UPDATEd and its section rows replaced, in one transaction.
+
+Stage-1 column decisions (each traces to the migration doc):
+
+- `formula_version` / `rubric_version` stay NULL — stamped at score-compute
+  time in Stage 2 post-cutover (§3.6), never at draft time.
+- Manual sections with `na_applicable` land as the §3.8-point-7 NA shape
+  (`binary_value='NA'`, `score_source='manual_default'` — migration 012).
+  Manual sections without NA support get no Stage-1 row (the analyst fills
+  them at Stage 1.5/2; the §3.5 CHECK requires a populated value).
+- AI sections missing from the model output get no row (same reason).
+- `dialpad_agent_id` eager resolution (§3.11) is deferred to backfill B3 —
+  qa.agents is empty until then; `agent_name_raw` carries identity for now.
+
+The pool is lazy (first write creates it) and closed by the FastAPI
+lifespan teardown. No DATABASE_URL → dual-write is off, silently: local
+dev and tests never need a DB (Wave2Plan Phase 1 deliverable).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Optional
+
+from backend.models.formula import EvaluationSection, ModelInfo, ModelsUsed
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+    from backend.models.scorecard import ScorecardWithMeta
+
+logger = logging.getLogger(__name__)
+
+_CONFIDENCE_MAP = {"high": "HIGH", "medium": "MED", "low": "LOW"}
+_AUTO_VALUE_BINARY = {"Yes": "Y", "Y": "Y", "No": "N", "N": "N"}
+
+_pool = None
+_pool_lock: Optional[asyncio.Lock] = None
+
+
+# ---------------------------------------------------------------------------
+# Pure builders — everything testable without a DB
+# ---------------------------------------------------------------------------
+
+def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dict[str, Any]:
+    """qa.evaluations column dict for a Stage-1 draft (§3.2 row shape)."""
+    models_used = ModelsUsed(
+        text=ModelInfo(provider="gemini", model=scorecard.model)
+    )
+    duration_ms = int(scorecard.duration_ms) if scorecard.duration_ms else None
+    return {
+        "team_id": config.team_id,
+        "agent_name_raw": scorecard.agent_name or "",
+        "state": "draft",
+        "source": "ai",
+        "call_connected_at": scorecard.call_started_at_utc,
+        "call_started_at": scorecard.call_started_at_utc,
+        "call_ended_at": scorecard.call_ended_at_utc,
+        "call_duration_ms": duration_ms,
+        "dialpad_call_id": scorecard.call_id,
+        "dialpad_link": scorecard.dialpad_link,
+        "caller_name": scorecard.caller_name,
+        "caller_phone": scorecard.caller_phone,
+        "call_summary": scorecard.call_summary or None,
+        "key_strengths": scorecard.key_strengths or None,
+        "opportunities": scorecard.opportunities or None,
+        "models_used": json.dumps(models_used.model_dump(exclude_none=True)),
+        "ai_provider_primary": "gemini",
+        "scoring_status": "flagged_long_call" if scorecard.flagged_long_call else "complete",
+        "dialpad_call_metadata": json.dumps({
+            "sop_used": scorecard.sop_used,
+            "stage1_flags": sorted({f for s in scorecard.sections for f in s.flags}),
+        }),
+    }
+
+
+def build_draft_sections(
+    scorecard: "ScorecardWithMeta", config: "TeamConfig"
+) -> list[EvaluationSection]:
+    """qa.evaluation_sections rows for a Stage-1 draft, Pydantic-validated
+    at the writer boundary (§3.5)."""
+    ai_by_id = {s.id: s for s in scorecard.sections}
+    rows: list[EvaluationSection] = []
+
+    for sec in config.sections_by_number:
+        if sec.auto_value is not None:
+            rows.append(EvaluationSection(
+                section_id=sec.id,
+                section_number=sec.section_number,
+                score_type="auto_value",
+                binary_value=_AUTO_VALUE_BINARY.get(sec.auto_value, "Y"),
+                score_source="auto_value",
+            ))
+            continue
+
+        if sec.score_type in ("manual", "manual_yn"):
+            if sec.na_applicable:
+                rows.append(EvaluationSection(
+                    section_id=sec.id,
+                    section_number=sec.section_number,
+                    score_type="manual_numeric" if sec.score_type == "manual" else "manual_binary",
+                    binary_value="NA",
+                    score_source="manual_default",
+                ))
+            # no NA support → no draft row; analyst fills at Stage 1.5/2
+            continue
+
+        ai_section = ai_by_id.get(sec.id)
+        if ai_section is None:
+            logger.warning("eval_store: no AI output for section %r — no draft row", sec.id)
+            continue
+
+        is_na = ai_section.yn_value == "NA"
+        is_binary = sec.score_type == "yn"
+        rows.append(EvaluationSection(
+            section_id=sec.id,
+            section_number=sec.section_number,
+            score_type="binary" if is_binary else "numeric",
+            numeric_score=None if is_na else (None if is_binary else ai_section.score),
+            binary_value=(ai_section.yn_value if is_binary or is_na else None),
+            score_source="ai",
+            ai_provider="gemini",
+            model=scorecard.model,
+            confidence=_CONFIDENCE_MAP.get((ai_section.confidence or "").lower()),
+            reasoning=ai_section.reasoning or None,
+        ))
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Dual-write entry point — never raises (§7.3 Phase A)
+# ---------------------------------------------------------------------------
+
+async def record_draft_evaluation(
+    scorecard: "ScorecardWithMeta", config: "TeamConfig"
+) -> Optional[int]:
+    """Write the Stage-1 draft to Postgres. Returns the qa.evaluations id,
+    or None when dual-write is off or anything failed (logged, swallowed)."""
+    try:
+        pool = await _get_pool()
+        if pool is None:
+            return None
+        row = build_draft_row(scorecard, config)
+        sections = build_draft_sections(scorecard, config)
+        async with pool.acquire() as conn:
+            return await _upsert_draft(conn, row, sections)
+    except Exception:
+        logger.exception(
+            "eval_store: Stage 1 dual-write failed for team=%s call=%s — "
+            "swallowed per §7.3 Phase A",
+            config.team_id, scorecard.call_id,
+        )
+        return None
+
+
+async def _upsert_draft(conn: Any, row: dict[str, Any], sections: list[EvaluationSection]) -> int:
+    """INSERT the draft, or UPDATE the existing row matched by
+    (team_id, dialpad_link) — the Stage-1 re-score overwrite. Section rows
+    are replaced wholesale either way, in one transaction."""
+    async with conn.transaction():
+        evaluation_id = None
+        if row["dialpad_link"]:
+            evaluation_id = await conn.fetchval(
+                "SELECT id FROM qa.evaluations WHERE team_id = $1 AND dialpad_link = $2",
+                row["team_id"], row["dialpad_link"],
+            )
+
+        columns = list(row)
+        values = [row[c] for c in columns]
+        if evaluation_id is None:
+            placeholders = ", ".join(f"${i + 1}" for i in range(len(columns)))
+            evaluation_id = await conn.fetchval(
+                f"INSERT INTO qa.evaluations ({', '.join(columns)}) "
+                f"VALUES ({placeholders}) RETURNING id",
+                *values,
+            )
+        else:
+            assignments = ", ".join(f"{c} = ${i + 2}" for i, c in enumerate(columns))
+            await conn.execute(
+                f"UPDATE qa.evaluations SET {assignments} WHERE id = $1",
+                evaluation_id, *values,
+            )
+            await conn.execute(
+                "DELETE FROM qa.evaluation_sections WHERE evaluation_id = $1",
+                evaluation_id,
+            )
+
+        for section in sections:
+            await conn.execute(
+                "INSERT INTO qa.evaluation_sections "
+                "(evaluation_id, section_id, section_number, score_type, "
+                " numeric_score, binary_value, score_source, ai_provider, "
+                " model, confidence, reasoning) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+                evaluation_id, section.section_id, section.section_number,
+                section.score_type, section.numeric_score, section.binary_value,
+                section.score_source, section.ai_provider, section.model,
+                section.confidence, section.reasoning,
+            )
+    return evaluation_id
+
+
+# ---------------------------------------------------------------------------
+# Pool lifecycle
+# ---------------------------------------------------------------------------
+
+async def _get_pool():
+    global _pool, _pool_lock
+    if _pool is not None:
+        return _pool
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        return None
+    if _pool_lock is None:
+        _pool_lock = asyncio.Lock()
+    async with _pool_lock:
+        if _pool is None:
+            import asyncpg
+            _pool = await asyncpg.create_pool(dsn, min_size=0, max_size=4, timeout=5)
+    return _pool
+
+
+async def close_pool() -> None:
+    """Lifespan teardown."""
+    global _pool
+    if _pool is not None:
+        await _pool.close()
+        _pool = None
+
+
+__all__ = [
+    "record_draft_evaluation",
+    "build_draft_row",
+    "build_draft_sections",
+    "close_pool",
+]

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -1,0 +1,283 @@
+"""Stage 1 dual-write tests — Wave 2 Phase 4a.
+
+The pure builders (scorecard → qa.evaluations dict + qa.evaluation_sections
+models) carry most of the correctness weight; the upsert flow and the §7.3
+swallow-everything contract are exercised against a stub pool/connection.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.models.scorecard import ScorecardSection, ScorecardWithMeta
+from backend.services import eval_store
+from backend.services.eval_store import (
+    build_draft_row,
+    build_draft_sections,
+    record_draft_evaluation,
+)
+from tests.conftest import load_test_config
+
+
+@pytest.fixture(scope="module")
+def ms_config():
+    return load_test_config("member_support")
+
+
+def _ai_section(sec_id, name, *, score=None, yn=None, score_type="numeric",
+                confidence="high", reasoning="because", flags=None):
+    return ScorecardSection(
+        id=sec_id, name=name, score=score, yn_value=yn, score_type=score_type,
+        confidence=confidence, reasoning=reasoning, flags=flags or [],
+    )
+
+
+def _scorecard(ms_config, **overrides):
+    """A full MS draft: 8 AI-scored sections (manual + auto get no AI output)."""
+    sections = [
+        _ai_section("greeting", "Greeting", score=5),
+        _ai_section("caller_id", "Caller ID", yn="Y", score_type="yn", confidence="medium"),
+        _ai_section("purpose", "Purpose", score=4),
+        _ai_section("matching", "Matching", score=4, confidence="low"),
+        _ai_section("process_adherence", "Process", score=5),
+        _ai_section("call_resolution", "Resolution", score=3),
+        _ai_section("comms", "Communication", score=4),
+        _ai_section("efficiency", "Efficiency", score=2, flags=["long_hold"]),
+    ]
+    defaults = dict(
+        sections=sections,
+        key_strengths="Good tone",
+        opportunities="Faster holds",
+        call_summary="Member called about billing",
+        call_id="DP123",
+        agent_name="Jane Agent",
+        manager_email="lead@landing.com",
+        dialpad_link="https://dialpad.test/call/DP123",
+        duration_ms=354000.0,
+        model="gemini-2.5-flash",
+        sop_used="Billing SOP",
+        caller_name="Pat Caller",
+        caller_phone="+15550100",
+        call_started_at_utc=datetime(2026, 7, 2, 15, 30, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return ScorecardWithMeta(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# build_draft_row
+# ---------------------------------------------------------------------------
+
+class TestBuildDraftRow:
+
+    def test_stage1_row_shape(self, ms_config):
+        row = build_draft_row(_scorecard(ms_config), ms_config)
+        assert row["state"] == "draft"
+        assert row["source"] == "ai"
+        assert row["team_id"] == "member_support"
+        assert row["dialpad_call_id"] == "DP123"
+        assert row["call_duration_ms"] == 354000
+        assert row["ai_provider_primary"] == "gemini"
+        assert row["scoring_status"] == "complete"
+
+    def test_versions_not_stamped_at_draft_time(self, ms_config):
+        """§3.6 — formula/rubric versions are stamped at score-compute time
+        (Stage 2 post-cutover), never at draft."""
+        row = build_draft_row(_scorecard(ms_config), ms_config)
+        assert "formula_version" not in row
+        assert "rubric_version" not in row
+        assert "overall_score" not in row
+
+    def test_models_used_shape(self, ms_config):
+        row = build_draft_row(_scorecard(ms_config), ms_config)
+        assert json.loads(row["models_used"]) == {
+            "text": {"provider": "gemini", "model": "gemini-2.5-flash"}
+        }
+
+    def test_flagged_long_call_sets_scoring_status(self, ms_config):
+        row = build_draft_row(_scorecard(ms_config, flagged_long_call=True), ms_config)
+        assert row["scoring_status"] == "flagged_long_call"
+
+    def test_section_flags_collected_into_metadata(self, ms_config):
+        meta = json.loads(build_draft_row(_scorecard(ms_config), ms_config)["dialpad_call_metadata"])
+        assert meta["stage1_flags"] == ["long_hold"]
+        assert meta["sop_used"] == "Billing SOP"
+
+
+# ---------------------------------------------------------------------------
+# build_draft_sections
+# ---------------------------------------------------------------------------
+
+class TestBuildDraftSections:
+
+    def test_ms_draft_has_nine_rows(self, ms_config):
+        """8 AI sections + human_review_required NA-default; MS has no
+        auto_value sections; cri got no AI output in this fixture? — no:
+        cri IS in the rubric but absent from the scorecard, so no row."""
+        rows = build_draft_sections(_scorecard(ms_config), ms_config)
+        by_id = {r.section_id: r for r in rows}
+        assert len(rows) == 9
+        assert "cri" not in by_id  # no AI output → no draft row
+
+    def test_numeric_ai_section(self, ms_config):
+        rows = build_draft_sections(_scorecard(ms_config), ms_config)
+        greeting = next(r for r in rows if r.section_id == "greeting")
+        assert greeting.score_type == "numeric"
+        assert greeting.numeric_score == 5
+        assert greeting.binary_value is None
+        assert greeting.score_source == "ai"
+        assert greeting.ai_provider == "gemini"
+        assert greeting.model == "gemini-2.5-flash"
+        assert greeting.confidence == "HIGH"
+
+    def test_binary_ai_section_and_confidence_map(self, ms_config):
+        rows = build_draft_sections(_scorecard(ms_config), ms_config)
+        caller = next(r for r in rows if r.section_id == "caller_id")
+        assert caller.score_type == "binary"
+        assert caller.binary_value == "Y"
+        assert caller.numeric_score is None
+        assert caller.confidence == "MED"
+
+    def test_manual_na_default_row(self, ms_config):
+        """human_review_required — the §3.8-point-7 / migration-012 shape."""
+        rows = build_draft_sections(_scorecard(ms_config), ms_config)
+        hrr = next(r for r in rows if r.section_id == "human_review_required")
+        assert hrr.score_type == "manual_numeric"
+        assert hrr.binary_value == "NA"
+        assert hrr.numeric_score is None
+        assert hrr.score_source == "manual_default"
+        assert hrr.ai_provider is None
+
+    def test_binary_na_from_ai(self, ms_config):
+        sc = _scorecard(ms_config)
+        sc.sections[1] = _ai_section("caller_id", "Caller ID", yn="NA", score_type="yn")
+        caller = next(
+            r for r in build_draft_sections(sc, ms_config) if r.section_id == "caller_id"
+        )
+        assert caller.score_type == "binary"
+        assert caller.binary_value == "NA"
+
+    def test_numeric_na_from_ai_uses_migration_012_shape(self, ms_config):
+        """An NA on a numeric na_applicable section (efficiency is not —
+        use a matching-shaped override) lands as numeric + binary_value NA."""
+        sc = _scorecard(ms_config)
+        sc.sections[7] = ScorecardSection(
+            id="efficiency", name="Efficiency", score=None, yn_value="NA",
+            score_type="numeric", confidence="low", reasoning="silent call",
+        )
+        eff = next(
+            r for r in build_draft_sections(sc, ms_config) if r.section_id == "efficiency"
+        )
+        assert eff.score_type == "numeric"
+        assert eff.numeric_score is None
+        assert eff.binary_value == "NA"
+        assert eff.score_source == "ai"
+
+    def test_auto_value_sections_write_auto_rows(self):
+        """Sales Q18 screen_recording: auto_value='Yes' → binary Y row."""
+        sales = load_test_config("sales")
+        sc = ScorecardWithMeta(
+            sections=[], key_strengths="", opportunities="",
+            model="gemini-2.5-flash",
+        )
+        rows = build_draft_sections(sc, sales)
+        auto = [r for r in rows if r.score_source == "auto_value"]
+        assert auto, "sales config has an auto_value section"
+        assert all(r.binary_value == "Y" for r in auto)
+
+
+# ---------------------------------------------------------------------------
+# record_draft_evaluation — upsert + §7.3 swallow
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    def __init__(self, existing_id=None):
+        self.existing_id = existing_id
+        self.inserts: list[tuple] = []
+        self.updates: list[tuple] = []
+        self.deletes: list[tuple] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+    async def fetchval(self, query, *args):
+        if query.startswith("SELECT id"):
+            return self.existing_id
+        assert query.startswith("INSERT INTO qa.evaluations")
+        self.inserts.append(("evaluations", args))
+        return 101
+
+    async def execute(self, query, *args):
+        if query.startswith("UPDATE"):
+            self.updates.append(args)
+        elif query.startswith("DELETE"):
+            self.deletes.append(args)
+        else:
+            self.inserts.append(("sections", args))
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+class TestRecordDraftEvaluation:
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.fixture(autouse=True)
+    def _no_real_pool(self, monkeypatch):
+        self.conn = FakeConn()
+
+        async def fake_get_pool():
+            return FakePool(self.conn)
+
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_new_draft_inserts_eval_and_sections(self, ms_config):
+        evaluation_id = await record_draft_evaluation(_scorecard(ms_config), ms_config)
+        assert evaluation_id == 101
+        eval_inserts = [i for i in self.conn.inserts if i[0] == "evaluations"]
+        section_inserts = [i for i in self.conn.inserts if i[0] == "sections"]
+        assert len(eval_inserts) == 1
+        assert len(section_inserts) == 9
+        assert all(args[0] == 101 for _, args in section_inserts)
+
+    async def test_rescore_updates_row_and_replaces_sections(self, ms_config):
+        self.conn.existing_id = 77
+        evaluation_id = await record_draft_evaluation(_scorecard(ms_config), ms_config)
+        assert evaluation_id == 77
+        assert len(self.conn.updates) == 1
+        assert self.conn.deletes == [(77,)]
+        assert not [i for i in self.conn.inserts if i[0] == "evaluations"]
+
+    async def test_db_failure_is_swallowed(self, ms_config, monkeypatch):
+        async def exploding_pool():
+            raise ConnectionError("pg down")
+
+        monkeypatch.setattr(eval_store, "_get_pool", exploding_pool)
+        assert await record_draft_evaluation(_scorecard(ms_config), ms_config) is None
+
+    async def test_mid_write_failure_is_swallowed(self, ms_config, monkeypatch):
+        async def boom(*a, **k):
+            raise RuntimeError("constraint violation")
+
+        self.conn.fetchval = boom
+        assert await record_draft_evaluation(_scorecard(ms_config), ms_config) is None
+
+
+class TestPoolDisabled:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_no_database_url_returns_none(self, ms_config, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setattr(eval_store, "_pool", None)
+        assert await record_draft_evaluation(_scorecard(ms_config), ms_config) is None


### PR DESCRIPTION
## Summary

Phase 4a of [Wave2Plan.md](qa-automation/AI-Scoring/references/Wave2Plan.md): every new AI-scored draft now lands in Postgres alongside the sheet.

**`backend/services/eval_store.py`** — `record_draft_evaluation(scorecard, config)`:
- One `qa.evaluations` row (`state='draft'`, `source='ai'`, call clocks, Dialpad ids, `models_used` cascade JSON, `scoring_status` from the long-call flag) + bulk `qa.evaluation_sections`, exactly the §3.2 Stage-1 shape.
- **§7.3 Phase A at the boundary:** the function cannot raise. DB failures are logged and swallowed (returns `None`); no `DATABASE_URL` → dual-write is off. Sheets stays truth.
- **Idempotent like the sheet:** re-scores match on `(team_id, dialpad_link)` and UPDATE + replace section rows in one transaction — no duplicate drafts, no §3.4.1 UNIQUE violations.
- Section rows are Pydantic-validated at the writer boundary: AI sections carry `ai_provider='gemini'`/model/confidence; `human_review_required` lands as the migration-012 NA-default shape (`binary_value='NA'`, `score_source='manual_default'`); Sales' auto_value section writes a binary `Y` row; analyst-only sections without NA support get no Stage-1 row.
- `formula_version`/`rubric_version`/`overall_score` deliberately absent — stamped at Stage 2 score-compute time (§3.6), which is PR 4b.

Wiring: both scoring routes call it immediately after `write_draft_to_fr_ai`; job payloads now expose `evaluation_id`. Lazy asyncpg pool, closed in the lifespan teardown.

## Deferred by design

- `dialpad_agent_id` eager resolution (§3.11) — `qa.agents` is empty until backfill B3; `agent_name_raw` carries identity meanwhile.
- Stage 1.5 (analyst-edit UPDATE) and Stage 2 (approve transition) dual-writes — next PRs (4b).

## Test plan

- [x] 17 new tests in `tests/test_eval_store.py`: row/section builders (versions-not-stamped, models_used shape, long-call status, confidence mapping, binary + numeric NA shapes, manual NA-default, Sales auto_value), insert vs re-score upsert, swallow-on-DB-failure, swallow-mid-write, disabled-without-DSN.
- [x] Import smoke-check (`backend.main`, scoring routes) + scoring route suites green.
- [x] Full suite: **401 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

## Post-merge behavior

On the next Railway deploy, every new scoring job writes a draft row to `qa.evaluations` — Wave 2's first production writes to that table (per plan; the Wave 2 no-write list — assessments/coachings/tags/command_center — is untouched). Verify with:
`SELECT id, team_id, state, dialpad_call_id, created_at FROM qa.evaluations ORDER BY id DESC LIMIT 5;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)