### PR TITLE
feat(qa-automation): Wave 2 Phase 4b — approve-transition dual-write

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -27,7 +27,7 @@ from backend.services.history_service import (
     agent_name_for_email,
     email_in_team_mails,
 )
-from backend.services.eval_store import record_draft_evaluation
+from backend.services.eval_store import record_approval, record_draft_evaluation
 from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
@@ -528,6 +528,22 @@ async def approve_scorecard(
             config=config,
         )
         print(f"[approve] Stage 4 complete. Analyst_History row: {history_row}")
+
+        # Postgres dual-write for the whole approve transition (Stages
+        # 1.5+2+3+4 — Wave 2 Phase 4b). §7.3 Phase A: never raises.
+        job["evaluation_id"] = await record_approval(
+            config,
+            evaluation_id=job.get("evaluation_id"),
+            dialpad_link=sc.get("dialpad_link"),
+            evaluator_email=evaluator_email,
+            approved_sections=approval.sections,
+            draft_sections=sc.get("sections", []),
+            key_strengths=approval.key_strengths,
+            opportunities=approval.opportunities,
+            overall_score_raw=overall_score,
+            agent_email=job.get("agent_email") or None,
+            model=sc.get("model", "gemini-2.5-flash"),
+        )
 
         # Audit the approval BEFORE Stage 5 so a downstream Apps Script
         # failure doesn't lose the record. Identity comes from the API key

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -217,6 +217,204 @@ async def _upsert_draft(conn: Any, row: dict[str, Any], sections: list[Evaluatio
 
 
 # ---------------------------------------------------------------------------
+# Stages 1.5 + 2 + 3 + 4 — the approve transition (Wave 2 Phase 4b)
+# ---------------------------------------------------------------------------
+#
+# The /approve endpoint runs Stage 1.5 (analyst edits) through Stage 4
+# (Analyst_History) in one request, so Postgres records the combined
+# transition once, after Stage 4 succeeds:
+#
+#   - sections replaced with the analyst-approved payload; a section whose
+#     value changed vs. the Stage-1 draft becomes score_source='manual'
+#     (no ai_provider/confidence — §3.5 says those are AI-only); unchanged
+#     sections keep their AI provenance.
+#   - evaluations: evaluator_email, approved_at, key_strengths/opportunities,
+#     agent_email when known, source ai→ai_reviewed if anything changed
+#     (§3.2 Stage 1.5), overall_score from the Stage-3 ARRAYFORMULA readback
+#     (pre-cutover truth), state='finalized' — or 'approved' when the
+#     readback produced no number (the §3.4.3 CHECK requires a score to
+#     finalize).
+#   - formula_version/rubric_version stay NULL: the readback value is the
+#     sheet's, not the engine's — stamping starts at cutover (§3.6).
+
+def build_approval_sections(
+    approved: list[Any],
+    draft_sections: list[dict[str, Any]],
+    config: "TeamConfig",
+    model: str,
+) -> tuple[list[EvaluationSection], bool]:
+    """Approved payload -> section rows + whether anything changed vs draft.
+
+    `approved` is the ApprovalRequest.sections list; `draft_sections` is the
+    Stage-1 scorecard dump (job['scorecard']['sections'])."""
+    approved_by_id = {s.id: s for s in approved}
+    draft_by_id = {s["id"]: s for s in draft_sections}
+    rows: list[EvaluationSection] = []
+    any_changed = False
+
+    for sec in config.sections_by_number:
+        if sec.auto_value is not None:
+            rows.append(EvaluationSection(
+                section_id=sec.id,
+                section_number=sec.section_number,
+                score_type="auto_value",
+                binary_value=_AUTO_VALUE_BINARY.get(sec.auto_value, "Y"),
+                score_source="auto_value",
+            ))
+            continue
+
+        section = approved_by_id.get(sec.id)
+        if section is None:
+            continue  # not in the payload -> nothing to record
+
+        is_manual = sec.score_type in ("manual", "manual_yn")
+        is_binary = sec.score_type in ("yn", "manual_yn")
+        is_na = section.yn_value == "NA"
+
+        if is_manual and is_na:
+            # untouched na_default section — the Stage-1 draft never carries
+            # manual sections, and NA is their default state, not an edit.
+            rows.append(EvaluationSection(
+                section_id=sec.id,
+                section_number=sec.section_number,
+                score_type="manual_numeric" if sec.score_type == "manual" else "manual_binary",
+                binary_value="NA",
+                score_source="manual_default",
+            ))
+            continue
+
+        if is_manual:
+            changed = True  # analyst actively scored a manual section
+        else:
+            draft = draft_by_id.get(sec.id)
+            changed = draft is None or (
+                (draft.get("score"), draft.get("yn_value") or None)
+                != (section.score, section.yn_value or None)
+            )
+        any_changed = any_changed or changed
+
+        if is_manual or changed:
+            rows.append(EvaluationSection(
+                section_id=sec.id,
+                section_number=sec.section_number,
+                score_type=(
+                    ("manual_binary" if is_manual else "binary") if is_binary
+                    else ("manual_numeric" if is_manual else "numeric")
+                ),
+                numeric_score=None if is_na else (None if is_binary else section.score),
+                binary_value=(section.yn_value if is_binary or is_na else None),
+                score_source="manual",
+                reasoning=section.reasoning or None,
+            ))
+        else:
+            rows.append(EvaluationSection(
+                section_id=sec.id,
+                section_number=sec.section_number,
+                score_type="binary" if is_binary else "numeric",
+                numeric_score=None if is_na else (None if is_binary else section.score),
+                binary_value=(section.yn_value if is_binary or is_na else None),
+                score_source="ai",
+                ai_provider="gemini",
+                model=model,
+                confidence=_CONFIDENCE_MAP.get((section.confidence or "").lower()),
+                reasoning=section.reasoning or None,
+            ))
+
+    return rows, any_changed
+
+
+def _parse_overall(raw: Any):
+    try:
+        value = float(str(raw).strip().replace("%", ""))
+    except (TypeError, ValueError):
+        return None
+    return round(value, 1)
+
+
+async def record_approval(
+    config: "TeamConfig",
+    *,
+    evaluation_id: Optional[int],
+    dialpad_link: Optional[str],
+    evaluator_email: str,
+    approved_sections: list[Any],
+    draft_sections: list[dict[str, Any]],
+    key_strengths: str,
+    opportunities: str,
+    overall_score_raw: Any,
+    agent_email: Optional[str] = None,
+    model: str = "gemini-2.5-flash",
+) -> Optional[int]:
+    """Record the approve transition. Never raises (§7.3 Phase A)."""
+    try:
+        pool = await _get_pool()
+        if pool is None:
+            return None
+        sections, any_changed = build_approval_sections(
+            approved_sections, draft_sections, config, model
+        )
+        overall = _parse_overall(overall_score_raw)
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                if evaluation_id is None and dialpad_link:
+                    evaluation_id = await conn.fetchval(
+                        "SELECT id FROM qa.evaluations WHERE team_id = $1 AND dialpad_link = $2",
+                        config.team_id, dialpad_link,
+                    )
+                if evaluation_id is None:
+                    logger.warning(
+                        "eval_store: approve for team=%s link=%s has no draft row — "
+                        "Stage 1 dual-write missed it; skipping",
+                        config.team_id, dialpad_link,
+                    )
+                    return None
+                await conn.execute(
+                    "UPDATE qa.evaluations SET "
+                    "  evaluator_email = $2, "
+                    "  agent_email = COALESCE($3, agent_email), "
+                    "  key_strengths = $4, "
+                    "  opportunities = $5, "
+                    "  overall_score = $6, "
+                    "  source = $7, "
+                    "  state = $8, "
+                    "  approved_at = NOW(), "
+                    "  finalized_at = CASE WHEN $8 = 'finalized' THEN NOW() ELSE finalized_at END "
+                    "WHERE id = $1",
+                    evaluation_id,
+                    evaluator_email,
+                    agent_email,
+                    key_strengths or None,
+                    opportunities or None,
+                    overall,
+                    "ai_reviewed" if any_changed else "ai",
+                    "finalized" if overall is not None else "approved",
+                )
+                await conn.execute(
+                    "DELETE FROM qa.evaluation_sections WHERE evaluation_id = $1",
+                    evaluation_id,
+                )
+                for section in sections:
+                    await conn.execute(
+                        "INSERT INTO qa.evaluation_sections "
+                        "(evaluation_id, section_id, section_number, score_type, "
+                        " numeric_score, binary_value, score_source, ai_provider, "
+                        " model, confidence, reasoning) "
+                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+                        evaluation_id, section.section_id, section.section_number,
+                        section.score_type, section.numeric_score, section.binary_value,
+                        section.score_source, section.ai_provider, section.model,
+                        section.confidence, section.reasoning,
+                    )
+        return evaluation_id
+    except Exception:
+        logger.exception(
+            "eval_store: approve dual-write failed for team=%s — swallowed per §7.3 Phase A",
+            config.team_id,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Pool lifecycle
 # ---------------------------------------------------------------------------
 
@@ -246,7 +444,9 @@ async def close_pool() -> None:
 
 __all__ = [
     "record_draft_evaluation",
+    "record_approval",
     "build_draft_row",
     "build_draft_sections",
+    "build_approval_sections",
     "close_pool",
 ]

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -16,6 +16,7 @@ import pytest
 from backend.models.scorecard import ScorecardSection, ScorecardWithMeta
 from backend.services import eval_store
 from backend.services.eval_store import (
+    build_approval_sections,
     build_draft_row,
     build_draft_sections,
     record_draft_evaluation,
@@ -281,3 +282,179 @@ class TestPoolDisabled:
         monkeypatch.delenv("DATABASE_URL", raising=False)
         monkeypatch.setattr(eval_store, "_pool", None)
         assert await record_draft_evaluation(_scorecard(ms_config), ms_config) is None
+
+
+# ---------------------------------------------------------------------------
+# record_approval — Stages 1.5+2+3+4 (Phase 4b)
+# ---------------------------------------------------------------------------
+
+def _approval_sections(ms_config, **edits):
+    """Approval payload mirroring the Stage-1 draft, with optional edits."""
+    base = {
+        "greeting": _ai_section("greeting", "Greeting", score=5),
+        "caller_id": _ai_section("caller_id", "Caller ID", yn="Y", score_type="yn", confidence="medium"),
+        "purpose": _ai_section("purpose", "Purpose", score=4),
+        "matching": _ai_section("matching", "Matching", score=4, confidence="low"),
+        "process_adherence": _ai_section("process_adherence", "Process", score=5),
+        "call_resolution": _ai_section("call_resolution", "Resolution", score=3),
+        "comms": _ai_section("comms", "Communication", score=4),
+        "efficiency": _ai_section("efficiency", "Efficiency", score=2),
+        "human_review_required": ScorecardSection(
+            id="human_review_required", name="HRR", score=None, yn_value="NA",
+            score_type="manual", confidence="high", reasoning="",
+        ),
+        # cri deliberately absent — the Stage-1 draft fixture has no AI
+        # output for it, and the payload mirrors the draft.
+    }
+    base.update(edits)
+    return list(base.values())
+
+
+class TestBuildApprovalSections:
+
+    def test_unchanged_sections_keep_ai_provenance(self, ms_config):
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        rows, changed = build_approval_sections(
+            _approval_sections(ms_config), draft, ms_config, "gemini-2.5-flash"
+        )
+        assert not changed
+        greeting = next(r for r in rows if r.section_id == "greeting")
+        assert greeting.score_source == "ai"
+        assert greeting.ai_provider == "gemini"
+
+    def test_edited_section_becomes_manual_without_ai_fields(self, ms_config):
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        rows, changed = build_approval_sections(
+            _approval_sections(ms_config, comms=_ai_section("comms", "Communication", score=2)),
+            draft, ms_config, "gemini-2.5-flash",
+        )
+        assert changed
+        comms = next(r for r in rows if r.section_id == "comms")
+        assert comms.score_source == "manual"
+        assert comms.numeric_score == 2
+        assert comms.ai_provider is None
+        assert comms.confidence is None
+        # only the edited section flips; the rest keep AI provenance
+        assert next(r for r in rows if r.section_id == "purpose").score_source == "ai"
+
+    def test_untouched_hrr_keeps_manual_default_na(self, ms_config):
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        rows, _ = build_approval_sections(
+            _approval_sections(ms_config), draft, ms_config, "gemini-2.5-flash"
+        )
+        hrr = next(r for r in rows if r.section_id == "human_review_required")
+        assert hrr.score_source == "manual_default"
+        assert hrr.binary_value == "NA"
+
+    def test_value_without_ai_draft_counts_as_analyst_edit(self, ms_config):
+        """A section that appears at approval without a Stage-1 AI value was
+        supplied by the analyst — manual provenance, source flips."""
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]  # no cri
+        rows, changed = build_approval_sections(
+            _approval_sections(ms_config) + [_ai_section("cri", "CRI", yn="Y", score_type="yn")],
+            draft, ms_config, "gemini-2.5-flash",
+        )
+        assert changed
+        cri = next(r for r in rows if r.section_id == "cri")
+        assert cri.score_source == "manual"
+        assert cri.ai_provider is None
+
+    def test_supervisor_scored_hrr_becomes_manual(self, ms_config):
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        rows, changed = build_approval_sections(
+            _approval_sections(ms_config, human_review_required=ScorecardSection(
+                id="human_review_required", name="HRR", score=1, yn_value=None,
+                score_type="manual", confidence="high", reasoning="agreed with flag",
+            )),
+            draft, ms_config, "gemini-2.5-flash",
+        )
+        assert changed
+        hrr = next(r for r in rows if r.section_id == "human_review_required")
+        assert hrr.score_type == "manual_numeric"
+        assert hrr.numeric_score == 1
+        assert hrr.score_source == "manual"
+
+
+class ApprovalFakeConn(FakeConn):
+    def __init__(self, existing_id=None):
+        super().__init__(existing_id)
+        self.eval_updates: list[tuple] = []
+
+    async def execute(self, query, *args):
+        if query.startswith("UPDATE qa.evaluations"):
+            self.eval_updates.append(args)
+        elif query.startswith("DELETE"):
+            self.deletes.append(args)
+        else:
+            self.inserts.append(("sections", args))
+
+
+class TestRecordApproval:
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.fixture(autouse=True)
+    def _no_real_pool(self, monkeypatch):
+        self.conn = ApprovalFakeConn()
+
+        async def fake_get_pool():
+            return FakePool(self.conn)
+
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def _approve(self, ms_config, overall="87", evaluation_id=101, **kwargs):
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        return await eval_store.record_approval(
+            ms_config,
+            evaluation_id=evaluation_id,
+            dialpad_link="https://dialpad.test/call/DP123",
+            evaluator_email="lead@landing.com",
+            approved_sections=kwargs.pop("sections", _approval_sections(ms_config)),
+            draft_sections=draft,
+            key_strengths="Good tone",
+            opportunities="Faster holds",
+            overall_score_raw=overall,
+            **kwargs,
+        )
+
+    async def test_finalizes_with_readback_score(self, ms_config):
+        assert await self._approve(ms_config) == 101
+        (args,) = self.conn.eval_updates
+        # (id, evaluator, agent_email, ks, opp, overall, source, state)
+        assert args[0] == 101
+        assert args[1] == "lead@landing.com"
+        assert args[5] == 87.0
+        assert args[6] == "ai"          # nothing edited
+        assert args[7] == "finalized"
+        assert self.conn.deletes == [(101,)]
+        # 8 AI sections + human_review_required (cri absent from payload)
+        assert len([i for i in self.conn.inserts if i[0] == "sections"]) == 9
+
+    async def test_blank_readback_lands_as_approved_not_finalized(self, ms_config):
+        """§3.4.3: finalized requires overall_score — a failed ARRAYFORMULA
+        readback leaves the row 'approved' with NULL score."""
+        await self._approve(ms_config, overall="")
+        (args,) = self.conn.eval_updates
+        assert args[5] is None
+        assert args[7] == "approved"
+
+    async def test_edited_sections_flip_source_to_ai_reviewed(self, ms_config):
+        await self._approve(
+            ms_config,
+            sections=_approval_sections(
+                ms_config, comms=_ai_section("comms", "Communication", score=2)
+            ),
+        )
+        (args,) = self.conn.eval_updates
+        assert args[6] == "ai_reviewed"
+
+    async def test_missing_draft_row_is_skipped(self, ms_config):
+        self.conn.existing_id = None
+        assert await self._approve(ms_config, evaluation_id=None) is None
+        assert self.conn.eval_updates == []
+
+    async def test_db_failure_is_swallowed(self, ms_config, monkeypatch):
+        async def exploding_pool():
+            raise ConnectionError("pg down")
+
+        monkeypatch.setattr(eval_store, "_get_pool", exploding_pool)
+        assert await self._approve(ms_config) is None


### PR DESCRIPTION
## Summary

Phase 4b of [Wave2Plan.md](qa-automation/AI-Scoring/references/Wave2Plan.md): the approve flow now lands in Postgres. Since `/score/{job_id}/approve` runs Stage 1.5 (analyst edits) → Stage 2 (score destination) → Stage 3 (ARRAYFORMULA readback) → Stage 4 (Analyst_History) in a single request, one `record_approval()` call after Stage 4 captures the combined transition.

**What lands on `qa.evaluations`:** `evaluator_email`, `approved_at`, key strengths/opportunities, `agent_email` when known, `source` flips `ai → ai_reviewed` iff anything changed (§3.2 Stage 1.5), `overall_score` from the Stage-3 readback (pre-cutover truth), and `state='finalized'` — degrading to `'approved'` when the readback produced no number, because the §3.4.3 CHECK requires a score to finalize.

**Section provenance matrix (§3.5):**
- Unchanged AI sections keep full AI provenance (`ai`/gemini/model/confidence).
- A section whose value differs from the Stage-1 draft — **or that appears at approval without an AI draft value** — is an analyst edit: `score_source='manual'`, AI-only fields NULL.
- Manual sections at their NA default keep the `manual_default`/`'NA'` shape; supervisor-scored ones become `'manual'`.

**Versions stay NULL on purpose:** the readback score is the sheet's, not the engine's — `formula_version` stamping begins at cutover when `compute_overall_score()` fires inside Stage 2 (§3.6). §7.3 Phase A semantics unchanged: the recorder cannot raise; rows are located by the job's Stage-1 `evaluation_id` with a `dialpad_link` fallback.

## Deferred (tracked)

- `qa.agent_stat_points` seed on finalize (4c, §9.2) and `agent_id` resolution (backfill B3).
- 4e §3.14 human-review trigger (`scoring_status='flagged_human_review'`).
- 4d remap layer — MS has written Ops-signed keys since Phase 1a; Sales remaps at its own cutover.
- **The cutover design doc** (Postgres-owned scoring, Sheets as pure DB projection, no Sheets→Postgres flow — owner directive) is queued next as task #10; design-doc-first.

## Test plan

- [x] 10 new tests: provenance matrix, HRR default-vs-supervisor-scored, blank-readback → `approved`, source flip, missing-draft skip, DB-failure swallow.
- [x] Import smoke + scoring route suite green.
- [x] Full suite: **418 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

## Post-merge behavior

Next approved eval on Railway: its draft row transitions `draft → finalized` with the sheet's score attached. Verify:
`SELECT id, state, evaluator_email, overall_score, source, approved_at FROM qa.evaluations ORDER BY id DESC LIMIT 5;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)