### PR TITLE
fix(qa-automation): qa-schema read path in db_provider + layout-driven backfill_history

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/db_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/db_provider.py
@@ -1,19 +1,73 @@
-"""PostgreSQL data provider — optional accelerator."""
+"""PostgreSQL data provider — the qa.* read path for the post-backfill flip.
+
+Mirrors SheetsProvider's EvaluationRecord contract exactly (sections keyed
+by history_id, the manager_email/improvements naming bridges, tz-aware UTC
+timestamps) so the read-path flip is a provider swap inside
+``data_provider.get_provider``, not a shape change. Until that flip, the
+factory still returns SheetsProvider and nothing instantiates this class.
+
+Row membership matches Analyst_History: only ``state='finalized'``
+evaluations exist in the sheet (Stage 4 writes on finalize), so only those
+are served here.
+"""
+
+from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
+import time
+from datetime import datetime, timedelta, timezone
+
+from backend.config.team_config import TeamConfig
 from backend.models.dashboard import EvaluationRecord, SectionScore
 from backend.services.data_provider import DataProvider
+from backend.services.history_service import _extract_eval_id
+from backend.services.sheets_service import YN_DISPLAY
+
+# Same 5-minute freshness window as history_service's sheet cache.
+_ROSTER_TTL_SECONDS = 300
+
+_EVAL_COLUMNS = (
+    "id, agent_name_raw, agent_email, evaluator_email, "
+    "COALESCE(call_connected_at, created_at) AS ts, "
+    "overall_score, dialpad_link, key_strengths, opportunities, "
+    "call_summary, caller_name, caller_phone, source"
+)
+
+
+def _display_score(section_row) -> str:
+    """Render a qa.evaluation_sections row the way the sheet cell reads.
+
+    The Stage-4 projection writes numeric scores as digits and binary/NA
+    via YN_DISPLAY; matching that here keeps SectionScore.score strings
+    identical across providers.
+    """
+    if section_row is None:
+        return ""
+    if section_row["numeric_score"] is not None:
+        return str(section_row["numeric_score"])
+    if section_row["binary_value"] is not None:
+        return YN_DISPLAY.get(section_row["binary_value"], "Not Applicable")
+    return ""
 
 
 class PostgresProvider(DataProvider):
-    """Reads evaluation data from PostgreSQL qa_scoring schema."""
+    """Reads evaluation data from the PostgreSQL ``qa`` schema."""
 
     name = "PostgreSQL"
 
-    def __init__(self):
+    def __init__(self, config: TeamConfig | None = None):
+        if config is None:
+            from backend.config.team_config import get_team_config
+            config = get_team_config()
+        self._config = config
+        self._team_id = config.team_id
         self._pool = None
         self._dsn = os.environ.get("DATABASE_URL", "")
+        # Mails-shaped roster snapshot from qa.agents; _get_mails_sheet is
+        # sync (interface parity with SheetsProvider) so it serves this
+        # snapshot, refreshed by the async entry points when stale.
+        self._roster: list[list[str]] | None = None
+        self._roster_at = 0.0
 
     async def connect(self):
         import asyncpg
@@ -22,49 +76,134 @@ class PostgresProvider(DataProvider):
         self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5, timeout=3)
         async with self._pool.acquire() as conn:
             await conn.fetchval("SELECT 1")
+        await self._refresh_roster()
 
     async def close(self):
         if self._pool:
             await self._pool.close()
 
+    # ------------------------------------------------------------------
     async def list_agents(self) -> list[str]:
+        await self._refresh_roster_if_stale()
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(
-                "SELECT DISTINCT agent_name FROM qa_scoring.evaluations ORDER BY agent_name"
+                "SELECT DISTINCT agent_name_raw FROM qa.evaluations "
+                "WHERE team_id = $1 AND state = 'finalized' "
+                "ORDER BY agent_name_raw",
+                self._team_id,
             )
-        return [r["agent_name"] for r in rows]
+        return [r["agent_name_raw"].strip() for r in rows if r["agent_name_raw"].strip()]
 
     async def get_agent_history(self, agent_name: str, days: int = 30) -> list[EvaluationRecord]:
