### PR TITLE
refactor(qa-automation): slice 5 — delete pre-cutover scoring paths (CutoverDesign §8 PR-5)

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -35,12 +35,8 @@ from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
     append_score_audit_row,
-    apply_analyst_edits_to_fr_ai,
-    finalize_to_analyst_history,
-    read_score_and_writeback,
     trigger_apps_script,
     write_draft_to_fr_ai,
-    write_to_score_destination,
 )
 from backend.services.dialpad_client import (
     DialpadRateLimited,
@@ -401,17 +397,16 @@ async def score_single_call(
                     call_details=call_details,
                 )
             row_num = write_draft_to_fr_ai(scorecard, config)
-            # Stage 1 dual-write. Pre-flip (§7.3 Phase A): never raises.
-            # Post-flip (scoring_owner='postgres', Phase C): DB errors raise
-            # and the whole job errors — the DB row is truth.
-            owner = await eval_store.get_scoring_owner(team_id)
+            # Stage 1 dual-write (§7.3 Phase C): the DB row is truth — DB
+            # errors raise and the whole job errors. The FR-AI sheet write
+            # above is the projection side of the dual-write.
             evaluation_id = await record_draft_evaluation(
-                scorecard, config, strict=(owner == "postgres")
+                scorecard, config, strict=True
             )
             _jobs[key]["sheets_row"] = row_num
             _jobs[key]["evaluation_id"] = evaluation_id
             _jobs[key]["scorecard"] = scorecard.model_dump()
-            if owner == "postgres" and evaluation_id is not None:
+            if evaluation_id is not None:
                 await _postgres_post_stage1(
                     _jobs[key], evaluation_id, scorecard, config, team_id
                 )
@@ -526,14 +521,13 @@ async def score_batch(
                         duration_ms=dur,
                     )
                 row_num = write_draft_to_fr_ai(scorecard, config)
-                owner = await eval_store.get_scoring_owner(team_id)
                 evaluation_id = await record_draft_evaluation(
-                    scorecard, config, strict=(owner == "postgres")
+                    scorecard, config, strict=True
                 )
                 _jobs[k]["sheets_row"] = row_num
                 _jobs[k]["evaluation_id"] = evaluation_id
                 _jobs[k]["scorecard"] = scorecard.model_dump()
-                if owner == "postgres" and evaluation_id is not None:
+                if evaluation_id is not None:
                     await _postgres_post_stage1(
                         _jobs[k], evaluation_id, scorecard, config, team_id
                     )
@@ -556,11 +550,15 @@ async def approve_scorecard(
 ):
     """
     Manager approves a scored call (optionally with edits).
-    Updates Form Responses AI, copies to Form Responses 1,
-    waits for ARRAYFORMULA, then triggers Apps Script email pipeline.
 
-    Writes a Score_Audit row with action="approved" once Stage 4
-    succeeds — captured before the Apps Script email dispatch so an
+    Engine path (CutoverDesign §2/§5): DB state transition + engine
+    compute + Sheets projection, then the Apps Script email dispatch.
+    No destination tab, no ARRAYFORMULA readback — DB errors are hard
+    errors (§7.3 Phase C). The pre-cutover four-stage sheet flow was
+    deleted in the §8 slice-5 cleanup.
+
+    Writes a Score_Audit row with action="approved" once the evaluation
+    finalizes — captured before the Apps Script email dispatch so an
     Apps Script failure still leaves the audit trail intact.
     """
     team_id = team_id_from_path(request)
@@ -603,150 +601,23 @@ async def approve_scorecard(
         job["status"] = "complete"
         raise HTTPException(status_code=409, detail="Evaluation is finalized (engine-scored) — read-only")
 
-    owner = await eval_store.get_scoring_owner(team_id)
-    if owner == "postgres":
-        # Flagged-call resolution path (CutoverDesign §2/§5): DB transition +
-        # engine compute + projections. No destination tab, no readback —
-        # DB errors are hard errors (§7.3 Phase C).
-        sc = job["scorecard"]
-        evaluator_email = sc.get("manager_email", "")
-        # Backend guard behind the frontend's "Score Required" gate: manual
-        # sections without a formula na_default must carry real scores —
-        # NA would ride into full credit (the 2026-07-06 Sales find).
-        unscored = eval_store.missing_manual_scores(config, approval.sections)
-        if unscored:
-            job["status"] = "complete"
-            raise HTTPException(
-                status_code=422,
-                detail=f"Manual sections require scores before approval: {unscored}",
-            )
-        try:
-            evaluation_id = await record_approval(
-                config,
-                evaluation_id=job.get("evaluation_id"),
-                dialpad_link=sc.get("dialpad_link"),
-                evaluator_email=evaluator_email,
-                approved_sections=approval.sections,
-                draft_sections=sc.get("sections", []),
-                key_strengths=approval.key_strengths,
-                opportunities=approval.opportunities,
-                overall_score_raw=None,  # the engine produces the number
-                agent_email=job.get("agent_email") or None,
-                model=sc.get("model", "gemini-2.5-flash"),
-                strict=True,
-                resolving_review=job.get("scoring_status") == "flagged_human_review",
-            )
-            if evaluation_id is None:
-                raise HTTPException(status_code=500, detail="No draft evaluation row to approve")
-            detail = await eval_store.stamp_and_finalize(
-                evaluation_id, config, evaluator_email=evaluator_email
-            )
-            pool = await eval_store.get_pool()
-            history_row = await project_evaluation(
-                pool, evaluation_id, config, include_history=True
-            )
-            if history_row is not None and history_row > 0:
-                try:
-                    script_response = trigger_apps_script(history_row, team_id)
-                    job["email_dispatch"] = script_response
-                except Exception as e:
-                    job["email_dispatch"] = {"status": "error", "message": str(e)}
-                    logging.getLogger(__name__).exception(
-                        "approve: Apps Script dispatch failed for eval %s (retryable)",
-                        evaluation_id,
-                    )
-            await _publish_finalized_event(
-                team_id, job,
-                agent_name=job.get("agent_name") or sc.get("agent_name"),
-                evaluator_email=evaluator_email,
-                overall_score=float(detail.overall_score),
-                history_row=history_row,
-                dialpad_link=sc.get("dialpad_link"),
-                call_summary=sc.get("call_summary", ""),
-                key_strengths=approval.key_strengths,
-                opportunities=approval.opportunities,
-            )
-            append_score_audit_row(
-                api_key_role=identity.role,
-                evaluator_email=evaluator_email,
-                agent_email=job.get("agent_email", ""),
-                agent_name=job.get("agent_name") or sc.get("agent_name") or "",
-                call_id=job.get("call_id", ""),
-                target_team=team_id,
-                action=audit_cfg.ACTION_APPROVED,
-                result_row=history_row,
-                notes="engine-scored",
-            )
-            job["status"] = "approved"
-            job["state"] = "finalized"
-            job["scoring_status"] = "complete"
-            job["overall_score"] = float(detail.overall_score)
-            job["evaluation_id"] = evaluation_id
-            return {
-                "status": "approved",
-                "state": "finalized",
-                "overall_score": float(detail.overall_score),
-                "history_row": history_row,
-            }
-        except HTTPException:
-            job["status"] = "complete"
-            raise
-        except Exception as e:
-            # Roll back to 'complete' so the manager can retry — the failed
-            # DB transaction rolled back too, so the row is still consistent.
-            # (Mirrors the legacy path's retry semantics.)
-            job["status"] = "complete"
-            job["error"] = str(e)
-            raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
-
+    # Engine approval (CutoverDesign §2/§5): DB transition + engine compute
+    # + projections. No destination tab, no readback — DB errors are hard
+    # errors (§7.3 Phase C).
+    sc = job["scorecard"]
+    evaluator_email = sc.get("manager_email", "")
+    # Backend guard behind the frontend's "Score Required" gate: manual
+    # sections without a formula na_default must carry real scores —
+    # NA would ride into full credit (the 2026-07-06 Sales find).
+    unscored = eval_store.missing_manual_scores(config, approval.sections)
+    if unscored:
+        job["status"] = "complete"
+        raise HTTPException(
+            status_code=422,
+            detail=f"Manual sections require scores before approval: {unscored}",
+        )
     try:
-        sections_dicts = [s.model_dump() for s in approval.sections]
-        sc = job["scorecard"]
-        # Treat the scoring-time manager_email as the evaluator at approval
-        # time. Future: replace with authenticated session user.
-        evaluator_email = sc.get("manager_email", "")
-
-        # Stage 1.5 — apply analyst edits (sections + feedback) to FR-AI
-        print(f"[approve] Stage 1.5: applying analyst edits to FR-AI row {sheets_row}...")
-        apply_analyst_edits_to_fr_ai(
-            fr_ai_row_num=sheets_row,
-            sections=sections_dicts,
-            config=config,
-            key_strengths=approval.key_strengths,
-            opportunities=approval.opportunities,
-        )
-        print("[approve] Stage 1.5 complete.")
-
-        # Stage 2 — write to per-team score destination tab
-        print(f"[approve] Stage 2: writing to score destination ({config.sheets.score_destination.tab_name})...")
-        dest_row = write_to_score_destination(
-            fr_ai_row_num=sheets_row,
-            config=config,
-            evaluator_email=evaluator_email,
-        )
-        print(f"[approve] Stage 2 complete. Destination row: {dest_row}")
-
-        # Stage 3 — poll readback col, write overall_score back to FR-AI col F
-        print(f"[approve] Stage 3: polling {config.sheets.score_destination.score_readback_col}{dest_row} for ARRAYFORMULA result...")
-        overall_score = await read_score_and_writeback(
-            dest_row_num=dest_row,
-            fr_ai_row_num=sheets_row,
-            config=config,
-        )
-        print(f"[approve] Stage 3 complete. Overall score: '{overall_score}'")
-
-        # Stage 4 — finalize to Analyst_History
-        print(f"[approve] Stage 4: finalizing to Analyst_History...")
-        history_row = finalize_to_analyst_history(
-            fr_ai_row_num=sheets_row,
-            evaluator_email=evaluator_email,
-            config=config,
-        )
-        print(f"[approve] Stage 4 complete. Analyst_History row: {history_row}")
-
-        # Postgres dual-write for the whole approve transition (Stages
-        # 1.5+2+3+4 — Wave 2 Phase 4b). §7.3 Phase A: never raises.
-        job["evaluation_id"] = await record_approval(
+        evaluation_id = await record_approval(
             config,
             evaluation_id=job.get("evaluation_id"),
             dialpad_link=sc.get("dialpad_link"),
@@ -755,15 +626,42 @@ async def approve_scorecard(
             draft_sections=sc.get("sections", []),
             key_strengths=approval.key_strengths,
             opportunities=approval.opportunities,
-            overall_score_raw=overall_score,
+            overall_score_raw=None,  # the engine produces the number
             agent_email=job.get("agent_email") or None,
             model=sc.get("model", "gemini-2.5-flash"),
+            strict=True,
+            resolving_review=job.get("scoring_status") == "flagged_human_review",
         )
-
-        # Audit the approval BEFORE Stage 5 so a downstream Apps Script
-        # failure doesn't lose the record. Identity comes from the API key
-        # used to hit /approve (may differ from the one that hit /score —
-        # e.g. a privileged operator approving on behalf of a team).
+        if evaluation_id is None:
+            raise HTTPException(status_code=500, detail="No draft evaluation row to approve")
+        detail = await eval_store.stamp_and_finalize(
+            evaluation_id, config, evaluator_email=evaluator_email
+        )
+        pool = await eval_store.get_pool()
+        history_row = await project_evaluation(
+            pool, evaluation_id, config, include_history=True
+        )
+        if history_row is not None and history_row > 0:
+            try:
+                script_response = trigger_apps_script(history_row, team_id)
+                job["email_dispatch"] = script_response
+            except Exception as e:
+                job["email_dispatch"] = {"status": "error", "message": str(e)}
+                logging.getLogger(__name__).exception(
+                    "approve: Apps Script dispatch failed for eval %s (retryable)",
+                    evaluation_id,
+                )
+        await _publish_finalized_event(
+            team_id, job,
+            agent_name=job.get("agent_name") or sc.get("agent_name"),
+            evaluator_email=evaluator_email,
+            overall_score=float(detail.overall_score),
+            history_row=history_row,
+            dialpad_link=sc.get("dialpad_link"),
+            call_summary=sc.get("call_summary", ""),
+            key_strengths=approval.key_strengths,
+            opportunities=approval.opportunities,
+        )
         append_score_audit_row(
             api_key_role=identity.role,
             evaluator_email=evaluator_email,
@@ -773,69 +671,25 @@ async def approve_scorecard(
             target_team=team_id,
             action=audit_cfg.ACTION_APPROVED,
             result_row=history_row,
-            notes="",
+            notes="engine-scored",
         )
-
-        # Publish "eval_approved" to subscribed dashboards. Fires AFTER
-        # the audit row is written (no event for a half-finalized eval)
-        # and BEFORE Apps Script dispatch (the toast races the email,
-        # which is fine — the dashboard reflects approved state; the
-        # email is the deliverable). Truncates free-text fields to 280
-        # chars to bound per-client SSE payload bytes (LiveDashboard.md
-        # resolved Q2). Full text remains available via /datapoint.
-        def _truncate(s: str, n: int = 280) -> str:
-            s = s or ""
-            return s if len(s) <= n else s[: n - 1] + "…"
-
-        # `eval_id` is the datapoint-route key (entry_point_call_id for
-        # inbound queue calls, master call_id for direct calls). It comes
-        # from the trailing path segment of `dialpad_link`, which
-        # scoring_service.py already builds via build_dialpad_link with
-        # the entry_point_call_id captured by get_call_details. Mirrors
-        # the parse in services/team_stats.py:_parse_row so SSE drill-down
-        # URLs match the Analyst_History eval_id used by /datapoint.
-        def _eval_id_from_link(link: str) -> str:
-            if not link:
-                return ""
-            clean = link.split("[")[0].strip().split("?")[0].strip()
-            return clean.rstrip("/").split("/")[-1]
-
-        dialpad_link = sc.get("dialpad_link", "")
-        eval_id = _eval_id_from_link(dialpad_link) or job.get("call_id", "")
-
-        await get_event_bus().publish(team_id, "eval_approved", {
-            "call_id": job.get("call_id", ""),
-            "eval_id": eval_id,
-            "history_row": history_row,
-            "agent": job.get("agent_name") or sc.get("agent_name") or "",
-            "evaluator_email": evaluator_email,
-            "overall_score": overall_score,
-            "summary": _truncate(sc.get("call_summary", "")),
-            "strengths": _truncate(approval.key_strengths),
-            "opportunities": _truncate(approval.opportunities),
-            "dialpad_link": dialpad_link,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        })
-
-        # Stage 5 — dispatch QA email via Apps Script (reads AH row).
-        print(f"[approve] Triggering Apps Script doPost (history_row={history_row})...")
-        script_response = trigger_apps_script(history_row, config.team_id)
-        print(f"[approve] Apps Script response: {script_response}")
-
         job["status"] = "approved"
-        job["destination_row"] = dest_row
-        job["history_row"] = history_row
-        job["overall_score"] = overall_score
-
+        job["state"] = "finalized"
+        job["scoring_status"] = "complete"
+        job["overall_score"] = float(detail.overall_score)
+        job["evaluation_id"] = evaluation_id
         return {
             "status": "approved",
-            "fr_ai_row": sheets_row,
-            "destination_row": dest_row,
+            "state": "finalized",
+            "overall_score": float(detail.overall_score),
             "history_row": history_row,
-            "overall_score": overall_score,
-            "script_response": script_response,
         }
-
+    except HTTPException:
+        job["status"] = "complete"
+        raise
     except Exception as e:
-        job["status"] = "complete"  # roll back so manager can retry
-        raise HTTPException(status_code=500, detail=f"Approval failed: {str(e)}")
+        # Roll back to 'complete' so the manager can retry — the failed
+        # DB transaction rolled back too, so the row is still consistent.
+        job["status"] = "complete"
+        job["error"] = str(e)
+        raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -58,26 +58,10 @@ _pool = None
 _pool_lock: Optional[asyncio.Lock] = None
 
 
-# ---------------------------------------------------------------------------
-# Per-team scoring truth flag (migration 013 / CutoverDesign §4)
-# ---------------------------------------------------------------------------
-
-async def get_scoring_owner(team_id: str) -> str:
-    """'sheets' (legacy pipeline is truth) or 'postgres' (engine scores,
-    Sheets are projections). Queried per request — the flip is a one-line
-    UPDATE and must take effect without a deploy. Any failure or missing
-    DB degrades to 'sheets' (the safe, legacy mode)."""
-    try:
-        pool = await _get_pool()
-        if pool is None:
-            return "sheets"
-        owner = await pool.fetchval(
-            "SELECT scoring_owner FROM public.teams WHERE id = $1", team_id
-        )
-        return owner or "sheets"
-    except Exception:
-        logger.exception("eval_store: scoring_owner lookup failed for %s — using 'sheets'", team_id)
-        return "sheets"
+# NOTE: get_scoring_owner (the per-request public.teams.scoring_owner
+# lookup) was deleted in the CutoverDesign §8 slice-5 cleanup — both teams
+# run engine-scored, and every caller now assumes 'postgres' semantics.
+# The migration-013 column itself stays in the DB (historical record).
 
 
 # ---------------------------------------------------------------------------
@@ -722,7 +706,6 @@ __all__ = [
     "record_draft_evaluation",
     "record_approval",
     "stamp_and_finalize",
-    "get_scoring_owner",
     "get_pool",
     "build_draft_row",
     "build_draft_sections",

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -1,19 +1,21 @@
-"""Google Sheets writer — Phase 2, four-stage pipeline.
+"""Google Sheets writer — Stage-1 draft projection + Apps Script trigger.
 
-Replaces the monolithic ``append_scorecard_row`` /
-``update_scorecard_reasoning`` / ``write_approved_to_form_responses_1``
-trio with four staged functions:
+Post-cutover surface (CutoverDesign §8 slice-5 cleanup): the engine owns
+scoring, so this module keeps only what the engine pipeline still needs
+from Sheets:
 
-    Stage 1 — write_draft_to_fr_ai          (AI scoring → FR-AI)
-    Stage 1.5 (in route) — apply analyst edits to FR-AI
-    Stage 2 — write_to_score_destination    (on Approve → FR1 / Scores tab)
-    Stage 3 — read_score_and_writeback      (poll readback col → FR-AI col F)
-    Stage 4 — finalize_to_analyst_history   (FR-AI → Analyst_History)
+    Stage 1 — write_draft_to_fr_ai   (AI scoring → FR-AI draft row)
+    Score_Audit append               (action-level audit tab)
+    trigger_apps_script              (email dispatch by AH row number)
 
-Both FR-AI and Analyst_History use the derived layout
-(``config.history_layout``); the only hardcoded letters live in the
-per-team ``score_destination`` block (mirrors legacy form layouts that
-ARRAYFORMULAs depend on).
+The pre-cutover four-stage flow (analyst edits → destination write →
+ARRAYFORMULA readback → Analyst_History finalize, plus the Mails
+runtime lookup) was deleted in slice 5; on approve, the DB transitions
+and ``sheets_projection.project_evaluation`` writes the FR-AI overwrite
+and the Analyst_History row from the qa.* record.
+
+FR-AI and Analyst_History use the derived layout
+(``config.history_layout``).
 
 ``trigger_apps_script`` posts the Analyst_History row number to the
 team's Apps Script web app, which reads the populated row and
@@ -28,7 +30,6 @@ Setup:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import re
@@ -142,20 +143,6 @@ def _format_ai_score(sec_def: RubricSection, ai_section: dict) -> str:
     return str(score) if score is not None else "N/A"
 
 
-def _combine_feedback(key_strengths: str, opportunities: str) -> str:
-    """Combine key_strengths + opportunities into a single feedback cell.
-
-    Used by teams whose score destination has one Feedback column rather
-    than separate strengths/opportunities cells (Sales' Scores tab → X).
-    """
-    parts = []
-    if key_strengths:
-        parts.append(f"What went well:\n{key_strengths}")
-    if opportunities:
-        parts.append(f"Opportunities for improvement:\n{opportunities}")
-    return "\n\n".join(parts)
-
-
 def _find_row_by_dialpad_link(sheet, dialpad_link: str) -> Optional[int]:
     """Return 1-indexed row number whose dialpad_link cell matches, else None.
 
@@ -169,26 +156,6 @@ def _find_row_by_dialpad_link(sheet, dialpad_link: str) -> Optional[int]:
     for i, val in enumerate(col_values, start=1):
         if val == dialpad_link:
             return i
-    return None
-
-
-def _lookup_agent_email(agent_name: str, config: TeamConfig) -> Optional[str]:
-    """Resolve an agent's email from the Mails tab. Case-insensitive.
-
-    Mails layout: A=Name, B=Email, (C=Supervisor, D=Canonical Name).
-    """
-    if not agent_name:
-        return None
-    try:
-        mails_sheet = _get_sheet(config, config.sheets.mails_tab)
-        rows = mails_sheet.get_all_values()
-    except Exception as e:
-        print(f"[sheets] _lookup_agent_email failed: {e}")
-        return None
-    needle = agent_name.strip().lower()
-    for row in rows[1:]:  # skip header
-        if len(row) >= 2 and row[0].strip().lower() == needle:
-            return row[1].strip()
     return None
 
 
@@ -231,9 +198,8 @@ def write_draft_to_fr_ai(scorecard: ScorecardWithMeta, config: TeamConfig) -> in
 
     Layout uses ``config.history_layout``:
       * Cols A, C, E filled (agent_name, timestamp, dialpad_link)
-      * Col B (agent_email) blank — filled at Stage 4 from Mails lookup
-      * Col D (evaluator_email) blank — filled at Stage 2 from session
-      * Col F (overall_score) blank — filled at Stage 3 from readback
+      * Cols B, D, F (agent_email, evaluator_email, overall_score) blank —
+        the post-approve projection fills them from the qa.* record
       * Section scores in canonical section_number order:
           - auto_value sections → sec.auto_value (e.g. Sales Q18 = "Yes")
           - manual sections → blank (analyst fills via dashboard)
@@ -265,8 +231,8 @@ def write_draft_to_fr_ai(scorecard: ScorecardWithMeta, config: TeamConfig) -> in
     # See references/CallTimeOnAnalystHistory.md.
     row[history_layout.COL_TIMESTAMP] = _format_call_started(scorecard.call_started_at_utc)
     row[history_layout.COL_DIALPAD_LINK] = scorecard.dialpad_link or ""
-    # eval_approved_at (new trailing column) is filled at Stage 4 by
-    # finalize_to_analyst_history. Leave blank here.
+    # eval_approved_at (trailing column) is filled by the post-approve
+    # projection. Leave blank here.
 
     for i, sec_def in enumerate(config.sections_by_number):
         if sec_def.auto_value is not None:
@@ -324,316 +290,6 @@ def write_draft_to_fr_ai(scorecard: ScorecardWithMeta, config: TeamConfig) -> in
         print(f"[stage_1] Wrote new FR-AI row {target_row}.")
     return target_row
 
-
-# ---------------------------------------------------------------------------
-# Stage 1.5 — Analyst edits → FR-AI
-# ---------------------------------------------------------------------------
-
-def apply_analyst_edits_to_fr_ai(
-    fr_ai_row_num: int,
-    sections: list[dict],
-    config: TeamConfig,
-    key_strengths: str = "",
-    opportunities: str = "",
-) -> None:
-    """Stage 1.5: apply analyst's dashboard edits to the FR-AI row.
-
-    Writes (or overwrites) section scores, reasoning, confidence, and
-    trailing feedback cells. Manual sections receive whatever the
-    analyst entered. Auto_value sections are skipped (writer-managed).
-    """
-    L = config.history_layout
-    sheet = _get_fr_ai_sheet(config)
-    sections_by_id = {s["id"]: s for s in sections}
-
-    # We update each row's score + reasoning + confidence per section,
-    # plus the trailing feedback cells, in a single batch_update.
-    updates: list[dict] = []
-
-    for i, sec_def in enumerate(config.sections_by_number):
-        if sec_def.auto_value is not None:
-            continue  # writer-managed; analyst can't override
-
-        section = sections_by_id.get(sec_def.id)
-        if section is None:
-            continue
-
-        # Manual sections carry an analyst-entered value rather than the
-        # AI's. `manual` stores a 1-5 score; `manual_yn` stores a Y/N/NA
-        # in yn_value (rendered via the same display map as AI yn).
-        # Explicit N/A (yn_value="NA") wins for both shapes — analyst can
-        # mark a manual numeric section N/A when the team config allows.
-        if section.get("yn_value") == "NA":
-            score_value = YN_DISPLAY["NA"]
-        elif sec_def.score_type == "manual":
-            score = section.get("score")
-            score_value = str(score) if score is not None else ""
-        elif sec_def.score_type == "manual_yn":
-            yn = section.get("yn_value") or "NA"
-            score_value = YN_DISPLAY.get(yn, "Not Applicable")
-        else:
-            score_value = _format_ai_score(sec_def, section)
-        score_letter = col_index_to_letter(L.col_score(i))
-        reasoning_letter = col_index_to_letter(L.col_reasoning(i))
-        confidence_letter = col_index_to_letter(L.col_confidence(i))
-
-        updates.append({
-            "range": f"{score_letter}{fr_ai_row_num}",
-            "values": [[score_value]],
-        })
-        updates.append({
-            "range": f"{reasoning_letter}{fr_ai_row_num}",
-            "values": [[section.get("reasoning", "")]],
-        })
-        updates.append({
-            "range": f"{confidence_letter}{fr_ai_row_num}",
-            "values": [[section.get("confidence", "")]],
-        })
-
-    ks_letter = col_index_to_letter(L.col_key_strengths)
-    op_letter = col_index_to_letter(L.col_opportunities)
-    updates.append({
-        "range": f"{ks_letter}{fr_ai_row_num}:{op_letter}{fr_ai_row_num}",
-        "values": [[key_strengths, opportunities]],
-    })
-
-    print(f"[stage_1.5] Applying {len(updates)} edits to FR-AI row {fr_ai_row_num}...")
-    sheet.batch_update(updates, value_input_option="USER_ENTERED")
-    print(f"[stage_1.5] Done.")
-
-
-# ---------------------------------------------------------------------------
-# Stage 2 — On Approve → score destination
-# ---------------------------------------------------------------------------
-
-def write_to_score_destination(
-    fr_ai_row_num: int,
-    config: TeamConfig,
-    evaluator_email: str,
-) -> int:
-    """Stage 2: read FR-AI row, write section scores + metadata to the
-    per-team score destination tab (MS: Form Responses 1; Sales: Scores).
-
-    Also writes ``evaluator_email`` to FR-AI col D so Stage 4 can carry
-    it forward into Analyst_History.
-
-    Section column placement comes from
-    ``config.sheets.score_destination.section_score_columns`` — the only
-    hardcoded-letters mapping in the system. Auto-value sections write
-    their declared value; manual sections fall back to
-    ``manual_default_value`` if the analyst left the FR-AI cell blank.
-
-    Call-time initiative (PR-1) — see
-    references/CallTimeOnAnalystHistory.md: the ``timestamp`` cell in
-    ``metadata_cols`` (FR1 col A for MS, col C for Sales) is sourced
-    from ``fr_ai_row[COL_TIMESTAMP]``, which Stage 1 now populates from
-    the call's ``date_connected`` instead of the draft clock. The Apps
-    Script email's "Evaluation Date" line therefore renders as the
-    call date going forward — usually what agents/managers actually
-    want to see. Renaming that label on the GAS side is a follow-up.
-
-    Returns the destination tab's appended row number.
-    """
-    L = config.history_layout
-    sd = config.sheets.score_destination
-
-    fr_ai_sheet = _get_fr_ai_sheet(config)
-
-    # Persist evaluator_email to FR-AI col D so Stage 4 carries it forward.
-    eval_letter = col_index_to_letter(history_layout.COL_EVALUATOR_EMAIL)
-    fr_ai_sheet.update(
-        f"{eval_letter}{fr_ai_row_num}",
-        [[evaluator_email]],
-        value_input_option="USER_ENTERED",
-    )
-
-    # Colocated destination: when score_destination IS the FR-AI tab
-    # (Sales post-collapse), the FR-AI row already holds every value the
-    # destination would receive — sections, metadata, and the
-    # ARRAYFORMULA at score_readback_col fires on the same row. Skip the
-    # append and return fr_ai_row_num so Stage 3 polls the FR-AI row.
-    if sd.tab_name == config.sheets.form_responses_ai.tab_name:
-        print(f"[stage_2] Destination colocated with FR-AI ('{sd.tab_name}'); skipping append.")
-        return fr_ai_row_num
-
-    fr_ai_row = fr_ai_sheet.row_values(fr_ai_row_num)
-    fr_ai_row = (fr_ai_row + [""] * L.total_width)[: L.total_width]
-
-    # Compute destination row width
-    section_letters = list(sd.section_score_columns.keys())
-    metadata_letters = list(sd.metadata_cols.values())
-    all_letters = section_letters + metadata_letters
-    dest_width = max(col_letter_to_index(L_) for L_ in all_letters) + 1
-    dest_row = [""] * dest_width
-
-    # Section scores
-    sections_ordered = config.sections_by_number
-    section_idx_by_id = {s.id: i for i, s in enumerate(sections_ordered)}
-    for letter, section_id in sd.section_score_columns.items():
-        col_idx = col_letter_to_index(letter)
-        sec_def = config.scoring_id_to_section.get(section_id)
-        if not sec_def:
-            continue
-        layout_idx = section_idx_by_id.get(section_id)
-        if layout_idx is None:
-            continue
-        fr_ai_value = fr_ai_row[L.col_score(layout_idx)]
-
-        if sec_def.auto_value is not None:
-            dest_row[col_idx] = sec_def.auto_value
-        elif sec_def.score_type in ("manual", "manual_yn") and not fr_ai_value:
-            dest_row[col_idx] = sec_def.manual_default_value or ""
-        else:
-            dest_row[col_idx] = fr_ai_value
-
-    # Metadata
-    key_strengths = fr_ai_row[L.col_key_strengths]
-    opportunities = fr_ai_row[L.col_opportunities]
-    metadata_values = {
-        # "timestamp" semantically = the call's date_connected since the
-        # call-time initiative (PR-1) flipped col C. Pre-cutover rows
-        # passing through Stage 2 (rare; only re-approvals of historical
-        # drafts) still carry the legacy eval-time value in col C —
-        # acceptable transient. Backfill (PR-2) makes the semantic
-        # uniform across all rows.
-        "timestamp": fr_ai_row[history_layout.COL_TIMESTAMP],
-        "agent_name": fr_ai_row[history_layout.COL_AGENT_NAME],
-        "dialpad_link": fr_ai_row[history_layout.COL_DIALPAD_LINK],
-        "manager_email": evaluator_email,        # MS schema name
-        "evaluator_email": evaluator_email,      # Sales schema name
-        "key_strengths": key_strengths,
-        "opportunities": opportunities,
-        "feedback_combined": _combine_feedback(key_strengths, opportunities),
-    }
-    for field, letter in sd.metadata_cols.items():
-        col_idx = col_letter_to_index(letter)
-        if field in metadata_values:
-            dest_row[col_idx] = metadata_values[field]
-        else:
-            print(f"[stage_2] WARNING: metadata field '{field}' not produced by writer; col {letter} stays blank.")
-
-    dest_sheet = _get_sheet(config, sd.tab_name)
-    print(f"[stage_2] Appending row to '{sd.tab_name}'...")
-    result = dest_sheet.append_row(dest_row, value_input_option="USER_ENTERED")
-    dest_row_num = _parse_appended_row_num(result)
-    print(f"[stage_2] Done. Row {dest_row_num}.")
-    return dest_row_num
-
-
-# ---------------------------------------------------------------------------
-# Stage 3 — Poll readback → FR-AI col F
-# ---------------------------------------------------------------------------
-
-async def read_score_and_writeback(
-    dest_row_num: int,
-    fr_ai_row_num: int,
-    config: TeamConfig,
-) -> str:
-    """Stage 3: poll the score destination's readback col with bounded
-    retries until the ARRAYFORMULA-computed overall score appears, then
-    write that value back to FR-AI col F.
-
-    Polling: 5 attempts × 800 ms = 4 s ceiling (matches PhaseOne's
-    documented 3-4 s ARRAYFORMULA buffer).
-
-    Returns the score string written, or '' if it never appeared.
-    """
-    sd = config.sheets.score_destination
-    dest_sheet = _get_sheet(config, sd.tab_name)
-
-    overall = ""
-    max_attempts = 5
-    delay_s = sd.arrayformula_buffer_seconds / max_attempts
-    for attempt in range(max_attempts):
-        cell_value = dest_sheet.acell(f"{sd.score_readback_col}{dest_row_num}").value
-        if cell_value:
-            overall = cell_value
-            print(f"[stage_3] Readback hit on attempt {attempt + 1}: '{overall}'")
-            break
-        if attempt < max_attempts - 1:
-            await asyncio.sleep(delay_s)
-
-    if not overall:
-        print(
-            f"[stage_3] WARNING: readback {sd.score_readback_col}{dest_row_num} "
-            f"stayed blank after {sd.arrayformula_buffer_seconds}s — formula may "
-            f"have failed."
-        )
-        return ""
-
-    # Colocated destination: readback cell IS FR-AI col F. The
-    # ARRAYFORMULA already wrote the value there — writing it back as a
-    # literal would clobber the formula's output for this row. Skip the
-    # writeback in that case.
-    if sd.tab_name == config.sheets.form_responses_ai.tab_name:
-        print(f"[stage_3] Destination colocated with FR-AI; readback already at FR-AI col F. Skipping writeback.")
-        return overall
-
-    fr_ai_sheet = _get_fr_ai_sheet(config)
-    score_letter = col_index_to_letter(history_layout.COL_OVERALL_SCORE)
-    fr_ai_sheet.update(
-        f"{score_letter}{fr_ai_row_num}",
-        [[overall]],
-        value_input_option="USER_ENTERED",
-    )
-    return overall
-
-
-# ---------------------------------------------------------------------------
-# Stage 4 — FR-AI → Analyst_History
-# ---------------------------------------------------------------------------
-
-def finalize_to_analyst_history(
-    fr_ai_row_num: int,
-    evaluator_email: str,
-    config: TeamConfig,
-) -> int:
-    """Stage 4: copy the now-complete FR-AI row to Analyst_History.
-
-    Resolves agent_email via the Mails lookup, sets evaluator_email,
-    and stamps the approval time on the new ``col_eval_approved_at``
-    trailing column.
-
-    Call-time initiative (PR-1) — see
-    references/CallTimeOnAnalystHistory.md: this no longer overrides
-    col C. COL_TIMESTAMP was set at Stage 1 (`write_draft_to_fr_ai`)
-    from the call's `date_connected`; it travels untouched into
-    Analyst_History. The approval-time UTC string that used to live
-    in col C now lives in `col_eval_approved_at`.
-
-    Returns the Analyst_History row number.
-    """
-    L = config.history_layout
-
-    fr_ai_sheet = _get_fr_ai_sheet(config)
-    fr_ai_row = fr_ai_sheet.row_values(fr_ai_row_num)
-    fr_ai_row = (fr_ai_row + [""] * L.total_width)[: L.total_width]
-
-    agent_name = fr_ai_row[history_layout.COL_AGENT_NAME]
-    agent_email = _lookup_agent_email(agent_name, config) or ""
-
-    history_row = list(fr_ai_row)
-    history_row[history_layout.COL_AGENT_EMAIL] = agent_email
-    history_row[history_layout.COL_EVALUATOR_EMAIL] = evaluator_email
-    # NOTE: COL_TIMESTAMP intentionally NOT touched here — it holds
-    # call_connected from Stage 1. The approval clock writes to the new
-    # trailing column instead.
-    history_row[L.col_eval_approved_at] = datetime.now(timezone.utc).strftime(
-        "%m/%d/%Y %H:%M:%S"
-    )
-
-    history_sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
-    print(f"[stage_4] Appending to Analyst_History (agent_email='{agent_email}')...")
-    result = history_sheet.append_row(history_row, value_input_option="USER_ENTERED")
-    history_row_num = _parse_appended_row_num(result)
-    print(f"[stage_4] Done. Row {history_row_num}.")
-    return history_row_num
-
-
-# ---------------------------------------------------------------------------
-# Apps Script trigger (Phase B (a): still passes destination row;
-# Phase C will switch to Analyst_History row)
-# ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # Score_Audit append (LookupToScore.md design)
@@ -729,7 +385,8 @@ def trigger_apps_script(history_row_num: int, team_id: str) -> dict:
     """POST to the team's Apps Script web app to dispatch the QA email.
 
     The Apps Script reads ``Analyst_History`` row ``history_row_num``
-    (already finalized by Stage 4) and sends the evaluation email.
+    (already written by the post-approve projection) and sends the
+    evaluation email.
     """
     import httpx
 

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -630,38 +630,10 @@ class TestApprovalRecomputeAndShadow:
 
 
 # ---------------------------------------------------------------------------
-# scoring_owner flag + strict mode + stamp_and_finalize (cutover slice 2)
+# strict mode + stamp_and_finalize (cutover slice 2)
 # ---------------------------------------------------------------------------
-
-class OwnerFakePool:
-    def __init__(self, owner):
-        self.owner = owner
-
-    async def fetchval(self, query, *args):
-        assert "scoring_owner FROM public.teams" in query
-        return self.owner
-
-
-class TestScoringOwner:
-    pytestmark = pytest.mark.asyncio
-
-    async def test_no_pool_defaults_to_sheets(self, monkeypatch):
-        async def no_pool():
-            return None
-        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
-        assert await eval_store.get_scoring_owner("member_support") == "sheets"
-
-    async def test_reads_flag(self, monkeypatch):
-        async def pool():
-            return OwnerFakePool("postgres")
-        monkeypatch.setattr(eval_store, "_get_pool", pool)
-        assert await eval_store.get_scoring_owner("member_support") == "postgres"
-
-    async def test_lookup_failure_degrades_to_sheets(self, monkeypatch):
-        async def exploding():
-            raise ConnectionError("pg down")
-        monkeypatch.setattr(eval_store, "_get_pool", exploding)
-        assert await eval_store.get_scoring_owner("member_support") == "sheets"
+# TestScoringOwner was deleted with get_scoring_owner in the §8 slice-5
+# cleanup — the engine path no longer consults the flag.
 
 
 class TestStrictMode:

--- a/qa-automation/AI-Scoring/tests/test_events_route.py
+++ b/qa-automation/AI-Scoring/tests/test_events_route.py
@@ -126,13 +126,18 @@ def test_approve_publish_includes_eval_id_field():
     """The published eval_approved payload must include `eval_id` derived
     from dialpad_link so the toast click navigates to the same datapoint
     URL the rest of the dashboard uses (entry_point_call_id, not master
-    call_id). Source-presence guard against regression of the fix."""
+    call_id). Source-presence guard against regression of the fix.
+
+    Post-slice-5 the only publisher is `_publish_finalized_event` (the
+    auto-finalize and flagged-resolution paths both route through it),
+    so the guard fingerprints its link-derived eval_id."""
     src = inspect.getsource(scoring_module)
-    assert "_eval_id_from_link" in src, (
-        "_eval_id_from_link helper is missing — approve publish would "
+    assert "_sse_eval_id_from_link" in src, (
+        "_sse_eval_id_from_link helper is missing — approve publish would "
         "fall back to master call_id and the toast would link to the "
         "wrong datapoint URL"
     )
-    assert '"eval_id": eval_id' in src, (
-        "eval_id is no longer published in the eval_approved payload"
+    assert '"eval_id": _sse_eval_id_from_link' in src, (
+        "eval_id is no longer derived from dialpad_link in the "
+        "eval_approved payload"
     )

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -340,7 +340,7 @@ def test_score_endpoint_privileged_bypasses_roster(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_approve_writes_audit_row(client, monkeypatch):
-    """Stage 4 success appends a Score_Audit row with action="approved"."""
+    """Engine approval appends a Score_Audit row with action="approved"."""
     # Pre-seed a completed job with the metadata the approve handler reads.
     job_id = "call-approve_Luis_Rubio"
     key = scoring_module._job_key("member_support", job_id)
@@ -351,6 +351,7 @@ def test_approve_writes_audit_row(client, monkeypatch):
         "agent_name": "Luis Rubio",
         "manager_email": "ana@landing.com",
         "sheets_row": 99,
+        "evaluation_id": 77,
         "scorecard": {
             "manager_email": "ana@landing.com",
             "agent_name": "Luis Rubio",
@@ -361,12 +362,31 @@ def test_approve_writes_audit_row(client, monkeypatch):
         },
     }
 
-    # Stub the four sheets stages + Apps Script trigger so we don't hit gspread.
-    monkeypatch.setattr(scoring_module, "apply_analyst_edits_to_fr_ai", lambda **kw: None)
-    monkeypatch.setattr(scoring_module, "write_to_score_destination", lambda **kw: 200)
-    async def fake_readback(**kw): return "85"
-    monkeypatch.setattr(scoring_module, "read_score_and_writeback", fake_readback)
-    monkeypatch.setattr(scoring_module, "finalize_to_analyst_history", lambda **kw: 555)
+    # Stub the engine path (DB transition + projection + Apps Script) so
+    # the test never reaches Postgres or gspread.
+    monkeypatch.setattr(
+        scoring_module.eval_store, "missing_manual_scores",
+        lambda config, sections: [],
+    )
+
+    async def fake_record_approval(config, **kw):
+        return 77
+    monkeypatch.setattr(scoring_module, "record_approval", fake_record_approval)
+
+    class _Detail:
+        overall_score = 85.0
+
+    async def fake_stamp(evaluation_id, config, evaluator_email):
+        return _Detail()
+    monkeypatch.setattr(scoring_module.eval_store, "stamp_and_finalize", fake_stamp)
+
+    async def fake_pool():
+        return object()
+    monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
+
+    async def fake_project(pool, evaluation_id, config, include_history=True):
+        return 555
+    monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
     monkeypatch.setattr(scoring_module, "trigger_apps_script", lambda row, team_id: {"status": "ok"})
 
     resp = client.post(
@@ -382,6 +402,8 @@ def test_approve_writes_audit_row(client, monkeypatch):
         },
     )
     assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "finalized"
+    assert resp.json()["overall_score"] == 85.0
     approved = [r for r in client.audit_rows if r["action"] == "approved"]
     assert len(approved) == 1
     row = approved[0]
@@ -392,6 +414,7 @@ def test_approve_writes_audit_row(client, monkeypatch):
     assert row["call_id"] == "call-approve"
     assert row["target_team"] == "member_support"
     assert row["result_row"] == 555
+    assert row["notes"] == "engine-scored"
 
 
 def test_score_endpoint_legacy_name_only_resolves_email_for_roster_check(client, monkeypatch):


### PR DESCRIPTION
The §8 cleanup PR, now that both teams run engine-scored. Net **−506 lines**.

## Deleted
- **Stage 3 readback** (`read_score_and_writeback`), **destination write** (`write_to_score_destination`, taking `_combine_feedback` with it), **Stage 1.5 analyst edits** (`apply_analyst_edits_to_fr_ai`), and **Stage 4 finalize** (`finalize_to_analyst_history`) — the Mails runtime lookup (`_lookup_agent_email`) died with Stage 4, its only caller.
- The `owner == 'sheets'` branches in `/score`, `/score/batch`, and `/approve` — the engine path is unconditional now: `record_draft_evaluation` always runs `strict=True` (§7.3 Phase C: the DB row is truth), and `/approve` is purely DB transition + engine compute + `project_evaluation`.
- `eval_store.get_scoring_owner` (no callers remain). The migration-013 `scoring_owner` column stays in the DB as historical record.

## Kept, deliberately
- `write_draft_to_fr_ai` (Stage-1 dual-write projection), Score_Audit append, `trigger_apps_script`.
- The `score_destination` config blocks + the ARRAYFORMULA/weights sheet tabs — CutoverDesign §7 keeps the tabs until a full bonus cycle passes post-flip. Config cleanup is a follow-up once that window closes.

## ⚠️ Rollback story changes
Pre-slice-5, rollback was `UPDATE public.teams SET scoring_owner='sheets'`. After this merges, restoring the sheet pipeline means reverting this PR + redeploy. The sheet tabs themselves remain intact per §7, so a revert restores the pipeline wholesale.

## Tests
- `test_approve_writes_audit_row` rewritten onto the engine path (stubs DB transition/projection; asserts `notes='engine-scored'`, finalized state, overall score).
- SSE `eval_id` source-guard re-fingerprints `_publish_finalized_event` — post-slice-5 the sole `eval_approved` publisher.
- `TestScoringOwner` deleted with its subject.
- Full suite: **730 passed**; only failure is the pre-existing task #7 date-flake.

Next roadmap steps ride on this: Backfill B0–B4, then the read-path flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)