### PR TITLE
docs: record formal Sales Management sign-off (B1–B7) in sales spec §10 + Wave2Plan

### DIFF
--- a/database/sales_scoring_migration.md
+++ b/database/sales_scoring_migration.md
@@ -237,24 +237,29 @@ No pre-sum weight moves and no post-sum scaling exist in this version. NA is res
 
 ---
 
-## 10. Open Items — closed 2026-07-04 (Sales management)
+## 10. Open Items — CLOSED. Formal Sales Management sign-off 2026-07-07 (B1–B7)
 
-- [x] **Scaled 1–5 → points curve: `(rating − 1) / 4` confirmed.** Requirement attached to the
-      decision: the curve must be reconfigurable in the same manager UI that ships a new scoring
-      version (formula or rubric). Architecturally satisfied today — the curve lives in the
-      formula JSON (`normalization.rating_1_5.output`), so any version-ship surface can change it;
-      the requirement binds the future rubric-editor UI (§3.19.2 editor write path).
-- [x] **NA = full credit confirmed as written**, all 15 sections, no redistribution. No other NA
-      behaviors in this version.
-- [x] **Version id: `sales_v2`** (formula AND rubric — the seeded `sales_v1` rubric id is
-      immutable and stays with the legacy 19-section rubric). `supersedes: null` for the formula;
-      the `sales_v2` rubric row closes `sales_v1` when shipped. Historic Analyst_History export
-      incoming for the backfill seed.
-- [x] **Section keys adopted as proposed** — no renames. Legacy 19-section ids remain valid
-      forever on historic rows via rubric pinning.
-- [x] **`category` persisted** on formula sections (reporting).
-- [x] **`client_experience` stays under *Post-Call & Documentation*.**
-- [x] **No rules / no triggers for `sales_v2`** — `evaluation_order: ["weighted_sum"]`.
+Resolutions staged 2026-07-04, formally confirmed by Sales Management on 2026-07-07. The
+**B1–B7** ids reference the per-item briefs in
+`qa-automation/AI-Scoring/references/Section10SignoffBriefs.md`.
+
+- [x] **B1 — Scaled 1–5 → points curve: `(rating − 1) / 4` confirmed.** Requirement attached to
+      the decision: the curve must be reconfigurable in the same manager UI that ships a new
+      scoring version (formula OR rubric). Architecturally satisfied today — the curve lives in
+      the formula JSON (`normalization.rating_1_5.output`), so any version-ship surface can
+      change it; the requirement binds the future rubric-editor UI (§3.19.2 editor write path).
+- [x] **B2 — NA = full credit confirmed as written**, all 15 sections, no redistribution. The
+      newest formula iteration uses no other NA/NS behaviors.
+- [x] **B3 — Version id: `sales_v2`** (formula AND rubric — the seeded `sales_v1` rubric id is
+      immutable and stays with the legacy 19-section rubric; supersedes the earlier
+      `sales_v1_ops` naming recommendation in the B3 brief). `supersedes: null` for the formula;
+      the `sales_v2` rubric row closes `sales_v1` when shipped. Historic Analyst_History rows
+      being provided by the owner (2026-07-07) for the backfill seed.
+- [x] **B4 — Section keys adopted as proposed** — no renames; the new 15 section keys land
+      as-is. Legacy 19-section ids remain valid forever on historic rows via rubric pinning.
+- [x] **B5 — `category` persisted** on formula sections (reporting).
+- [x] **B6 — `client_experience` stays under *Post-Call & Documentation*.**
+- [x] **B7 — No rules / no triggers for `sales_v2`** (per B2) — `evaluation_order: ["weighted_sum"]`.
 
 ### 10a. Rubric build decisions (2026-07-06)
 

--- a/qa-automation/AI-Scoring/references/Wave2Plan.md
+++ b/qa-automation/AI-Scoring/references/Wave2Plan.md
@@ -38,7 +38,7 @@ That's the finish line. Nothing else needs to ship for that outcome.
 | File | Team | Status |
 |---|---|---|
 | `database/member_support_scoring_migration.md` | Member Support | ✅ **Finalized** — Ops VP sign-off. 4 minor items in §10 still to confirm (see §5 below). |