-        cutoff = datetime.now() - timedelta(days=days)
+        return await self._fetch_records(days=days, agent_name=agent_name)
+
+    async def get_all_history(self, days: int = 90) -> list[EvaluationRecord]:
+        return await self._fetch_records(days=days)
+
+    # ------------------------------------------------------------------
+    async def _fetch_records(
+        self, days: int, agent_name: str | None = None
+    ) -> list[EvaluationRecord]:
+        await self._refresh_roster_if_stale()
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        query = (
+            f"SELECT {_EVAL_COLUMNS} FROM qa.evaluations "
+            "WHERE team_id = $1 AND state = 'finalized' "
+            "AND COALESCE(call_connected_at, created_at) >= $2 "
+        )
+        params: list = [self._team_id, cutoff]
+        if agent_name is not None:
+            query += "AND LOWER(agent_name_raw) = LOWER($3) "
+            params.append(agent_name.strip())
+        query += "ORDER BY COALESCE(call_connected_at, created_at)"
+
         async with self._pool.acquire() as conn:
-            evals = await conn.fetch(
-                "SELECT * FROM qa_scoring.evaluations "
-                "WHERE LOWER(agent_name) = LOWER($1) AND created_at >= $2 "
-                "ORDER BY created_at",
-                agent_name, cutoff,
+            evals = await conn.fetch(query, *params)
+            if not evals:
+                return []
+            sections = await conn.fetch(
+                "SELECT evaluation_id, section_id, numeric_score, binary_value, "
+                "confidence, reasoning "
+                "FROM qa.evaluation_sections WHERE evaluation_id = ANY($1::bigint[])",
+                [ev["id"] for ev in evals],
             )
-            records = []
-            for ev in evals:
-                scores = await conn.fetch(
-                    "SELECT * FROM qa_scoring.evaluation_scores WHERE evaluation_id = $1",
-                    ev["id"],
-                )
-                sections = {}
-                for sr in scores:
-                    sections[sr["section_name"]] = SectionScore(
-                        score=str(sr["score"]),
-                        confidence=sr.get("confidence"),
-                        reasoning=sr.get("reasoning"),
-                    )
-                records.append(EvaluationRecord(
-                    timestamp=ev["created_at"],
-                    agent_name=ev["agent_name"],
-                    agent_email=ev.get("agent_email", ""),
-                    manager_email=ev.get("manager_email", ""),
-                    overall_score=float(ev["overall_score"]),
-                    sections=sections,
-                    key_strengths=ev.get("key_strengths"),
-                    improvements=ev.get("improvements"),
-                    source=ev.get("source", "manual"),
-                ))
-        return records
+
+        sections_by_eval: dict[int, list] = {}
+        for s in sections:
+            sections_by_eval.setdefault(s["evaluation_id"], []).append(s)
+        return [
+            self._record_from_rows(ev, sections_by_eval.get(ev["id"], []))
+            for ev in evals
+        ]
+
+    def _record_from_rows(self, ev, section_rows) -> EvaluationRecord:
+        """Build an EvaluationRecord shaped exactly like SheetsProvider._parse_row."""
+        by_section_id = {s["section_id"]: s for s in section_rows}
+        # Every configured section appears in the dict, blank when the
+        # evaluation predates it — same as reading an empty sheet cell.
+        # DB rows for sections no longer in the active rubric are dropped,
+        # matching the sheet reader which only looks at configured columns.
+        sections: dict[str, SectionScore] = {}
+        for sec in self._config.sections_by_number:
+            row = by_section_id.get(sec.id)
+            sections[sec.history_id] = SectionScore(
+                score=_display_score(row),
+                confidence=row["confidence"] if row else None,
+                reasoning=row["reasoning"] if row else None,
+            )
+
+        ts = ev["ts"]
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+
+        dialpad_link = ev["dialpad_link"] or None
+        return EvaluationRecord(
+            timestamp=ts,
+            agent_name=ev["agent_name_raw"],
+            agent_email=ev["agent_email"] or "",
+            # Naming bridge (see SheetsProvider._parse_row): the schema
+            # renamed manager_email → evaluator_email; the record field
+            # stays manager_email for downstream compatibility.
+            manager_email=ev["evaluator_email"] or "",
+            overall_score=float(ev["overall_score"]) if ev["overall_score"] is not None else 0.0,
+            sections=sections,
+            eval_id=_extract_eval_id(dialpad_link or ""),
+            dialpad_link=dialpad_link,
+            key_strengths=ev["key_strengths"] or None,
+            # Same bridge: schema cell is "opportunities", record field is
+            # "improvements" until the Phase D frontend rename.
+            improvements=ev["opportunities"] or None,
+            call_summary=ev["call_summary"] or None,
+            caller_name=ev["caller_name"] or None,
+            caller_phone=ev["caller_phone"] or None,
+            source=ev["source"] or "manual",
+        )
+
+    # ------------------------------------------------------------------
+    # Roster (qa.agents replaces the Mails tab — CutoverDesign §2)
+    # ------------------------------------------------------------------
+    async def _refresh_roster(self) -> None:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT name, email, supervisor_email, canonical_name "
+                "FROM qa.agents WHERE team_id = $1 AND active ORDER BY name",
+                self._team_id,
+            )
+        self._roster = [["Name", "Email", "Supervisor", "Canonical Name"]] + [
+            [r["name"], r["email"], r["supervisor_email"] or "", r["canonical_name"] or ""]
+            for r in rows
+        ]
+        self._roster_at = time.monotonic()
+
+    async def _refresh_roster_if_stale(self) -> None:
+        if self._roster is not None and time.monotonic() - self._roster_at < _ROSTER_TTL_SECONDS:
+            return
+        await self._refresh_roster()
+
+    def _get_mails_sheet(self) -> list[list[str]]:
+        """Mails-shaped roster rows (A=Name, B=Email, C=Supervisor,
+        D=Canonical Name, header included) served from the qa.agents
+        snapshot so history_service's roster helpers work unchanged."""
+        if self._roster is None:
+            raise RuntimeError("PostgresProvider roster not loaded — call connect() first")
+        return self._roster

