### PR TITLE
fix(qa-automation): member_support_v4 — accept cri = NA (rubric/formula mismatch)

### DIFF
--- a/database/member_support_scoring_migration.md
+++ b/database/member_support_scoring_migration.md
@@ -1,6 +1,6 @@
 # Member Support — QA Scoring Migration Spec
 
-> Canonical specification for the Member Support scoring formula (current: `member_support_v3`).
+> Canonical specification for the Member Support scoring formula (current: `member_support_v4`).
 > **Purpose:** decouple the QA scoring pipeline from Google Sheets-as-database and make the
 > **PostgreSQL engine the single owner of score production**. Scope is deliberately limited to the
 > agreed rubric sections, their initial weights, the scoring formula/rules, and triggers.
@@ -8,11 +8,11 @@
 | | |
 |---|---|
 | **Status** | Finalized (Ops VP sign-off; §10 open items **closed 2026-07-04** — see Section10SignoffBriefs.md) |
-| **Formula ID** | `member_support_v3` *(v1 = original sign-off; v2 = Ops-signed keys, archived; v3 = §10-close threshold tightening)* |
+| **Formula ID** | `member_support_v4` *(v1 = original sign-off; v2 = Ops-signed keys; v3 = §10-close threshold tightening; v4 = cri NA handling, 2026-07-05)* |
 | **Rubric version** | `member_support_v2` |
 | **Score scale** | 0–100 |
 | **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
-| **Last updated** | 2026-07-04 |
+| **Last updated** | 2026-07-05 |
 
 ---
 
@@ -40,7 +40,7 @@ at most, a read-only mirror.
 
 | Field | Value |
 |---|---|
-| `formula_id` | `member_support_v3` |
+| `formula_id` | `member_support_v4` |
 | `rubric_version` | `member_support_v2` |
 | `scale` | 0–100 |
 | weight basis | percentage points summing to 100 |
@@ -64,7 +64,7 @@ Base weight is **canonical** (stored). The **Automated** weight is *derived at r
 | 7 | `comms` | Communication | rating 1–5 | 10% | 11.11% | — |
 | 8 | `efficiency` | Efficiency | rating 1–5 | 10% | 11.11% | candidate |
 | 9 | `human_review_required` | Human Review Required *(was "Documentation")* | rating 1–5 / NA | 10% | 0% *(NA default)* | — |
-| 10 | `cri` | Customer Resolution Indicator | Y / N | 5% | 6.11% | — |
+| 10 | `cri` | Customer Resolution Indicator | Y / N / NA | 5% | 6.11% | — |
 | | | **Total** | | **100%** | **100%** | |
 
 \* Automated column assumes the standard automated case (only `human_review_required = NA` → 9 active
@@ -85,7 +85,7 @@ sections that remain active).
 
 ## 5. Formula Rules (Rule Library)
 
-Rules belong to a shared engine and are gated per team. For `member_support_v3`:
+Rules belong to a shared engine and are gated per team. For `member_support_v4`:
 
 | id | type | enabled | Condition | Effect |
 |---|---|---|---|---|
@@ -93,11 +93,12 @@ Rules belong to a shared engine and are gated per team. For `member_support_v3`:
 | `caller_id_na_transfer` | weight_transfer | true | `caller_id = NA` | Move all `caller_id` weight → `call_resolution`. |
 | `frequent_caller_shift` | weight_transfer | true | `frequent_caller` signal | Move a configurable share (**default 0.5**) of `call_resolution` weight → `process_adherence` (target selectable). Also biases `caller_id` scoring toward NA (prompt-level). |
 | `hrr_na_spread` | weight_redistribution | true | `human_review_required = NA` | Split its weight **equally (additive)** across the active scored sections: `+weight / N` each. |
+| `cri_na_spread` | weight_redistribution | true | `cri = NA` | Split its weight **equally (additive)** across the active scored sections — same A4 house style as `hrr_na_spread`. *(v4, 2026-07-05: outbound/property calls have no member resolution; the rubric always allowed `cri = NA`, the formula now does too.)* |
 | `caller_id_scale_half` | score_scale | true | `caller_id = N` | Multiply final score × **0.5**. (Section also contributes 0 on its own slot.) |
 | `escalation_flag` | flag | true | `process_adherence` frac ≤ 0.25 **OR** `call_resolution` frac ≤ 0.25 | Emit `human_review_required` event; route to supervisor review. *(Tightened from ≤ 0.5 at §10 close — ratings 1–2 only.)* |
 
 **Notes**
