### PR TITLE
feat(qa-automation): HR bonus backend — hr_export config + month-payload endpoint (spec P1+P2)

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -97,6 +97,27 @@ class StatsConfig(BaseModel):
     spc_sigma_multiplier: float = 2.0
 
 
+class HrExportSectionConfig(BaseModel):
+    """One HR-visible section: rubric section id + the header HR sees."""
+    id: str
+    hr_label: str
+
+
+class HrExportConfig(BaseModel):
+    """HR bonus sheet export surface (references/HRBonusSheet.md §3).
+
+    Lives at the top level of the team JSON — NOT inside the rubric block,
+    which is content-hashed for version archiving. Aggregation shape
+    (numeric mean vs binary %Yes) is derived from the rubric section's
+    score_type, never restated here.
+    """
+    sections: list[HrExportSectionConfig]
+    excluded_agents: list[str] = Field(
+        default_factory=list,
+        description="Raw agent names (case-insensitive) filtered out of the HR export.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # TeamConfig
 # ---------------------------------------------------------------------------
@@ -120,8 +141,39 @@ class TeamConfig(BaseModel):
     sheets: SheetsConfig
     rubric: Rubric
     stats: StatsConfig = Field(default_factory=StatsConfig)
+    hr_export: Optional[HrExportConfig] = None
+    hr_internal_section_ids: list[str] = Field(
+        default_factory=list,
+        description="Section ids that must never leave internal surfaces "
+                    "(HR export rejects them — HRBonusSheet.md §3).",
+    )
 
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _validate_hr_export(self) -> "TeamConfig":
+        """hr_export sections must be non-empty, unique, rubric-known, and
+        never internal-only. This is the mechanical form of the
+        "Documentation / Human Review Required never leaves the building"
+        guarantee from the HR bonus sheet spec."""
+        if self.hr_export is None:
+            return self
+        if not self.hr_export.sections:
+            raise ValueError("hr_export.sections must not be empty")
+        known = {s.id for s in self.rubric.sections}
+        internal = set(self.hr_internal_section_ids)
+        seen: set[str] = set()
+        for sec in self.hr_export.sections:
+            if sec.id not in known:
+                raise ValueError(f"hr_export section '{sec.id}' is not a rubric section")
+            if sec.id in internal:
+                raise ValueError(
+                    f"hr_export section '{sec.id}' is internal-only and must never be exported"
+                )
+            if sec.id in seen:
+                raise ValueError(f"hr_export section '{sec.id}' listed twice")
+            seen.add(sec.id)
+        return self
 
     # --- Rubric passthroughs (backward-compat surface) ----------------------
 

--- a/qa-automation/AI-Scoring/backend/config/teams/member_support.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/member_support.json
@@ -5,6 +5,23 @@
 
   "excluded_test_agents": ["Maximiliano Perez"],
 
+  "hr_internal_section_ids": ["human_review_required"],
+
+  "hr_export": {
+    "sections": [
+      {"id": "greeting",          "hr_label": "Greeting"},
+      {"id": "caller_id",         "hr_label": "Caller ID"},
+      {"id": "purpose",           "hr_label": "Purpose of the call"},
+      {"id": "matching",          "hr_label": "Matching the moment"},
+      {"id": "process_adherence", "hr_label": "Process Adherence"},
+      {"id": "call_resolution",   "hr_label": "Call Resolution"},
+      {"id": "comms",             "hr_label": "Communication"},
+      {"id": "efficiency",        "hr_label": "Efficiency & Call Handling"},
+      {"id": "cri",               "hr_label": "CRI"}
+    ],
+    "excluded_agents": ["maximiliano perez", "maximiliano.perez"]
+  },
+
   "stats": {
     "min_evals_for_outlier": 5,
     "outlier_z_threshold": 3.5,

--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -32,6 +32,7 @@ from backend.routes.team import router as team_router
 from backend.routes.datapoints import router as datapoints_router
 from backend.routes.lookup import router as lookup_router
 from backend.routes.events import router as events_router
+from backend.routes.hr_bonus import router as hr_bonus_router
 from backend.middleware.auth import AUTH_DEPENDENCY, TEAM_AUTH_DEPENDENCY
 from backend.middleware.audit import AuditLogMiddleware
 
@@ -73,11 +74,11 @@ app.add_middleware(
 app.add_middleware(AuditLogMiddleware)
 
 # Team-aware routes (primary). API key's team_id must match the URL team_id.
-for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router, events_router):
+for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router, events_router, hr_bonus_router):
     app.include_router(r, prefix="/api/{team_id}", dependencies=TEAM_AUTH_DEPENDENCY)
 
 # Legacy single-team shim (30-day transition). team_id defaults to 'member_support'.
-# Events router intentionally excluded — SSE is new and team-scoped only.
+# Events + hr-bonus routers intentionally excluded — both are new and team-scoped only.
 for r in (scoring_router, dashboard_router, team_router, datapoints_router, lookup_router):
     app.include_router(r, prefix="/api", dependencies=AUTH_DEPENDENCY)
 

--- a/qa-automation/AI-Scoring/backend/routes/hr_bonus.py
+++ b/qa-automation/AI-Scoring/backend/routes/hr_bonus.py
@@ -1,0 +1,41 @@
+"""HR bonus sheet endpoint — the month payload the GAS renderer consumes.
+
+references/HRBonusSheet.md §5. Mounted team-aware only (/api/{team_id}/
+hr-bonus/{month}); the GAS suite calls it with that team's API key. A
+team without an hr_export config block 404s — this is how Sales stays
+dark until its HR-visible section subset is decided (spec §8).
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.config.team_config import get_team_config
+from backend.middleware.auth import team_id_from_path
+from backend.services.hr_bonus_service import fetch_month_payload
+
+router = APIRouter(prefix="/hr-bonus", tags=["hr-bonus"])
+
+_MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+
+
+@router.get("/{month}")
+async def hr_bonus_month(month: str, request: Request):
+    team_id = team_id_from_path(request)
+    try:
+        config = get_team_config(team_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Unknown team '{team_id}'")
+    if config.hr_export is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Team '{team_id}' has no HR export configured",
+        )
+    if not _MONTH_RE.match(month):
+        raise HTTPException(status_code=422, detail="month must be YYYY-MM")
+    payload = await fetch_month_payload(config, month)
+    if payload is None:
+        raise HTTPException(status_code=503, detail="No database configured")
+    return payload

--- a/qa-automation/AI-Scoring/backend/services/hr_bonus_service.py
+++ b/qa-automation/AI-Scoring/backend/services/hr_bonus_service.py
@@ -1,0 +1,188 @@
+"""HR bonus sheet month payload — references/HRBonusSheet.md §4–§5.
+
+Builds the JSON the GAS renderer consumes 1:1. Every number is computed
+here (aggregation, rounding, display strings, ordering) so the GAS layer
+stays math-free. Population and semantics mirror the qa.* read path:
+``state='finalized'`` rows, call time = ``COALESCE(call_connected_at,
+created_at)``, month bucketing in the project bucket TZ.
+
+`build_payload_from_rows` is pure (rows in, payload out) so the
+aggregation math — including the mockup golden-parity test — runs
+without a database; `fetch_month_payload` is the thin asyncpg wrapper.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from backend.config.team_config import TeamConfig
+from backend.services.eval_store import get_pool
+from backend.services.team_stats import BUCKET_TZ_NAME
+
+_BUCKET_TZ = ZoneInfo(BUCKET_TZ_NAME)
+
+# HR workbook display for binary section values (mockup parity — note the
+# HR sheet shows "N/A", not the Analyst_History projection's "Not Applicable").
+_BINARY_DISPLAY = {"Y": "Yes", "N": "No", "NA": "N/A"}
+_BINARY_AS_FRACTION = {"Y": 1.0, "N": 0.0}
+
+_NUMERIC_TYPES = ("numeric", "manual")
+_BINARY_TYPES = ("yn", "manual_yn")
+
+
+def month_window_utc(month: str) -> tuple[datetime, datetime]:
+    """[start, end) of a ``YYYY-MM`` month in the project bucket TZ, as
+    UTC instants. A call at 03:33 UTC on June 1 sits before June's start
+    (America/Los_Angeles) and belongs to May — same bucketing seam as
+    team_stats._months_in_bucket_tz."""
+    year, mon = int(month[:4]), int(month[5:7])
+    start = datetime(year, mon, 1, tzinfo=_BUCKET_TZ)
+    if mon == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=_BUCKET_TZ)
+    else:
+        end = datetime(year, mon + 1, 1, tzinfo=_BUCKET_TZ)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
+
+
+def _detail_cell(section_row) -> str:
+    """One detail-tab section cell: digits for numeric, Yes/No/N/A for
+    binary, blank when the evaluation has no row for the section."""
+    if section_row is None:
+        return ""
+    if section_row["numeric_score"] is not None:
+        return str(section_row["numeric_score"])
+    if section_row["binary_value"] is not None:
+        return _BINARY_DISPLAY.get(section_row["binary_value"], "N/A")
+    return ""
+
+
+def _summary_cell(score_type: str, section_rows: list) -> str:
+    """One summary-tab section cell: mean to 2 decimals for numeric,
+    integer %Yes for binary (N/A excluded from the denominator), blank
+    when the agent has no data for the section."""
+    if score_type in _NUMERIC_TYPES:
+        values = [r["numeric_score"] for r in section_rows
+                  if r is not None and r["numeric_score"] is not None]
+        return f"{sum(values) / len(values):.2f}" if values else ""
+    values = [_BINARY_AS_FRACTION[r["binary_value"]] for r in section_rows
+              if r is not None and r["binary_value"] in _BINARY_AS_FRACTION]
+    return f"{sum(values) / len(values) * 100:.0f}%" if values else ""
+
+
+def build_payload_from_rows(
+    config: TeamConfig,
+    month: str,
+    eval_rows: list,
+    sections_by_eval: dict[int, dict[str, dict]],
+) -> dict:
+    """Assemble the §5 response payload from already-fetched rows.
+
+    ``eval_rows`` must be newest-first; ``sections_by_eval`` maps
+    evaluation id -> {section_id -> section row}. Rows outside the target
+    month are dropped here even though the SQL window already excludes
+    them — the no-prior-month-leakage rule is load-bearing (owner-
+    confirmed 2026-07-07), so it holds regardless of the caller.
+    """
+    hr = config.hr_export
+    if hr is None:
+        raise ValueError(f"team '{config.team_id}' has no hr_export block")
+
+    start_utc, end_utc = month_window_utc(month)
+    excluded = {name.lower() for name in hr.excluded_agents}
+    section_defs = [(entry.id, config.scoring_id_to_section[entry.id].score_type)
+                    for entry in hr.sections]
+
+    by_agent: dict[str, list] = {}
+    for ev in eval_rows:
+        ts = ev["ts"]
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if not start_utc <= ts < end_utc:
+            continue
+        name = ev["agent_name_raw"].strip()
+        if not name or name.lower() in excluded:
+            continue
+        by_agent.setdefault(name, []).append({**dict(ev), "ts": ts})
+
+    agents = []
+    for name in sorted(by_agent, key=str.lower):
+        evals = sorted(by_agent[name], key=lambda e: e["ts"], reverse=True)
+        email = next(
+            (e["agent_email"].strip() for e in evals if (e["agent_email"] or "").strip()),
+            "",
+        )
+        overall = [float(e["overall_score"]) for e in evals
+                   if e["overall_score"] is not None]
+        rows_per_section = {
+            sec_id: [sections_by_eval.get(e["id"], {}).get(sec_id) for e in evals]
+            for sec_id, _ in section_defs
+        }
+        agents.append({
+            "name": name,
+            "email": email,
+            "monthly_avg": round(sum(overall) / len(overall), 1) if overall else "",
+            "section_summaries": [
+                _summary_cell(score_type, rows_per_section[sec_id])
+                for sec_id, score_type in section_defs
+            ],
+            "evaluations": [
+                {
+                    "period": e["ts"].astimezone(_BUCKET_TZ).strftime("%Y-%m"),
+                    "date": e["ts"].astimezone(_BUCKET_TZ).strftime("%m/%d/%Y %H:%M"),
+                    "overall_score": float(e["overall_score"])
+                    if e["overall_score"] is not None else "",
+                    "sections": [
+                        _detail_cell(sections_by_eval.get(e["id"], {}).get(sec_id))
+                        for sec_id, _ in section_defs
+                    ],
+                    "evaluator": e["evaluator_email"] or "",
+                    "dialpad_link": e["dialpad_link"] or "",
+                }
+                for e in evals
+            ],
+        })
+
+    return {
+        "team_id": config.team_id,
+        "month": month,
+        "month_label": datetime(int(month[:4]), int(month[5:7]), 1).strftime("%B %Y"),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "section_labels": [entry.hr_label for entry in hr.sections],
+        "agents": agents,
+    }
+
+
+async def fetch_month_payload(config: TeamConfig, month: str) -> dict | None:
+    """Query Postgres and build the month payload. Returns None when no
+    DATABASE_URL is configured (route maps this to 503)."""
+    pool = await get_pool()
+    if pool is None:
+        return None
+    start_utc, end_utc = month_window_utc(month)
+    hr_section_ids = [entry.id for entry in config.hr_export.sections]
+
+    async with pool.acquire() as conn:
+        eval_rows = await conn.fetch(
+            "SELECT id, agent_name_raw, agent_email, evaluator_email, "
+            "COALESCE(call_connected_at, created_at) AS ts, "
+            "overall_score, dialpad_link "
+            "FROM qa.evaluations "
+            "WHERE team_id = $1 AND state = 'finalized' "
+            "AND COALESCE(call_connected_at, created_at) >= $2 "
+            "AND COALESCE(call_connected_at, created_at) < $3 "
+            "ORDER BY COALESCE(call_connected_at, created_at) DESC",
+            config.team_id, start_utc, end_utc,
+        )
+        sections_by_eval: dict[int, dict[str, dict]] = {}
+        if eval_rows:
+            section_rows = await conn.fetch(
+                "SELECT evaluation_id, section_id, numeric_score, binary_value "
+                "FROM qa.evaluation_sections "
+                "WHERE evaluation_id = ANY($1::bigint[]) AND section_id = ANY($2::text[])",
+                [e["id"] for e in eval_rows], hr_section_ids,
+            )
+            for row in section_rows:
+                sections_by_eval.setdefault(row["evaluation_id"], {})[row["section_id"]] = row
+
+    return build_payload_from_rows(config, month, eval_rows, sections_by_eval)

