### PR TITLE
feat(qa-automation): July R1 — member_support_v5 plain-sum rollout formula

### DIFF
--- a/database/member_support_scoring_migration.md
+++ b/database/member_support_scoring_migration.md
@@ -1,6 +1,6 @@
 # Member Support — QA Scoring Migration Spec
 
-> Canonical specification for the Member Support scoring formula (current: `member_support_v4`).
+> Canonical specification for the Member Support scoring formula (current: `member_support_v5` — July rollout).
 > **Purpose:** decouple the QA scoring pipeline from Google Sheets-as-database and make the
 > **PostgreSQL engine the single owner of score production**. Scope is deliberately limited to the
 > agreed rubric sections, their initial weights, the scoring formula/rules, and triggers.
@@ -8,11 +8,11 @@
 | | |
 |---|---|
 | **Status** | Finalized (Ops VP sign-off; §10 open items **closed 2026-07-04** — see Section10SignoffBriefs.md) |
-| **Formula ID** | `member_support_v4` *(v1 = original sign-off; v2 = Ops-signed keys; v3 = §10-close threshold tightening; v4 = cri NA handling, 2026-07-05)* |
+| **Formula ID** | `member_support_v5` *(v3 = §10 thresholds; v4 = cri NA fix; **v5 = July-rollout plain sum**, Director sign-off 2026-07-06 — the v4 rule library returns ~August)* |
 | **Rubric version** | `member_support_v2` |
 | **Score scale** | 0–100 |
 | **System of record** | this spec → PostgreSQL scoring engine (replaces Sheets) |
-| **Last updated** | 2026-07-05 |
+| **Last updated** | 2026-07-06 |
 
 ---
 
@@ -40,7 +40,7 @@ at most, a read-only mirror.
 
 | Field | Value |
 |---|---|
-| `formula_id` | `member_support_v4` |
+| `formula_id` | `member_support_v5` |
 | `rubric_version` | `member_support_v2` |
 | `scale` | 0–100 |
 | weight basis | percentage points summing to 100 |
@@ -85,7 +85,16 @@ sections that remain active).
 
 ## 5. Formula Rules (Rule Library)
 
-Rules belong to a shared engine and are gated per team. For `member_support_v4`:
+**July 2026 rollout (`member_support_v5`, Director sign-off 2026-07-06):** plain weighted sum
+only. Every behavioral rule below is **disabled for July** — no hard-zero, no caller_id transfer
+(replaced by a uniform equal-additive NA spread), no frequent-caller shift, no ×0.5 scale, no
+escalation flag, and `human_review_triggers` is empty (every scored call auto-finalizes). The only
+v5 rules are the three NA bookkeeping spreads (`caller_id_na_spread`, `hrr_na_spread`,
+`cri_na_spread`). The archived `member_support_v4` file is preserved at
+`config/scoring/member_support/v4_full_rules.json` and returns (as v6+) with the August
+full-feature rollout.
+
+Rules belong to a shared engine and are gated per team. The **full rule library** (August target, archived as `member_support_v4`):
 
 | id | type | enabled | Condition | Effect |
 |---|---|---|---|---|
