### PR TITLE
feat(qa-automation): §10 sign-off close — member_support_v3 + both spec updates

### DIFF
--- a/database/member_support_scoring_migration.md
+++ b/database/member_support_scoring_migration.md
@@ -1,18 +1,18 @@
 # Member Support — QA Scoring Migration Spec
 
-> Canonical specification for the `member_support_v1` scoring formula.
+> Canonical specification for the Member Support scoring formula (current: `member_support_v3`).
 > **Purpose:** decouple the QA scoring pipeline from Google Sheets-as-database and make the
 > **PostgreSQL engine the single owner of score production**. Scope is deliberately limited to the
 > agreed rubric sections, their initial weights, the scoring formula/rules, and triggers.
 
 | | |
 |---|---|
-| **Status** | Finalized (Ops VP sign-off) |
-| **Formula ID** | `member_support_v1` |
-| **Rubric version** | `v1` |
+| **Status** | Finalized (Ops VP sign-off; §10 open items **closed 2026-07-04** — see Section10SignoffBriefs.md) |
+| **Formula ID** | `member_support_v3` *(v1 = original sign-off; v2 = Ops-signed keys, archived; v3 = §10-close threshold tightening)* |
+| **Rubric version** | `member_support_v2` |
 | **Score scale** | 0–100 |
 | **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
-| **Last updated** | 2026-06-30 |
+| **Last updated** | 2026-07-04 |
 
 ---
 
@@ -40,8 +40,8 @@ at most, a read-only mirror.
 
 | Field | Value |
 |---|---|
-| `formula_id` | `member_support_v1` |
-| `rubric_version` | `v1` |
+| `formula_id` | `member_support_v3` |
+| `rubric_version` | `member_support_v2` |
 | `scale` | 0–100 |
 | weight basis | percentage points summing to 100 |
 | team rule set | Member Support (scale ×0.5; hard-zero disabled) |
@@ -85,7 +85,7 @@ sections that remain active).
 
 ## 5. Formula Rules (Rule Library)
 
-Rules belong to a shared engine and are gated per team. For `member_support_v1`:
+Rules belong to a shared engine and are gated per team. For `member_support_v3`:
 
 | id | type | enabled | Condition | Effect |
 |---|---|---|---|---|
@@ -94,7 +94,7 @@ Rules belong to a shared engine and are gated per team. For `member_support_v1`:
 | `frequent_caller_shift` | weight_transfer | true | `frequent_caller` signal | Move a configurable share (**default 0.5**) of `call_resolution` weight → `process_adherence` (target selectable). Also biases `caller_id` scoring toward NA (prompt-level). |
 | `hrr_na_spread` | weight_redistribution | true | `human_review_required = NA` | Split its weight **equally (additive)** across the active scored sections: `+weight / N` each. |
 | `caller_id_scale_half` | score_scale | true | `caller_id = N` | Multiply final score × **0.5**. (Section also contributes 0 on its own slot.) |
-| `escalation_flag` | flag | true | `process_adherence` frac ≤ 0.5 **OR** `call_resolution` frac ≤ 0.5 | Emit `human_review_required` event; route to supervisor review. |
+| `escalation_flag` | flag | true | `process_adherence` frac ≤ 0.25 **OR** `call_resolution` frac ≤ 0.25 | Emit `human_review_required` event; route to supervisor review. *(Tightened from ≤ 0.5 at §10 close — ratings 1–2 only.)* |
 
 **Notes**
 - `cri = N` needs **no rule**: binary normalization already gives it `0`, so it simply forfeits its weight. *(The former ×0.9 score-wide multiplier is deprecated.)*
@@ -122,9 +122,13 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
 
 ## 7. Triggers
 
