### PR TITLE
feat(qa-automation): cutover slice 2 — projection module, flag-branched flow, lookup UX

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -27,7 +27,9 @@ from backend.services.history_service import (
     agent_name_for_email,
     email_in_team_mails,
 )
+from backend.services import eval_store
 from backend.services.eval_store import record_approval, record_draft_evaluation
+from backend.services.sheets_projection import project_evaluation
 from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
@@ -78,6 +80,42 @@ def _job_key(team_id: str, job_id: str) -> str:
 
 def _make_job_id(call_id: str, agent_name: str) -> str:
     return f"{call_id}_{agent_name}".replace(" ", "_")
+
+
+async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
+    """Post-flip auto-flow (CutoverDesign §2): after the Stage-1 draft row
+    lands, decide auto-finalize vs. human-review pause.
+
+    CLEAN → engine computes + stamps versions, row finalizes, Analyst_History
+    is projected from the DB row, the GAS email fires — zero analyst touch.
+    FLAGGED → the row stays draft with scoring_status='flagged_human_review';
+    the operator resolves it via the (red) editor + approve.
+
+    Job payload gains state/scoring_status/overall_score so the lookup UI can
+    color the button (CutoverDesign §5)."""
+    flagged = eval_store.human_review_trigger_fired(
+        eval_store._active_formula(team_id), scorecard.sections
+    )
+    if flagged:
+        job["state"] = "draft"
+        job["scoring_status"] = "flagged_human_review"
+        return
+
+    detail = await eval_store.stamp_and_finalize(
+        evaluation_id, config, evaluator_email=scorecard.manager_email or ""
+    )
+    pool = await eval_store.get_pool()
+    history_row = await project_evaluation(
+        pool, evaluation_id, config, include_history=True
+    )
+    if history_row is not None and history_row > 0:
+        try:
+            trigger_apps_script(history_row, team_id)
+        except Exception as e:
+            print(f"[auto-flow] Apps Script dispatch failed (retryable): {e}")
+    job["state"] = "finalized"
+    job["scoring_status"] = "complete"
+    job["overall_score"] = float(detail.overall_score)
 
 
 @router.get("/calls")
@@ -302,13 +340,21 @@ async def score_single_call(
                     call_details=call_details,
                 )
             row_num = write_draft_to_fr_ai(scorecard, config)
-            # Stage 1 dual-write (Wave 2 Phase 4a) — §7.3 Phase A: never
-            # raises; Postgres failures are logged and swallowed.
-            evaluation_id = await record_draft_evaluation(scorecard, config)
-            _jobs[key]["status"] = "complete"
+            # Stage 1 dual-write. Pre-flip (§7.3 Phase A): never raises.
+            # Post-flip (scoring_owner='postgres', Phase C): DB errors raise
+            # and the whole job errors — the DB row is truth.
+            owner = await eval_store.get_scoring_owner(team_id)
+            evaluation_id = await record_draft_evaluation(
+                scorecard, config, strict=(owner == "postgres")
+            )
             _jobs[key]["sheets_row"] = row_num
             _jobs[key]["evaluation_id"] = evaluation_id
             _jobs[key]["scorecard"] = scorecard.model_dump()
+            if owner == "postgres" and evaluation_id is not None:
+                await _postgres_post_stage1(
+                    _jobs[key], evaluation_id, scorecard, config, team_id
+                )
+            _jobs[key]["status"] = "complete"
         except Exception as e:
             _jobs[key]["status"] = "error"
             _jobs[key]["error"] = str(e)
@@ -419,11 +465,18 @@ async def score_batch(
                         duration_ms=dur,
                     )
                 row_num = write_draft_to_fr_ai(scorecard, config)
-                evaluation_id = await record_draft_evaluation(scorecard, config)
-                _jobs[k]["status"] = "complete"
+                owner = await eval_store.get_scoring_owner(team_id)
+                evaluation_id = await record_draft_evaluation(
+                    scorecard, config, strict=(owner == "postgres")
+                )
                 _jobs[k]["sheets_row"] = row_num
                 _jobs[k]["evaluation_id"] = evaluation_id
                 _jobs[k]["scorecard"] = scorecard.model_dump()
+                if owner == "postgres" and evaluation_id is not None:
+                    await _postgres_post_stage1(
+                        _jobs[k], evaluation_id, scorecard, config, team_id
+                    )
+                _jobs[k]["status"] = "complete"
             except Exception as e:
                 _jobs[k]["status"] = "error"
                 _jobs[k]["error"] = str(e)
@@ -483,6 +536,78 @@ async def approve_scorecard(
         )
     except Exception as e:
         raise HTTPException(status_code=422, detail=f"Approval payload invalid: {e}")
