### PR TITLE
feat(qa-automation): cutover slice 3.5 — SSE on finalize, qa.agents identity, dispatch visibility

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -8,6 +8,7 @@ Registered twice in main.py:
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -82,6 +83,44 @@ def _make_job_id(call_id: str, agent_name: str) -> str:
     return f"{call_id}_{agent_name}".replace(" ", "_")
 
 
+def _sse_eval_id_from_link(link: str) -> str:
+    """Trailing path segment of dialpad_link — the /datapoint route key
+    (mirrors team_stats._parse_row; see the legacy approve path)."""
+    if not link:
+        return ""
+    clean = link.split("[")[0].strip().split("?")[0].strip()
+    return clean.rstrip("/").split("/")[-1]
+
+
+async def _publish_finalized_event(
+    team_id, job, *, agent_name, evaluator_email, overall_score,
+    history_row, dialpad_link, call_summary, key_strengths, opportunities,
+):
+    """SSE 'eval_approved' for the postgres paths (auto-finalize + flagged
+    resolution) — same payload the legacy approve publishes, so dashboards
+    toast identically. Never breaks the flow."""
+    def _truncate(s: str, n: int = 280) -> str:
+        s = s or ""
+        return s if len(s) <= n else s[: n - 1] + "…"
+
+    try:
+        await get_event_bus().publish(team_id, "eval_approved", {
+            "call_id": job.get("call_id", ""),
+            "eval_id": _sse_eval_id_from_link(dialpad_link) or job.get("call_id", ""),
+            "history_row": history_row,
+            "agent": agent_name or "",
+            "evaluator_email": evaluator_email,
+            "overall_score": overall_score,
+            "summary": _truncate(call_summary),
+            "strengths": _truncate(key_strengths),
+            "opportunities": _truncate(opportunities),
+            "dialpad_link": dialpad_link or "",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+    except Exception as e:
+        print(f"[sse] eval_approved publish failed (non-fatal): {e}")
+
+
 async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
     """Post-flip auto-flow (CutoverDesign §2): after the Stage-1 draft row
     lands, decide auto-finalize vs. human-review pause.
@@ -108,14 +147,36 @@ async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
     history_row = await project_evaluation(
         pool, evaluation_id, config, include_history=True
     )
-    if history_row is not None and history_row > 0:
-        try:
-            trigger_apps_script(history_row, team_id)
-        except Exception as e:
-            print(f"[auto-flow] Apps Script dispatch failed (retryable): {e}")
     job["state"] = "finalized"
     job["scoring_status"] = "complete"
     job["overall_score"] = float(detail.overall_score)
+    job["history_row"] = history_row
+    await _publish_finalized_event(
+        team_id, job,
+        agent_name=scorecard.agent_name,
+        evaluator_email=scorecard.manager_email or "",
+        overall_score=float(detail.overall_score),
+        history_row=history_row,
+        dialpad_link=scorecard.dialpad_link,
+        call_summary=scorecard.call_summary,
+        key_strengths=scorecard.key_strengths,
+        opportunities=scorecard.opportunities,
+    )
+    if history_row is not None and history_row > 0:
+        try:
+            script_response = trigger_apps_script(history_row, team_id)
+            job["email_dispatch"] = script_response
+            print(f"[auto-flow] Apps Script response: {script_response}")
+        except Exception as e:
+            # Visible, not swallowed-into-print-limbo: the job payload
+            # carries the failure so operators see it in the UI/logs.
+            job["email_dispatch"] = {"status": "error", "message": str(e)}
+            logging.getLogger(__name__).exception(
+                "auto-flow: Apps Script dispatch failed for eval %s (retryable)",
+                evaluation_id,
+            )
+    else:
+        job["email_dispatch"] = {"status": "skipped", "message": "no Analyst_History row projected"}
 
 
 @router.get("/calls")
@@ -576,9 +637,25 @@ async def approve_scorecard(
             )
             if history_row is not None and history_row > 0:
                 try:
-                    trigger_apps_script(history_row, team_id)
+                    script_response = trigger_apps_script(history_row, team_id)
+                    job["email_dispatch"] = script_response
                 except Exception as e:
-                    print(f"[approve] Apps Script dispatch failed (retryable): {e}")
+                    job["email_dispatch"] = {"status": "error", "message": str(e)}
+                    logging.getLogger(__name__).exception(
+                        "approve: Apps Script dispatch failed for eval %s (retryable)",
+                        evaluation_id,
+                    )
+            await _publish_finalized_event(
+                team_id, job,
+                agent_name=job.get("agent_name") or sc.get("agent_name"),
+                evaluator_email=evaluator_email,
+                overall_score=float(detail.overall_score),
+                history_row=history_row,
+                dialpad_link=sc.get("dialpad_link"),
+                call_summary=sc.get("call_summary", ""),
+                key_strengths=approval.key_strengths,
+                opportunities=approval.opportunities,
+            )
             append_score_audit_row(
                 api_key_role=identity.role,
                 evaluator_email=evaluator_email,

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -607,6 +607,20 @@ async def stamp_and_finalize(
             rubric_version=versions.rubric_version,
         )
         async with conn.transaction():
+            # Identity from qa.agents (never the Mails tab — CutoverDesign §2):
+            # fills agent_id + agent_email so the Analyst_History projection
+            # carries a recipient for the GAS email pipeline. No-op while the
+            # agent is missing from qa.agents (importer: scripts/import_agents.py).
+            await conn.execute(
+                "UPDATE qa.evaluations e SET "
+                "  agent_id = a.id, "
+                "  agent_email = COALESCE(e.agent_email, a.email) "
+                "FROM qa.agents a "
+                "WHERE e.id = $1 AND a.team_id = e.team_id AND a.active "
+                "  AND (LOWER(a.name) = LOWER(e.agent_name_raw) "
+                "       OR LOWER(a.canonical_name) = LOWER(e.agent_name_raw))",
+                evaluation_id,
+            )
             await conn.execute(
                 "UPDATE qa.evaluations SET "
                 "  overall_score = $2, "

--- a/qa-automation/AI-Scoring/scripts/import_agents.py
+++ b/qa-automation/AI-Scoring/scripts/import_agents.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""One-time (re-runnable) Mails-tab → qa.agents importer.
+
+CutoverDesign.md §2: post-flip, agent identity comes from qa.agents, never
+the Mails tab at runtime. This script is the sanctioned, operator-run
+exception that seeds/refreshes qa.agents FROM the sheet — the only remaining
+Sheets→Postgres flow, explicit and on-demand.
+
+Mails tab layout: A=Name, B=Email, C=Supervisor, D=Canonical Name.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python scripts/import_agents.py --team member_support [--dry-run]
+
+Upserts on the uq_agents_team_lower_name index — re-running refreshes
+emails/supervisors without duplicating rows. Rows without an email are
+skipped (qa.agents.email is NOT NULL).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_AI_SCORING))
+load_dotenv(_AI_SCORING / ".env")
+
+from backend.config.team_config import get_team_config  # noqa: E402
+from backend.services.sheets_service import _get_sheet  # noqa: E402
+
+_UPSERT = """
+INSERT INTO qa.agents (team_id, name, canonical_name, email, supervisor_email)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (team_id, LOWER(name)) DO UPDATE SET
+    canonical_name   = EXCLUDED.canonical_name,
+    email            = EXCLUDED.email,
+    supervisor_email = EXCLUDED.supervisor_email,
+    active           = TRUE,
+    updated_at       = NOW()
+"""
+
+
+def _read_mails_rows(team_id: str) -> list[tuple[str, str | None, str, str | None]]:
+    config = get_team_config(team_id)
+    sheet = _get_sheet(config, config.sheets.mails_tab)
+    rows = sheet.get_all_values()
+    out, skipped = [], 0
+    for row in rows[1:]:  # skip header
+        row = (row + [""] * 4)[:4]
+        name, email, supervisor, canonical = (c.strip() for c in row)
+        if not name:
+            continue
+        if not email:
+            skipped += 1
+            continue
+        out.append((name, canonical or None, email, supervisor or None))
+    if skipped:
+        print(f"skipped {skipped} row(s) without an email (qa.agents.email is NOT NULL)")
+    return out
+
+
+async def _run(team_id: str, dry_run: bool) -> int:
+    agents = _read_mails_rows(team_id)
+    print(f"team={team_id}: {len(agents)} agent row(s) from the Mails tab")
+    if dry_run:
+        for name, canonical, email, supervisor in agents[:10]:
+            print(f"  {name} <{email}>" + (f" (canonical: {canonical})" if canonical else ""))
+        print("dry-run: nothing written")
+        return 0
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        async with conn.transaction():
+            for name, canonical, email, supervisor in agents:
+                await conn.execute(_UPSERT, team_id, name, canonical, email, supervisor)
+        total = await conn.fetchval(
+            "SELECT COUNT(*) FROM qa.agents WHERE team_id = $1 AND active", team_id
+        )
+    finally:
+        await conn.close()
+    print(f"qa.agents upserted; {total} active agent(s) for {team_id}")
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--team", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_run(args.team, args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -688,6 +688,7 @@ class TestResolvingReview:
 class FinalizeFakeConn:
     def __init__(self):
         self.executed: list[tuple] = []
+        self.queries: list[str] = []
 
     @asynccontextmanager
     async def transaction(self):
@@ -696,6 +697,7 @@ class FinalizeFakeConn:
     async def execute(self, query, *args):
         assert query.startswith("UPDATE qa.evaluations")
         self.executed.append(args)
+        self.queries.append(query)
 
 
 class FinalizePool:
@@ -739,7 +741,13 @@ class TestStampAndFinalize:
 
         detail = await eval_store.stamp_and_finalize(55, ms_config, "op@landing.com")
         assert detail.overall_score == Decimal("91.7")
-        (args,) = conn.executed
+        # Two statements, one transaction: qa.agents identity resolution
+        # (slice 3.5 — fills agent_email for the GAS email recipient), then
+        # the finalize UPDATE.
+        resolve_args, args = conn.executed
+        assert resolve_args == (55,)
+        assert "FROM qa.agents" in conn.queries[0]
+        assert "agent_email = COALESCE(e.agent_email, a.email)" in conn.queries[0]
         # (id, overall, formula_version, rubric_version, evaluator)
         assert args[0] == 55
         assert args[1] == Decimal("91.7")


### PR DESCRIPTION
## Summary

Post-flip hardening from the QC report — §2 (SSEs + emails) and the email-enabling half of §3 (`qa.agents`), pulled forward from backfill B3 because the Gmail pipeline depends on it.

### §2 — SSEs restored
The legacy approve's `eval_approved` publish sits *after* where the postgres branch returns, so no events fired post-flip. Both postgres paths (auto-finalize in `_postgres_post_stage1`, flagged resolution in approve) now publish the identical payload — same `eval_id` derivation from the dialpad link, same truncation — so dashboard toasts and drill-down URLs behave exactly as before.

### §2/§3 — Gmail recipient restored
`EmailSender` sends to the `agent_email` cell of the Analyst_History row, which the projection fills from the DB — NULL until now. `stamp_and_finalize` resolves `agent_id` + `agent_email` from **`qa.agents`** (match on `name` OR `canonical_name`, case-insensitive) inside the finalize transaction, so the projection carries a recipient again. Identity never comes from the Mails tab at runtime — instead:

**`scripts/import_agents.py`** — the design's sanctioned, operator-run Sheets→Postgres exception. Reads the Mails tab (A=Name, B=Email, C=Supervisor, D=Canonical), upserts on `uq_agents_team_lower_name`, re-runnable, `--dry-run` supported.

### Dispatch visibility
Apps Script responses and failures now land in the job payload (`email_dispatch`) and the structured log instead of print-limbo — a failed email is operator-visible in the UI and Railway logs.

## Operator steps after merge

1. `python scripts/import_agents.py --team member_support --dry-run` → review → run without the flag.
2. Score + approve a call; confirm: dashboard toast fires, Analyst_History col B has the agent email, the Gmail arrives, and `email_dispatch` in the job payload shows the Apps Script `ok`.

## What this deliberately does not include

- §1 prompt work + §4 ≤49∧caller_id=N flag → **slice 3.6** (rubric `member_support_v3` + formula `member_support_v4`, one ceremony) — queued as task #11, awaiting your GLR v2 bullet points.
- §3's `qa.agent_stat_points` → lands with the read-path flip as planned.

## Test plan

- [x] `stamp_and_finalize` asserts the two-statement transaction (agents resolution with `COALESCE(e.agent_email, a.email)`, then finalize).
- [x] Full suite: **446 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)