--- a/qa-automation/AI-Scoring/scripts/backfill_history.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_history.py
@@ -1,22 +1,38 @@
 #!/usr/bin/env python3
-"""
-One-time backfill script: copies Dialpad Link, Key Strengths, and
-Opportunities from Form Responses 1 into Analyst_History rows that
-are missing them.
+"""One-time backfill: copies Dialpad Link, Key Strengths, and
+Opportunities from a legacy form-responses tab into Analyst_History
+rows that are missing them.
 
-Matches rows by timestamp + agent name between the two sheets.
+Matches rows by eval timestamp + agent name between the two tabs.
+Column positions on the Analyst_History side are derived from the
+team's config (`HistoryLayout`) — never hardcoded, so the script is
+safe against the post-Phase-2 43/70-column layouts and any future
+section-count change.
+
+Timestamp note (call-time initiative): the eval/approval time this
+script matches on lives in the trailing `eval_approved_at` column on
+new-shape rows, falling back to col C on rows the PR-2
+`backfill_call_started.py` migration hasn't touched yet — the same
+transition semantics as `load_and_clean`.
 
 Usage:
     cd qa-automation/AI-Scoring
-    python3 scripts/backfill_history.py [--dry-run]
+    python3 scripts/backfill_history.py --team-id member_support [--dry-run]
 
 Flags:
