### PR TITLE
fix(qa-automation): manual-review gate — unscored manual sections block auto-finalize

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -134,7 +134,7 @@ async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
     color the button (CutoverDesign §5)."""
     flagged = eval_store.human_review_trigger_fired(
         eval_store._active_formula(team_id), scorecard.sections
-    )
+    ) or eval_store.requires_analyst_review(config)
     if flagged:
         job["state"] = "draft"
         job["scoring_status"] = "flagged_human_review"
@@ -610,6 +610,16 @@ async def approve_scorecard(
         # DB errors are hard errors (§7.3 Phase C).
         sc = job["scorecard"]
         evaluator_email = sc.get("manager_email", "")
+        # Backend guard behind the frontend's "Score Required" gate: manual
+        # sections without a formula na_default must carry real scores —
+        # NA would ride into full credit (the 2026-07-06 Sales find).
+        unscored = eval_store.missing_manual_scores(config, approval.sections)
+        if unscored:
+            job["status"] = "complete"
+            raise HTTPException(
+                status_code=422,
+                detail=f"Manual sections require scores before approval: {unscored}",
+            )
         try:
             evaluation_id = await record_approval(
                 config,

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -95,6 +95,43 @@ def _active_formula(team_id: str) -> Optional[Formula]:
     return Formula.model_validate(json.loads(path.read_text(encoding="utf-8")))
 
 
+def requires_analyst_review(config: "TeamConfig") -> bool:
+    """True when the team's rubric has manual sections whose formula entry
+    lacks `na_default` — those scores MUST come from an analyst, so the eval
+    can never auto-finalize (production find 2026-07-06: Sales'
+    potential_booking/notes_mc rode their NA-default draft rows into FULL
+    credit under the full_credit NA policy). MS is unaffected:
+    human_review_required declares na_default=true — NA is its designed
+    auto value."""
+    formula = _active_formula(config.team_id)
+    if formula is None:
+        return False
+    na_defaults = {s.key for s in formula.sections if s.na_default}
+    return any(s.id not in na_defaults for s in config.manual_sections)
+
+
+def missing_manual_scores(config: "TeamConfig", approved_sections: list[Any]) -> list[str]:
+    """Manual sections (without formula na_default) still unscored in an
+    approval payload — the backend guard behind the frontend's
+    'Score Required' gate. NA does not count as scored here: it would ride
+    into full credit exactly like the auto-flow bug this closes."""
+    formula = _active_formula(config.team_id)
+    na_defaults = (
+        {s.key for s in formula.sections if s.na_default} if formula else set()
+    )
+    by_id = {s.id: s for s in approved_sections}
+    missing = []
+    for section in config.manual_sections:
+        if section.id in na_defaults:
+            continue
+        payload = by_id.get(section.id)
+        if payload is None or (
+            payload.score is None and payload.yn_value in (None, "", "NA")
+        ):
+            missing.append(section.id)
+    return missing
+
+
 def human_review_trigger_fired(formula: Optional[Formula], sections: list[Any]) -> bool:
     """§3.14: any configured section's numeric score ≤ max_score_to_trigger.
     `sections` is any list with .id and .score (scorecard or approval
@@ -122,9 +159,11 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
     duration_ms = int(scorecard.duration_ms) if scorecard.duration_ms else None
     # §3.14 gate beats long-call telemetry when both apply — the human-review
     # pause is load-bearing post-flip; flagged_long_call is informational.
+    # Manual-section teams (Sales) flag on EVERY call: analyst scores are
+    # required before the eval may finalize.
     flagged_review = human_review_trigger_fired(
         _active_formula(config.team_id), scorecard.sections
-    )
+    ) or requires_analyst_review(config)
     if flagged_review:
         scoring_status = "flagged_human_review"
     elif scorecard.flagged_long_call:
@@ -689,5 +728,7 @@ __all__ = [
     "build_draft_sections",
     "build_approval_sections",
     "human_review_trigger_fired",
+    "requires_analyst_review",
+    "missing_manual_scores",
     "close_pool",
 ]

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -808,3 +808,69 @@ class TestStampAndFinalize:
         monkeypatch.setattr(eval_store, "_get_pool", no_pool)
         with pytest.raises(RuntimeError, match="no DATABASE_URL"):
             await eval_store.stamp_and_finalize(1, ms_config, "x@y.com")