-| `database/sales_scoring_migration.md` | Sales | ⚠️ **Populated from source PDF, PENDING sign-off** — 7 open items in its §10. Blocks Sales bonus math. |
+| `database/sales_scoring_migration.md` | Sales | ✅ **Finalized** — Sales Management sign-off 2026-07-07 (B1–B7, recorded in its §10). Sales bonus math unblocked. |
 
 **These files DEFINE THE SCHEMA that the specs load into:**
 
@@ -118,17 +118,19 @@ The Ops-signed specs use a **richer formula shape** than `SQLMigration.md §3.8`
 - [ ] Confirm hard-zero stays globally available (enabled per team) vs. removed outright for MS
 - [ ] Confirm NA-spread behavior when **multiple** sections are NA (current: recompute equal-additive over remaining active sections)
 
-**Sales (§10 of the Sales scoring spec):**
+**Sales (§10 of the Sales scoring spec)** — CLOSED 2026-07-07, Sales Management sign-off
+B1–B7 (answers recorded in the Sales spec's §10; briefs in Section10SignoffBriefs.md):
 
-- [ ] Confirm rating→points curve (`(rating − 1) / 4` vs `rating / 5`) — **materially changes every scaled section's score**
-- [ ] Confirm NA = full credit on-slot **for all 15 sections** with no redistribution
-- [ ] Confirm `formula_id = sales_v1` and version lineage
-- [ ] Confirm section keys (the spec's proposed keys)
-- [ ] Confirm whether to persist the PDF's `category` grouping on `qa.formula_section`
-- [ ] Confirm `client_experience` placement under *Post-Call & Documentation*
-- [ ] Confirm no rules / no triggers planned for `sales_v1`
+- [x] Confirm rating→points curve (`(rating − 1) / 4` vs `rating / 5`) — **B1: `(rating − 1) / 4`**, must stay reconfigurable in the version-ship manager UI
+- [x] Confirm NA = full credit on-slot **for all 15 sections** with no redistribution — **B2: confirmed**
+- [x] Confirm `formula_id = sales_v1` and version lineage — **B3: `sales_v2`** (formula and rubric; `sales_v1` stays with the legacy 19-section rubric)
+- [x] Confirm section keys (the spec's proposed keys) — **B4: adopted as-is, no renames**
+- [x] Confirm whether to persist the PDF's `category` grouping on `qa.formula_section` — **B5: keep it**
+- [x] Confirm `client_experience` placement under *Post-Call & Documentation* — **B6: confirmed**
+- [x] Confirm no rules / no triggers planned — **B7: none for `sales_v2`**
 
-**Nothing else can start on Sales bonus math until §10 is closed.** MS can start now.
+**Sales bonus math is unblocked.** Still open on the Sales side: the 13 default
+`na_applies_when` texts (spec §10a pre-flip checklist).
 
 **Q — should we get all sign-offs before writing any code?** No — Phase 1 and 2 (Foundation + Compute Engine) are entirely internal, agnostic to which sections/weights end up locked. Formula sign-off gates Phase 3 (ship the versions) onward, not the engine itself.
 


### PR DESCRIPTION
Records the 2026-07-07 formal Sales Management sign-off of the 7 open §10 items (briefed as B1–B7 in `Section10SignoffBriefs.md`):

- `database/sales_scoring_migration.md` §10 — header now reflects the formal sign-off date, each resolution carries its brief id (B1–B7), and B3 notes the owner is providing the historic Analyst_History rows for the backfill seed (and that `sales_v2` supersedes the brief's `sales_v1_ops` recommendation).
- `references/Wave2Plan.md` — the authority table and §5 checklist still said "PENDING sign-off / blocks Sales bonus math"; both closed out with the per-item answers.

Only remaining open Sales item: the 13 default `na_applies_when` texts (spec §10a pre-flip checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)