### PR TITLE
feat(qa-automation): sales_v2 formula + staged rubric from scorer prose

### DIFF
--- a/database/sales_scoring_migration.md
+++ b/database/sales_scoring_migration.md
@@ -256,6 +256,25 @@ No pre-sum weight moves and no post-sum scaling exist in this version. NA is res
 - [x] **`client_experience` stays under *Post-Call & Documentation*.**
 - [x] **No rules / no triggers for `sales_v2`** — `evaluation_order: ["weighted_sum"]`.
 
+### 10a. Rubric build decisions (2026-07-06)
+
+The scorer-facing rubric prose (QA_Scoring_Guide-derived) was reviewed and staged as
+`config/scoring/sales/rubric_v2.json`. Decisions taken with the owner:
+
+- **`potential_booking` and `notes_mc` are analyst-filled (`manual_yn`)** — post-call artifacts in
+  the PB system / MC that the AI cannot observe from the recording; excluded from the AI prompt.
+  Aug–Sept integrations may automate them. `contact_shared` stays AI-scored (verbally observable).
+- **Per-section `confidence` (high/medium/low) added** to the scorer output, matching Member
+  Support — feeds the DB confidence column and the Plan-B routing signal.
+- **Prompt config:** `audio_dependent_sections = [move_reason, client_experience]` (tone/empathy
+  judgments, medium confidence cap); `sop_sections = [landing_guarantee, pricing]`.
+- **Version ids corrected to `sales_v2`** per B3 (the prose draft said `sales_v1`, which is
+  immutably occupied by the legacy 19-section rubric).
+- The rubric introduces **`na_applies_when`** per section (strict-NA policy text — NA grants full
+  credit downstream, so it must be earned). ⚠️ **Pre-flip checklist:** the `na_applies_when`
+  wording for 13 of 15 sections is an operational default — confirm with Sales Management before
+  go-live (only `landing_guarantee` and `objection_handling` are source-implied).
+
 ---
 
 ## 11. Worked Example (test vector)