-- **Threshold:** a trigger section scoring **1–3** (`frac ≤ 0.50`, inclusive) escalates the call.
+- **Threshold:** a trigger section scoring **1–2** (`frac ≤ 0.25`, inclusive) escalates the call.
+  *(Tightened from 1–3 at §10 close: over the 1,678-eval history the 1–3 threshold escalated
+  26.1% of calls; 1–2 escalates 12.0% — intervention where it's most effective.)*
 - **Active triggers:** `process_adherence`, `call_resolution`.
 - **Candidate triggers** (under review, **not live**): `matching`, `efficiency`.
+  *(§10 close: stay candidates — activating them at the old threshold would have escalated 52.4%
+  of all calls.)*
 - **Routes to:** `human_review_required` — the supervisor scores that section on review.
 
 ---
@@ -133,8 +137,9 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
 
 ```json
 {
-  "formula_id": "member_support_v1",
-  "rubric_version": "v1",
+  "formula_id": "member_support_v3",
+  "rubric_version": "member_support_v2",
+  "supersedes": "member_support_v2",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -150,16 +155,16 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
     { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
     { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
     { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
-    { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "default": "NA" },
+    { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
     { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn",     "weight": 5.0,  "trigger": null }
   ],
   "rules": [
-    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; off for member_support_v1" },
+    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
     { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
-    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true } },
+    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
     { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
     { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
-    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.5 }, { "section": "call_resolution", "frac_lte": 0.5 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" } }
+    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
   ],
   "evaluation_order": [
     "hard_zero",
@@ -171,14 +176,18 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
     "escalation_flag"
   ],
   "triggers": {
-    "threshold": { "op": "lte", "frac": 0.5, "ratings": [1, 2, 3] },
+    "threshold": { "op": "lte", "frac": 0.25, "ratings": [1, 2] },
     "active": ["process_adherence", "call_resolution"],
     "candidates": ["matching", "efficiency"],
     "routes_to": "human_review_required"
   },
   "external_signals": {
     "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
-  }
+  },
+  "human_review_triggers": [
+    { "section_id": "process_adherence", "max_score_to_trigger": 2 },
+    { "section_id": "call_resolution",   "max_score_to_trigger": 2 }
+  ]
 }
 ```
 
@@ -196,7 +205,12 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
 
 ## 10. Open Decisions
 
-- [ ] Confirm whether `matching` / `efficiency` become **active** triggers or stay candidates.
-- [ ] Confirm `frequent_caller_shift` default fraction (0.5) and default target (`process_adherence`).
-- [ ] Confirm hard-zero stays globally available (enabled per team) vs. removed outright for Member Support.
-- [ ] Confirm the NA-spread behavior when **multiple** sections are NA (current: recompute equal-additive over remaining active sections).
+All items **closed 2026-07-04** (Ops VP, via Section10SignoffBriefs.md Part A):
+
+- [x] `matching` / `efficiency` **stay candidates**. Additionally, the active-trigger threshold was
+      tightened from ratings 1–3 to **1–2** (frac ≤ 0.25) — shipped as `member_support_v3`.
+      Historic incidence: 26.1% → 12.0% of calls escalate.
+- [x] `frequent_caller_shift` defaults confirmed as-is (fraction 0.5, target `process_adherence`).
+- [x] Hard-zero **stays globally available, disabled for Member Support**.
+- [x] Multiple-NA spread confirmed as shipped: recompute equal-additive over remaining active
+      sections, order per §6; NA weight is never silently lost (engine hard-fails otherwise).

--- a/database/sales_scoring_migration.md
+++ b/database/sales_scoring_migration.md
@@ -14,12 +14,12 @@
 
 | | |
 |---|---|
-| **Status** | Rubric finalized (Sales QA — Revised 15-Point Matrix); spec **populated from source PDF**, pending confirmation on the §10 flagged items |
-| **Formula ID** | `sales_v1` *(proposed — confirm)* |
-| **Rubric version** | `v1` *(proposed)* |
+| **Status** | Finalized — §10 items **closed 2026-07-04** by Sales management (see Section10SignoffBriefs.md Part B) |
+| **Formula ID** | `sales_v2` *(the seeded `sales_v1` id belongs to the legacy 19-section rubric; archive ids are immutable)* |
+| **Rubric version** | `sales_v2` |
 | **Score scale** | 0–100 (15 questions, 100 points) |
 | **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
-| **Last updated** | 2026-06-30 |
+| **Last updated** | 2026-07-04 |
 
 ---
 
@@ -51,9 +51,9 @@ PostgreSQL engine to own score production end-to-end; retire Sheets-as-DB.
 
 | Field | Value |
 |---|---|
-| `formula_id` | `sales_v1` &nbsp; *(proposed — confirm)* |
-| `rubric_version` | `v1` &nbsp; *(proposed)* |
-| `supersedes` | `null` &nbsp; *(confirm — see §10)* |
+| `formula_id` | `sales_v2` |
+| `rubric_version` | `sales_v2` *(closes the seeded legacy `sales_v1` rubric when shipped)* |
+| `supersedes` | `null` *(first engine-owned Sales formula)* |
 | `scale` | 0–100 (15 questions, 100 points) |
 | weight basis | points ≡ percentage points; sum = 100 |
 | **NA policy** | **full credit on-slot** (frac 1.0, **no redistribution**) — differs from Member Support |
@@ -96,15 +96,16 @@ Score-type display: `0/1/NA` = binary (`binary_yn_na`), `1–5/NA` = rating (`ra
 
 ### 3a. Deprecated sections (removed vs. the prior Sales version)
 
-**Blocked — requires the prior Sales rubric.** The PDF is the *revised* matrix (new state) only; the
-section add/deprecate diff cannot be derived from it. Provide the previous rubric to populate this.
-*(If `sales_v1` is the first engine-owned version, this section is empty.)*
+**Unblocked at §10 close:** the prior rubric **exists in the archive** — `qa.rubric_versions`
+row `sales_v1` (the 19-section rubric seeded by migration 010). The add/deprecate diff below is
+populated against it once the section-semantics mapping (e.g. is `move_reason` new, or
+`situation_match` renamed?) is confirmed against `QA_Scoring_Guide.pdf`.
 
-- `<old_section_key>` — *reason / replaced by* &nbsp; **TODO (needs prior rubric)**
+- *diff pending semantics mapping* &nbsp; **TODO (mapping confirmation, not a missing document)**
 
 ### 3b. New sections (added vs. the prior Sales version)
 
-**Blocked — same reason as §3a.**
+**Same status as §3a — populatable from the archived `sales_v1` rubric once the mapping is confirmed.**
 
 - `<new_section_key>` — *definition* &nbsp; **TODO (needs prior rubric)**
 
@@ -168,8 +169,8 @@ No pre-sum weight moves and no post-sum scaling exist in this version. NA is res
 
 ```json
 {
-  "formula_id": "sales_v1",
-  "rubric_version": "v1",
+  "formula_id": "sales_v2",
+  "rubric_version": "sales_v2",
   "supersedes": null,
   "scale": { "min": 0, "max": 100 },
   "normalization": {
@@ -232,25 +233,24 @@ No pre-sum weight moves and no post-sum scaling exist in this version. NA is res
 
 ---
 
-## 10. Open Items — confirm before locking `sales_v1`
+## 10. Open Items — closed 2026-07-04 (Sales management)
 
-- [ ] **Scaled 1–5 → points curve.** Assumed `(rating − 1) / 4` (worst = 0, best = full; consistent with
-      the binary "0 or full points" anchors). Confirm vs. `rating / 5`. *Materially changes every scaled
-      section's score.*
-- [ ] **NA = full credit.** Confirm the PDF footer ("N/A = full points when not applicable") applies to
-      **all 15 sections** and means full-credit-on-slot with **no redistribution** (opposite of Member
-      Support).
-- [ ] **Version number & lineage.** Confirm `formula_id = sales_v1` and whether it supersedes a prior
-      engine-owned version. If so, **provide the prior rubric** so §3a / §3b can be populated — the diff
-      can't be produced from the new PDF alone.
-- [ ] **Section keys.** Proposed keys are mine; confirm/rename to match existing column names in the
-      codebase.
-- [ ] **`category` field.** Confirm you want the PDF's category grouping persisted on `qa.formula_section`
-      (engine can ignore it; useful for reporting).
-- [ ] **`client_experience` placement.** The PDF files it under *Post-Call & Documentation*; confirm
-      that's intended (it reads as a call-wide measure).
-- [ ] **No rules / no triggers.** Confirmed absent in the PDF. Confirm none are planned for v1 before
-      engineering builds against an empty rule set.
+- [x] **Scaled 1–5 → points curve: `(rating − 1) / 4` confirmed.** Requirement attached to the
+      decision: the curve must be reconfigurable in the same manager UI that ships a new scoring
+      version (formula or rubric). Architecturally satisfied today — the curve lives in the
+      formula JSON (`normalization.rating_1_5.output`), so any version-ship surface can change it;
+      the requirement binds the future rubric-editor UI (§3.19.2 editor write path).
+- [x] **NA = full credit confirmed as written**, all 15 sections, no redistribution. No other NA
+      behaviors in this version.
+- [x] **Version id: `sales_v2`** (formula AND rubric — the seeded `sales_v1` rubric id is
+      immutable and stays with the legacy 19-section rubric). `supersedes: null` for the formula;
+      the `sales_v2` rubric row closes `sales_v1` when shipped. Historic Analyst_History export
+      incoming for the backfill seed.
+- [x] **Section keys adopted as proposed** — no renames. Legacy 19-section ids remain valid
+      forever on historic rows via rubric pinning.
+- [x] **`category` persisted** on formula sections (reporting).
+- [x] **`client_experience` stays under *Post-Call & Documentation*.**
+- [x] **No rules / no triggers for `sales_v2`** — `evaluation_order: ["weighted_sum"]`.
 
 ---
 

--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
@@ -1,7 +1,7 @@
 {
-  "formula_id": "member_support_v2",
+  "formula_id": "member_support_v3",
   "rubric_version": "member_support_v2",
-  "supersedes": "member_support_v1",
+  "supersedes": "member_support_v2",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -26,7 +26,7 @@
     { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
     { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
     { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
-    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.5 }, { "section": "call_resolution", "frac_lte": 0.5 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" } }
+    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
   ],
   "evaluation_order": [
     "hard_zero",
@@ -38,7 +38,7 @@
     "escalation_flag"
   ],
   "triggers": {
-    "threshold": { "op": "lte", "frac": 0.5, "ratings": [1, 2, 3] },
+    "threshold": { "op": "lte", "frac": 0.25, "ratings": [1, 2] },
     "active": ["process_adherence", "call_resolution"],
     "candidates": ["matching", "efficiency"],
     "routes_to": "human_review_required"
@@ -47,7 +47,7 @@
     "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
   },
   "human_review_triggers": [
-    { "section_id": "process_adherence", "max_score_to_trigger": 3 },
-    { "section_id": "call_resolution",   "max_score_to_trigger": 3 }
+    { "section_id": "process_adherence", "max_score_to_trigger": 2 },
+    { "section_id": "call_resolution",   "max_score_to_trigger": 2 }
   ]
 }

--- a/qa-automation/AI-Scoring/references/Section10SignoffBriefs.md
+++ b/qa-automation/AI-Scoring/references/Section10SignoffBriefs.md
@@ -1,5 +1,15 @@
 # §10 Sign-off Briefs — Member Support (Ops VP) + Sales (Sales Management)
 
+> **CLOSED 2026-07-04.** All 11 items decided; both specs updated same day. Outcomes:
+> **A1** candidates stay + active-trigger threshold tightened to ratings 1–2 (frac ≤ 0.25) →
+> shipped as `member_support_v3` (escalation incidence 26.1% → 12.0%). **A2** defaults as-is.
+> **A3** hard-zero stays global, disabled for MS. **A4** shipped multi-NA behavior confirmed.
+> **B1** `(rating−1)/4`, with the requirement that the curve be reconfigurable in the future
+> manager version-ship UI (satisfied: it lives in formula JSON). **B2** NA full-credit as written.
+> **B3** ids = `sales_v2` / `sales_v2` (not `sales_v1_ops`); Sales Analyst_History export incoming.
+> **B4** 15 keys adopted as-is. **B5** category persisted. **B6** placement kept. **B7** no rules.
+> The sections below are preserved as the decision record's supporting analysis.
+
 > Decision prep for Wave2Plan Phases **3b** and **3c**. Each open item below quotes the spec,
 > states what the shipped engine does *today*, adds the real-history numbers where the backfill
 > seed can speak (1,678 MS evaluations — see [BackfillPlan.md §1](../../../database/BackfillPlan.md)),

--- a/qa-automation/AI-Scoring/tests/test_formula_models.py
+++ b/qa-automation/AI-Scoring/tests/test_formula_models.py
@@ -61,7 +61,8 @@ class TestMemberSupportShippedConfig:
     """The MS files in the repo must load. If these break, downstream is blocked."""
 
     def test_formula_loads(self, ms_formula):
-        assert ms_formula.formula_id == "member_support_v2"
+        assert ms_formula.formula_id == "member_support_v3"
+        assert ms_formula.supersedes == "member_support_v2"
         assert len(ms_formula.sections) == 10
         assert len(ms_formula.rules) == 6
 
@@ -99,8 +100,8 @@ class TestSalesCanonicalConfig:
     @pytest.fixture(scope="class")
     def sales_formula(self) -> Formula:
         return Formula.model_validate({
-            "formula_id": "sales_v1",
-            "rubric_version": "sales_v1",
+            "formula_id": "sales_v2",
+            "rubric_version": "sales_v2",
             "supersedes": None,
             "scale": {"min": 0, "max": 100},
             "normalization": {

--- a/qa-automation/AI-Scoring/tests/test_rule_engine.py
+++ b/qa-automation/AI-Scoring/tests/test_rule_engine.py
@@ -61,8 +61,8 @@ def ms_answers(**overrides):
 def sales_formula() -> Formula:
     """Sales §8 canonical config (inline until §10 sign-off ships the file)."""
     return Formula.model_validate({
-        "formula_id": "sales_v1",
-        "rubric_version": "sales_v1",
+        "formula_id": "sales_v2",
+        "rubric_version": "sales_v2",
         "supersedes": None,
         "scale": {"min": 0, "max": 100},
         "normalization": {
@@ -246,8 +246,10 @@ class TestMemberSupportEngine:
         shift = next(t for t in result.trace if t.rule_id == "frequent_caller_shift")
         assert not shift.fired
 
-    def test_escalation_flag_fires_at_rating_3_and_below(self, ms_formula):
-        for rating, should_fire in [(1, True), (2, True), (3, True), (4, False), (5, False)]:
+    def test_escalation_flag_fires_at_rating_2_and_below(self, ms_formula):
+        """Threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04
+        (member_support_v3): rating 3 no longer escalates."""
+        for rating, should_fire in [(1, True), (2, True), (3, False), (4, False), (5, False)]:
             result = evaluate_formula(ms_formula, ms_answers(process_adherence=rating))
             fired = any(e.rule_id == "escalation_flag" for e in result.events)
             assert fired is should_fire, f"rating {rating}"

--- a/qa-automation/AI-Scoring/tests/test_score_compute.py
+++ b/qa-automation/AI-Scoring/tests/test_score_compute.py
@@ -30,7 +30,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
 _MS_TEAM_JSON = _REPO_ROOT / "backend" / "config" / "teams" / "member_support.json"
 
-MS_FORMULA_VERSION = "member_support_v2"
+MS_FORMULA_VERSION = "member_support_v3"
 MS_RUBRIC_VERSION = "member_support_v2"
 
 


### PR DESCRIPTION
## Summary

All 11 §10 items closed 2026-07-04. This PR encodes the decisions; the two `_scoring_migration.md` specs are edited for the first time in Wave 2, as authorized by the sign-off.

### The one behavioral change: `member_support_v3` (decision A1)

Escalation threshold tightened from ratings **1–3** (`frac ≤ 0.5`) to **1–2** (`frac ≤ 0.25`) on `process_adherence`/`call_resolution` — `escalation_flag` when-clauses, `triggers.threshold`, and `human_review_triggers` (`max_score_to_trigger` 3→2) all follow. Measured on the 1,678-eval history: escalation incidence drops **26.1% → 12.0%** — intervention where it's most effective. `supersedes: member_support_v2`, rubric unchanged.

**Ship is automatic:** on the next Railway deploy the startup path archives `member_support_v3` and closes v2 — no operator step (the rubric it references is already archived). Verify post-deploy: `SELECT formula_version, effective_until FROM qa.formula_versions ORDER BY id;`

### Confirmed as shipped (no code change)

A2 `frequent_caller_shift` defaults · A3 hard-zero stays global, disabled for MS · A4 equal-additive multi-NA spread · B2 NA full-credit · B4 15 section keys as-is · B5 `category` persisted · B6 `client_experience` placement · B7 no rules for Sales v1.

### Decisions with recorded constraints

- **B1**: `(rating−1)/4` confirmed; requirement recorded that the curve be reconfigurable in the future manager version-ship UI — architecturally satisfied (curve lives in formula JSON; any ship surface can change it), binds the §3.19.2 editor UI when built.
- **B3**: Sales ids = **`sales_v2` / `sales_v2`** (the seeded `sales_v1` rubric id is immutable and stays legacy). Spec §3a/§3b flipped from "blocked — needs prior rubric" to "populatable — the prior rubric exists in the archive," pending only section-semantics mapping against the PDF.

### Spec/doc updates

- MS spec: metadata → v3, §5/§7 thresholds with the historic-incidence data, **§8 canonical JSON now mirrors the shipped file verbatim**, §10 boxes checked with decisions.
- Sales spec: metadata/§2/§8 ids → `sales_v2`, §3a/§3b unblock note, §10 boxes checked.
- Sign-off brief: closure record prepended (analysis preserved as the decision's supporting record).

## Test plan

- [x] Escalation boundary test moved (rating 3 asserted NOT to fire under v3), shipped-config asserts on `formula_id`/`supersedes`, inline Sales fixtures → `sales_v2`.
- [x] Full suite: **401 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

## Follow-ups

- Phase 4b (Stage 1.5/2 dual-writes) — next engineering lane, unblocked throughout.
- Sales rubric construction (`sales_v2` nested config) still needs descriptor prose from `QA_Scoring_Guide.pdf` + the §3a/§3b mapping + sheet-side cutover coordination (tracked in task #5).
- Sales Analyst_History export (incoming) → backfill seed + legacy-curve verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)