### PR TITLE
fix(qa-automation): flagged-resolution pair CHECK, approve retry, test DB isolation

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -605,7 +605,10 @@ async def approve_scorecard(
             job["status"] = "complete"
             raise
         except Exception as e:
-            job["status"] = "error"
+            # Roll back to 'complete' so the manager can retry — the failed
+            # DB transaction rolled back too, so the row is still consistent.
+            # (Mirrors the legacy path's retry semantics.)
+            job["status"] = "complete"
             job["error"] = str(e)
             raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
 

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -504,6 +504,12 @@ async def record_approval(
                         config.team_id, dialpad_link,
                     )
                     return None
+                # human-review timestamps must respect the 009 pair CHECK
+                # (completed_at requires required_at): a §3.14 resolution
+                # PRESERVES required_at (the record of when it flagged) and
+                # stamps completed_at; a recompute-fire keeps/sets
+                # required_at; only a recompute-clear (edits lifted the
+                # scores, never reviewed) NULLs it.
                 await conn.execute(
                     "UPDATE qa.evaluations SET "
                     "  evaluator_email = $2, "
@@ -514,8 +520,12 @@ async def record_approval(
                     "  source = $7, "
                     "  state = $8, "
                     "  scoring_status = $9, "
-                    "  human_review_required_at = $10, "
-                    "  human_review_completed_at = COALESCE($11, human_review_completed_at), "
+                    "  human_review_required_at = CASE "
+                    "    WHEN $10::boolean THEN COALESCE(human_review_required_at, NOW()) "
+                    "    WHEN $11::boolean THEN human_review_required_at "
+                    "    ELSE NULL END, "
+                    "  human_review_completed_at = CASE "
+                    "    WHEN $11::boolean THEN NOW() ELSE human_review_completed_at END, "
                     "  approved_at = NOW(), "
                     "  finalized_at = CASE WHEN $8 = 'finalized' THEN NOW() ELSE finalized_at END "
                     "WHERE id = $1",
@@ -528,8 +538,8 @@ async def record_approval(
                     "ai_reviewed" if any_changed else "ai",
                     "finalized" if overall is not None else "approved",
                     "flagged_human_review" if flagged_review else "complete",
-                    datetime.now(timezone.utc) if flagged_review else None,
-                    datetime.now(timezone.utc) if resolving_review else None,
+                    flagged_review,
+                    resolving_review,
                 )
                 await conn.execute(
                     "DELETE FROM qa.evaluation_sections WHERE evaluation_id = $1",

--- a/qa-automation/AI-Scoring/tests/conftest.py
+++ b/qa-automation/AI-Scoring/tests/conftest.py
@@ -29,6 +29,24 @@ if str(_REPO_ROOT) not in sys.path:
 
 from backend.config import history_layout  # noqa: E402
 from backend.config.team_config import TeamConfig, _assemble_rubric_block  # noqa: E402
+from backend.services import eval_store  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_real_database(monkeypatch):
+    """The unit suite must NEVER reach a real Postgres.
+
+    backend.main's load_dotenv puts the production DATABASE_URL into the
+    environment at import time; with the cutover's per-request
+    scoring_owner lookup, an unguarded route test would silently read the
+    LIVE Railway flag and branch on production state (observed 2026-07-05:
+    test_approve_writes_audit_row took the postgres path after the MS
+    flip). Every test starts with no DSN and no cached pool; tests that
+    want a DB monkeypatch eval_store._get_pool with a fake.
+    """
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(eval_store, "_pool", None)
+
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "teams"
 _PROD_CONFIG_DIR = _REPO_ROOT / "backend" / "config" / "teams"

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -379,10 +379,12 @@ class ApprovalFakeConn(FakeConn):
     def __init__(self, existing_id=None):
         super().__init__(existing_id)
         self.eval_updates: list[tuple] = []
+        self.eval_update_queries: list[str] = []
 
     async def execute(self, query, *args):
         if query.startswith("UPDATE qa.evaluations"):
             self.eval_updates.append(args)
+            self.eval_update_queries.append(query)
         elif query.startswith("DELETE"):
             self.deletes.append(args)
         else:
@@ -548,13 +550,14 @@ class TestApprovalRecomputeAndShadow:
         await self._approve(ms_config, sections)
         (args,) = self.conn.eval_updates
         assert args[8] == "flagged_human_review"
-        assert args[9] is not None
+        assert args[9] is True      # flagged -> required_at kept/set (SQL CASE)
 
     async def test_clean_approval_clears_flag(self, ms_config):
         await self._approve(ms_config, _approval_sections(ms_config))
         (args,) = self.conn.eval_updates
         assert args[8] == "complete"
-        assert args[9] is None
+        assert args[9] is False
+        assert args[10] is False    # not a resolution -> completed_at untouched
 
     async def test_shadow_log_emitted(self, ms_config, caplog):
         import logging
@@ -671,9 +674,15 @@ class TestResolvingReview:
             overall_score_raw=None, resolving_review=True,
         )
         (args,) = self.conn.eval_updates
-        assert args[8] == "complete"          # flag cleared
-        assert args[9] is None                # required_at cleared
-        assert args[10] is not None           # completed_at stamped
+        assert args[8] == "complete"          # status back to complete
+        assert args[9] is False               # NOT the recompute-fire branch
+        assert args[10] is True               # resolution branch
+        # Regression (production 2026-07-05, evaluations_human_review_pair_check):
+        # the SQL must PRESERVE required_at on resolution — completed_at
+        # without required_at violates the 009 pair CHECK.
+        query = self.conn.eval_update_queries[0]
+        assert "WHEN $11::boolean THEN human_review_required_at" in query
+        assert "WHEN $11::boolean THEN NOW() ELSE human_review_completed_at" in query
 
 
 class FinalizeFakeConn:


### PR DESCRIPTION
## Summary

Three fixes from the first post-flip flagged-call smoke — the two errors you hit, plus a test-isolation hole the investigation surfaced.

### 1. The CHECK violation (your first screenshot)
The §3.14 resolution path cleared `human_review_required_at` while stamping `human_review_completed_at` — migration 009's `evaluations_human_review_pair_check` forbids completed-without-required. The UPDATE now encodes the three cases in SQL: a **resolution preserves `required_at`** (it's the historical record of when the call flagged) and stamps `completed_at`; a recompute-fire keeps/sets `required_at`; only a recompute-clear (analyst lifted the scores, never reviewed) NULLs it. Regression test asserts the exact SQL semantics.

### 2. The bricked retry (your second screenshot)
The postgres approve branch set the job to `'error'` on failure, but the endpoint only approves from `'complete'` — so "You can retry" couldn't work. Failures now roll the job back to `'complete'`, mirroring the legacy path's explicit retry semantics. Safe because the failed DB transaction rolled back atomically.

### 3. Tests could reach production (found while reproducing)
`backend.main`'s `load_dotenv` puts the real `DATABASE_URL` into the environment at import, and the new per-request `scoring_owner` lookup meant a route test **read your live Railway flag** and branched on production state (that's why the failure only appeared in the full suite, right after your flip — the deciding variable was live). A new autouse conftest fixture strips `DATABASE_URL` and resets the pool for every test: the unit suite can no longer touch a real Postgres under any ordering. Read-only exposure only, but this class is now closed.

## After merge

Re-run the flagged half of the smoke: **re-score the same call from lookup** (Stage 1 upserts by dialpad link, so it reuses the existing draft row — the failed transaction rolled back cleanly), red Open Editor → review → Approve. It should finalize with `human_review_required_at` AND `human_review_completed_at` both set.

## Test plan

- [x] Resolution regression (SQL preserves `required_at` — the exact production failure), recompute fire/clear branches, no-real-database guard.
- [x] Full suite: **446 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected) — now deterministic regardless of the live flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)