@@ -138,9 +147,9 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
 
 ```json
 {
-  "formula_id": "member_support_v4",
+  "formula_id": "member_support_v5",
   "rubric_version": "member_support_v2",
-  "supersedes": "member_support_v3",
+  "supersedes": "member_support_v4",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -151,46 +160,29 @@ flag (7) reads raw ratings, so redistribution never changes whether a call escal
     { "key": "greeting",              "label": "Greeting",                      "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
     { "key": "caller_id",             "label": "Caller ID",                     "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
     { "key": "purpose",               "label": "Purpose of Call",               "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
-    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": "candidate" },
-    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": "active" },
-    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
+    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": null },
+    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": null },
     { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
-    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
+    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
     { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
     { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null }
   ],
   "rules": [
-    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
-    { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
-    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
-    { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
-    { "id": "cri_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "cri", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" }, "note": "v4 (2026-07-05): rubric declares cri na_applicable (outbound/property calls have no member resolution); the v3 formula said binary_yn and the engine rejected real NA output at compute time. Same equal-additive house style as hrr_na_spread per the A4 sign-off." },
-    { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
-    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
+    { "id": "caller_id_na_spread", "type": "weight_redistribution", "enabled": true, "when": { "section": "caller_id", "equals": "NA" },             "effect": { "method": "equal_additive", "from": "caller_id", "to": "active_sections" }, "note": "July rollout: pure NA bookkeeping replaces the v4 transfer-to-resolution (a behavioral choice). Uniform equal-additive spreads per the A4 house style." },
+    { "id": "hrr_na_spread",       "type": "weight_redistribution", "enabled": true, "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "cri_na_spread",       "type": "weight_redistribution", "enabled": true, "when": { "section": "cri", "equals": "NA" },                   "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" } }
   ],
   "evaluation_order": [
-    "hard_zero",
-    "caller_id_na_transfer",
-    "frequent_caller_shift",
+    "caller_id_na_spread",
     "hrr_na_spread",
     "cri_na_spread",
-    "weighted_sum",
-    "caller_id_scale_half",
-    "escalation_flag"
+    "weighted_sum"
   ],
-  "triggers": {
-    "threshold": { "op": "lte", "frac": 0.25, "ratings": [1, 2] },
-    "active": ["process_adherence", "call_resolution"],
-    "candidates": ["matching", "efficiency"],
-    "routes_to": "human_review_required"
-  },
-  "external_signals": {
-    "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
-  },
-  "human_review_triggers": [
-    { "section_id": "process_adherence", "max_score_to_trigger": 2 },
-    { "section_id": "call_resolution",   "max_score_to_trigger": 2 }
-  ]
+  "triggers": {},
+  "external_signals": {},
+  "deprecated_sections": [],
+  "human_review_triggers": []
 }
 ```
 