-    --dry-run   Print what would be updated without writing to Sheets.
+    --team-id <id>      (required) Team config to load (e.g. sales,
+                        member_support). Drives the sheet ID env var
+                        and the history layout.
+    --source-tab NAME   Form-responses tab to copy from
+                        (default: "Form Responses 1").
+    --dry-run           Print what would be updated without writing.
 """
 
+import argparse
 import json
 import os
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -24,28 +40,31 @@ from dotenv import load_dotenv
 import gspread
 from google.oauth2.service_account import Credentials
 
-# Load .env from AI-Scoring directory
-_env_path = Path(__file__).resolve().parent.parent / ".env"
-load_dotenv(_env_path)
+# Load .env from AI-Scoring directory regardless of where the script is launched.
+_AI_SCORING = Path(__file__).resolve().parent.parent
+load_dotenv(_AI_SCORING / ".env")
+
+# Make `backend.*` importable so we reuse the production config.
+if str(_AI_SCORING) not in sys.path:
+    sys.path.insert(0, str(_AI_SCORING))
+
+from backend.config import history_layout
+from backend.config.history_layout import col_index_to_letter
+from backend.config.env import env_for_team
+from backend.config.team_config import get_team_config
 
 SCOPES = [
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive.readonly",
 ]
 
-# Form Responses 1 column indices (0-based)
+# Form-responses source column indices (0-based). The legacy form tab is
+# frozen — no new rows land there — so these stay literal.
 F1_TIMESTAMP = 0
 F1_AGENT_NAME = 2
 F1_KEY_STRENGTHS = 13   # col N
 F1_OPPORTUNITIES = 14   # col O
 F1_DIALPAD_LINK = 15    # col P
-
-# Analyst_History column indices (0-based)
-AH_AGENT_NAME = 0
-AH_TIMESTAMP = 2
-AH_DIALPAD_LINK = 15    # col P
-AH_KEY_STRENGTHS = 16   # col Q
-AH_IMPROVEMENTS = 17    # col R
 
 # Timestamp formats to try
 TS_FORMATS = [
@@ -74,14 +93,34 @@ def safe(row, idx):
 
 
 def main():
-    dry_run = "--dry-run" in sys.argv
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--team-id", required=True,
+                        help="Team config to load (e.g. sales, member_support)")
+    parser.add_argument("--source-tab", default="Form Responses 1",
+                        help='Form-responses tab to copy from (default: "Form Responses 1")')
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be updated without writing to Sheets")
+    args = parser.parse_args()
+
+    config = get_team_config(args.team_id)
+    layout = config.history_layout
+
+    # Analyst_History columns, derived from the team's section count.
+    ah_dialpad = history_layout.COL_DIALPAD_LINK
+    ah_strengths = layout.col_key_strengths
+    ah_opportunities = layout.col_opportunities
+
+    dialpad_letter = col_index_to_letter(ah_dialpad)
+    strengths_letter = col_index_to_letter(ah_strengths)
+    opportunities_letter = col_index_to_letter(ah_opportunities)
 
     # Connect to Sheets
     creds_env = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON", "")
-    sheet_id = os.getenv("GOOGLE_SHEETS_ID", "")
+    sheet_id = env_for_team("GOOGLE_SHEETS_ID", args.team_id, legacy_ok=True)
 
     if not creds_env or not sheet_id:
-        print("ERROR: GOOGLE_SERVICE_ACCOUNT_JSON and GOOGLE_SHEETS_ID must be set in .env")
+        print("ERROR: GOOGLE_SERVICE_ACCOUNT_JSON and GOOGLE_SHEETS_ID"
+              f" (or GOOGLE_SHEETS_ID_{args.team_id.upper()}) must be set in .env")
         sys.exit(1)
 
     if creds_env.strip().startswith("{"):
@@ -93,52 +132,57 @@ def main():
     client.set_timeout(120)
     spreadsheet = client.open_by_key(sheet_id)
 
-    print("Reading Form Responses 1...")
-    form1 = spreadsheet.worksheet("Form Responses 1")
+    print(f"Team: {args.team_id} (N={layout.n} sections, "
+          f"dialpad={dialpad_letter}, strengths={strengths_letter}, "
+          f"opportunities={opportunities_letter})")
+
+    print(f"Reading {args.source_tab}...")
+    form1 = spreadsheet.worksheet(args.source_tab)
     form1_data = form1.get_all_values()
     print(f"  {len(form1_data) - 1} data rows")
 
-    print("Reading Analyst_History...")
-    history = spreadsheet.worksheet("Analyst_History")
+    history_tab = config.sheets.analyst_history.tab_name
+    print(f"Reading {history_tab}...")
+    history = spreadsheet.worksheet(history_tab)
     history_data = history.get_all_values()
     print(f"  {len(history_data) - 1} data rows")
 
-    # Build lookup from Form Responses 1: (normalized_ts, agent_lower) -> row
+    # Build lookup from the source tab: (normalized_ts, agent_lower) -> row
     form1_lookup = {}
-    for i, row in enumerate(form1_data[1:], start=2):  # skip header, 1-indexed
+    for row in form1_data[1:]:  # skip header
         ts = parse_ts(safe(row, F1_TIMESTAMP))
         agent = safe(row, F1_AGENT_NAME).lower()
-        key = (ts, agent)
-        form1_lookup[key] = row
+        form1_lookup[(ts, agent)] = row
 
-    print(f"  Form 1 lookup: {len(form1_lookup)} unique (timestamp, agent) pairs")
+    print(f"  Source lookup: {len(form1_lookup)} unique (timestamp, agent) pairs")
 
-    # Scan Analyst_History for rows missing Dialpad Link, Key Strengths, or Improvements
+    # Scan Analyst_History for rows missing Dialpad Link, Key Strengths,
+    # or Opportunities
     updates = []
     matched = 0
     skipped_no_match = 0
     skipped_already_filled = 0
 
     for i, row in enumerate(history_data[1:], start=2):  # skip header, 1-indexed in sheet
-        ts = parse_ts(safe(row, AH_TIMESTAMP))
-        agent = safe(row, AH_AGENT_NAME).lower()
+        # Eval time: new-shape rows carry it in eval_approved_at; pre-PR-2
+        # rows still have it in col C (see module docstring).
+        raw_ts = safe(row, layout.col_eval_approved_at) or safe(row, history_layout.COL_TIMESTAMP)
+        ts = parse_ts(raw_ts)
+        agent = safe(row, history_layout.COL_AGENT_NAME).lower()
 
         if not ts or not agent:
             continue
 
-        key = (ts, agent)
-        form1_row = form1_lookup.get(key)
-
+        form1_row = form1_lookup.get((ts, agent))
         if not form1_row:
             skipped_no_match += 1
             continue
 
         matched += 1
 
-        # Check what's missing in Analyst_History
-        current_link = safe(row, AH_DIALPAD_LINK)
-        current_strengths = safe(row, AH_KEY_STRENGTHS)
-        current_improvements = safe(row, AH_IMPROVEMENTS)
+        current_link = safe(row, ah_dialpad)
+        current_strengths = safe(row, ah_strengths)
+        current_opportunities = safe(row, ah_opportunities)
 
         new_link = safe(form1_row, F1_DIALPAD_LINK)
         new_strengths = safe(form1_row, F1_KEY_STRENGTHS)
@@ -146,16 +190,16 @@ def main():
 
         row_updates = {}
         if not current_link and new_link:
-            row_updates["P"] = new_link
+            row_updates["dialpad_link"] = new_link
         if not current_strengths and new_strengths:
-            row_updates["Q"] = new_strengths
-        if not current_improvements and new_opportunities:
-            row_updates["R"] = new_opportunities
+            row_updates["key_strengths"] = new_strengths
+        if not current_opportunities and new_opportunities:
+            row_updates["opportunities"] = new_opportunities
 
         if row_updates:
             updates.append({
                 "sheet_row": i,
-                "agent": safe(row, AH_AGENT_NAME),
+                "agent": safe(row, history_layout.COL_AGENT_NAME),
                 "timestamp": ts,
                 "updates": row_updates,
             })
@@ -176,21 +220,22 @@ def main():
     # Show preview
     print(f"\nPreview (first 10):")
     for u in updates[:10]:
-        cols = ", ".join(f"{k}={v[:40]}..." if len(v) > 40 else f"{k}={v}" for k, v in u["updates"].items())
+        cols = ", ".join(f"{k}={v[:40]}..." if len(v) > 40 else f"{k}={v}"
+                         for k, v in u["updates"].items())
         print(f"  Row {u['sheet_row']}: {u['agent']} ({u['timestamp']}) -> {cols}")
 
     if len(updates) > 10:
         print(f"  ... and {len(updates) - 10} more")
 
-    if dry_run:
+    if args.dry_run:
         print("\n[DRY RUN] No changes written. Remove --dry-run to apply.")
         return
 
-    # Apply updates — batch P/Q/R into a single row update per row,
-    # with rate limiting (max 50 requests/min to stay under 60/min quota)
-    import time
-
-    print(f"\nWriting {len(updates)} row updates to Analyst_History...")
+    # Apply updates. The dialpad-link cell sits in the fixed prefix while
+    # strengths/opportunities are trailing columns, so each row needs two
+    # ranges — batched into a single API call per row, rate-limited to
+    # stay under the 60 writes/min quota.
+    print(f"\nWriting {len(updates)} row updates to {history_tab}...")
     print(f"  Rate limit: 50 writes/min (~1.2s between writes)")
 
     written = 0
@@ -201,18 +246,23 @@ def main():
         row_num = u["sheet_row"]
         cols = u["updates"]
 
-        # Build a single batch: always write P, Q, R (use existing value if no update)
+        # Always write all three cells, keeping existing values where no
+        # update applies — same batching strategy as the original script.
         row_data = history_data[row_num - 1]  # 0-indexed
-        p_val = cols.get("P", safe(row_data, AH_DIALPAD_LINK))
-        q_val = cols.get("Q", safe(row_data, AH_KEY_STRENGTHS))
-        r_val = cols.get("R", safe(row_data, AH_IMPROVEMENTS))
+        link_val = cols.get("dialpad_link", safe(row_data, ah_dialpad))
+        strengths_val = cols.get("key_strengths", safe(row_data, ah_strengths))
+        opportunities_val = cols.get("opportunities", safe(row_data, ah_opportunities))
+
+        batch = [
+            {"range": f"{dialpad_letter}{row_num}", "values": [[link_val]]},
+            {"range": f"{strengths_letter}{row_num}:{opportunities_letter}{row_num}",
+             "values": [[strengths_val, opportunities_val]]},
+        ]
 
         retries = 0
         while retries < 3:
             try:
-                # Single API call writes all 3 columns at once (P=16, Q=17, R=18 → 1-indexed)
-                history.update([[p_val, q_val, r_val]], f"P{row_num}:R{row_num}",
-                               value_input_option="USER_ENTERED")
+                history.batch_update(batch, value_input_option="USER_ENTERED")
                 written += 1
                 break
             except Exception as e:

--- a/qa-automation/AI-Scoring/tests/test_db_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_db_provider.py
@@ -1,0 +1,245 @@
+"""PostgresProvider — contract parity with SheetsProvider.
+
+The provider swap at the read-path flip only works if both providers
+emit identical EvaluationRecord shapes: sections keyed by history_id,
+the manager_email/evaluator_email and improvements/opportunities naming
+bridges, YN_DISPLAY score strings, tz-aware UTC timestamps.
+
+All DB access goes through a fake asyncpg pool — the autouse
+_no_real_database fixture guarantees no DSN is present anyway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import backend.services.db_provider as db_provider
+from backend.services.db_provider import PostgresProvider, _display_score
+from backend.services.history_service import (
+    _agent_email_for_name_in_rows,
+    _email_in_mails_rows,
+)
+from tests.conftest import load_test_config
+
+
+# ---------------------------------------------------------------------------
+# Fake asyncpg pool
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    def __init__(self, eval_rows, section_rows, agent_rows):
+        self.eval_rows = eval_rows
+        self.section_rows = section_rows
+        self.agent_rows = agent_rows
+        self.queries: list[str] = []
+
+    async def fetch(self, query, *params):
+        self.queries.append(query)
+        if "FROM qa.evaluation_sections" in query:
+            wanted = set(params[0])
+            return [s for s in self.section_rows if s["evaluation_id"] in wanted]
+        if "FROM qa.evaluations" in query:
+            return self.eval_rows
+        if "FROM qa.agents" in query:
+            return self.agent_rows
+        raise AssertionError(f"unexpected query: {query}")
+
+    async def fetchval(self, query):
+        return 1
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+def make_provider(eval_rows=(), section_rows=(), agent_rows=()):
+    provider = PostgresProvider(config=load_test_config("sales_lite"))
+    provider._pool = FakePool(FakeConn(list(eval_rows), list(section_rows), list(agent_rows)))
+    return provider
+
+
+def make_eval_row(eval_id=1, **overrides):
+    row = {
+        "id": eval_id,
+        "agent_name_raw": "Jane Doe",
+        "agent_email": "jane@landing.com",
+        "evaluator_email": "boss@landing.com",
+        "ts": datetime(2026, 7, 2, 15, 30, tzinfo=timezone.utc),
+        "overall_score": 87.5,
+        "dialpad_link": "https://dialpad.com/launchpad/call/12345",
+        "key_strengths": "warm greeting",
+        "opportunities": "slow wrap-up",
+        "call_summary": "billing question",
+        "caller_name": "Bob",
+        "caller_phone": "+15550001111",
+        "source": "ai",
+    }
+    row.update(overrides)
+    return row
+
+
+def make_section_rows(config, eval_id=1):
+    """One DB row per configured section, shaped by its score_type."""
+    rows = []
+    for sec in config.sections_by_number:
+        binaryish = "binary" in str(sec.score_type) or str(sec.score_type) == "auto_value"
+        rows.append({
+            "evaluation_id": eval_id,
+            "section_id": sec.id,
+            "numeric_score": None if binaryish else 4,
+            "binary_value": "Y" if binaryish else None,
+            "confidence": "high",
+            "reasoning": f"reasoning for {sec.id}",
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# _display_score — sheet-cell rendering parity
+# ---------------------------------------------------------------------------
+
+def test_display_score_missing_row_is_blank_cell():
+    assert _display_score(None) == ""
+
+
+def test_display_score_numeric_renders_digit_string():
+    assert _display_score({"numeric_score": 4, "binary_value": None}) == "4"
+
+
+def test_display_score_binary_renders_via_yn_display():
+    assert _display_score({"numeric_score": None, "binary_value": "Y"}) == "Yes"
+    assert _display_score({"numeric_score": None, "binary_value": "N"}) == "No"
+    assert _display_score({"numeric_score": None, "binary_value": "NA"}) == "Not Applicable"
+
+
+def test_display_score_empty_row_is_blank():
+    assert _display_score({"numeric_score": None, "binary_value": None}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Record shape parity
+# ---------------------------------------------------------------------------
+
+def test_sections_keyed_by_history_id():
+    provider = make_provider()
+    config = provider._config
+    rec = provider._record_from_rows(make_eval_row(), make_section_rows(config))
+    assert set(rec.sections) == {s.history_id for s in config.sections_by_number}
+
+
+def test_naming_bridges_and_field_mapping():
+    provider = make_provider()
+    rec = provider._record_from_rows(make_eval_row(), [])
+    assert rec.agent_name == "Jane Doe"
+    assert rec.manager_email == "boss@landing.com"   # ← evaluator_email
+    assert rec.improvements == "slow wrap-up"        # ← opportunities
+    assert rec.eval_id == "12345"                    # trailing link segment
+    assert rec.overall_score == 87.5
+    assert rec.source == "ai"
+
+
+def test_unscored_configured_section_reads_as_blank_cell():
+    provider = make_provider()
+    config = provider._config
+    rows = make_section_rows(config)[1:]  # drop the first section's row
+    rec = provider._record_from_rows(make_eval_row(), rows)
+    first = config.sections_by_number[0]
+    assert rec.sections[first.history_id].score == ""
+    assert rec.sections[first.history_id].confidence is None
+
+
+def test_section_rows_outside_active_rubric_are_dropped():
+    provider = make_provider()
+    rows = [{
+        "evaluation_id": 1, "section_id": "retired_section",
+        "numeric_score": 3, "binary_value": None,
+        "confidence": None, "reasoning": None,
+    }]
+    rec = provider._record_from_rows(make_eval_row(), rows)
+    assert "retired_section" not in rec.sections
+
+
+def test_naive_timestamp_tagged_utc():
+    provider = make_provider()
+    rec = provider._record_from_rows(
+        make_eval_row(ts=datetime(2026, 7, 2, 15, 30)), []
+    )
+    assert rec.timestamp.tzinfo is not None
+    assert rec.timestamp.utcoffset().total_seconds() == 0
+
+
+# ---------------------------------------------------------------------------
+# Query surface
+# ---------------------------------------------------------------------------
+
+def test_history_query_is_team_scoped_and_finalized_only():
+    provider = make_provider(
+        eval_rows=[make_eval_row()],
+        section_rows=make_section_rows(load_test_config("sales_lite")),
+    )
+    records = asyncio.run(provider.get_agent_history("Jane Doe", days=30))
+    assert len(records) == 1
+    eval_query = next(
+        q for q in provider._pool._conn.queries if "FROM qa.evaluations" in q
+    )
+    assert "team_id = $1" in eval_query
+    assert "state = 'finalized'" in eval_query
+    assert "LOWER(agent_name_raw)" in eval_query
+
+
+def test_all_history_query_has_no_agent_filter():
+    provider = make_provider(eval_rows=[], section_rows=[])
+    records = asyncio.run(provider.get_all_history(days=90))
+    assert records == []
+    eval_query = next(
+        q for q in provider._pool._conn.queries if "FROM qa.evaluations" in q
+    )
+    assert "LOWER(agent_name_raw)" not in eval_query
+
+
+def test_no_stale_qa_scoring_schema_references():
+    src = Path(db_provider.__file__).read_text(encoding="utf-8")
+    assert "qa_scoring" not in src
+
+
+# ---------------------------------------------------------------------------
+# Roster (qa.agents → Mails-shaped rows)
+# ---------------------------------------------------------------------------
+
+def test_get_mails_sheet_requires_connect():
+    provider = make_provider()
+    try:
+        provider._get_mails_sheet()
+        raise AssertionError("expected RuntimeError before roster load")
+    except RuntimeError:
+        pass
+
+
+def test_roster_rows_work_with_history_service_helpers():
+    agent_rows = [{
+        "name": "jane doe", "email": "jane@landing.com",
+        "supervisor_email": "boss@landing.com", "canonical_name": "Jane Doe",
+    }]
+    provider = make_provider(agent_rows=agent_rows)
+    asyncio.run(provider._refresh_roster())
+    rows = provider._get_mails_sheet()
+    assert rows[0] == ["Name", "Email", "Supervisor", "Canonical Name"]
+    assert _email_in_mails_rows("JANE@landing.com", rows)
+    assert _agent_email_for_name_in_rows("Jane Doe", rows) == "jane@landing.com"


### PR DESCRIPTION
## What

Two fixes surfaced by the post-#93 repo sweep, both prerequisites for upcoming roadmap steps:

**`backend/services/db_provider.py` — rewritten against the `qa` schema.** `PostgresProvider` still queried the retired `qa_scoring` schema and a nonexistent `evaluation_scores` table, and didn't implement `get_all_history`/`_get_mails_sheet`, so it couldn't even instantiate. Now:
- Queries `qa.evaluations`/`qa.evaluation_sections` (correct columns: `agent_name_raw`, `evaluator_email`, `opportunities`), team-scoped, `state='finalized'` only — matching Analyst_History row membership.
- Exact `SheetsProvider` record parity: sections keyed by `history_id` (explicit `sec.id` → `history_id` remap), `manager_email`/`improvements` naming bridges, `YN_DISPLAY` score strings, tz-aware UTC timestamps. The read-path flip becomes a provider swap in `get_provider()`, not a shape change.
- Mails-shaped roster served from `qa.agents` (5-min snapshot) so `history_service` roster helpers work unchanged.
- Sections fetched with one `ANY($1)` query instead of N+1.

**`scripts/backfill_history.py` — layout-driven.** The hardcoded pre-Phase-2 column indices (P/Q/R) would have written into section columns on the migrated 43/70-col layouts if run during B0–B4. Now derives positions from `HistoryLayout` via required `--team-id`, reads eval time from `eval_approved_at` with the col-C fallback (same transition semantics as `load_and_clean`), and uses `env_for_team` for the sheet ID.

## Tests

- 14 new tests in `tests/test_db_provider.py` (fake asyncpg pool; includes a `qa_scoring`-string regression guard).
- Full suite: 710 passed; only failure is the pre-existing task #7 date-flake (`test_monthly_summary_buckets_in_project_local_time`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)