--- a/qa-automation/AI-Scoring/backend/config/scoring/sales/overall_formula.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/sales/overall_formula.json
@@ -1,0 +1,34 @@
+{
+  "formula_id": "sales_v2",
+  "rubric_version": "sales_v2",
+  "supersedes": null,
+  "scale": { "min": 0, "max": 100 },
+  "normalization": {
+    "rating_1_5": { "type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0] },
+    "binary_yn": { "Y": 1.0, "N": 0.0 },
+    "na": "full_credit"
+  },
+  "sections": [
+    { "key": "greeting",           "label": "Greeting",                               "category": "Opening & Professionalism", "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "stay_type",          "label": "Personal or COHO Stay",                  "category": "Opening & Professionalism", "score_type": "binary_yn_na",  "weight": 4.0,  "trigger": null },
+    { "key": "move_reason",        "label": "Discover & Personalize the Move Reason", "category": "Discovery",                  "score_type": "rating_1_5_na", "weight": 15.0, "trigger": null },
+    { "key": "landing_intro",      "label": "First Time Hearing About Landing",       "category": "Discovery",                  "score_type": "binary_yn_na",  "weight": 6.0,  "trigger": null },
+    { "key": "timeline_housing",   "label": "Timeline & Housing Needs",               "category": "Discovery",                  "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "landing_guarantee",  "label": "Landing Guarantee (Tour Objection)",     "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 6.0,  "trigger": null },
+    { "key": "pricing",            "label": "Pricing Breakdown",                      "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "fit_confirmation",   "label": "Confirmation of Fit",                    "category": "Pitch & Value Selling",      "score_type": "rating_1_5_na", "weight": 5.0,  "trigger": null },
+    { "key": "objection_handling", "label": "Objection Handling",                     "category": "Objections & Closing",       "score_type": "rating_1_5_na", "weight": 8.0,  "trigger": null },
+    { "key": "urgency",            "label": "Urgency",                                "category": "Objections & Closing",       "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "follow_up",          "label": "Follow-up",                              "category": "Objections & Closing",       "score_type": "binary_yn_na",  "weight": 6.0,  "trigger": null },
+    { "key": "potential_booking",  "label": "Potential Booking (PB)",                 "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 4.0,  "trigger": null },
+    { "key": "notes_mc",           "label": "Detailed Notes in MC",                   "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "contact_shared",     "label": "Contact Information Shared",             "category": "Post-Call & Documentation",  "score_type": "binary_yn_na",  "weight": 5.0,  "trigger": null },
+    { "key": "client_experience",  "label": "Client Experience",                      "category": "Post-Call & Documentation",  "score_type": "rating_1_5_na", "weight": 10.0, "trigger": null }
+  ],
+  "rules": [],
+  "evaluation_order": ["weighted_sum"],
+  "triggers": {},
+  "external_signals": {},
+  "deprecated_sections": [],
+  "human_review_triggers": []
+}

--- a/qa-automation/AI-Scoring/backend/config/scoring/sales/rubric_v2.json
+++ b/qa-automation/AI-Scoring/backend/config/scoring/sales/rubric_v2.json
@@ -1,0 +1,310 @@
+{
+  "rubric_version": "sales_v2",
+  "sections": [
+    {
+      "id": "greeting",
+      "history_id": "greeting",
+      "name": "Greeting",
+      "section_number": 1,
+      "score_type": "yn",
+      "category": "Opening & Professionalism",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent say their name, mention 'Landing', and use or confirm the lead's name during the opening?",
+      "score_descriptions": {
+        "0": "The agent did not say their name, did not mention \"Landing,\" or failed to use or confirm the lead's name.",
+        "1": "The agent said their name, mentioned \"Landing,\" and used or confirmed the lead's name at some point during the opening."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies to every call that has an opening. NA only if the agent had no opening segment to evaluate (e.g., a mid-stream transfer continuation). Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "Award 1 only if ALL three conditions are satisfied; if any single condition is missing, award 0."
+    },
+    {
+      "id": "stay_type",
+      "history_id": "stay_type",
+      "name": "Personal or COHO Stay",
+      "section_number": 2,
+      "score_type": "yn",
+      "category": "Opening & Professionalism",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent ask whether this would be a personal or COHO stay at any point during the call?",
+      "score_descriptions": {
+        "0": "The agent did not ask whether this would be a personal or COHO stay at any point during the call.",
+        "1": "The agent asked whether the stay would be personal or COHO at some point during the call."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies to essentially all sales calls. NA only if stay type was already firmly established outside this call. Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "move_reason",
+      "history_id": "move_reason",
+      "name": "Discover & Personalize the Move Reason",
+      "section_number": 3,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Discovery",
+      "audio_dependent": true,
+      "rubric_question": "Did the agent discover the reason for the move, respond with empathy, and weave it through the call?",
+      "score_descriptions": {
+        "1": "The agent did not ask about the reason for the move, or asked but showed no empathy and never referenced it again.",
+        "2": "The agent asked about the move reason and acknowledged it briefly, but never used it again during the call.",
+        "3": "The agent asked, showed some empathy, and referenced the move reason once during the pitch, but the connection felt generic or forced.",
+        "4": "The agent asked, reacted with empathy, and tied the move reason into the pitch or objection handling in a natural way. Could have been more personalized.",
+        "5": "The agent asked about the move reason, responded with genuine empathy, and wove it meaningfully throughout the call — making the lead feel truly heard and understood."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Core discovery; applies to all sales calls. NA is not expected. Default: score 1-5.",
+      "confidence_cap": "medium",
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "landing_intro",
+      "history_id": "landing_intro",
+      "name": "First Time Hearing About Landing",
+      "section_number": 4,
+      "score_type": "yn",
+      "category": "Discovery",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent ask if this was the lead's first time hearing about Landing and explain what Landing does?",
+      "score_descriptions": {
+        "0": "The agent did not ask if this was the lead's first time hearing about Landing and did not explain what Landing does.",
+        "1": "The agent asked if it was the lead's first time hearing about Landing and provided an explanation to educate and uplift Landing's value."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies to most calls. NA only if the lead is a known/returning contact for whom a Landing introduction is clearly unnecessary. Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "timeline_housing",
+      "history_id": "timeline_housing",
+      "name": "Timeline & Housing Needs",
+      "section_number": 5,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Discovery",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent explore timeline and housing needs, probe for flexibility, and use it to recommend the right product?",
+      "score_descriptions": {
+        "1": "The agent did not ask about the lead's timeline or housing needs at any point.",
+        "2": "The agent asked about dates but did not probe housing needs or explore whether the timeline could be flexible.",
+        "3": "The agent asked about both timeline and housing needs but accepted the first answer without exploring flexibility or trying to maximize the stay length.",
+        "4": "The agent asked about timeline and housing needs and made a reasonable attempt to understand whether the stay could be extended, using it to recommend the right product.",
+        "5": "The agent thoroughly explored timeline and housing needs, probed for flexibility, and used that insight to recommend the best product while naturally maximizing the length of stay."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Core discovery; applies to all sales calls. NA is not expected. Default: score 1-5.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "landing_guarantee",
+      "history_id": "landing_guarantee",
+      "name": "Landing Guarantee (Tour Objection)",
+      "section_number": 6,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Pitch & Value Selling",
+      "audio_dependent": false,
+      "rubric_question": "After a tour request, did the agent explain the Landing Guarantee correctly, step-by-step, using the correct name?",
+      "score_descriptions": {
+        "1": "The lead asked for a tour and the agent did not mention the Landing Guarantee or failed to explain why tours are not offered.",
+        "2": "The agent mentioned the Landing Guarantee but the explanation was incomplete or used the wrong name.",
+        "3": "The agent explained the Landing Guarantee correctly but the delivery felt scripted and did not fully reassure the lead.",
+        "4": "The agent explained the Landing Guarantee correctly and step-by-step, addressing the tour objection clearly. Could have been more confident or reassuring.",
+        "5": "The agent handled the tour objection confidently, explained the Landing Guarantee step-by-step using the correct name, and left the lead feeling reassured about booking without a tour."
+      },
+      "na_applicable": true,
+      "na_applies_when": "NA when the lead never requests a tour and no tour objection arises.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "IMPORTANT: if a tour WAS requested but handled poorly, that is a low score (1), NOT NA."
+    },
+    {
+      "id": "pricing",
+      "history_id": "pricing",
+      "name": "Pricing Breakdown",
+      "section_number": 7,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Pitch & Value Selling",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent deliver a clear, confident pricing breakdown tailored to the lead's situation?",
+      "score_descriptions": {
+        "1": "The agent did not offer a pricing breakdown or provided confusing, inaccurate pricing information.",
+        "2": "The agent gave a basic price but did not tailor the breakdown to the lead's situation or explain the components clearly.",
+        "3": "The agent provided a reasonable pricing breakdown but it felt generic and did not fully account for the lead's specific situation or needs.",
+        "4": "The agent offered a clear pricing breakdown tailored to the lead's situation. Could have been more confident or added more context to justify the value.",
+        "5": "The agent delivered a clear, confident, and well-tailored pricing breakdown that matched the lead's situation and made the value easy to understand."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies whenever the call reaches a pitch. NA only if the call ended before pricing was appropriate (e.g., the lead was disqualified during discovery). Default: score 1-5.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "fit_confirmation",
+      "history_id": "fit_confirmation",
+      "name": "Confirmation of Fit",
+      "section_number": 8,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Pitch & Value Selling",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent ask whether the options presented felt like a good fit and use the answer to guide next steps?",
+      "score_descriptions": {
+        "1": "The agent never asked whether the options presented felt like a good fit for the lead.",
+        "2": "The agent asked a vague or indirect confirmation question that did not clearly gauge the lead's interest or fit.",
+        "3": "The agent asked a confirmation-of-fit question but it felt like a formality rather than a genuine check-in with the lead.",
+        "4": "The agent asked a clear confirmation-of-fit question and used the response to guide the next steps of the conversation.",
+        "5": "The agent asked a natural, well-timed confirmation-of-fit question that felt conversational, and used the lead's response to strengthen the pitch or move toward closing."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies when options/products were presented. NA only if the call ended before any options were presented. Default: score 1-5.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "objection_handling",
+      "history_id": "objection_handling",
+      "name": "Objection Handling",
+      "section_number": 9,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Objections & Closing",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent distinguish real concerns from smokescreens, resolve them with Landing's benefits, and confirm next steps?",
+      "score_descriptions": {
+        "1": "The agent failed to address objections or gave up too easily without attempting to resolve concerns.",
+        "2": "The agent attempted to handle objections but could not distinguish real concerns from smokescreens, and the responses felt weak or scripted.",
+        "3": "The agent handled objections adequately but relied on generic responses rather than tailoring them to the lead's specific situation.",
+        "4": "The agent handled objections well, distinguished real concerns from smokescreens, and resolved most of them using Landing's benefits. Could have confirmed next steps more clearly.",
+        "5": "The agent confidently handled all objections, identified real concerns vs. smokescreens, resolved them with Landing's benefits, and confirmed clear next steps with the lead."
+      },
+      "na_applicable": true,
+      "na_applies_when": "NA when the lead raises no objections at all.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "IMPORTANT: if objections arose but were handled poorly, that is a low score (1), NOT NA."
+    },
+    {
+      "id": "urgency",
+      "history_id": "urgency",
+      "name": "Urgency",
+      "section_number": 10,
+      "score_type": "yn",
+      "category": "Objections & Closing",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent mention that prices can change and/or that the apartment could be taken online?",
+      "score_descriptions": {
+        "0": "The agent did not mention that prices can change or that the apartment could be taken by someone else.",
+        "1": "The agent mentioned at some point that prices can change and/or that the apartment could be taken online."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies whenever the call reaches a pitch/close. NA only if the call ended before any close attempt was appropriate. Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "follow_up",
+      "history_id": "follow_up",
+      "name": "Follow-up",
+      "section_number": 11,
+      "score_type": "yn",
+      "category": "Objections & Closing",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent set up a follow-up with a specific medium and a specific time before ending the call?",
+      "score_descriptions": {
+        "0": "The agent did not set up a follow-up with a specific medium and time before ending the call.",
+        "1": "The agent set up a follow-up with a specific medium and a specific time before ending the call."
+      },
+      "na_applicable": true,
+      "na_applies_when": "NA when a follow-up is genuinely unnecessary (e.g., the lead booked on the call, or gave a definitive no). Otherwise score 0 or 1. (Proposed — confirm with Sales Management.)",
+      "confidence_cap": null,
+      "special_reasoning_instructions": null
+    },
+    {
+      "id": "potential_booking",
+      "history_id": "potential_booking",
+      "name": "Potential Booking (PB)",
+      "section_number": 12,
+      "score_type": "manual_yn",
+      "category": "Post-Call & Documentation",
+      "audio_dependent": false,
+      "rubric_question": null,
+      "score_descriptions": {
+        "0": "No PB with a name was created after the call.",
+        "1": "A PB with a name was created after the call."
+      },
+      "na_applicable": true,
+      "na_applies_when": "NA when there is no viable lead to create a PB for (e.g., wrong number, spam, non-prospect). Otherwise score 0 or 1. (Proposed — confirm with Sales Management.)",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "Post-call artifact in the PB system — NOT observable from the recording; analyst-filled (decision 2026-07-06, integrations may automate in Aug-Sept)."
+    },
+    {
+      "id": "notes_mc",
+      "history_id": "notes_mc",
+      "name": "Detailed Notes in MC",
+      "section_number": 13,
+      "score_type": "manual_yn",
+      "category": "Post-Call & Documentation",
+      "audio_dependent": false,
+      "rubric_question": null,
+      "score_descriptions": {
+        "0": "The agent did not leave notes in MC or the notes lacked sufficient context to be useful for follow-up.",
+        "1": "The agent left detailed notes in MC with enough context to understand the call and support the next interaction."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies to every genuine call. NA is not expected. Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "Post-call artifact in MC — NOT observable from the recording; analyst-filled (decision 2026-07-06)."
+    },
+    {
+      "id": "contact_shared",
+      "history_id": "contact_shared",
+      "name": "Contact Information Shared",
+      "section_number": 14,
+      "score_type": "yn",
+      "category": "Post-Call & Documentation",
+      "audio_dependent": false,
+      "rubric_question": "Did the agent send their contact information to the lead at some point during the interaction?",
+      "score_descriptions": {
+        "0": "The agent did not send their contact information to the lead during the call.",
+        "1": "The agent sent their contact information to the lead at some point during the interaction."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Applies to most calls. NA only if the interaction was not a real lead or ended immediately (e.g., wrong number). Default: score 0 or 1.",
+      "confidence_cap": null,
+      "special_reasoning_instructions": "Judge from verbal evidence in the call (e.g., the agent saying they are sending/texting their info)."
+    },
+    {
+      "id": "client_experience",
+      "history_id": "client_experience",
+      "name": "Client Experience",
+      "section_number": 15,
+      "score_type": "numeric",
+      "score_range": [1, 5],
+      "category": "Post-Call & Documentation",
+      "audio_dependent": true,
+      "rubric_question": "Across the whole call, did the lead feel genuinely heard and cared for rather than processed through a script?",
+      "score_descriptions": {
+        "1": "The call felt cold and transactional. The agent followed a script without showing genuine interest in the lead's situation.",
+        "2": "The agent showed occasional warmth but the overall experience felt scripted and the lead's concerns did not feel genuinely acknowledged.",
+        "3": "The agent was polite and professional but the interaction still felt like a sales call rather than a genuine conversation. Some moments of connection but inconsistent.",
+        "4": "The agent made the lead feel heard for most of the call, maintained a warm and helpful tone, and the experience felt more like a conversation than a pitch.",
+        "5": "The lead felt genuinely heard and cared for throughout the entire call. The agent was warm, attentive, and natural — the interaction never felt scripted or transactional."
+      },
+      "na_applicable": true,
+      "na_applies_when": "Call-wide measure; applies to every real conversation. NA is not expected. Default: score 1-5.",
+      "confidence_cap": "medium",
+      "special_reasoning_instructions": null
+    }
+  ],
+  "scoring_prompt": {
+    "system_prompt_template": "You are a QA analyst for the Sales team at {company}.\nYou score a single recorded Sales call against a fixed rubric. You judge only what the agent actually did, based on evidence in the call transcript/recording, and you return a structured score for every section.\n\nSCORING PROTOCOL:\n- Score each section independently and only from evidence in the transcript/recording. Do not assume facts that were not said or done.\n- For each section, pick the single level whose description best matches what actually happened. If the call falls between two levels, choose the LOWER level unless every condition of the higher level is fully met.\n- Binary sections: award 1 (Yes) only if ALL conditions in the '1' description are satisfied. If any single condition is missing, award 0 (No).\n- Scaled sections: return an integer 1-5 matching the level descriptions.\n- NA means the criterion was genuinely NOT APPLICABLE to this call — each section states when NA applies. Downstream, NA awards FULL credit, so it is favorable to the agent. Apply NA strictly: never use it to avoid a hard judgment, and never use it when evidence is merely ambiguous or missing. If the criterion applied but the agent performed poorly or you cannot find evidence they did it, score it on the merits (usually the lowest level) — NOT NA.\n- Provide short supporting evidence (a brief quote or paraphrase with an approximate timestamp) inside the reasoning for every non-NA score. For an NA score, state why the criterion did not apply.\n\nCRITICAL OUTPUT RULES:\n- Return ONLY a valid JSON object. No markdown fences, no prose, no explanations outside the JSON.\n- All string values must have apostrophes and internal quotes escaped.\n- Never use raw newlines inside string values — use a space instead.\n- The JSON must be parseable by Python json.loads() without modification.\n- Use the Second person (\"you\") when referring to the rep in the reasoning AND feedback sections, as if you are directly addressing them with a personal tone, DO NOT use the Third person (\"they/them\") anywhere in your outputs.",
+    "confidence_levels_note": "- \"high\": Clear evidence in audio, no ambiguity\n- \"medium\": Reasonable inference, some ambiguity or audio-dependent nuance\n- \"low\": Insufficient signal, heavy guessing required",
+    "sop_sections": ["landing_guarantee", "pricing"],
+    "long_call_focus_sections": [],
+    "audio_dependent_sections": ["move_reason", "client_experience"]
+  }
+}

--- a/qa-automation/AI-Scoring/backend/models/formula.py
+++ b/qa-automation/AI-Scoring/backend/models/formula.py
@@ -455,6 +455,12 @@ class RubricSection(BaseModel):
     rubric_question: Optional[str] = None
     score_descriptions: Optional[dict[str, str]] = None
     na_applicable: bool = False
+    na_applies_when: Optional[str] = None
+    """Scorer-facing policy: when NA is legitimately earned (sales_v2 rubric
+    introduced this — NA grants full credit downstream, so it must be strict).
+    Additive per §3.8 point 5; absent on older archived rubrics."""
+    category: Optional[str] = None
+    """Reporting group (Sales carries the PDF's category; B5 sign-off)."""
     confidence_cap: Optional[str] = None
     special_reasoning_instructions: Optional[str] = None
     auto_value: Optional[str] = None

--- a/qa-automation/AI-Scoring/backend/scripts/ship_rubric.py
+++ b/qa-automation/AI-Scoring/backend/scripts/ship_rubric.py
@@ -29,12 +29,21 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
 
 from backend.config.team_config import get_team_config  # noqa: E402
+from backend.models.formula import Rubric  # noqa: E402
 from backend.services.version_ship import ship_rubric  # noqa: E402
 
 
-async def _run(team_id: str, dry_run: bool) -> int:
-    config = get_team_config(team_id)  # validates the rubric shape on load
-    rubric = config.rubric
+async def _run(team_id: str, dry_run: bool, file: str | None = None) -> int:
+    if file:
+        # Ship a staged rubric file (e.g. config/scoring/sales/rubric_v2.json)
+        # BEFORE the runtime team config migrates to it — the sales_v2 flow:
+        # archive the rubric first, the formula ships at the next restart,
+        # the team-config/pipeline swap follows in the flip bundle.
+        import json as _json
+        rubric = Rubric.model_validate(_json.loads(Path(file).read_text(encoding="utf-8")))
+    else:
+        config = get_team_config(team_id)  # validates the rubric shape on load
+        rubric = config.rubric
     print(f"team={team_id} rubric_version={rubric.rubric_version} "
           f"sections={len(rubric.sections)}")
 
@@ -61,9 +70,10 @@ async def _run(team_id: str, dry_run: bool) -> int:
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--team", required=True)
+    ap.add_argument("--file", help="Ship a staged rubric JSON file instead of the team config's rubric")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
-    raise SystemExit(asyncio.run(_run(args.team, args.dry_run)))
+    raise SystemExit(asyncio.run(_run(args.team, args.dry_run, args.file)))
 
 
 if __name__ == "__main__":

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -511,8 +511,16 @@ class TestHumanReviewTrigger:
         assert not eval_store.human_review_trigger_fired(ms_formula, exactly_three.sections)
 
     def test_no_formula_never_fires(self):
-        assert eval_store._active_formula("sales") is None  # pre-sales_v2
         assert not eval_store.human_review_trigger_fired(None, _scorecard(None).sections)
+
+    def test_sales_v2_has_no_triggers(self):
+        """The staged sales_v2 formula file exists but declares no
+        human_review_triggers (B7 sign-off) — the gate never fires."""
+        eval_store._active_formula.cache_clear()
+        sales = eval_store._active_formula("sales")
+        assert sales is not None and sales.formula_id == "sales_v2"
+        assert sales.human_review_triggers == []
+        assert not eval_store.human_review_trigger_fired(sales, _scorecard(None).sections)
 
     def test_non_numeric_sections_never_trigger(self, ms_formula):
         na_only = _scorecard(None, sections=[

--- a/qa-automation/AI-Scoring/tests/test_formula_models.py
+++ b/qa-automation/AI-Scoring/tests/test_formula_models.py
@@ -94,47 +94,19 @@ class TestMemberSupportShippedConfig:
         Formula.model_validate(dumped)
 
 
-class TestSalesCanonicalConfig:
-    """Sales §8 canonical config parses cleanly even though the JSON file
-    hasn't been regenerated yet (blocked on §10 sign-off)."""
+class TestSalesShippedConfig:
+    """The shipped sales_v2 formula file (config/scoring/sales/) — the
+    signed §8 shape. Ships via the startup ceremony once the sales_v2
+    RUBRIC is archived."""
 
     @pytest.fixture(scope="class")
     def sales_formula(self) -> Formula:
-        return Formula.model_validate({
-            "formula_id": "sales_v2",
-            "rubric_version": "sales_v2",
-            "supersedes": None,
-            "scale": {"min": 0, "max": 100},
-            "normalization": {
-                "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
-                "binary_yn": {"Y": 1.0, "N": 0.0},
-                "na": "full_credit",
-            },
-            "sections": [
-                {"key": "greeting",           "label": "Greeting",              "category": "Opening",     "score_type": "binary_yn_na",  "weight": 5.0},
-                {"key": "stay_type",          "label": "Personal or COHO Stay", "category": "Opening",     "score_type": "binary_yn_na",  "weight": 4.0},
-                {"key": "move_reason",        "label": "Move Reason",           "category": "Discovery",   "score_type": "rating_1_5_na", "weight": 15.0},
-                {"key": "landing_intro",      "label": "Landing Intro",         "category": "Discovery",   "score_type": "binary_yn_na",  "weight": 6.0},
-                {"key": "timeline_housing",   "label": "Timeline & Housing",    "category": "Discovery",   "score_type": "rating_1_5_na", "weight": 8.0},
-                {"key": "landing_guarantee",  "label": "Landing Guarantee",     "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 6.0},
-                {"key": "pricing",            "label": "Pricing Breakdown",     "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 8.0},
-                {"key": "fit_confirmation",   "label": "Confirmation of Fit",   "category": "Pitch",       "score_type": "rating_1_5_na", "weight": 5.0},
-                {"key": "objection_handling", "label": "Objection Handling",    "category": "Objections",  "score_type": "rating_1_5_na", "weight": 8.0},
-                {"key": "urgency",            "label": "Urgency",               "category": "Objections",  "score_type": "binary_yn_na",  "weight": 5.0},
-                {"key": "follow_up",          "label": "Follow-up",             "category": "Objections",  "score_type": "binary_yn_na",  "weight": 6.0},
-                {"key": "potential_booking",  "label": "Potential Booking",     "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 4.0},
-                {"key": "notes_mc",           "label": "Detailed Notes in MC",  "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 5.0},
-                {"key": "contact_shared",     "label": "Contact Shared",        "category": "Post-Call",   "score_type": "binary_yn_na",  "weight": 5.0},
-                {"key": "client_experience",  "label": "Client Experience",     "category": "Post-Call",   "score_type": "rating_1_5_na", "weight": 10.0},
-            ],
-            "rules": [],
-            "evaluation_order": [WEIGHTED_SUM],
-            "triggers": {},
-            "external_signals": {},
-            "deprecated_sections": [],
-        })
+        path = _REPO_ROOT / "backend" / "config" / "scoring" / "sales" / "overall_formula.json"
+        return Formula.model_validate(json.loads(path.read_text(encoding="utf-8")))
 
     def test_loads_fifteen_sections(self, sales_formula):
+        assert sales_formula.formula_id == "sales_v2"
+        assert sales_formula.rubric_version == "sales_v2"
         assert len(sales_formula.sections) == 15
 
     def test_full_credit_na_policy(self, sales_formula):
@@ -149,6 +121,10 @@ class TestSalesCanonicalConfig:
 
     def test_weights_sum_to_hundred(self, sales_formula):
         assert sum(s.weight for s in sales_formula.sections) == pytest.approx(100.0)
+
+    def test_categories_persisted(self, sales_formula):
+        """B5 sign-off: category kept for reporting."""
+        assert all(s.category for s in sales_formula.sections)
 
 
 # ---------------------------------------------------------------------------
@@ -575,3 +551,62 @@ class TestRecordingUrls:
             "screen": ["https://x/s.mp4"],
         })
         assert r.audio[0].endswith("a.mp3")
+
+
+class TestSalesV2Rubric:
+    """The staged sales_v2 rubric (config/scoring/sales/rubric_v2.json) —
+    built 2026-07-06 from the QA_Scoring_Guide-derived scorer prose. Ships
+    via `ship_rubric --team sales --file ...` ahead of the pipeline flip."""
+
+    @pytest.fixture(scope="class")
+    def sales_rubric(self) -> Rubric:
+        path = _REPO_ROOT / "backend" / "config" / "scoring" / "sales" / "rubric_v2.json"
+        return Rubric.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    @pytest.fixture(scope="class")
+    def sales_formula(self) -> Formula:
+        path = _REPO_ROOT / "backend" / "config" / "scoring" / "sales" / "overall_formula.json"
+        return Formula.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    def test_fifteen_sections_with_na_policy_prose(self, sales_rubric):
+        assert sales_rubric.rubric_version == "sales_v2"
+        assert len(sales_rubric.sections) == 15
+        # every section carries the strict-NA policy text (new field)
+        assert all(s.na_applies_when for s in sales_rubric.sections)
+        assert all(s.na_applicable for s in sales_rubric.sections)
+        assert all(s.category for s in sales_rubric.sections)
+
+    def test_cross_validates_against_sales_v2_formula(self, sales_formula, sales_rubric):
+        """§3.19.3 — the pairing compute_overall_score() will load."""
+        assert sales_formula.rubric_version == sales_rubric.rubric_version
+        validate_formula_against_rubric(sales_formula, sales_rubric)
+
+    def test_post_call_sections_are_analyst_filled(self, sales_rubric):
+        """Decision 2026-07-06: potential_booking + notes_mc are post-call
+        artifacts the AI cannot observe — manual_yn, excluded from the AI
+        prompt; contact_shared stays AI-scored (verbally observable)."""
+        by_id = {s.id: s for s in sales_rubric.sections}
+        assert by_id["potential_booking"].score_type == "manual_yn"
+        assert by_id["notes_mc"].score_type == "manual_yn"
+        assert by_id["contact_shared"].score_type == "yn"
+
+    def test_prompt_config_decisions(self, sales_rubric):
+        prompt = sales_rubric.scoring_prompt
+        assert prompt.audio_dependent_sections == ["move_reason", "client_experience"]
+        assert prompt.sop_sections == ["landing_guarantee", "pricing"]
+        # audio-dependent sections carry the medium confidence cap like MS
+        by_id = {s.id: s for s in sales_rubric.sections}
+        assert by_id["move_reason"].confidence_cap == "medium"
+        assert by_id["client_experience"].confidence_cap == "medium"
+
+    def test_strict_na_guards_on_source_implied_sections(self, sales_rubric):
+        """landing_guarantee / objection_handling: poorly-handled is a 1,
+        never NA — the anti-gaming guard for full-credit NA."""
+        by_id = {s.id: s for s in sales_rubric.sections}
+        for key in ("landing_guarantee", "objection_handling"):
+            assert "NOT NA" in by_id[key].special_reasoning_instructions
+
+    def test_new_rubric_section_fields_round_trip(self, sales_rubric):
+        dumped = sales_rubric.model_dump(by_alias=True)
+        again = Rubric.model_validate(dumped)
+        assert again == sales_rubric

--- a/qa-automation/AI-Scoring/tests/test_rule_engine.py
+++ b/qa-automation/AI-Scoring/tests/test_rule_engine.py
@@ -62,40 +62,9 @@ def ms_answers(**overrides):
 
 @pytest.fixture(scope="module")
 def sales_formula() -> Formula:
-    """Sales §8 canonical config (inline until §10 sign-off ships the file)."""
-    return Formula.model_validate({
-        "formula_id": "sales_v2",
-        "rubric_version": "sales_v2",
-        "supersedes": None,
-        "scale": {"min": 0, "max": 100},
-        "normalization": {
-            "rating_1_5": {"type": "linear", "input_min": 1, "input_max": 5, "output": [0.0, 1.0]},
-            "binary_yn": {"Y": 1.0, "N": 0.0},
-            "na": "full_credit",
-        },
-        "sections": [
-            {"key": "greeting",           "label": "Greeting",              "score_type": "binary_yn_na",  "weight": 5.0},
-            {"key": "stay_type",          "label": "Personal or COHO Stay", "score_type": "binary_yn_na",  "weight": 4.0},
-            {"key": "move_reason",        "label": "Move Reason",           "score_type": "rating_1_5_na", "weight": 15.0},
-            {"key": "landing_intro",      "label": "Landing Intro",         "score_type": "binary_yn_na",  "weight": 6.0},
-            {"key": "timeline_housing",   "label": "Timeline & Housing",    "score_type": "rating_1_5_na", "weight": 8.0},
-            {"key": "landing_guarantee",  "label": "Landing Guarantee",     "score_type": "rating_1_5_na", "weight": 6.0},
-            {"key": "pricing",            "label": "Pricing Breakdown",     "score_type": "rating_1_5_na", "weight": 8.0},
-            {"key": "fit_confirmation",   "label": "Confirmation of Fit",   "score_type": "rating_1_5_na", "weight": 5.0},
-            {"key": "objection_handling", "label": "Objection Handling",    "score_type": "rating_1_5_na", "weight": 8.0},
-            {"key": "urgency",            "label": "Urgency",               "score_type": "binary_yn_na",  "weight": 5.0},
-            {"key": "follow_up",          "label": "Follow-up",             "score_type": "binary_yn_na",  "weight": 6.0},
-            {"key": "potential_booking",  "label": "Potential Booking",     "score_type": "binary_yn_na",  "weight": 4.0},
-            {"key": "notes_mc",           "label": "Detailed Notes in MC",  "score_type": "binary_yn_na",  "weight": 5.0},
-            {"key": "contact_shared",     "label": "Contact Shared",        "score_type": "binary_yn_na",  "weight": 5.0},
-            {"key": "client_experience",  "label": "Client Experience",     "score_type": "rating_1_5_na", "weight": 10.0},
-        ],
-        "rules": [],
-        "evaluation_order": [WEIGHTED_SUM],
-        "triggers": {},
-        "external_signals": {},
-        "deprecated_sections": [],
-    })
+    """The shipped sales_v2 formula (signed §8 shape, plain weighted sum)."""
+    path = _REPO_ROOT / "backend" / "config" / "scoring" / "sales" / "overall_formula.json"
+    return Formula.model_validate(json.loads(path.read_text(encoding="utf-8")))
 
 
 def _formula(**overrides) -> Formula:


### PR DESCRIPTION
## Summary

Slice 4's first bundle: the `sales_v2` **formula** (signed §8 shape — 15 sections with categories, `(r−1)/4`, NA full-credit, `evaluation_order: [weighted_sum]`) and the **archive rubric** built from your scorer prose, staged at `config/scoring/sales/rubric_v2.json`.

### The prose review, encoded

- **`potential_booking` + `notes_mc` → `manual_yn`** (your call): post-call artifacts in the PB system / MC that the AI cannot observe from the recording — the exact rubric-vs-reality mismatch class that produced PR #87, caught at build time instead. `contact_shared` stays AI-scored (verbally observable).
- **Per-section `confidence` added** to the scorer contract, matching MS — DB column, dashboards, and the Aug-Sept Plan-B routing all get their signal. `scored_at` dropped from the model output (the pipeline stamps real clocks).
- **Prompt config:** `audio_dependent = [move_reason, client_experience]` with medium confidence caps (tone/empathy judgments), `sop_sections = [landing_guarantee, pricing]`.
- **Ids corrected `sales_v1` → `sales_v2`** per B3 (`sales_v1` is immutably the legacy 19-section rubric).
- The source's **strict-NA guards preserved** (`"handled poorly is a 1, NOT NA"`) as `special_reasoning_instructions` — the anti-gaming protection full-credit NA needs.
- New `RubricSection` fields: **`na_applies_when`** (the strict-NA policy prose, per section) and **`category`** (B5) — additive, archive-compatible.

### The ceremony (when you're ready)

```
python -m backend.scripts.ship_rubric --team sales --file backend/config/scoring/sales/rubric_v2.json
```
then restart → the formula ships itself. Until the rubric ships, each deploy logs the ship-the-rubric-first reminder (by design). **Note:** archiving the rubric/formula does NOT flip Sales — `scoring_owner` stays `'sheets'` and the live 19-section pipeline is untouched.

### Pre-flip checklist (spec §10a)

1. Sales Mgmt confirms the 13 default `na_applies_when` texts (only landing_guarantee/objection_handling are source-implied).
2. The flip bundle proper: `sales.json` runtime swap (19→15 + prompt integration), Analyst_History/FR-AI tab restructure, `Config.js` regen, your GAS deploy.

## Test plan

- [x] 6 new rubric tests: 15 sections with NA prose, §3.19.3 cross-validation against the formula, manual/AI section decisions, prompt-config decisions, strict-NA guards, new-field round-trip.
- [x] Sales fixtures de-duped against the shipped files (inline copies removed).
- [x] Full suite: **463 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)