### PR TITLE
feat(qa-automation): hr-bonus GAS suite — monthly workbook renderer (spec P3)

### DIFF
--- a/push.projects
+++ b/push.projects
@@ -14,3 +14,4 @@
 mass-notifications	mass-notifications/src	no	Mass Notifications
 qa-member-support	qa-automation/teams/member_support	yes	QA Automation — Member Support
 qa-sales	qa-automation/teams/sales	no	QA Automation — Sales (staging until cutover)
+hr-bonus	qa-automation/hr-bonus	no	HR Bonus Sheet — monthly export renderer (MS)

--- a/qa-automation/AI-Scoring/references/HRBonusSheet.md
+++ b/qa-automation/AI-Scoring/references/HRBonusSheet.md
@@ -197,25 +197,27 @@ Implementation: `backend/services/hr_bonus_service.py` (pure query + aggregation
 
 ## 6. GAS suite
 
-New top-level GAS project `qa-automation/hr-bonus/`, built and pushed through the existing
-pipeline (`push.sh` target + `scripts/build_config.py` emitting its `Config.js`). It reuses the
-established patterns from `src/` (config-driven, render-only) but is deliberately tiny:
+New top-level GAS project `qa-automation/hr-bonus/`, registered as the `hr-bonus` target in
+`push.projects` (single-project layout — no team overlay, no build step). It reuses the
+established patterns from `src/` (render-only, backend preps the data) but is deliberately tiny:
 
 | File | Responsibility |
 |---|---|
-| `Main.js` | `runMonthlyExport()` — trigger entry; computes prior month, orchestrates; `runExportFor(month)` for manual re-runs (custom menu) |
+| `Main.js` | `runMonthlyExport()` — trigger entry; `runManualExport()` (re-run via `MANUAL_MONTH` Script Property); `installMonthlyTrigger()`; failure alerts |
 | `ApiClient.js` | `UrlFetchApp` GET to the backend with the API key from Script Properties; JSON parse + error surfacing |
 | `SheetWriter.js` | Summary + detail tab rendering per §2 (clear-in-place, freeze header, index 0 for summary) |
-| `Config.js` | generated — backend base URL, team id |
+| `Config.js` | static — team id only (everything dynamic arrives in the payload; deployment values live in Script Properties) |
 
-- **Script Properties:** `HR_BONUS_API_KEY` (the reporting key), `HR_BONUS_SPREADSHEET_ID`
-  (the workbook — GAS opens by id; the suite is not container-bound so the workbook can be
-  swapped without redeploying).
-- **Trigger:** time-driven, **1st of each month, 06:00–07:00 America/Los_Angeles**, exporting
-  the month that just ended.
+- **Script Properties:** `BACKEND_BASE_URL`, `HR_BONUS_API_KEY` (the team API key),
+  `HR_BONUS_SPREADSHEET_ID` (the workbook — GAS opens by id; the suite is not
+  container-bound so the workbook can be swapped without redeploying), optional
+  `ALERT_EMAIL` and `MANUAL_MONTH`.
+- **Trigger:** time-driven, **1st of each month, 06:00–07:00 America/Los_Angeles** (the
+  script timezone in `appsscript.json`), exporting the month that just ended. Installed
+  once via `installMonthlyTrigger()` (idempotent — never stacks duplicates).
 - **Failure handling:** any error → `MailApp` alert to the operator with the error and month;
   no partial-write cleanup needed because re-runs are idempotent (§2). No retry loop in v1 —
-  the operator re-runs from the menu.
+  the operator re-runs via `runManualExport()` (standalone scripts have no spreadsheet menu).
 - **Write pacing:** `SpreadsheetApp` batched `setValues` per tab (one write per tab — the
   Sheets-API-quota pacing that shaped the mockup's `_paced` writer doesn't apply to GAS).
 

--- a/qa-automation/hr-bonus/ApiClient.js
+++ b/qa-automation/hr-bonus/ApiClient.js
@@ -1,0 +1,41 @@
+/**
+ * HR Bonus Sheet — backend API client (references/HRBonusSheet.md §5)
+ *
+ * One GET per export: /api/{team_id}/hr-bonus/{month} with the team's
+ * API key. The response is consumed 1:1 by SheetWriter — no math, no
+ * reshaping happens on this side.
+ */
+
+/**
+ * Fetch the month payload from the backend.
+ * @param {string} month "YYYY-MM"
+ * @return {Object} the §5 payload
+ */
+function fetchMonthPayload_(month) {
+  var props = PropertiesService.getScriptProperties();
+  var base = requiredProperty_(props, "BACKEND_BASE_URL").replace(/\/+$/, "");
+  var key = requiredProperty_(props, "HR_BONUS_API_KEY");
+
+  var url = base + "/api/" + encodeURIComponent(CONFIG.TEAM_ID)
+    + "/hr-bonus/" + encodeURIComponent(month);
+  var response = UrlFetchApp.fetch(url, {
+    method: "get",
+    headers: { Authorization: "Bearer " + key },
+    muteHttpExceptions: true,
+  });
+
+  var code = response.getResponseCode();
+  if (code !== 200) {
+    throw new Error("Backend returned " + code + " for " + url + ": "
+      + response.getContentText().slice(0, 500));
+  }
+  return JSON.parse(response.getContentText());
+}
+
+function requiredProperty_(props, name) {
+  var value = props.getProperty(name);
+  if (!value) {
+    throw new Error("Script Property " + name + " is not set — see hr-bonus/README.md.");
+  }
+  return value;
+}

--- a/qa-automation/hr-bonus/Config.js
+++ b/qa-automation/hr-bonus/Config.js
@@ -1,0 +1,13 @@
+/**
+ * HR Bonus Sheet — Config (static)
+ *
+ * Deliberately NOT build_config.py-generated: the backend month payload
+ * carries every dynamic value (section labels, order, display strings),
+ * so this suite only needs to know which team to ask for. Deployment-
+ * specific values (backend URL, API key, workbook id) live in Script
+ * Properties — see README.md.
+ */
+
+var CONFIG = {
+  TEAM_ID: "member_support",
+};

--- a/qa-automation/hr-bonus/Main.js
+++ b/qa-automation/hr-bonus/Main.js
@@ -1,0 +1,95 @@
+/**
+ * HR Bonus Sheet — entry points (references/HRBonusSheet.md §6)
+ *
+ * Standalone (not container-bound) script. The monthly trigger fires in
+ * the script timezone (America/Los_Angeles per appsscript.json) on the
+ * 1st and exports the month that just ended. Re-runs are idempotent —
+ * tabs are cleared and rewritten in place — so any failure is recovered
+ * by simply running the export again.
+ */
+
+/**
+ * Trigger entry point: export the month that just ended.
+ * Installed by installMonthlyTrigger().
+ */
+function runMonthlyExport() {
+  exportMonth_(priorMonth_(new Date()));
+}
+
+/**
+ * Manual re-run for an arbitrary month: set the Script Property
+ * MANUAL_MONTH to "YYYY-MM" and run this function from the editor.
+ * (Standalone scripts have no spreadsheet menu to hang a prompt on.)
+ */
+function runManualExport() {
+  var month = PropertiesService.getScriptProperties().getProperty("MANUAL_MONTH");
+  if (!month || !/^\d{4}-(0[1-9]|1[0-2])$/.test(month)) {
+    throw new Error('Set Script Property MANUAL_MONTH to "YYYY-MM" before running.');
+  }
+  exportMonth_(month);
+}
+
+/**
+ * One-time setup: install the monthly trigger (1st of each month,
+ * 06:00–07:00 script time). Deletes any prior runMonthlyExport triggers
+ * first so repeated runs never stack duplicates.
+ */
+function installMonthlyTrigger() {
+  ScriptApp.getProjectTriggers().forEach(function (t) {
+    if (t.getHandlerFunction() === "runMonthlyExport") {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+  ScriptApp.newTrigger("runMonthlyExport")
+    .timeBased()
+    .onMonthDay(1)
+    .atHour(6)
+    .create();
+  Logger.log("Monthly trigger installed: runMonthlyExport, 1st of month ~06:00 %s",
+             Session.getScriptTimeZone());
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the month payload from the backend and render the workbook.
+ * On any error: email the operator, then rethrow so the failure is
+ * visible in the Apps Script executions log.
+ */
+function exportMonth_(month) {
+  try {
+    var payload = fetchMonthPayload_(month);
+    var counts = writeMonthToWorkbook_(payload);
+    Logger.log("Exported %s: %s agents, %s evaluations",
+               month, counts.agents, counts.evaluations);
+  } catch (e) {
+    notifyFailure_(month, e);
+    throw e;
+  }
+}
+
+/** "YYYY-MM" of the month before the given date, in the script timezone. */
+function priorMonth_(now) {
+  var tz = Session.getScriptTimeZone();
+  var year = Number(Utilities.formatDate(now, tz, "yyyy"));
+  var month = Number(Utilities.formatDate(now, tz, "MM"));
+  if (month === 1) {
+    return (year - 1) + "-12";
+  }
+  return year + "-" + (month - 1 < 10 ? "0" : "") + (month - 1);
+}
+
+/** Email the operator about a failed export. ALERT_EMAIL Script Property
+ *  overrides the default (the account the trigger runs as). */
+function notifyFailure_(month, error) {
+  var to = PropertiesService.getScriptProperties().getProperty("ALERT_EMAIL")
+    || Session.getEffectiveUser().getEmail();
+  MailApp.sendEmail({
+    to: to,
+    subject: "[HR Bonus Sheet] Export FAILED for " + month,
+    body: "The HR bonus export for " + month + " failed.\n\n" +
+          "Error: " + error + "\n\n" +
+          "Re-run is safe (tabs rewrite in place): fix the cause, then run " +
+          "runManualExport with Script Property MANUAL_MONTH=" + month + ".",
+  });
+}

--- a/qa-automation/hr-bonus/README.md
+++ b/qa-automation/hr-bonus/README.md
@@ -1,0 +1,44 @@
+# HR Bonus Sheet — GAS suite
+
+Monthly renderer for the HR-facing Agent Bonus workbook. Spec:
+`qa-automation/AI-Scoring/references/HRBonusSheet.md` (§6). The backend
+computes every number (`GET /api/{team_id}/hr-bonus/{month}`); this
+suite fetches the JSON and writes the tabs — zero math on this side.
+
+| File | Responsibility |
+|---|---|
+| `Main.js` | trigger entry (`runMonthlyExport`), manual re-run, trigger install, failure alerts |
+| `ApiClient.js` | authenticated GET to the backend |
+| `SheetWriter.js` | summary + detail tab rendering (clear-in-place, idempotent) |
+| `Config.js` | static — team id only (everything dynamic arrives in the payload) |
+
+## One-time setup (operator)
+
+1. **Create the standalone Apps Script project** (not container-bound —
+   the workbook stays swappable): `clasp create --type standalone
+   --title "HR Bonus Sheet — Member Support"` from this directory, or in
+   the web editor. Put the resulting script id into `.clasp.json`.
+2. **Register is already done** — `push.projects` has the `hr-bonus`
+   row; deploy with `./push.sh hr-bonus` from the repo root.
+3. **Script Properties** (Project Settings → Script Properties):
+   - `BACKEND_BASE_URL` — the Railway app origin, no trailing slash
+   - `HR_BONUS_API_KEY` — the member_support team API key
+   - `HR_BONUS_SPREADSHEET_ID` — the HR bonus workbook id
+   - `ALERT_EMAIL` — (optional) failure-alert recipient; defaults to the
+     trigger owner
+4. **Install the trigger**: run `installMonthlyTrigger()` once from the
+   editor. It fires on the 1st of each month at ~06:00
+   America/Los_Angeles (the script timezone) and exports the month that
+   just ended. Re-running the installer never stacks duplicate triggers.
+
+## Operations
+
+- **Re-run any month**: set Script Property `MANUAL_MONTH` to `YYYY-MM`
+  and run `runManualExport()`. Re-runs are idempotent — tabs are cleared
+  and rewritten in place; nothing is ever deleted.
+- **Failures**: the operator gets a `MailApp` alert with the month and
+  error; the execution also shows in the Apps Script executions log.
+  Fix the cause and re-run — no cleanup needed.
+- **First supervised run** (spec P4): 2026-08-01 for July data, operator
+  watching; verify the alert path by running once with a deliberately
+  wrong `HR_BONUS_API_KEY` beforehand if desired.

--- a/qa-automation/hr-bonus/SheetWriter.js
+++ b/qa-automation/hr-bonus/SheetWriter.js
@@ -1,0 +1,67 @@
+/**
+ * HR Bonus Sheet — workbook renderer (references/HRBonusSheet.md §2)
+ *
+ * Renders the backend month payload verbatim: one summary tab per month
+ * (inserted at index 0 when new) + one detail tab per agent. Existing
+ * tabs are cleared and rewritten in place — never deleted — so re-runs
+ * are idempotent and external links to tabs survive.
+ */
+
+/**
+ * Write the whole month: summary tab + one detail tab per agent.
+ * @param {Object} payload the §5 backend payload
+ * @return {{agents: number, evaluations: number}} counts for logging
+ */
+function writeMonthToWorkbook_(payload) {
+  var props = PropertiesService.getScriptProperties();
+  var workbook = SpreadsheetApp.openById(
+    requiredProperty_(props, "HR_BONUS_SPREADSHEET_ID"));
+
+  writeSummaryTab_(workbook, payload);
+  var evaluations = 0;
+  payload.agents.forEach(function (agent) {
+    writeDetailTab_(workbook, payload, agent);
+    evaluations += agent.evaluations.length;
+  });
+  return { agents: payload.agents.length, evaluations: evaluations };
+}
+
+function writeSummaryTab_(workbook, payload) {
+  var header = ["Agent Name", "Agent Email", "Monthly Avg"]
+    .concat(payload.section_labels);
+  var rows = payload.agents.map(function (agent) {
+    return [agent.name, agent.email, agent.monthly_avg]
+      .concat(agent.section_summaries);
+  });
+  renderTab_(workbook, payload.month_label, [header].concat(rows), 0);
+}
+
+function writeDetailTab_(workbook, payload, agent) {
+  var header = ["Period", "Date", "Overall Score"]
+    .concat(payload.section_labels)
+    .concat(["Evaluator", "Dialpad Link"]);
+  var rows = agent.evaluations.map(function (e) {
+    return [e.period, e.date, e.overall_score]
+      .concat(e.sections)
+      .concat([e.evaluator, e.dialpad_link]);
+  });
+  renderTab_(workbook, agent.name, [header].concat(rows), null);
+}
+
+/**
+ * Clear-in-place render: reuse the tab when it exists (preserving its id
+ * and external links), otherwise insert it — at `index` when given.
+ * One setValues call per tab; SpreadsheetApp batches internally, so the
+ * Sheets-API write-quota pacing the mockup needed doesn't apply here.
+ */
+function renderTab_(workbook, title, grid, index) {
+  var sheet = workbook.getSheetByName(title);
+  if (!sheet) {
+    sheet = index === null
+      ? workbook.insertSheet(title)
+      : workbook.insertSheet(title, index);
+  }
+  sheet.clear();
+  sheet.getRange(1, 1, grid.length, grid[0].length).setValues(grid);
+  sheet.setFrozenRows(1);
+}


### PR DESCRIPTION
Implements checkpoint **P3** of `references/HRBonusSheet.md`: the standalone GAS project that renders the HR bonus workbook from the #97 endpoint.

- **Math-free by design**: one authenticated `GET /api/{team_id}/hr-bonus/{month}`, then verbatim rendering — summary tab (index 0 when new) + one detail tab per agent, single `setValues` per tab, clear-in-place so re-runs are idempotent and external tab links survive.
- **Trigger**: `installMonthlyTrigger()` installs the 1st-of-month ~06:00 run (America/Los_Angeles via the script timezone; the installer never stacks duplicates). Manual re-run of any month via `MANUAL_MONTH` Script Property + `runManualExport()` — standalone scripts have no spreadsheet menu, so the spec's "menu" wording was corrected (§6 synced in this PR).
- **Failure path**: any error emails the operator (`ALERT_EMAIL`, defaulting to the trigger owner) with the month and a re-run recipe, then rethrows so it lands in the executions log.
- **Pipeline**: registered as the `hr-bonus` target in `push.projects` (single-project layout — verified with `./push.sh hr-bonus --dry-run`). `Config.js` is static (team id only): everything dynamic arrives in the payload; `BACKEND_BASE_URL` / `HR_BONUS_API_KEY` / `HR_BONUS_SPREADSHEET_ID` live in Script Properties.
- **Operator setup** (clasp create → script id → properties → trigger install) documented in `hr-bonus/README.md`; `.clasp.json` ships with a placeholder until `clasp create`.

Remaining before P4 (supervised 2026-08-01 first run): operator creates the Apps Script project + fills Script Properties, one manual smoke into a copy workbook (P3's manual checkpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)