+
+    # Post-flip: finalized evaluations are immutable from the UI.
+    if job.get("state") == "finalized":
+        job["status"] = "complete"
+        raise HTTPException(status_code=409, detail="Evaluation is finalized (engine-scored) — read-only")
+
+    owner = await eval_store.get_scoring_owner(team_id)
+    if owner == "postgres":
+        # Flagged-call resolution path (CutoverDesign §2/§5): DB transition +
+        # engine compute + projections. No destination tab, no readback —
+        # DB errors are hard errors (§7.3 Phase C).
+        sc = job["scorecard"]
+        evaluator_email = sc.get("manager_email", "")
+        try:
+            evaluation_id = await record_approval(
+                config,
+                evaluation_id=job.get("evaluation_id"),
+                dialpad_link=sc.get("dialpad_link"),
+                evaluator_email=evaluator_email,
+                approved_sections=approval.sections,
+                draft_sections=sc.get("sections", []),
+                key_strengths=approval.key_strengths,
+                opportunities=approval.opportunities,
+                overall_score_raw=None,  # the engine produces the number
+                agent_email=job.get("agent_email") or None,
+                model=sc.get("model", "gemini-2.5-flash"),
+                strict=True,
+                resolving_review=job.get("scoring_status") == "flagged_human_review",
+            )
+            if evaluation_id is None:
+                raise HTTPException(status_code=500, detail="No draft evaluation row to approve")
+            detail = await eval_store.stamp_and_finalize(
+                evaluation_id, config, evaluator_email=evaluator_email
+            )
+            pool = await eval_store.get_pool()
+            history_row = await project_evaluation(
+                pool, evaluation_id, config, include_history=True
+            )
+            if history_row is not None and history_row > 0:
+                try:
+                    trigger_apps_script(history_row, team_id)
+                except Exception as e:
+                    print(f"[approve] Apps Script dispatch failed (retryable): {e}")
+            append_score_audit_row(
+                api_key_role=identity.role,
+                evaluator_email=evaluator_email,
+                agent_email=job.get("agent_email", ""),
+                agent_name=job.get("agent_name") or sc.get("agent_name") or "",
+                call_id=job.get("call_id", ""),
+                target_team=team_id,
+                action=audit_cfg.ACTION_APPROVED,
+                result_row=history_row,
+                notes="engine-scored",
+            )
+            job["status"] = "approved"
+            job["state"] = "finalized"
+            job["scoring_status"] = "complete"
+            job["overall_score"] = float(detail.overall_score)
+            job["evaluation_id"] = evaluation_id
+            return {
+                "status": "approved",
+                "state": "finalized",
+                "overall_score": float(detail.overall_score),
+                "history_row": history_row,
+            }
+        except HTTPException:
+            job["status"] = "complete"
+            raise
+        except Exception as e:
+            job["status"] = "error"
+            job["error"] = str(e)
+            raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
 
     try:
         sections_dicts = [s.model_dump() for s in approval.sections]

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -59,6 +59,28 @@ _pool_lock: Optional[asyncio.Lock] = None
 
 
 # ---------------------------------------------------------------------------
+# Per-team scoring truth flag (migration 013 / CutoverDesign §4)
+# ---------------------------------------------------------------------------
+
+async def get_scoring_owner(team_id: str) -> str:
+    """'sheets' (legacy pipeline is truth) or 'postgres' (engine scores,
+    Sheets are projections). Queried per request — the flip is a one-line
+    UPDATE and must take effect without a deploy. Any failure or missing
+    DB degrades to 'sheets' (the safe, legacy mode)."""
+    try:
+        pool = await _get_pool()
+        if pool is None:
+            return "sheets"
+        owner = await pool.fetchval(
+            "SELECT scoring_owner FROM public.teams WHERE id = $1", team_id
+        )
+        return owner or "sheets"
+    except Exception:
+        logger.exception("eval_store: scoring_owner lookup failed for %s — using 'sheets'", team_id)
+        return "sheets"
+
+
+# ---------------------------------------------------------------------------
 # §3.14 human-review trigger (Wave 2 Phase 4e / CutoverDesign slice 1)
 # ---------------------------------------------------------------------------
 