+
+
+# ---------------------------------------------------------------------------
+# Sales manual-review gate (production find 2026-07-06)
+# ---------------------------------------------------------------------------
+
+class TestSalesManualReviewGate:
+    """Sales' potential_booking/notes_mc are analyst-scored with NO formula
+    na_default — under full_credit NA their unscored draft rows rode into
+    9 free points and the call auto-finalized. Every Sales call now pauses
+    for review; approval refuses unscored manual sections."""
+
+    @pytest.fixture(scope="class")
+    def sales_config(self):
+        return load_test_config("sales")
+
+    def test_sales_requires_analyst_review(self, sales_config):
+        eval_store._active_formula.cache_clear()
+        assert eval_store.requires_analyst_review(sales_config) is True
+
+    def test_ms_does_not_require_analyst_review(self, ms_config):
+        """MS's only manual section (human_review_required) declares
+        na_default=true — NA is its designed auto value."""
+        eval_store._active_formula.cache_clear()
+        assert eval_store.requires_analyst_review(ms_config) is False
+
+    def test_sales_draft_row_flags_for_review(self, sales_config):
+        sc = ScorecardWithMeta(
+            sections=[], key_strengths="", opportunities="",
+            model="gemini-2.5-flash",
+        )
+        row = build_draft_row(sc, sales_config)
+        assert row["scoring_status"] == "flagged_human_review"
+        assert row["human_review_required_at"] is not None
+
+    def test_missing_manual_scores_lists_unscored(self, sales_config):
+        # AI payload never carries the manual sections
+        missing = eval_store.missing_manual_scores(sales_config, [])
+        assert missing == ["potential_booking", "notes_mc"]
+
+    def test_na_counts_as_unscored(self, sales_config):
+        payload = [
+            ScorecardSection(id="potential_booking", name="PB", score=None,
+                             yn_value="NA", score_type="manual_yn",
+                             confidence="high", reasoning=""),
+        ]
+        missing = eval_store.missing_manual_scores(sales_config, payload)
+        assert "potential_booking" in missing
+        assert "notes_mc" in missing
+
+    def test_scored_manual_sections_clear_the_guard(self, sales_config):
+        payload = [
+            ScorecardSection(id="potential_booking", name="PB", score=None,
+                             yn_value="Y", score_type="manual_yn",
+                             confidence="high", reasoning="PB created for Henry"),
+            ScorecardSection(id="notes_mc", name="Notes", score=None,
+                             yn_value="N", score_type="manual_yn",
+                             confidence="high", reasoning="no notes found"),
+        ]
+        assert eval_store.missing_manual_scores(sales_config, payload) == []
+
+    def test_ms_hrr_na_default_never_blocks(self, ms_config):
+        """MS approvals with hrr still at NA must NOT be blocked — NA is the
+        designed state (only reviewer-flagged calls score it)."""
+        eval_store._active_formula.cache_clear()
+        assert eval_store.missing_manual_scores(ms_config, []) == []


### PR DESCRIPTION
## Summary

Your smoke-call find, closed with a general rule rather than a Sales special case.

**The mechanism behind the 61:** `potential_booking`/`notes_mc` got their Stage-1 NA-default rows, and Sales' signed **full-credit NA** policy awarded them their full 9 points — unscored sections silently *passed*. MS never hits this because `human_review_required` declares `na_default: true` in the formula: NA is its *designed* auto value.

**The rule:** an eval cannot auto-finalize while a manual section **without** a formula `na_default` is unscored.

- `requires_analyst_review(config)` — true when any manual rubric section lacks `na_default` in the active formula. Sales: true on **every call** (matching the team's review-first design — no special flag, the rubric itself says so). Stage 1 pauses the draft as `flagged_human_review`, the lookup shows the red Open Editor, the analyst fills the "Score Required" fields, approves, and the engine computes with real answers.
- `missing_manual_scores(config, payload)` — the backend guard behind the frontend's gate: approval **422s** if a required manual section is unscored *or NA* (NA would ride into full credit exactly like the bug).

## Recovery for the smoke call

After deploy, **re-score the Diego Loera call from lookup** — it flags this time; fill PB (looks like `N`, no PB was mentioned) and notes, approve. The row upserts by dialpad link, the Analyst_History projection overwrites in place, and a corrected Gmail fires. The 61 becomes its true score.

## Test plan

- [x] 7 new tests: per-team gate outcomes (Sales true / MS false, keyed on `na_default` not team id), Sales draft rows flag at Stage 1, the guard lists unscored sections, treats NA as unscored, clears with real Y/N scores, and never blocks MS's NA-default hrr.
- [x] Full suite: **470 passed, 6 skipped, 3 xfailed** (pre-existing date-flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)