--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/overall_formula.json
@@ -1,7 +1,7 @@
 {
-  "formula_id": "member_support_v4",
+  "formula_id": "member_support_v5",
   "rubric_version": "member_support_v2",
-  "supersedes": "member_support_v3",
+  "supersedes": "member_support_v4",
   "scale": { "min": 0, "max": 100 },
   "normalization": {
     "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
@@ -12,44 +12,27 @@
     { "key": "greeting",              "label": "Greeting",                      "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
     { "key": "caller_id",             "label": "Caller ID",                     "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
     { "key": "purpose",               "label": "Purpose of Call",               "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
-    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": "candidate" },
-    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": "active" },
-    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
+    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": null },
+    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": null },
     { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
-    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
+    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
     { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
     { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null }
   ],
   "rules": [
-    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
-    { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
-    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
-    { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
-    { "id": "cri_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "cri", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" }, "note": "v4 (2026-07-05): rubric declares cri na_applicable (outbound/property calls have no member resolution); the v3 formula said binary_yn and the engine rejected real NA output at compute time. Same equal-additive house style as hrr_na_spread per the A4 sign-off." },
-    { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
-    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
+    { "id": "caller_id_na_spread", "type": "weight_redistribution", "enabled": true, "when": { "section": "caller_id", "equals": "NA" },             "effect": { "method": "equal_additive", "from": "caller_id", "to": "active_sections" }, "note": "July rollout: pure NA bookkeeping replaces the v4 transfer-to-resolution (a behavioral choice). Uniform equal-additive spreads per the A4 house style." },
+    { "id": "hrr_na_spread",       "type": "weight_redistribution", "enabled": true, "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "cri_na_spread",       "type": "weight_redistribution", "enabled": true, "when": { "section": "cri", "equals": "NA" },                   "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" } }
   ],
   "evaluation_order": [
-    "hard_zero",
-    "caller_id_na_transfer",
-    "frequent_caller_shift",
+    "caller_id_na_spread",
     "hrr_na_spread",
     "cri_na_spread",
-    "weighted_sum",
-    "caller_id_scale_half",
-    "escalation_flag"
+    "weighted_sum"
   ],
-  "triggers": {
-    "threshold": { "op": "lte", "frac": 0.25, "ratings": [1, 2] },
-    "active": ["process_adherence", "call_resolution"],
-    "candidates": ["matching", "efficiency"],
-    "routes_to": "human_review_required"
-  },
-  "external_signals": {
-    "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
-  },
-  "human_review_triggers": [
-    { "section_id": "process_adherence", "max_score_to_trigger": 2 },
-    { "section_id": "call_resolution",   "max_score_to_trigger": 2 }
-  ]
+  "triggers": {},
+  "external_signals": {},
+  "deprecated_sections": [],
+  "human_review_triggers": []
 }

--- a/qa-automation/AI-Scoring/backend/config/scoring/member_support/v4_full_rules.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/member_support/v4_full_rules.json
@@ -1,0 +1,55 @@
+{
+  "formula_id": "member_support_v4",
+  "rubric_version": "member_support_v2",
+  "supersedes": "member_support_v3",
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "redistribute_per_rules"
+  },
+  "sections": [
+    { "key": "greeting",              "label": "Greeting",                      "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "caller_id",             "label": "Caller ID",                     "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "purpose",               "label": "Purpose of Call",               "score_type": "rating_1_5",    "weight": 5.0,  "trigger": null },
+    { "key": "matching",              "label": "Matching the Moment",           "score_type": "rating_1_5",    "weight": 5.0,  "trigger": "candidate" },
+    { "key": "process_adherence",     "label": "Process Adherence",             "score_type": "rating_1_5",    "weight": 25.0, "trigger": "active" },
+    { "key": "call_resolution",       "label": "Call Resolution",               "score_type": "rating_1_5",    "weight": 20.0, "trigger": "active" },
+    { "key": "comms",                 "label": "Communication",                 "score_type": "rating_1_5",    "weight": 10.0, "trigger": null },
+    { "key": "efficiency",            "label": "Efficiency",                    "score_type": "rating_1_5",    "weight": 10.0, "trigger": "candidate" },
+    { "key": "human_review_required", "label": "Human Review Required",         "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null, "na_default": true },
+    { "key": "cri",                   "label": "Customer Resolution Indicator", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null }
+  ],
+  "rules": [
+    { "id": "hard_zero",             "type": "score_override",        "enabled": false, "when": { "section": "caller_id", "equals": "N" },  "effect": { "set_score": 0 }, "note": "retained for collections/billing/legal; disabled for member_support_v2" },
+    { "id": "caller_id_na_transfer", "type": "weight_transfer",       "enabled": true,  "when": { "section": "caller_id", "equals": "NA" }, "effect": { "from": "caller_id", "to": "call_resolution", "amount": "all" } },
+    { "id": "frequent_caller_shift", "type": "weight_transfer",       "enabled": true,  "when": { "signal": "frequent_caller" },            "effect": { "from": "call_resolution", "to": "process_adherence", "fraction": 0.5, "target_configurable": true }, "note": "signal wired false-by-default until command_center ships (Wave 3)" },
+    { "id": "hrr_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "human_review_required", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "human_review_required", "to": "active_sections" } },
+    { "id": "cri_na_spread",         "type": "weight_redistribution", "enabled": true,  "when": { "section": "cri", "equals": "NA" }, "effect": { "method": "equal_additive", "from": "cri", "to": "active_sections" }, "note": "v4 (2026-07-05): rubric declares cri na_applicable (outbound/property calls have no member resolution); the v3 formula said binary_yn and the engine rejected real NA output at compute time. Same equal-additive house style as hrr_na_spread per the A4 sign-off." },
+    { "id": "caller_id_scale_half",  "type": "score_scale",           "enabled": true,  "when": { "section": "caller_id", "equals": "N" },  "effect": { "multiply": 0.5 } },
+    { "id": "escalation_flag",       "type": "flag",                  "enabled": true,  "when": { "any": [ { "section": "process_adherence", "frac_lte": 0.25 }, { "section": "call_resolution", "frac_lte": 0.25 } ] }, "effect": { "emit_event": "human_review_required", "route": "supervisor_review" }, "note": "threshold tightened 1-3 -> 1-2 per Ops VP sign-off 2026-07-04 (Section10SignoffBriefs A1)" }
+  ],
+  "evaluation_order": [
+    "hard_zero",
+    "caller_id_na_transfer",
+    "frequent_caller_shift",
+    "hrr_na_spread",
+    "cri_na_spread",
+    "weighted_sum",
+    "caller_id_scale_half",
+    "escalation_flag"
+  ],
+  "triggers": {
+    "threshold": { "op": "lte", "frac": 0.25, "ratings": [1, 2] },
+    "active": ["process_adherence", "call_resolution"],
+    "candidates": ["matching", "efficiency"],
+    "routes_to": "human_review_required"
+  },
+  "external_signals": {
+    "frequent_caller": { "source": "looker_snapshot", "via": "command_center" }
+  },
+  "human_review_triggers": [
+    { "section_id": "process_adherence", "max_score_to_trigger": 2 },
+    { "section_id": "call_resolution",   "max_score_to_trigger": 2 }
+  ]
+}

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from contextlib import asynccontextmanager
+from pathlib import Path
 from datetime import datetime, timezone
 
 import pytest
@@ -466,11 +467,33 @@ class TestRecordApproval:
 # §3.14 human-review trigger + shadow logging (cutover slice 1)
 # ---------------------------------------------------------------------------
 
+V4_FULL_RULES = (Path(__file__).resolve().parent.parent / "backend" / "config"
+                 / "scoring" / "member_support" / "v4_full_rules.json")
+
+
+def _v4_formula():
+    from backend.models.formula import Formula
+    return Formula.model_validate(json.loads(V4_FULL_RULES.read_text(encoding="utf-8")))
+
+
 class TestHumanReviewTrigger:
+    """Trigger MECHANICS against the archived v4 full-rule formula; the
+    shipped July v5 has human_review_triggers=[] (gate off, Director
+    2026-07-06) — asserted below."""
 
     @pytest.fixture(scope="class")
     def ms_formula(self):
-        return eval_store._active_formula("member_support")
+        return _v4_formula()
+
+    def test_shipped_v5_gate_is_off(self):
+        active = eval_store._active_formula("member_support")
+        assert active.formula_id == "member_support_v5"
+        assert active.human_review_triggers == []
+        assert not eval_store.human_review_trigger_fired(
+            active, _scorecard(None, sections=[
+                _ai_section("process_adherence", "Process", score=1),
+            ]).sections
+        )
 
     def test_v3_thresholds(self, ms_formula):
         """member_support_v3: process/resolution rating <= 2 fires; 3 does
@@ -500,6 +523,13 @@ class TestHumanReviewTrigger:
 
 
 class TestDraftFlagging:
+    """Mechanics under the v4 full-rule formula (monkeypatched in) — the
+    shipped July v5 never flags, which TestHumanReviewTrigger asserts."""
+
+    @pytest.fixture(autouse=True)
+    def _v4_policy(self, monkeypatch):
+        formula = _v4_formula()
+        monkeypatch.setattr(eval_store, "_active_formula", lambda team_id: formula)
 
     def test_flagged_draft_row(self, ms_config):
         sc = _scorecard(ms_config)
@@ -531,6 +561,10 @@ class TestApprovalRecomputeAndShadow:
             return FakePool(self.conn)
 
         monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+        # Recompute/shadow MECHANICS run against the archived v4 full-rule
+        # formula; the shipped v5 gate-off behavior is covered separately.
+        formula = _v4_formula()
+        monkeypatch.setattr(eval_store, "_active_formula", lambda team_id: formula)
 
     async def _approve(self, ms_config, sections):
         draft = [s.model_dump() for s in _scorecard(ms_config).sections]
@@ -570,7 +604,7 @@ class TestApprovalRecomputeAndShadow:
                   if m.startswith("shadow: team=member_support")]
         assert len(shadow) == 1
         assert "engine=" in shadow[0] and "sheet=87" in shadow[0]
-        assert "formula=member_support_v4" in shadow[0]
+        assert "formula=member_support_v4" in shadow[0]  # v4 monkeypatched in
         assert "trigger_fired=False" in shadow[0]
 
     async def test_shadow_skips_incomplete_payload(self, ms_config, caplog):

--- a/qa-automation/AI-Scoring/tests/test_formula_models.py
+++ b/qa-automation/AI-Scoring/tests/test_formula_models.py
@@ -61,10 +61,10 @@ class TestMemberSupportShippedConfig:
     """The MS files in the repo must load. If these break, downstream is blocked."""
 
     def test_formula_loads(self, ms_formula):
-        assert ms_formula.formula_id == "member_support_v4"
-        assert ms_formula.supersedes == "member_support_v3"
+        assert ms_formula.formula_id == "member_support_v5"
+        assert ms_formula.supersedes == "member_support_v4"
         assert len(ms_formula.sections) == 10
-        assert len(ms_formula.rules) == 7
+        assert len(ms_formula.rules) == 3
 
     def test_rubric_loads(self, ms_rubric):
         assert ms_rubric.rubric_version == "member_support_v2"
@@ -83,9 +83,10 @@ class TestMemberSupportShippedConfig:
     def test_ms_na_policy_is_redistribute(self, ms_formula):
         assert ms_formula.normalization.na == "redistribute_per_rules"
 
-    def test_ms_has_human_review_triggers(self, ms_formula):
-        keys = {t.section_id for t in ms_formula.human_review_triggers}
-        assert keys == {"process_adherence", "call_resolution"}
+    def test_ms_july_v5_gate_is_off(self, ms_formula):
+        """July rollout (Director 2026-07-06): human_review_triggers empty —
+        every scored call auto-finalizes. The v4 gate returns ~August."""
+        assert ms_formula.human_review_triggers == []
 
     def test_ms_formula_round_trips(self, ms_formula_raw, ms_formula):
         # Preserve alias-keyed dict (`from` → `from_`) via by_alias=True.

--- a/qa-automation/AI-Scoring/tests/test_rule_engine.py
+++ b/qa-automation/AI-Scoring/tests/test_rule_engine.py
@@ -27,7 +27,10 @@ from backend.services.rule_engine import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
+# Rule-MECHANICS tests exercise the archived full-rule formula (v4) — the
+# richest real config; the shipped July file is plain-sum (see TestJulyV5).
+_MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "v4_full_rules.json"
+_MS_ACTIVE_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
 
 
 # ---------------------------------------------------------------------------
@@ -555,3 +558,45 @@ class TestCriNaSpread:
         result = evaluate_formula(ms_formula, ms_answers(cri="NA", caller_id="NA"))
         assert result.final_score == pytest.approx(100.0)
         assert sum(result.effective_weights.values()) == pytest.approx(100.0)
+
+
+class TestJulyV5Shipped:
+    """The ACTIVE July-rollout formula: plain weighted sum + NA bookkeeping
+    only (Director sign-off 2026-07-06). Behavioral rules live on in the
+    archived v4 file above and return ~August."""
+
+    @pytest.fixture(scope="class")
+    def v5(self) -> Formula:
+        return Formula.model_validate(json.loads(_MS_ACTIVE_JSON.read_text(encoding="utf-8")))
+
+    def test_only_na_bookkeeping_rules(self, v5):
+        assert v5.formula_id == "member_support_v5"
+        assert v5.supersedes == "member_support_v4"
+        assert [r.id for r in v5.rules] == ["caller_id_na_spread", "hrr_na_spread", "cri_na_spread"]
+        assert all(r.type == "weight_redistribution" for r in v5.rules)
+        assert v5.human_review_triggers == []
+        assert v5.external_signals == {}
+
+    def test_caller_id_n_no_longer_halves(self, v5):
+        result = evaluate_formula(v5, ms_answers(caller_id="N"))
+        assert result.final_score == pytest.approx(100 - (5 + 10 / 9))
+        assert result.events == []
+
+    def test_caller_id_na_spreads_instead_of_transferring(self, v5):
+        result = evaluate_formula(v5, ms_answers(caller_id="NA"))
+        w = result.effective_weights
+        assert w["caller_id"] == 0.0
+        # 5 and 10 each spread equally over the 8 remaining active sections
+        assert w["call_resolution"] == pytest.approx(20 + 5 / 8 + 10 / 8)
+        assert result.final_score == pytest.approx(100.0)
+
+    def test_low_scores_emit_no_events(self, v5):
+        result = evaluate_formula(v5, ms_answers(process_adherence=1, call_resolution=1))
+        assert result.events == []
+        assert result.final_score == pytest.approx(100 - (25 + 10 / 9) - (20 + 10 / 9))
+
+    def test_signals_have_no_effect(self, v5):
+        base = evaluate_formula(v5, ms_answers())
+        with_signal = evaluate_formula(v5, ms_answers(), signals={"frequent_caller": True})
+        assert base.final_score == with_signal.final_score
+        assert base.effective_weights == with_signal.effective_weights

--- a/qa-automation/AI-Scoring/tests/test_score_compute.py
+++ b/qa-automation/AI-Scoring/tests/test_score_compute.py
@@ -30,7 +30,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _MS_FORMULA_JSON = _REPO_ROOT / "backend" / "config" / "scoring" / "member_support" / "overall_formula.json"
 _MS_TEAM_JSON = _REPO_ROOT / "backend" / "config" / "teams" / "member_support.json"
 
-MS_FORMULA_VERSION = "member_support_v4"
+MS_FORMULA_VERSION = "member_support_v5"
 MS_RUBRIC_VERSION = "member_support_v2"
 
 
@@ -157,10 +157,10 @@ class TestComputeOverallScore:
         score = await compute_overall_score(_conn(answers), 1)
         assert score == Decimal("78.1")
 
-    async def test_caller_id_n_halves_score(self):
-        """(100 − (5 + 10/9)) × 0.5 = 46.944… → 46.9."""
+    async def test_caller_id_n_costs_only_its_slot_under_v5(self):
+        """July plain sum: no ×0.5 — 100 − (5 + 10/9) = 93.888… → 93.9."""
         score = await compute_overall_score(_conn(_perfect_answers(caller_id="N")), 1)
-        assert score == Decimal("46.9")
+        assert score == Decimal("93.9")
 
     async def test_hrr_na_numeric_row_shape_converts(self):
         """The migration-012 shape (numeric section, numeric_score NULL,
@@ -171,23 +171,23 @@ class TestComputeOverallScore:
         detail = await compute_score_detail(_conn(), 1)
         assert detail.result.na_sections == ["human_review_required"]
 
-    async def test_signals_reach_the_engine(self):
-        """frequent_caller moves resolution weight before its frac-0 loss:
-        without signal 100 − (20+10/9) → 78.9; with it 100 − (10+10/9) → 88.9."""
+    async def test_signals_are_inert_under_v5(self):
+        """July plain sum has no signal-gated rules — the signals parameter
+        must be a pure no-op (it returns with the v4 library in August)."""
         answers = _perfect_answers(call_resolution=1)
         without = await compute_overall_score(_conn(answers), 1)
         with_signal = await compute_overall_score(
             _conn(answers), 1, signals={"frequent_caller": True}
         )
-        assert without == Decimal("78.9")
-        assert with_signal == Decimal("88.9")
+        assert without == with_signal == Decimal("78.9")
 
     async def test_detail_carries_versions_and_trace(self):
         detail = await compute_score_detail(_conn(_perfect_answers(process_adherence=1)), 1)
         assert detail.team_id == "member_support"
         assert detail.formula_version == MS_FORMULA_VERSION
         assert detail.rubric_version == MS_RUBRIC_VERSION
-        assert any(e.rule_id == "escalation_flag" for e in detail.result.events)
+        assert detail.result.events == []  # July v5: no flag rules
+        assert any(t.rule_id == "hrr_na_spread" and t.fired for t in detail.result.trace)
         assert detail.overall_score == Decimal(str(detail.result.final_score)).quantize(Decimal("0.1"))
 
     async def test_jsonb_returned_as_str_is_decoded(self):


### PR DESCRIPTION
## Summary

R1 of the July rollout (Director sign-off 2026-07-06): **`member_support_v5`** — plain weighted sum.

**What v5 keeps:** the three NA bookkeeping spreads (`caller_id_na_spread`, `hrr_na_spread`, `cri_na_spread`) — uniform equal-additive per the A4 house style, so NA weight is never silently lost and HRR's default-NA doesn't inflate scores. Note `caller_id` NA now *spreads* rather than transferring to Call Resolution — the v4 transfer was a behavioral choice, so July drops it for uniformity.

**What July turns off:** hard-zero, the frequent-caller shift + external signal, the ×0.5 caller-ID scale, the escalation flag, and the §3.14 gate (`human_review_triggers: []`) — **every scored call auto-finalizes**; the red/flagged lookup path lies dormant until August.

**Nothing is torn down.** The full v4 rule library is preserved verbatim at `config/scoring/member_support/v4_full_rules.json` (ignored by startup, like `v0_sheet.json`) and returns as v6 with the August full-feature rollout — one ceremony each way. Every July score stays reproducible under archived v5 forever.

**Score-visible changes to socialize:** caller_id=N calls no longer halve (a perfect-otherwise call scores 93.9, not 46.9), and no call pauses for review.

## Ship

Automatic on deploy — the startup path archives v5 and closes v4; rubric `member_support_v2` unchanged.

## Test plan

- [x] Rule-mechanics suites repointed at the archived v4 file — coverage of all six rule types is fully intact.
- [x] New `TestJulyV5Shipped`: 3 bookkeeping rules only, no halving, spread-not-transfer, zero events at low scores, signals inert, gate off (plus the shipped-config pin that `human_review_triggers == []`).
- [x] Spec §8 mirrors the shipped JSON verbatim; §5 documents the full library as the August target.
- [x] Full suite: **455 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

## Next (July board)

- **R2** — monthly per-agent/per-team CSV exports + sampling coverage in lookup (task #12)
- **R3** — `qa.assessments` persistence + Landing one-pager with the AI Assessment (task #13)
- **August** — v6 = the archived rule library + gate + ≤49∧caller-ID flag + GLR v2 prompt (task #11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)