-- `cri = N` needs **no rule**: binary normalization already gives it `0`, so it simply forfeits its weight. *(The former ×0.9 score-wide multiplier is deprecated.)*
+- `cri = N` needs **no rule**: binary normalization already gives it `0`, so it simply forfeits its weight. *(The former ×0.9 score-wide multiplier is deprecated.)* `cri = NA` redistributes via `cri_na_spread` (v4).
 - `caller_id = N` and `caller_id = NA` are mutually exclusive branches.
 - The `frequent_caller` signal originates from a **Looker snapshot delivered via Command Center** (external dependency; see §8 `external_signals`).
 
@@ -137,9 +138,9 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
 
 ```json
 {
-  "formula_id": "member_support_v3",
+  "formula_id": "member_support_v4",
   "rubric_version": "member_support_v2",
-  "supersedes": "member_support_v2",
+  "supersedes": "member_support_v3",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -156,13 +157,14 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
     { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
     { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
     { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
-    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn",     "weight": 5.0,  "trigger": null }
+    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null }
   ],
   "rules": [
     { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
     { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
     { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
     { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "cri_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "cri", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" }, "note": "v4 (2026-07-05): rubric declares cri na_applicable (outbound/property calls have no member resolution); the v3 formula said binary_yn and the engine rejected real NA output at compute time. Same equal-additive house style as hrr_na_spread per the A4 sign-off." },
     { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
     { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
   ],
@@ -171,6 +173,7 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
     "caller_id_na_transfer",
     "frequent_caller_shift",
     "hrr_na_spread",
+    "cri_na_spread",
     "weighted_sum",
     "caller_id_scale_half",
     "escalation_flag"

--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
@@ -1,7 +1,7 @@
 {
-  "formula_id": "member_support_v3",
+  "formula_id": "member_support_v4",
   "rubric_version": "member_support_v2",
-  "supersedes": "member_support_v2",
+  "supersedes": "member_support_v3",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -18,13 +18,14 @@
     { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
     { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
     { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
-    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn",     "weight": 5.0,  "trigger": null }
+    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null }
   ],
   "rules": [
     { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
     { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
     { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
     { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "cri_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "cri", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" }, "note": "v4 (2026-07-05): rubric declares cri na_applicable (outbound/property calls have no member resolution); the v3 formula said binary_yn and the engine rejected real NA output at compute time. Same equal-additive house style as hrr_na_spread per the A4 sign-off." },
     { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
     { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
   ],
@@ -33,6 +34,7 @@
     "caller_id_na_transfer",
     "frequent_caller_shift",
     "hrr_na_spread",
+    "cri_na_spread",
     "weighted_sum",
     "caller_id_scale_half",
     "escalation_flag"

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -570,7 +570,7 @@ class TestApprovalRecomputeAndShadow:
                   if m.startswith("shadow: team=member_support")]
         assert len(shadow) == 1
         assert "engine=" in shadow[0] and "sheet=87" in shadow[0]
-        assert "formula=member_support_v3" in shadow[0]
+        assert "formula=member_support_v4" in shadow[0]
         assert "trigger_fired=False" in shadow[0]
 
     async def test_shadow_skips_incomplete_payload(self, ms_config, caplog):

--- a/qa-automation/AI-Scoring/tests/test_formula_models.py
+++ b/qa-automation/AI-Scoring/tests/test_formula_models.py
@@ -61,10 +61,10 @@ class TestMemberSupportShippedConfig:
     """The MS files in the repo must load. If these break, downstream is blocked."""
 
     def test_formula_loads(self, ms_formula):
-        assert ms_formula.formula_id == "member_support_v3"
-        assert ms_formula.supersedes == "member_support_v2"
+        assert ms_formula.formula_id == "member_support_v4"
+        assert ms_formula.supersedes == "member_support_v3"
         assert len(ms_formula.sections) == 10
-        assert len(ms_formula.rules) == 6
+        assert len(ms_formula.rules) == 7
 
     def test_rubric_loads(self, ms_rubric):
         assert ms_rubric.rubric_version == "member_support_v2"

--- a/qa-automation/AI-Scoring/tests/test_rule_engine.py
+++ b/qa-automation/AI-Scoring/tests/test_rule_engine.py
@@ -531,3 +531,27 @@ class TestAnswerValidation:
         (int 1 would be ambiguous with rating 1)."""
         with pytest.raises(AnswerValidationError):
             evaluate_formula(ms_formula, ms_answers(cri=bad))
+
+
+class TestCriNaSpread:
+    """member_support_v4 regression (production 2026-07-05): the rubric
+    always allowed cri = NA (outbound/property calls), the v3 formula said
+    binary_yn and the engine rejected real AI output at compute time."""
+
+    def test_cri_na_is_accepted_and_spread(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(cri="NA"))
+        assert result.final_score == pytest.approx(100.0)
+        assert result.effective_weights["cri"] == 0.0
+        # hrr (10) and cri (5) each spread equally over the 8 remaining active
+        assert result.effective_weights["greeting"] == pytest.approx(5 + 10 / 8 + 5 / 8)
+        assert sorted(result.na_sections) == ["cri", "human_review_required"]
+
+    def test_cri_na_with_imperfect_scores(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(cri="NA", greeting=1))
+        # greeting weight 5 + 10/8 + 5/8 = 6.875; frac 0 loses exactly that
+        assert result.final_score == pytest.approx(100 - 6.875)
+
+    def test_triple_na_still_never_loses_weight(self, ms_formula):
+        result = evaluate_formula(ms_formula, ms_answers(cri="NA", caller_id="NA"))
+        assert result.final_score == pytest.approx(100.0)
+        assert sum(result.effective_weights.values()) == pytest.approx(100.0)

--- a/qa-automation/AI-Scoring/tests/test_score_compute.py
+++ b/qa-automation/AI-Scoring/tests/test_score_compute.py
@@ -30,7 +30,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
 _MS_TEAM_JSON = _REPO_ROOT / "backend" / "config" / "teams" / "member_support.json"
 
-MS_FORMULA_VERSION = "member_support_v3"
+MS_FORMULA_VERSION = "member_support_v4"
 MS_RUBRIC_VERSION = "member_support_v2"
 
 


### PR DESCRIPTION
## Summary

Production bug (your screenshot): an outbound property call scored `cri = N/A` — which the **rubric has always allowed** (`na_applicable: true`) and the AI correctly produced — but the **v3 formula** declared `cri: binary_yn`, so the engine rejected the answer at compute time. Result: the call took *neither* path (no human-review flag, no auto-finalize/SSE), and retrying approve hit the same wall.

**`member_support_v4`** (supersedes v3, rubric unchanged):
- `cri`: `binary_yn` → `binary_yn_na`
- New rule **`cri_na_spread`**: equal-additive spread of cri's 5 points over the active sections — the same house style as `hrr_na_spread`, per the A4 sign-off ("equal-additive over remaining active sections" as MS's multi-NA behavior). NA weight is never silently lost.

The failing combination (caller_id NA + hrr NA-default + cri NA) now resolves: caller_id's 5 transfers to resolution, hrr's 10 and cri's 5 each spread over the 7 remaining active sections, weights still sum to 100.

Spec updated to the signed state: metadata → v4, §3 cri `Y / N / NA`, §5 rule row + note, §8 mirrors the shipped JSON verbatim.

## Ship + recovery

- Ships itself on deploy (the startup path archives v4 and closes v3 — rubric `member_support_v2` is already archived, so no operator step).
- The stuck call from the screenshot: hit **Retry Approve & Send** after the deploy — the draft row is intact and the engine now accepts it. Freshly scored calls with cri = N/A auto-finalize normally.

## Worth knowing

This is the §3.19.3 class of bug from the *other* direction: the cross-check validates that formula sections **exist** in the rubric, not that their NA-capability matches. A stricter cross-check (rubric `na_applicable` ⇒ formula `_na` score_type) would have caught this at ship time — noted for slice 3.6 while we're already touching the formula schema.

## Test plan

- [x] 3 regressions: cri NA spread + exact score math, imperfect-score case, triple-NA weight conservation (Σ weights = 100).
- [x] Version pins → v4 across suites.
- [x] Full suite: **449 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)