@@ -195,19 +217,27 @@ def build_draft_sections(
 # ---------------------------------------------------------------------------
 
 async def record_draft_evaluation(
-    scorecard: "ScorecardWithMeta", config: "TeamConfig"
+    scorecard: "ScorecardWithMeta", config: "TeamConfig", strict: bool = False
 ) -> Optional[int]:
     """Write the Stage-1 draft to Postgres. Returns the qa.evaluations id,
-    or None when dual-write is off or anything failed (logged, swallowed)."""
+    or None when dual-write is off or anything failed (logged, swallowed).
+    `strict` is the §7.3 Phase C mode (scoring_owner='postgres'): the DB row
+    is truth, so failures raise instead."""
     try:
         pool = await _get_pool()
         if pool is None:
+            if strict:
+                raise RuntimeError(
+                    f"scoring_owner='postgres' for {config.team_id} but no DATABASE_URL"
+                )
             return None
         row = build_draft_row(scorecard, config)
         sections = build_draft_sections(scorecard, config)
         async with pool.acquire() as conn:
             return await _upsert_draft(conn, row, sections)
     except Exception:
+        if strict:
+            raise
         logger.exception(
             "eval_store: Stage 1 dual-write failed for team=%s call=%s — "
             "swallowed per §7.3 Phase A",
@@ -430,19 +460,33 @@ async def record_approval(
     overall_score_raw: Any,
     agent_email: Optional[str] = None,
     model: str = "gemini-2.5-flash",
+    strict: bool = False,
+    resolving_review: bool = False,
 ) -> Optional[int]:
-    """Record the approve transition. Never raises (§7.3 Phase A)."""
+    """Record the approve transition. Never raises (§7.3 Phase A) unless
+    `strict` (Phase C). `resolving_review` marks a §3.14 step-4 resolution:
+    the reviewer has assessed the flagged call, so the flag clears and
+    `human_review_completed_at` is stamped even if the triggering scores
+    remain in range — their judgment IS the resolution."""
     try:
         pool = await _get_pool()
         if pool is None:
+            if strict:
+                raise RuntimeError(
+                    f"scoring_owner='postgres' for {config.team_id} but no DATABASE_URL"
+                )
             return None
         sections, any_changed = build_approval_sections(
             approved_sections, draft_sections, config, model
         )
         overall = _parse_overall(overall_score_raw)
-        # §3.14 recompute at approval: analyst edits can fire or clear the flag.
+        # §3.14 recompute at approval: analyst edits can fire or clear the
+        # flag — unless the reviewer is explicitly resolving it.
         formula = _active_formula(config.team_id)
-        flagged_review = human_review_trigger_fired(formula, approved_sections)
+        flagged_review = (
+            False if resolving_review
+            else human_review_trigger_fired(formula, approved_sections)
+        )
         _shadow_engine_compare(
             formula, approved_sections, overall_score_raw, flagged_review, config.team_id
         )
@@ -471,6 +515,7 @@ async def record_approval(
                     "  state = $8, "
                     "  scoring_status = $9, "
                     "  human_review_required_at = $10, "
+                    "  human_review_completed_at = COALESCE($11, human_review_completed_at), "
                     "  approved_at = NOW(), "
                     "  finalized_at = CASE WHEN $8 = 'finalized' THEN NOW() ELSE finalized_at END "
                     "WHERE id = $1",
@@ -484,6 +529,7 @@ async def record_approval(
                     "finalized" if overall is not None else "approved",
                     "flagged_human_review" if flagged_review else "complete",
                     datetime.now(timezone.utc) if flagged_review else None,
+                    datetime.now(timezone.utc) if resolving_review else None,
                 )
                 await conn.execute(
                     "DELETE FROM qa.evaluation_sections WHERE evaluation_id = $1",
@@ -503,11 +549,77 @@ async def record_approval(
                     )
         return evaluation_id
     except Exception:
+        if strict:
+            raise
         logger.exception(
             "eval_store: approve dual-write failed for team=%s — swallowed per §7.3 Phase A",
             config.team_id,
         )
         return None
+
+
+# ---------------------------------------------------------------------------
+# Post-flip finalize — engine score + version stamping (CutoverDesign §2)
+# ---------------------------------------------------------------------------
+
+async def stamp_and_finalize(
+    evaluation_id: int,
+    config: "TeamConfig",
+    evaluator_email: str,
+) -> Any:
+    """The post-cutover Stage 2 (§3.6): resolve the team's active
+    formula/rubric versions, stamp them on the row, compute the engine
+    score, and finalize — one transaction. Always strict (Phase C): this
+    only runs when scoring_owner='postgres', where the DB row is truth.
+
+    `evaluator_email` is the analyst on a flagged-call resolution, or the
+    operator who triggered scoring on the auto-flow (the §3.4.3 CHECK
+    requires an evaluator + approved_at to leave 'draft').
+
+    Returns the ScoreComputation (engine trace included) for the caller to
+    surface/project."""
+    from backend.services.score_compute import (
+        compute_score_detail,
+        get_active_versions,
+    )
+
+    pool = await _get_pool()
+    if pool is None:
+        raise RuntimeError(
+            f"scoring_owner='postgres' for {config.team_id} but no DATABASE_URL"
+        )
+    async with pool.acquire() as conn:
+        versions = await get_active_versions(conn, config.team_id)
+        detail = await compute_score_detail(
+            conn,
+            evaluation_id,
+            formula_version=versions.formula_version,
+            rubric_version=versions.rubric_version,
+        )
+        async with conn.transaction():
+            await conn.execute(
+                "UPDATE qa.evaluations SET "
+                "  overall_score = $2, "
+                "  formula_version = $3, "
+                "  rubric_version = $4, "
+                "  evaluator_email = COALESCE(evaluator_email, $5), "
+                "  state = 'finalized', "
+                "  scoring_status = 'complete', "
+                "  approved_at = COALESCE(approved_at, NOW()), "
+                "  finalized_at = NOW() "
+                "WHERE id = $1",
+                evaluation_id,
+                detail.overall_score,
+                versions.formula_version,
+                versions.rubric_version,
+                evaluator_email,
+            )
+    logger.info(
+        "eval_store: finalized eval %s under %s/%s — engine score %s",
+        evaluation_id, versions.formula_version, versions.rubric_version,
+        detail.overall_score,
+    )
+    return detail
 
 
 # ---------------------------------------------------------------------------
@@ -530,6 +642,11 @@ async def _get_pool():
     return _pool
 
 
+async def get_pool():
+    """Public accessor for co-located DB consumers (sheets_projection)."""
+    return await _get_pool()
+
+
 async def close_pool() -> None:
     """Lifespan teardown."""
     global _pool
@@ -541,6 +658,9 @@ async def close_pool() -> None:
 __all__ = [
     "record_draft_evaluation",
     "record_approval",
+    "stamp_and_finalize",
+    "get_scoring_owner",
+    "get_pool",
     "build_draft_row",
     "build_draft_sections",
     "build_approval_sections",

--- a/qa-automation/AI-Scoring/backend/services/sheets_projection.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_projection.py
@@ -1,0 +1,174 @@
+"""DB → Sheets projection — cutover slice 2 (CutoverDesign.md §3a).
+
+One job, one rule: **render sheet rows from a qa.evaluations row; never read
+cell values to construct DB state.** This is the post-flip replacement for
+the Stage-2/3/4 sheet flow — finalized evaluations land in Analyst_History
+straight from Postgres, the ARRAYFORMULA never runs, and the only Sheets
+reads are row-position lookups for idempotent overwrites.
+
+FR-AI and Analyst_History share the HistoryLayout shape, so one renderer
+serves both tabs; the projection writes every field the DB knows
+(agent_email, evaluator_email, overall_score, eval_approved_at), which is a
+superset of what each legacy stage filled — downstream consumers (GAS email
+pipeline, dashboards via history_service) read the same columns as before.
+
+Failure semantics: the DB row is truth, so projection failures are
+retryable — callers log and continue; the nightly reproject sweep
+(CutoverDesign §3a, follow-up) re-renders anything that missed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+from backend.config import history_layout
+from backend.config.history_layout import col_index_to_letter
+from backend.services.sheets_service import (
+    YN_DISPLAY,
+    _find_row_by_dialpad_link,
+    _get_fr_ai_sheet,
+    _get_sheet,
+    _next_data_row,
+    _sheets_configured,
+)
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+
+logger = logging.getLogger(__name__)
+
+_SHEET_TS_FORMAT = "%m/%d/%Y %H:%M:%S"
+
+
+# ---------------------------------------------------------------------------
+# Row rendering (pure)
+# ---------------------------------------------------------------------------
+
+def _render_section_value(section: dict[str, Any]) -> str:
+    """DB section row -> score-cell string, mirroring the legacy writer:
+    numeric scores as digits, binary/NA via YN_DISPLAY."""
+    if section["binary_value"] is not None:
+        return YN_DISPLAY.get(section["binary_value"], "Not Applicable")
+    if section["numeric_score"] is not None:
+        return str(section["numeric_score"])
+    return ""
+
+
+def _render_ts(value: Any) -> str:
+    return value.strftime(_SHEET_TS_FORMAT) if value else ""
+
+
+def _render_overall(value: Any) -> str:
+    """Engine scores are NUMERIC(5,1); render one decimal, trimming a
+    trailing .0 so clean integers keep the legacy look (87, not 87.0)."""
+    if value is None:
+        return ""
+    text = f"{float(value):.1f}"
+    return text[:-2] if text.endswith(".0") else text
+
+
+def build_projection_row(
+    evaluation: Any, sections: list[dict[str, Any]], config: "TeamConfig"
+) -> list[str]:
+    """qa.evaluations row + qa.evaluation_sections rows -> sheet row (full
+    HistoryLayout width). Serves FR-AI and Analyst_History identically."""
+    L = config.history_layout
+    by_id = {s["section_id"]: s for s in sections}
+
+    row = [""] * L.total_width
+    row[history_layout.COL_AGENT_NAME] = evaluation["agent_name_raw"] or ""
+    row[history_layout.COL_AGENT_EMAIL] = evaluation["agent_email"] or ""
+    row[history_layout.COL_TIMESTAMP] = _render_ts(evaluation["call_connected_at"])
+    row[history_layout.COL_EVALUATOR_EMAIL] = evaluation["evaluator_email"] or ""
+    row[history_layout.COL_DIALPAD_LINK] = evaluation["dialpad_link"] or ""
+    row[history_layout.COL_OVERALL_SCORE] = _render_overall(evaluation["overall_score"])
+
+    for i, sec_def in enumerate(config.sections_by_number):
+        section = by_id.get(sec_def.id)
+        if section is None:
+            continue  # unfilled manual slot — cell stays blank, like today
+        row[L.col_score(i)] = _render_section_value(section)
+        row[L.col_reasoning(i)] = section.get("reasoning") or ""
+        row[L.col_confidence(i)] = (section.get("confidence") or "").lower()
+
+    row[L.col_key_strengths] = evaluation["key_strengths"] or ""
+    row[L.col_opportunities] = evaluation["opportunities"] or ""
+    row[L.col_call_summary] = evaluation["call_summary"] or ""
+    row[L.col_caller_name] = evaluation["caller_name"] or ""
+    row[L.col_caller_phone] = evaluation["caller_phone"] or ""
+    row[L.col_source] = evaluation["source"] or ""
+    row[L.col_eval_approved_at] = _render_ts(evaluation["approved_at"])
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Sheet writes (idempotent on dialpad_link)
+# ---------------------------------------------------------------------------
+
+def _write_row(sheet, row: list[str], dialpad_link: str, config: "TeamConfig") -> int:
+    """Overwrite the row matching dialpad_link, else append. Returns the
+    1-indexed row number."""
+    end_letter = col_index_to_letter(len(row) - 1)
+    existing = _find_row_by_dialpad_link(sheet, dialpad_link)
+    if existing is not None:
+        sheet.update(f"A{existing}:{end_letter}{existing}", [row],
+                     value_input_option="USER_ENTERED")
+        return existing
+    target = _next_data_row(sheet)
+    sheet.update(f"A{target}:{end_letter}{target}", [row],
+                 value_input_option="USER_ENTERED")
+    return target
+
+
+async def project_evaluation(
+    conn: Any,
+    evaluation_id: int,
+    config: "TeamConfig",
+    include_history: bool = False,
+) -> Optional[int]:
+    """Project one evaluation to FR-AI (always) and Analyst_History (when
+    `include_history`, i.e. the row is finalized). Returns the
+    Analyst_History row number when written, for the Apps Script trigger.
+
+    Raises on DB errors (the row is truth — §7.3 Phase C); logs and
+    continues on Sheets errors (projections are retryable)."""
+    evaluation = await conn.fetchrow(
+        "SELECT * FROM qa.evaluations WHERE id = $1", evaluation_id
+    )
+    if evaluation is None:
+        raise ValueError(f"no qa.evaluations row with id={evaluation_id}")
+    sections = [
+        dict(r) for r in await conn.fetch(
+            "SELECT section_id, numeric_score, binary_value, confidence, reasoning "
+            "FROM qa.evaluation_sections WHERE evaluation_id = $1",
+            evaluation_id,
+        )
+    ]
+
+    if not _sheets_configured(config.team_id):
+        logger.warning("projection: Sheets not configured for %s — DB row %s stands alone",
+                       config.team_id, evaluation_id)
+        return None
+
+    row = build_projection_row(evaluation, sections, config)
+    link = evaluation["dialpad_link"] or ""
+    history_row_num: Optional[int] = None
+
+    try:
+        _write_row(_get_fr_ai_sheet(config), row, link, config)
+    except Exception:
+        logger.exception("projection: FR-AI write failed for eval %s — retryable", evaluation_id)
+
+    if include_history:
+        try:
+            history_sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
+            history_row_num = _write_row(history_sheet, row, link, config)
+        except Exception:
+            logger.exception("projection: Analyst_History write failed for eval %s — retryable",
+                             evaluation_id)
+
+    return history_row_num
+
+
+__all__ = ["project_evaluation", "build_projection_row"]

--- a/qa-automation/AI-Scoring/frontend/lookup.html
+++ b/qa-automation/AI-Scoring/frontend/lookup.html
@@ -150,6 +150,8 @@
       font-size: 0.7rem; color: var(--muted); display: inline-block; margin-left: 6px;
     }
     .score-status.complete { color: #137333; }
+    .score-status.flagged { color: #c5221f; font-weight: 600; }
+    .score-status.flagged a.editor-flagged { color: #c5221f; text-decoration: underline; }
     .score-status.error { color: var(--red); }
 
     /* Team-pick modal */
@@ -725,6 +727,14 @@ async function scoreCall(btn, callId) {
   pollScoreJob(targetTeam, jobId, statusEl, btn);
 }
 
+function openFlaggedEditor(url) {
+  // CutoverDesign §5: warn the operator before entering the editor.
+  alert('This call cannot be automatically scored until you review it.\n\n' +
+        'A section score triggered the human-review gate. Review the call, ' +
+        'score the Human Review section, and approve to finalize.');
+  window.open(url, '_blank');
+}
+
 function pollScoreJob(targetTeam, jobId, statusEl, btn) {
   const interval = setInterval(async () => {
     try {
@@ -733,8 +743,20 @@ function pollScoreJob(targetTeam, jobId, statusEl, btn) {
       const status = data.status || '?';
       statusEl.textContent = status;
       if (['complete', 'approved'].includes(status)) {
-        statusEl.className = 'score-status complete';
-        statusEl.innerHTML = `complete · <a href="/scorecard/${esc(targetTeam)}/${esc(jobId)}" target="_blank">Open editor</a>`;
+        const url = `/scorecard/${esc(targetTeam)}/${esc(jobId)}`;
+        if (data.scoring_status === 'flagged_human_review') {
+          // Post-cutover (CutoverDesign §5): the §3.14 trigger fired — the
+          // call cannot auto-finalize until a human reviews it.
+          statusEl.className = 'score-status flagged';
+          statusEl.innerHTML = `flagged · <a class="editor-flagged" href="#" onclick="openFlaggedEditor('${url}'); return false;">Open Editor</a>`;
+        } else if (data.state === 'finalized') {
+          // Engine-scored and finalized — the scorecard opens read-only.
+          statusEl.className = 'score-status complete';
+          statusEl.innerHTML = `scored ${data.overall_score ?? ''} · <a href="${url}" target="_blank">Open Editor</a>`;
+        } else {
+          statusEl.className = 'score-status complete';
+          statusEl.innerHTML = `complete · <a href="${url}" target="_blank">Open editor</a>`;
+        }
         clearInterval(interval);
       } else if (status === 'error') {
         statusEl.className = 'score-status error';

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -367,6 +367,21 @@ function renderPanel(data) {
     const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
     if (statusEl) statusEl.textContent = 'Approved — evaluation email already dispatched.';
   }
+
+  // Post-cutover (CutoverDesign §5): an engine-finalized evaluation is
+  // immutable — render everything, then lock it down completely.
+  if (data.state === 'finalized') {
+    panel.querySelectorAll('select, textarea, input, button').forEach(el => el.disabled = true);
+    const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+    if (btn) { btn.textContent = 'Finalized'; btn.style.background = '#065f46'; }
+    const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+    if (statusEl) {
+      const score = data.overall_score != null ? ` — overall score ${data.overall_score}` : '';
+      statusEl.textContent = `Finalized by the scoring engine${score}. This evaluation is read-only.`;
+    }
+    document.getElementById('scHeaderMeta').textContent =
+      `Job ${JOB_ID} — ${TEAM_ID} — finalized (read-only)`;
+  }
 }
 
 // --------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -577,3 +577,170 @@ class TestApprovalRecomputeAndShadow:
         with caplog.at_level(logging.INFO, logger="backend.services.eval_store"):
             await self._approve(ms_config, _approval_sections(ms_config))
         assert not [r for r in caplog.records if r.getMessage().startswith("shadow: team=")]
+
+
+# ---------------------------------------------------------------------------
+# scoring_owner flag + strict mode + stamp_and_finalize (cutover slice 2)
+# ---------------------------------------------------------------------------
+
+class OwnerFakePool:
+    def __init__(self, owner):
+        self.owner = owner
+
+    async def fetchval(self, query, *args):
+        assert "scoring_owner FROM public.teams" in query
+        return self.owner
+
+
+class TestScoringOwner:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_no_pool_defaults_to_sheets(self, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        assert await eval_store.get_scoring_owner("member_support") == "sheets"
+
+    async def test_reads_flag(self, monkeypatch):
+        async def pool():
+            return OwnerFakePool("postgres")
+        monkeypatch.setattr(eval_store, "_get_pool", pool)
+        assert await eval_store.get_scoring_owner("member_support") == "postgres"
+
+    async def test_lookup_failure_degrades_to_sheets(self, monkeypatch):
+        async def exploding():
+            raise ConnectionError("pg down")
+        monkeypatch.setattr(eval_store, "_get_pool", exploding)
+        assert await eval_store.get_scoring_owner("member_support") == "sheets"
+
+
+class TestStrictMode:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_draft_strict_raises_without_dsn(self, ms_config, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        with pytest.raises(RuntimeError, match="no DATABASE_URL"):
+            await record_draft_evaluation(_scorecard(ms_config), ms_config, strict=True)
+
+    async def test_draft_strict_reraises_db_errors(self, ms_config, monkeypatch):
+        async def exploding():
+            raise ConnectionError("pg down")
+        monkeypatch.setattr(eval_store, "_get_pool", exploding)
+        with pytest.raises(ConnectionError):
+            await record_draft_evaluation(_scorecard(ms_config), ms_config, strict=True)
+
+    async def test_approval_strict_reraises(self, ms_config, monkeypatch):
+        async def exploding():
+            raise ConnectionError("pg down")
+        monkeypatch.setattr(eval_store, "_get_pool", exploding)
+        with pytest.raises(ConnectionError):
+            await eval_store.record_approval(
+                ms_config, evaluation_id=1, dialpad_link=None,
+                evaluator_email="x@y.com", approved_sections=[],
+                draft_sections=[], key_strengths="", opportunities="",
+                overall_score_raw=None, strict=True,
+            )
+
+
+class TestResolvingReview:
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.fixture(autouse=True)
+    def _no_real_pool(self, monkeypatch):
+        self.conn = ApprovalFakeConn()
+
+        async def fake_get_pool():
+            return FakePool(self.conn)
+
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_reviewer_resolution_clears_flag_despite_low_scores(self, ms_config):
+        """§3.14 step 4: the reviewer's judgment IS the resolution — the
+        flag clears and completed_at stamps even with process still at 2."""
+        sections = _approval_sections(
+            ms_config,
+            process_adherence=_ai_section("process_adherence", "Process", score=2),
+        )
+        draft = [s.model_dump() for s in _scorecard(ms_config).sections]
+        await eval_store.record_approval(
+            ms_config, evaluation_id=101, dialpad_link=None,
+            evaluator_email="lead@landing.com", approved_sections=sections,
+            draft_sections=draft, key_strengths="", opportunities="",
+            overall_score_raw=None, resolving_review=True,
+        )
+        (args,) = self.conn.eval_updates
+        assert args[8] == "complete"          # flag cleared
+        assert args[9] is None                # required_at cleared
+        assert args[10] is not None           # completed_at stamped
+
+
+class FinalizeFakeConn:
+    def __init__(self):
+        self.executed: list[tuple] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+    async def execute(self, query, *args):
+        assert query.startswith("UPDATE qa.evaluations")
+        self.executed.append(args)
+
+
+class FinalizePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+class TestStampAndFinalize:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_stamps_versions_and_engine_score(self, ms_config, monkeypatch):
+        from decimal import Decimal
+        from backend.services import score_compute
+
+        conn = FinalizeFakeConn()
+
+        async def pool():
+            return FinalizePool(conn)
+
+        async def fake_versions(c, team_id):
+            assert team_id == "member_support"
+            return score_compute.ActiveVersions(
+                formula_version="member_support_v3", rubric_version="member_support_v2"
+            )
+
+        class FakeDetail:
+            overall_score = Decimal("91.7")
+
+        async def fake_detail(c, evaluation_id, formula_version=None, rubric_version=None, signals=None):
+            assert evaluation_id == 55
+            assert formula_version == "member_support_v3"
+            return FakeDetail()
+
+        monkeypatch.setattr(eval_store, "_get_pool", pool)
+        monkeypatch.setattr(score_compute, "get_active_versions", fake_versions)
+        monkeypatch.setattr(score_compute, "compute_score_detail", fake_detail)
+
+        detail = await eval_store.stamp_and_finalize(55, ms_config, "op@landing.com")
+        assert detail.overall_score == Decimal("91.7")
+        (args,) = conn.executed
+        # (id, overall, formula_version, rubric_version, evaluator)
+        assert args[0] == 55
+        assert args[1] == Decimal("91.7")
+        assert args[2] == "member_support_v3"
+        assert args[3] == "member_support_v2"
+        assert args[4] == "op@landing.com"
+
+    async def test_raises_without_dsn(self, ms_config, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        with pytest.raises(RuntimeError, match="no DATABASE_URL"):
+            await eval_store.stamp_and_finalize(1, ms_config, "x@y.com")

--- a/qa-automation/AI-Scoring/tests/test_sheets_projection.py
+++ b/qa-automation/AI-Scoring/tests/test_sheets_projection.py
@@ -1,0 +1,120 @@
+"""DB → Sheets projection tests — cutover slice 2 (CutoverDesign §3a).
+
+The row builder is pure: a qa.evaluations record + section rows in, a
+HistoryLayout-shaped list of cell strings out. These pin the rendering
+contract the GAS email pipeline and dashboards read.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.config import history_layout
+from backend.services.sheets_projection import _render_overall, build_projection_row
+from tests.conftest import load_test_config
+
+
+@pytest.fixture(scope="module")
+def ms_config():
+    return load_test_config("member_support")
+
+
+def _evaluation(**overrides):
+    base = {
+        "agent_name_raw": "Jane Agent",
+        "agent_email": "jane@landing.com",
+        "call_connected_at": datetime(2026, 7, 4, 15, 30, tzinfo=timezone.utc),
+        "evaluator_email": "lead@landing.com",
+        "dialpad_link": "https://dialpad.test/call/DP123",
+        "overall_score": 87.5,
+        "key_strengths": "Good tone",
+        "opportunities": "Faster holds",
+        "call_summary": "Billing question",
+        "caller_name": "Pat Caller",
+        "caller_phone": "+15550100",
+        "source": "ai",
+        "approved_at": datetime(2026, 7, 4, 16, 0, tzinfo=timezone.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def _sections():
+    def row(sid, numeric=None, binary=None, confidence="HIGH", reasoning="because"):
+        return {"section_id": sid, "numeric_score": numeric, "binary_value": binary,
+                "confidence": confidence, "reasoning": reasoning}
+    return [
+        row("greeting", numeric=5),
+        row("caller_id", binary="Y", confidence="MED"),
+        row("purpose", numeric=4),
+        row("matching", numeric=4),
+        row("process_adherence", numeric=5),
+        row("call_resolution", numeric=3),
+        row("comms", numeric=4),
+        row("efficiency", numeric=2),
+        row("human_review_required", binary="NA", confidence=None, reasoning=None),
+        row("cri", binary="Y", confidence=None, reasoning=None),
+    ]
+
+
+class TestBuildProjectionRow:
+
+    def test_prefix_and_trailing_columns(self, ms_config):
+        row = build_projection_row(_evaluation(), _sections(), ms_config)
+        L = ms_config.history_layout
+        assert len(row) == L.total_width
+        assert row[history_layout.COL_AGENT_NAME] == "Jane Agent"
+        assert row[history_layout.COL_AGENT_EMAIL] == "jane@landing.com"
+        assert row[history_layout.COL_TIMESTAMP] == "07/04/2026 15:30:00"
+        assert row[history_layout.COL_EVALUATOR_EMAIL] == "lead@landing.com"
+        assert row[history_layout.COL_DIALPAD_LINK] == "https://dialpad.test/call/DP123"
+        assert row[history_layout.COL_OVERALL_SCORE] == "87.5"
+        assert row[L.col_key_strengths] == "Good tone"
+        assert row[L.col_source] == "ai"
+        assert row[L.col_eval_approved_at] == "07/04/2026 16:00:00"
+
+    def test_section_cells_mirror_legacy_writer(self, ms_config):
+        """Numeric scores as digits; binary via YN_DISPLAY; NA as
+        'Not Applicable'; confidence lowercased like the Stage-1 writer."""
+        row = build_projection_row(_evaluation(), _sections(), ms_config)
+        L = ms_config.history_layout
+        by_number = {s.id: i for i, s in enumerate(ms_config.sections_by_number)}
+        assert row[L.col_score(by_number["greeting"])] == "5"
+        assert row[L.col_score(by_number["caller_id"])] == "Yes"
+        assert row[L.col_score(by_number["human_review_required"])] == "Not Applicable"
+        assert row[L.col_confidence(by_number["caller_id"])] == "med"
+        assert row[L.col_reasoning(by_number["greeting"])] == "because"
+
+    def test_missing_section_row_leaves_cells_blank(self, ms_config):
+        sections = [s for s in _sections() if s["section_id"] != "cri"]
+        row = build_projection_row(_evaluation(), sections, ms_config)
+        L = ms_config.history_layout
+        idx = next(i for i, s in enumerate(ms_config.sections_by_number) if s.id == "cri")
+        assert row[L.col_score(idx)] == ""
+
+    def test_null_fields_render_empty(self, ms_config):
+        evaluation = _evaluation(
+            agent_email=None, overall_score=None, approved_at=None,
+            call_connected_at=None, caller_name=None,
+        )
+        row = build_projection_row(evaluation, _sections(), ms_config)
+        L = ms_config.history_layout
+        assert row[history_layout.COL_AGENT_EMAIL] == ""
+        assert row[history_layout.COL_OVERALL_SCORE] == ""
+        assert row[history_layout.COL_TIMESTAMP] == ""
+        assert row[L.col_eval_approved_at] == ""
+
+
+class TestOverallRendering:
+
+    @pytest.mark.parametrize("value,expected", [
+        (87.5, "87.5"),
+        (87.0, "87"),      # clean integers keep the legacy look
+        (100.0, "100"),
+        (46.9, "46.9"),
+        (None, ""),
+    ])
+    def test_render_overall(self, value, expected):
+        assert _render_overall(value) == expected

--- a/qa-automation/teams/member_support/Config.js
+++ b/qa-automation/teams/member_support/Config.js
@@ -2,7 +2,7 @@
  * QA Automation — Config (auto-generated)
  *
  * Team: Member Support (member_support)
- * Rubric version: 2.0
+ * Rubric version: member_support_v2
  *
  * AUTO-GENERATED — DO NOT EDIT.
  * Run: python qa-automation/scripts/build_config.py member_support
@@ -19,7 +19,7 @@ CONFIG.MAILS_SHEET_NAME   = "Mails";
 // ── Derived row layout (from HistoryLayout(N)) ───────────────
 CONFIG.HISTORY_LAYOUT = {
   N_SECTIONS:         10,
-  TOTAL_WIDTH:        42,
+  TOTAL_WIDTH:        43,
   COL_AGENT_NAME:     0,
   COL_AGENT_EMAIL:    1,
   COL_TIMESTAMP:      2,
@@ -45,35 +45,35 @@ CONFIG.HISTORY_LAYOUT = {
 // `historyIdx` is the position in the derived layout's score range.
 CONFIG.NUMERIC_CATEGORIES = [
   { key: "greeting", label: "Greeting", historyIdx: 0 },
-  { key: "purpose_of_call", label: "Purpose of the Call", historyIdx: 2 },
-  { key: "matching_the_moment", label: "Matching the Moment", historyIdx: 3 },
+  { key: "purpose", label: "Purpose of the Call", historyIdx: 2 },
+  { key: "matching", label: "Matching the Moment", historyIdx: 3 },
   { key: "process_adherence", label: "Process Adherence", historyIdx: 4 },
   { key: "call_resolution", label: "Call Resolution", historyIdx: 5 },
-  { key: "communication", label: "Communication", historyIdx: 6 },
-  { key: "efficiency_call_handling", label: "Efficiency & Call Handling", historyIdx: 7 },
-  { key: "documentation", label: "Documentation", historyIdx: 8 },
+  { key: "comms", label: "Communication", historyIdx: 6 },
+  { key: "efficiency", label: "Efficiency & Call Handling", historyIdx: 7 },
+  { key: "human_review_required", label: "Human Review Required", historyIdx: 8 },
 ];
 
 CONFIG.BINARY_CATEGORIES = [
-  { key: "caller_identity_validation", label: "Caller Identity Validation", historyIdx: 1 },
-  { key: "customer_resolution_indicator", label: "Customer Resolution Indicator", historyIdx: 9 },
+  { key: "caller_id", label: "Caller ID", historyIdx: 1 },
+  { key: "cri", label: "Customer Resolution Indicator", historyIdx: 9 },
 ];
 
 CONFIG.MANUAL_CATEGORIES = [
-  { key: "documentation", label: "Documentation", historyIdx: 8 },
+  { key: "human_review_required", label: "Human Review Required", historyIdx: 8 },
 ];
 
 // ── Section labels + rubric prompts ──────────────────────────
 CONFIG.SECTION_LABELS = {
   "greeting": "Greeting",
-  "identity_validation": "Caller Identity Validation",
+  "identity_validation": "Caller ID",
   "purpose_of_call": "Purpose of the Call",
   "matching_the_moment": "Matching the Moment",
   "process_adherence": "Process Adherence",
   "call_resolution": "Call Resolution",
   "communication": "Communication",
   "efficiency": "Efficiency & Call Handling",
-  "documentation": "Documentation",
+  "human_review_required": "Human Review Required",
   "customer_resolution_indicator": "Customer Resolution Indicator",
 };
 
@@ -86,6 +86,6 @@ CONFIG.RUBRIC_QUESTIONS = {
   "call_resolution": "Was the issue fully resolved or clear resolution path provided?",
   "communication": "Clear, concise, helpful information?",
   "efficiency": "Handled efficiently without unnecessary delays?",
-  "documentation": "",
+  "human_review_required": "",
   "customer_resolution_indicator": "Did agent summarize result/actions AND ask if there is anything else they can do?",
 };


### PR DESCRIPTION
## Summary

Slice 2 of [CutoverDesign.md](qa-automation/AI-Scoring/references/CutoverDesign.md) §8 — **merges inert** (`scoring_owner='sheets'` for both teams). After this, the MS flip is exactly the design's slice 3: `UPDATE public.teams SET scoring_owner='postgres' WHERE id='member_support';`

### The projection module (§3a)
`sheets_projection.py` renders FR-AI and Analyst_History rows **from** the `qa.evaluations` row — one renderer, both tabs, and the hard rule enforced: no cell reads feed DB state. Cell formats mirror the legacy writer exactly (numeric digits, `Yes`/`No`/`Not Applicable`, lowercase confidence, `87` not `87.0`) so the GAS pipeline and dashboards keep reading what they've always read. Idempotent by `dialpad_link`; Sheets failures are logged-and-retryable, DB failures raise.

### The flag-branched flow (§2/§4)
- **Post-Stage-1 auto-flow**: clean drafts → `stamp_and_finalize()` (active versions resolved + stamped, engine score computed, `state='finalized'` in one transaction) → Analyst_History projection → GAS email. Zero analyst touch. Flagged drafts pause (`scoring_status='flagged_human_review'`) with the outcome exposed in the job payload.
- **Approve becomes the flagged-resolution path**: DB transition (strict, §7.3 Phase C) + engine compute + projection — no destination tab, no readback. `resolving_review` implements §3.14 step 4: the reviewer's judgment clears the flag and stamps `human_review_completed_at` even when the triggering scores remain low.
- Finalized evaluations answer **409** on re-approval — immutability at the API, not just the UI.
- `get_scoring_owner()` reads the flag per request (flip needs no deploy) and degrades to `'sheets'` on any failure.

### Lookup + scorecard UX (§5)
Flagged → **red "Open Editor"** + pop-up (*"This call cannot be automatically scored until you review it"*) → editable editor. Clean/finalized → green link showing the engine score → fully locked read-only scorecard. Pre-flip teams see today's behavior verbatim (the frontend branches on payload fields that don't exist until the flip).

### GAS (§3b)
`teams/member_support/Config.js` regenerated — it was stale since Phase 1a (Gmail cards still rendered "Documentation"). **Operator step: `./push.sh` + clasp deploy for member_support after merge.**

## Test plan

- [x] 28 new tests: projection row contract (layout positions, legacy cell formats, null/missing handling, overall rendering matrix), `scoring_owner` fallback matrix, strict-mode raises, `resolving_review` §3.14-step-4 semantics, `stamp_and_finalize` version+score transaction.
- [x] Import smoke + scoring-route suite green.
- [x] Full suite: **446 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

## After merge (design §8 slices 3+)

1. Operator: GAS deploy for MS (`./push.sh`), let the shadow week finish.
2. **Slice 3 — the MS flip** (one-line UPDATE) + the §7 smoke: score a known-clean and a known-flagged call from lookup; verify button colors, read-only scorecard, DB row, Analyst_History projection, Gmail render.
3. Slice 4 — the Sales bundle (task #5 prerequisites). Slice 5 — legacy-path cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)