--- a/qa-automation/AI-Scoring/references/HRBonusSheet.md
+++ b/qa-automation/AI-Scoring/references/HRBonusSheet.md
@@ -145,12 +145,15 @@ All numbers are computed by the backend from Postgres. Definitions:
 ## 5. Backend endpoint
 
 ```
-GET /hr-bonus/{team_id}/{month}          month = YYYY-MM
+GET /api/{team_id}/hr-bonus/{month}      month = YYYY-MM
 ```
 
-- **Auth:** existing API-key middleware; a dedicated read-only reporting key for the GAS suite
-  (same key-role machinery as the other GAS↔backend calls). Requests land in
-  `qa.api_audit_log` like every other endpoint.
+(Mounted team-aware like every other router — `/api/{team_id}` prefix with `TEAM_AUTH`;
+no legacy `/api` shim.)
+
+- **Auth:** existing API-key middleware; the GAS suite calls with a team-bound API key
+  (the key's team must match the URL team, same machinery as the other routers). Requests
+  land in `qa.api_audit_log` like every other endpoint.
 - **Validation:** unknown `team_id` → 404; malformed month → 422; a team without an
   `hr_export` block → 404 (this is how Sales stays dark until §8 is decided).
 - **Response** (shape the GAS renderer consumes 1:1):

--- a/qa-automation/AI-Scoring/tests/test_hr_bonus.py
+++ b/qa-automation/AI-Scoring/tests/test_hr_bonus.py
@@ -1,0 +1,430 @@
+"""HR bonus sheet backend — config block, month payload, endpoint.
+
+Spec: references/HRBonusSheet.md. P1 checkpoint tests cover the
+`hr_export` config block and its internal-only invariant; P2 covers the
+aggregation math, month bucketing (incl. the DST boundary), the
+no-prior-month-leakage rule, and — load-bearing — golden parity between
+the service and the HR-approved mockup exporter on identical data.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from backend.config.team_config import TeamConfig, _assemble_rubric_block
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity, TEAM_AUTH_DEPENDENCY
+from backend.routes import hr_bonus as hr_bonus_route
+from backend.services.hr_bonus_service import (
+    build_payload_from_rows,
+    month_window_utc,
+)
+from tests.conftest import load_test_config
+
+_LA = ZoneInfo("America/Los_Angeles")
+_AI_SCORING = Path(__file__).resolve().parent.parent
+
+MS_HR_SECTION_IDS = [
+    "greeting", "caller_id", "purpose", "matching", "process_adherence",
+    "call_resolution", "comms", "efficiency", "cri",
+]
+
+
+def _ms_raw() -> dict:
+    """Prod MS JSON, loader-normalized, ready for mutation + TeamConfig()."""
+    path = _AI_SCORING / "backend" / "config" / "teams" / "member_support.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["rubric"] = _assemble_rubric_block(raw)
+    for legacy_key in ("rubric_version", "sections", "scoring_prompt"):
+        raw.pop(legacy_key, None)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# P1 — hr_export config block
+# ---------------------------------------------------------------------------
+
+def test_shipped_ms_config_exports_exactly_the_nine_spec_sections():
+    config = load_test_config("member_support")
+    assert config.hr_export is not None
+    assert [s.id for s in config.hr_export.sections] == MS_HR_SECTION_IDS
+    assert config.hr_export.sections[0].hr_label == "Greeting"
+    assert config.hr_export.sections[-1].hr_label == "CRI"
+
+
+def test_shipped_ms_config_never_exports_human_review_required():
+    config = load_test_config("member_support")
+    assert "human_review_required" in config.hr_internal_section_ids
+    assert "human_review_required" not in {s.id for s in config.hr_export.sections}
+
+
+def test_teams_without_hr_export_load_fine():
+    config = load_test_config("sales")
+    assert config.hr_export is None
+
+
+def test_internal_only_section_in_hr_export_is_rejected():
+    raw = _ms_raw()
+    raw["hr_export"]["sections"].append(
+        {"id": "human_review_required", "hr_label": "HRR"}
+    )
+    with pytest.raises(ValidationError, match="internal-only"):
+        TeamConfig(**raw)
+
+
+def test_unknown_section_id_in_hr_export_is_rejected():
+    raw = _ms_raw()
+    raw["hr_export"]["sections"].append({"id": "nonexistent", "hr_label": "X"})
+    with pytest.raises(ValidationError, match="not a rubric section"):
+        TeamConfig(**raw)
+
+
+def test_duplicate_section_id_in_hr_export_is_rejected():
+    raw = _ms_raw()
+    raw["hr_export"]["sections"].append({"id": "greeting", "hr_label": "Greeting 2"})
+    with pytest.raises(ValidationError, match="listed twice"):
+        TeamConfig(**raw)
+
+
+def test_empty_hr_export_sections_is_rejected():
+    raw = _ms_raw()
+    raw["hr_export"]["sections"] = []
+    with pytest.raises(ValidationError, match="must not be empty"):
+        TeamConfig(**raw)
+
+
+# ---------------------------------------------------------------------------
+# P2 — month window (project bucket TZ)
+# ---------------------------------------------------------------------------
+
+def test_month_window_is_bucket_tz_not_utc():
+    start, end = month_window_utc("2026-06")
+    # June 1 midnight in LA is 07:00 UTC during DST.
+    assert start == datetime(2026, 6, 1, 7, 0, tzinfo=timezone.utc)
+    assert end == datetime(2026, 7, 1, 7, 0, tzinfo=timezone.utc)
+
+
+def test_dst_boundary_call_buckets_into_prior_month():
+    # 2026-06-01 03:33 UTC is May 31 20:33 in LA — a May call.
+    ts = datetime(2026, 6, 1, 3, 33, tzinfo=timezone.utc)
+    may_start, may_end = month_window_utc("2026-05")
+    june_start, _ = month_window_utc("2026-06")
+    assert may_start <= ts < may_end
+    assert ts < june_start
+
+
+def test_winter_month_window_uses_standard_offset():
+    start, _ = month_window_utc("2026-01")
+    assert start == datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc)  # PST = UTC-8
+
+
+def test_december_window_rolls_the_year():
+    _, end = month_window_utc("2026-12")
+    assert end == datetime(2027, 1, 1, 8, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# P2 — payload assembly
+# ---------------------------------------------------------------------------
+
+def _eval_row(eval_id, agent, ts, overall=90.0, email="a@landing.com",
+              evaluator="boss@landing.com", link="https://dialpad.com/call/1"):
+    return {
+        "id": eval_id, "agent_name_raw": agent, "agent_email": email,
+        "evaluator_email": evaluator, "ts": ts, "overall_score": overall,
+        "dialpad_link": link,
+    }
+
+
+def _num(section_id, value):
+    return {"section_id": section_id, "numeric_score": value, "binary_value": None}
+
+
+def _bin(section_id, value):
+    return {"section_id": section_id, "numeric_score": None, "binary_value": value}
+
+
+def _june(day, hour=12):
+    """LA wall-clock June 2026 instant, as UTC."""
+    return datetime(2026, 6, day, hour, tzinfo=_LA).astimezone(timezone.utc)
+
+
+@pytest.fixture
+def ms_config():
+    return load_test_config("member_support")
+
+
+def test_summary_aggregation_math(ms_config):
+    evals = [_eval_row(1, "Ana", _june(10), overall=88.0),
+             _eval_row(2, "Ana", _june(5), overall=91.0)]
+    sections = {
+        1: {"greeting": _num("greeting", 4), "caller_id": _bin("caller_id", "Y"),
+            "cri": _bin("cri", "NA")},
+        2: {"greeting": _num("greeting", 5), "caller_id": _bin("caller_id", "N"),
+            "cri": _bin("cri", "Y")},
+    }
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, sections)
+    [agent] = payload["agents"]
+    assert agent["monthly_avg"] == 89.5
+    summaries = dict(zip([s.id for s in ms_config.hr_export.sections],
+                         agent["section_summaries"]))
+    assert summaries["greeting"] == "4.50"
+    assert summaries["caller_id"] == "50%"
+    assert summaries["cri"] == "100%"      # NA excluded from the denominator
+    assert summaries["purpose"] == ""      # no data → blank, never 0
+
+
+def test_detail_rows_render_and_order(ms_config):
+    evals = [_eval_row(1, "Ana", _june(5, hour=9), overall=88.0),
+             _eval_row(2, "Ana", _june(20, hour=15), overall=91.0)]
+    sections = {
+        1: {"greeting": _num("greeting", 3), "caller_id": _bin("caller_id", "NA")},
+        2: {"greeting": _num("greeting", 5), "caller_id": _bin("caller_id", "Y")},
+    }
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, sections)
+    rows = payload["agents"][0]["evaluations"]
+    assert [r["date"] for r in rows] == ["06/20/2026 15:00", "06/05/2026 09:00"]  # newest first
+    assert rows[0]["period"] == "2026-06"
+    cells = dict(zip([s.id for s in ms_config.hr_export.sections], rows[0]["sections"]))
+    assert cells["greeting"] == "5"
+    assert cells["caller_id"] == "Yes"
+    assert cells["purpose"] == ""
+    older = dict(zip([s.id for s in ms_config.hr_export.sections], rows[1]["sections"]))
+    assert older["caller_id"] == "N/A"
+
+
+def test_prior_month_rows_never_leak(ms_config):
+    evals = [_eval_row(1, "Ana", _june(10)),
+             _eval_row(2, "Ana", datetime(2026, 5, 20, 19, 0, tzinfo=timezone.utc))]
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, {})
+    [agent] = payload["agents"]
+    assert len(agent["evaluations"]) == 1
+    assert agent["evaluations"][0]["period"] == "2026-06"
+
+
+def test_excluded_agents_filtered_case_insensitively(ms_config):
+    evals = [_eval_row(1, "Ana", _june(10)),
+             _eval_row(2, "Maximiliano Perez", _june(11))]
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, {})
+    assert [a["name"] for a in payload["agents"]] == ["Ana"]
+
+
+def test_agents_sorted_case_insensitively(ms_config):
+    evals = [_eval_row(1, "zoe", _june(10)),
+             _eval_row(2, "Ana", _june(11)),
+             _eval_row(3, "Bruno", _june(12))]
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, {})
+    assert [a["name"] for a in payload["agents"]] == ["Ana", "Bruno", "zoe"]
+
+
+def test_payload_header_fields(ms_config):
+    payload = build_payload_from_rows(ms_config, "2026-06", [], {})
+    assert payload["month"] == "2026-06"
+    assert payload["month_label"] == "June 2026"
+    assert payload["team_id"] == "member_support"
+    assert payload["section_labels"] == [
+        "Greeting", "Caller ID", "Purpose of the call", "Matching the moment",
+        "Process Adherence", "Call Resolution", "Communication",
+        "Efficiency & Call Handling", "CRI",
+    ]
+    assert payload["agents"] == []
+
+
+# ---------------------------------------------------------------------------
+# P2 — golden parity with the HR-approved mockup exporter
+# ---------------------------------------------------------------------------
+
+def _load_mockup_module():
+    path = _AI_SCORING / "scripts" / "export_hr_bonus_sheet.py"
+    spec = importlib.util.spec_from_file_location("export_hr_bonus_sheet", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# mockup CSV column name -> (section id, DB shape) per HRBonusSheet.md §3
+_CSV_TO_DB = [
+    ("Greeting", "greeting", "num"),
+    ("Caller Identity Validation", "caller_id", "bin"),
+    ("Purpose of the Call", "purpose", "num"),
+    ("Matching the Moment", "matching", "num"),
+    ("Process Adherence", "process_adherence", "num"),
+    ("Call Resolution", "call_resolution", "num"),
+    ("Communication", "comms", "num"),
+    ("Efficiency & Call Handling", "efficiency", "num"),
+    ("Customer Resolution Indicator", "cri", "bin"),
+]
+_CSV_BINARY = {"Y": "Yes", "N": "No", "NA": "Not Applicable"}
+
+
+def test_golden_parity_with_mockup_exporter(ms_config):
+    """The DB-sourced service must reproduce the numbers HR approved.
+
+    Two agents, five evaluations, mixed numeric/binary/NA/missing values.
+    The same dataset is fed to the mockup's _summary_row/_detail_rows
+    (CSV shape) and to build_payload_from_rows (DB shape); every summary
+    value and detail cell must agree.
+    """
+    import pandas as pd
+
+    mockup = _load_mockup_module()
+
+    dataset = [
+        # (agent, email, LA day, overall, {section_id: value})
+        ("Ana López", "ana@landing.com", 22, 93.0,
+         {"greeting": 5, "caller_id": "Y", "purpose": 4, "matching": 5,
+          "process_adherence": 4, "call_resolution": 5, "comms": 4,
+          "efficiency": 3, "cri": "Y"}),
+        ("Ana López", "ana@landing.com", 15, 88.0,
+         {"greeting": 4, "caller_id": "N", "purpose": 3, "matching": 4,
+          "process_adherence": 5, "call_resolution": 4, "comms": 5,
+          "efficiency": 4, "cri": "NA"}),
+        ("Ana López", "ana@landing.com", 3, 76.5,
+         {"greeting": 3, "caller_id": "Y", "purpose": 5, "matching": 3,
+          "process_adherence": 3, "call_resolution": 3, "comms": 3,
+          "efficiency": 5, "cri": "N"}),
+        ("bruno díaz", "bruno@landing.com", 18, 81.0,
+         {"greeting": 4, "caller_id": "NA", "purpose": 4, "matching": 2,
+          "call_resolution": 5, "comms": 4, "efficiency": 4, "cri": "Y"}),
+        ("bruno díaz", "bruno@landing.com", 9, 84.5,
+         {"greeting": 2, "caller_id": "Y", "purpose": 5, "matching": 4,
+          "call_resolution": 4, "comms": 5, "efficiency": 3, "cri": "Y"}),
+    ]
+
+    # --- CSV/DataFrame shape for the mockup ------------------------------
+    csv_rows = []
+    for agent, email, day, overall, values in dataset:
+        wall = datetime(2026, 6, day, 12, 0)
+        row = {
+            "Agent Name": agent, "Agent Email": email,
+            "Overall Score": overall,
+            "Evaluator Email": "boss@landing.com",
+            "Dialpad Link": f"https://dialpad.com/call/{day}",
+            "_ts": pd.Timestamp(wall), "_period": "2026-06", "_agent": agent,
+        }
+        for csv_col, sec_id, shape in _CSV_TO_DB:
+            v = values.get(sec_id)
+            if v is None:
+                row[csv_col] = ""
+            elif shape == "bin":
+                row[csv_col] = _CSV_BINARY[v]
+            else:
+                row[csv_col] = v
+        csv_rows.append(row)
+    df = pd.DataFrame(csv_rows).sort_values("_ts", ascending=False)
+
+    # --- DB shape for the service ----------------------------------------
+    eval_rows, sections_by_eval = [], {}
+    for i, (agent, email, day, overall, values) in enumerate(dataset, start=1):
+        eval_rows.append(_eval_row(
+            i, agent, _june(day), overall=overall, email=email,
+            link=f"https://dialpad.com/call/{day}",
+        ))
+        sections_by_eval[i] = {}
+        for _, sec_id, shape in _CSV_TO_DB:
+            v = values.get(sec_id)
+            if v is None:
+                continue
+            sections_by_eval[i][sec_id] = (
+                _bin(sec_id, v) if shape == "bin" else _num(sec_id, v)
+            )
+
+    payload = build_payload_from_rows(ms_config, "2026-06", eval_rows, sections_by_eval)
+
+    # --- Compare, agent by agent ------------------------------------------
+    assert [a["name"] for a in payload["agents"]] == ["Ana López", "bruno díaz"]
+    for agent_payload in payload["agents"]:
+        rows = df[df["_agent"] == agent_payload["name"]]
+        expected = mockup._summary_row(agent_payload["name"], rows)
+
+        assert agent_payload["email"] == expected[1]
+        assert agent_payload["monthly_avg"] == expected[2]
+        for got, want in zip(agent_payload["section_summaries"], expected[3:]):
+            if isinstance(want, float):
+                assert float(got) == pytest.approx(want)
+            else:
+                assert got == want  # "%Yes" strings and blanks
+
+        detail = mockup._detail_rows(rows)
+        header, mock_rows = detail[0], detail[1:]
+        assert len(mock_rows) == len(agent_payload["evaluations"])
+        for mock_row, got in zip(mock_rows, agent_payload["evaluations"]):
+            assert got["period"] == mock_row[0]
+            assert got["date"] == mock_row[1]
+            assert float(got["overall_score"]) == float(mock_row[2])
+            assert got["sections"] == [str(c) for c in mock_row[3:12]]
+            assert got["evaluator"] == mock_row[12]
+            assert got["dialpad_link"] == mock_row[13]
+
+
+# ---------------------------------------------------------------------------
+# P2 — endpoint
+# ---------------------------------------------------------------------------
+
+MS_TOKEN = "team-ms-tok"
+SALES_TOKEN = "team-sales-tok"
+
+
+@pytest.fixture
+def hr_client(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        MS_TOKEN: KeyIdentity(role="team", team_id="member_support"),
+        SALES_TOKEN: KeyIdentity(role="team", team_id="sales"),
+    })
+    app = FastAPI()
+    app.include_router(
+        hr_bonus_route.router,
+        prefix="/api/{team_id}",
+        dependencies=TEAM_AUTH_DEPENDENCY,
+    )
+    return TestClient(app)
+
+
+def _get(client, team, month, token):
+    return client.get(
+        f"/api/{team}/hr-bonus/{month}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_endpoint_returns_service_payload(hr_client, monkeypatch):
+    async def fake_fetch(config, month):
+        return {"team_id": config.team_id, "month": month, "agents": []}
+    monkeypatch.setattr(hr_bonus_route, "fetch_month_payload", fake_fetch)
+    resp = _get(hr_client, "member_support", "2026-06", MS_TOKEN)
+    assert resp.status_code == 200
+    assert resp.json() == {"team_id": "member_support", "month": "2026-06", "agents": []}
+
+
+def test_endpoint_rejects_malformed_month(hr_client):
+    for bad in ("2026-13", "junk", "2026-6", "2026-06-01"):
+        resp = _get(hr_client, "member_support", bad, MS_TOKEN)
+        assert resp.status_code == 422, bad
+
+
+def test_endpoint_404s_for_team_without_hr_export(hr_client):
+    resp = _get(hr_client, "sales", "2026-06", SALES_TOKEN)
+    assert resp.status_code == 404
+    assert "no HR export" in resp.json()["detail"]
+
+
+def test_endpoint_503s_without_database(hr_client, monkeypatch):
+    async def fake_fetch(config, month):
+        return None
+    monkeypatch.setattr(hr_bonus_route, "fetch_month_payload", fake_fetch)
+    resp = _get(hr_client, "member_support", "2026-06", MS_TOKEN)
+    assert resp.status_code == 503
+
+
+def test_endpoint_requires_matching_team_key(hr_client):
+    resp = _get(hr_client, "member_support", "2026-06", SALES_TOKEN)
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
Implements checkpoints **P1** and **P2** of `references/HRBonusSheet.md` (merged in #96).

## P1 — `hr_export` config block
- `HrExportConfig` on `TeamConfig`: ordered HR-visible section list (`id` + `hr_label`) and `excluded_agents`, both out of code.
- `hr_internal_section_ids` lives at the **top level** of the team JSON, deliberately outside the content-hashed `rubric` block, so the HR flag can't perturb rubric version archiving.
- Model validator rejects internal-only / unknown / duplicate ids and empty lists — `human_review_required` structurally cannot ship to HR.
- `member_support.json` gains the 9 approved sections; Sales has no block and 404s by design (spec §8).

## P2 — service + endpoint
- `hr_bonus_service.py`: pure `build_payload_from_rows` (rows → §5 payload) + thin asyncpg wrapper reusing `eval_store.get_pool()`. Semantics per spec §4: `state='finalized'`, `COALESCE(call_connected_at, created_at)` call time, `America/Los_Angeles` month bucketing, `%Yes` with NA-free denominator, blank-not-zero, one rounding site.
- **No prior-month leakage** enforced twice: SQL window + defensive in-service filter (owner-confirmed closing-month-only rule).
- Route mounted team-aware at `/api/{team_id}/hr-bonus/{month}` with `TEAM_AUTH` (spec §5 text synced to the house path in this PR); malformed month → 422, no `hr_export` → 404, no DB → 503.

## Tests (23 new)
- Config invariants (incl. the `human_review_required` rejection).
- Month window incl. the DST boundary (June 1 03:33 UTC is a May call) and December year-roll.
- Aggregation math, ordering, exclusion, leakage.
- **Golden parity**: the service reproduces the HR-approved mockup exporter's every summary value and detail cell on identical two-agent/five-eval data — proving HR gets exactly what they signed off on.
- Full suite: 733 passed; only failure is the pre-existing task #7 date-flake.

Next: P3 (the `hr-bonus/` GAS suite) per the spec's build plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)