### PR TITLE
fix(qa-automation): surface backend INFO logs — shadow lines were being dropped

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point."""
 
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -13,6 +14,16 @@ import os
 # Load .env from the AI-Scoring directory regardless of where uvicorn is launched
 _env_path = Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(_env_path)
+
+# Uvicorn only configures its own `uvicorn.*` loggers; without this, every
+# INFO line from backend.* (version-ship outcomes, cutover shadow compares,
+# eval_store finalizations) falls through to an unconfigured root logger and
+# is dropped. basicConfig is a no-op when a root handler already exists
+# (e.g. under pytest), so this never double-logs.
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
 
 from backend.services.version_ship import run_startup_ship
 from backend.routes.scoring import router as scoring_router


### PR DESCRIPTION
## Summary

The `shadow:` lines (and the `version ship:` lines you never saw either) were emitted at INFO through `backend.*` loggers that nothing configured — uvicorn only sets up its own `uvicorn.*` handlers, and the unconfigured root logger drops anything below WARNING. One `logging.basicConfig(INFO)` at app import fixes the whole class: version-ship outcomes, cutover shadow compares, and eval_store finalization lines all become visible in Railway runtime logs.

`LOG_LEVEL` env overrides the level; `basicConfig` is a no-op when a root handler exists (pytest), so no double-logging.

## Where to look after this deploys

Railway → the AI-Scoring service → **runtime logs** (not build/deploy logs). The lines appear **when an analyst approves a call** (Stage 2), one per approval:

```
2026-07-05 … INFO backend.services.eval_store — shadow: team=member_support engine=84.2 sheet=87 formula=member_support_v3 trigger_fired=False
```

MS only for now — Sales has no formula file until its slice-4 bundle, so its shadow is deliberately silent.

## Test plan

- [x] Import-time smoke: INFO line prints with the new config.
- [x] eval_store + scoring-route suites green (62 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)