### PR TITLE
feat(qa-automation): backfill B0 — seed sanitize + stage with gated run report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ docs/git-for-the-recruit.md
 database/analyst_history_*.csv
 database/export_document_test_data.csv
 database/onepager_*.html
+
+# B0 staging outputs (backfill_seed_b0.py) — derived from the seed CSVs,
+# same PII surface. Reports included: exclusion rows carry agent names.
+database/backfill_staging/

--- a/database/BackfillPlan.md
+++ b/database/BackfillPlan.md
@@ -95,6 +95,12 @@ row). Data quirks beyond MS: heavy *blank* cells (e.g. FLEX Pitch blank on 129 r
 treated blank exactly like "Not Applicable" (excluded + rescaled); one corrupted stray-value row
 (excluded); one row missing Overall Score (excluded).
 
+> **Re-export note (B0 run, 2026-07-11):** the CSV on disk is newer than this analysis. The
+> corrupted stray-value row was cleaned at the source (exclusions drop 2 → 1: only the
+> blank-Overall row remains), and an approval-clock trailing column appeared, populated on
+> ~64 AI-era rows — D1's Timestamp fallback now applies to 269 rows, not all. B0's expectation
+> gates encode the corrected numbers; anomaly and duplicate-group counts held (13 / 2).
+
 **Legacy Sales formula, reverse-engineered** (`sales_v0_sheet`, archived like MS's):
 
 ```

--- a/qa-automation/AI-Scoring/scripts/backfill_seed_b0.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_seed_b0.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""B0 — sanitize + stage the Analyst_History seed (BackfillPlan.md §4/§5).
+
+Offline, no DB, pure and re-runnable: reads the team's seed CSV, applies
+the §4 normalization rules and §8 decisions, and writes a reviewable
+staging file that B1 imports verbatim. Every transform is counted in the
+run report; nothing touches Railway.
+
+Outputs (under --out-dir, default database/backfill_staging/):
+    staging_<team>.jsonl            one object per importable evaluation
+    backfill_exclusions_<team>.csv  excluded rows + reason (§8 D5 etc.)
+    report_<team>_b0.json           machine-readable run report
+    (+ a printed human summary)
+
+Deterministic: same CSV in, byte-identical staging out — safe to re-run
+any time and diff. The natural key (team | dialpad_link | raw timestamp
+| agent) rides along so B1 upserts instead of duplicating.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/backfill_seed_b0.py --team-id member_support
+    python3 scripts/backfill_seed_b0.py --team-id sales --csv path.csv
+
+Exit codes: 0 = staged, gates green; 1 = structural failure (nothing
+written); 2 = staged but expectation gates drifted (review report).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _AI_SCORING.parent.parent
+_DEFAULT_OUT = _REPO_ROOT / "database" / "backfill_staging"
+
+# ---------------------------------------------------------------------------
+# Frozen per-team facts (archived v1 rubrics + reverse-engineered v0_sheet
+# formulas — BackfillPlan §2/§2a/§3). Deliberately hardcoded: this is
+# settled history keyed to the migration-010 archive, not live config.
+# ---------------------------------------------------------------------------
+
+# (archived section_id, kind) in CSV column order; kind: "numeric" | "yn"
+# | "manual" (analyst-filled 1-5) | "manual_yn" (analyst-filled Y/N/NA).
+TEAM_SECTIONS: dict[str, list[tuple[str, str]]] = {
+    "member_support": [
+        ("greeting", "numeric"),
+        ("caller_identity_validation", "yn"),
+        ("purpose_of_call", "numeric"),
+        ("matching_the_moment", "numeric"),
+        ("process_adherence", "numeric"),
+        ("call_resolution", "numeric"),
+        ("communication", "numeric"),
+        ("efficiency_call_handling", "numeric"),
+        ("documentation", "manual"),
+        ("customer_resolution_indicator", "yn"),
+    ],
+    "sales": [
+        ("greeting", "yn"),
+        ("pb_creation", "manual_yn"),
+        ("mc_call_notes", "manual_yn"),
+        ("situation_match", "numeric"),
+        ("reason_for_move_pitch", "yn"),
+        ("value_uplift", "numeric"),
+        ("membership_explanation", "yn"),
+        ("flex_long_stay_pitch", "yn"),
+        ("landing_guarantee", "numeric"),
+        ("pricing_explanation", "yn"),
+        ("book_attempt", "yn"),
+        ("objection_handling", "numeric"),
+        ("urgency_disclosure", "yn"),
+        ("followup_setup", "yn"),
+        ("tonality_pace", "yn"),
+        ("hold_usage", "yn"),
+        ("audio_quality", "yn"),
+        ("screen_recording", "yn"),
+        ("pre_send_intro", "manual_yn"),
+    ],
+}
+
+# v0_sheet weights (§2/§2a). overall = 100 × Σ w·frac / Σ w(scored);
+# NA/blank sections drop out of both sums (proportional redistribute).
+TEAM_WEIGHTS: dict[str, dict[str, float]] = {
+    "member_support": {
+        "call_resolution": 4, "communication": 2, "efficiency_call_handling": 2,
+        "documentation": 2, "purpose_of_call": 1, "customer_resolution_indicator": 1,
+        # greeting / caller_identity_validation / matching_the_moment /
+        # process_adherence carry weight 0 in the legacy sheet formula.
+        "greeting": 0, "caller_identity_validation": 0,
+        "matching_the_moment": 0, "process_adherence": 0,
+    },
+    "sales": {sec_id: (10 if sec_id == "situation_match" else 5)
+              for sec_id, _ in TEAM_SECTIONS["sales"]},
+}
+
+TEAM_FORMULA_VERSION = {
+    "member_support": "member_support_v0_sheet",
+    "sales": "sales_v0_sheet",
+}
+TEAM_RUBRIC_VERSION = {
+    "member_support": "member_support_v1",
+    "sales": "sales_v1",
+}
+
+# Expectation gates from the plan's inventory — drift means the CSV
+# changed since the analysis and a human should look before B1.
+TEAM_EXPECTATIONS = {
+    "member_support": {"rows": 1678, "excluded": 7, "anomalies": 3},
+    # Plan §2a expected 2 exclusions, but the CSV on disk is a newer
+    # re-export: the corrupted stray-value row was cleaned at the source
+    # and an approval-clock column appeared (partially populated). Only
+    # the blank-Overall row remains excludable.
+    "sales": {"rows": 334, "excluded": 1, "anomalies": 13},
+}
+
+BINARY_NORMALIZE = {"Y": "Y", "YES": "Y", "N": "N", "NO": "N",
+                    "NOT APPLICABLE": "NA", "NA": "NA", "N/A": "NA"}
+CONFIDENCE_NORMALIZE = {"high": "HIGH", "medium": "MED", "med": "MED", "low": "LOW"}
+
+MODELS_USED = {
+    "ai": {"text": {"provider": "gemini", "model": "gemini-2.5-flash"}},
+    "manual": {"text": {"provider": "human", "model": "human_brain"}},  # §8 D4
+}
+
+TS_FORMATS = ["%Y-%m-%d %H:%M:%S", "%m/%d/%Y %H:%M:%S", "%m/%d/%Y %H:%M",
+              "%Y-%m-%dT%H:%M:%S"]
+# Sheet clocks are UTC wall time without a marker (house convention);
+# anything before this is the epoch-zero corruption class (§1).
+MIN_PLAUSIBLE_YEAR = 2020
+
+
+def parse_ts(raw: str) -> str | None:
+    """Sheet timestamp → ISO-8601 UTC string, or None when broken."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    for fmt in TS_FORMATS:
+        try:
+            dt = datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+        if dt.year < MIN_PLAUSIBLE_YEAR:
+            return None  # epoch-zero corruption
+        return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    return None
+
+
+def normalize_cell(raw: str, kind: str) -> dict:
+    """One section cell → staged value dict.
+
+    Shapes: {"numeric": int} | {"binary": "Y"/"N"} | {"na": True} |
+    {"missing": True} (blank numeric on a non-NA-vocabulary cell) |
+    {"corrupt": raw} (unparseable — triggers row exclusion, §2a).
+    Blank cells are NA by sheet semantics (§2a: the sheet treated blank
+    exactly like Not Applicable).
+    """
+    val = (raw or "").strip()
+    if not val:
+        return {"na": True}
+    upper = val.upper()
+    if upper in BINARY_NORMALIZE:
+        norm = BINARY_NORMALIZE[upper]
+        if norm == "NA":
+            return {"na": True}
+        if kind in ("numeric", "manual"):
+            return {"corrupt": raw}  # Y/N in a rating column
+        return {"binary": norm}
+    try:
+        num = float(val)
+    except ValueError:
+        return {"corrupt": raw}
+    if kind in ("yn", "manual_yn"):
+        return {"corrupt": raw}  # rating in a binary column
+    if not num.is_integer() or not 0 <= num <= 5:
+        return {"corrupt": raw}
+    return {"numeric": int(num)}
+
+
+def cell_frac(value: dict) -> float | None:
+    """v0_sheet normalization: rating r/5, binary Y=1/N=0, NA/missing None."""
+    if "numeric" in value:
+        return value["numeric"] / 5.0
+    if "binary" in value:
+        return 1.0 if value["binary"] == "Y" else 0.0
+    return None
+
+
+def v0_sheet_score(team_id: str, values: dict[str, dict]) -> float | None:
+    """Recompute the reverse-engineered legacy sheet score (§2/§2a)."""
+    weights = TEAM_WEIGHTS[team_id]
+    num = den = 0.0
+    for sec_id, value in values.items():
+        frac = cell_frac(value)
+        if frac is None:
+            continue
+        w = weights[sec_id]
+        num += w * frac
+        den += w
+    if den == 0:
+        return None
+    return 100.0 * num / den
+
+
+def natural_key_basis(team_id: str, link: str, ts_raw: str, agent: str,
+                      approval_raw: str, overall_raw: str) -> str:
+    """Identity basis for a seed row. Link+timestamp alone is NOT unique:
+    col C is the *call* clock (PR-1), so re-evaluations of the same call
+    collide, and blank-link manual rows share date-only timestamps. The
+    approval clock + overall disambiguate; a per-basis ordinal (appended
+    by the caller) covers byte-identical repeats. Stable for a fixed CSV —
+    the seed is frozen history."""
+    return "|".join([team_id, link.strip(), ts_raw.strip(), agent.strip().lower(),
+                     approval_raw.strip(), overall_raw.strip()])
+
+
+def finalize_natural_keys(staged: list[dict]) -> None:
+    """Assign sha1 keys, adding an occurrence ordinal to repeated bases."""
+    seen: dict[str, int] = {}
+    for s in staged:
+        basis = s.pop("_key_basis")
+        ordinal = seen.get(basis, 0)
+        seen[basis] = ordinal + 1
+        s["natural_key"] = hashlib.sha1(
+            f"{basis}|{ordinal}".encode("utf-8")).hexdigest()
+
+
+def stage_rows(team_id: str, rows: list[dict], columns: list[str]) -> dict:
+    """Pure core: CSV rows → {staged, excluded, report_counts}."""
+    sections = TEAM_SECTIONS[team_id]
+    n = len(sections)
+    expected_width = 6 + 3 * n + 5 + 1 + 1
+    if len(columns) != expected_width:
+        raise SystemExit(
+            f"structural: {team_id} CSV has {len(columns)} columns, expected {expected_width}"
+        )
+    col = {name: i for i, name in enumerate(columns)}
+    approval_col = columns[-1]  # header-less trailing column (§8 D1)
+
+    staged: list[dict] = []
+    excluded: list[dict] = []
+    counts = {
+        "rows_in": len(rows), "binary_normalized_cells": 0,
+        "confidence_normalized_cells": 0, "broken_timestamps": 0,
+        "approval_clock_fallbacks": 0, "import_blocked_no_clock": 0,
+        "anomalies": 0, "source_migrated_mapped_manual": 0,
+        "duplicate_link_groups": 0, "superseded_links": 0,
+    }
+
+    def cell(row, name):
+        return (row[name] or "").strip()
+
+    for line_no, row in enumerate(rows, start=2):  # 1-based + header
+        agent = cell(row, "Agent Name")
+        raw_ts = cell(row, "Timestamp")
+        link = cell(row, "Dialpad Link")
+        overall_raw = cell(row, "Overall Score")
+
+        # ---- section cells -------------------------------------------------
+        values: dict[str, dict] = {}
+        corrupt = []
+        raw_binaries = 0
+        for i, (sec_id, kind) in enumerate(sections):
+            raw = cell(row, columns[6 + i])
+            v = normalize_cell(raw, kind)
+            if "corrupt" in v:
+                corrupt.append((sec_id, raw))
+            if raw.upper() in ("YES", "NO", "NOT APPLICABLE"):
+                raw_binaries += 1
+            values[sec_id] = v
+        counts["binary_normalized_cells"] += raw_binaries
+
+        # ---- exclusions (§1 inventory / §8 D5 / §2a) -----------------------
+        def exclude(reason):
+            excluded.append({"line": line_no, "agent": agent,
+                             "dialpad_link": link, "reason": reason})
+
+        try:
+            overall = float(overall_raw)
+        except ValueError:
+            exclude("missing_or_non_numeric_overall")
+            continue
+        if corrupt:
+            exclude("corrupt_section_value: " +
+                    "; ".join(f"{s}={r!r}" for s, r in corrupt))
+            continue
+        numeric_fracs = [cell_frac(v) for v in values.values()]
+        scored = [f for f in numeric_fracs if f is not None]
+        if not agent and scored and all(f == 0 for f in scored):
+            exclude("all_zero_test_artifact")
+            continue
+        if overall == 0 and any(f > 0 for f in scored):
+            exclude("manual_hard_zero_override")  # §8 D5
+            continue
+
+        # ---- clocks (§8 D1) -------------------------------------------------
+        annotations: dict = {}
+        call_connected_at = parse_ts(raw_ts)
+        if call_connected_at is None:
+            counts["broken_timestamps"] += 1
+            annotations["backfill_broken_timestamp"] = raw_ts or "(blank)"
+        approved_at = parse_ts(cell(row, approval_col))
+        if approved_at is None:
+            approved_at = call_connected_at
+            if approved_at is not None:
+                counts["approval_clock_fallbacks"] += 1
+                annotations["backfill_approved_at_fallback"] = "timestamp_col"
+        import_blocked = approved_at is None
+        if import_blocked:
+            counts["import_blocked_no_clock"] += 1
+            annotations["backfill_import_blocked"] = "no_usable_clock"
+
+        # ---- era / source (§3; sales 'migrated' + blank → manual) ----------
+        source_raw = cell(row, "Source").lower()
+        era = "ai" if source_raw == "ai" else "manual"
+        if source_raw not in ("", "ai"):
+            counts["source_migrated_mapped_manual"] += 1
+            annotations["backfill_source_raw"] = source_raw
+        db_source = "ai_reviewed" if era == "ai" else "manual"
+
+        # ---- anomaly check vs v0_sheet (§4) ---------------------------------
+        expected = v0_sheet_score(team_id, values)
+        if expected is not None and abs(overall - expected) > 0.5 + 1e-9:
+            counts["anomalies"] += 1
+            annotations["backfill_anomaly"] = (
+                f"overall_score inconsistent with v0_sheet formula "
+                f"(sheet={overall:g}, recomputed={expected:.2f})"
+            )
+
+        # ---- per-section staged rows ----------------------------------------
+        section_rows = []
+        for i, (sec_id, kind) in enumerate(sections):
+            value = values[sec_id]
+            reasoning = cell(row, columns[6 + n + i]) or None
+            confidence_raw = cell(row, columns[6 + 2 * n + i])
+            confidence = CONFIDENCE_NORMALIZE.get(confidence_raw.lower()) if confidence_raw else None
+            if confidence_raw and confidence != confidence_raw:
+                counts["confidence_normalized_cells"] += 1
+            is_ai_scored = era == "ai" and reasoning is not None and kind in ("numeric", "yn")
+            section_rows.append({
+                "section_id": sec_id,
+                "kind": kind,
+                "era": era,
+                "value": value,
+                "reasoning": reasoning if era == "ai" else None,  # §7: never fabricate
+                "confidence": confidence if era == "ai" else None,
+                "score_source": "ai" if is_ai_scored else "manual",
+            })
+
+        staged.append({
+            "_key_basis": natural_key_basis(
+                team_id, link, raw_ts, agent,
+                cell(row, approval_col), overall_raw),
+            "line": line_no,
+            "team_id": team_id,
+            "agent_name_raw": agent,
+            "agent_email": cell(row, "Agent Email") or None,
+            "evaluator_email": cell(row, "Evaluator Email") or None,
+            "dialpad_link": link or None,
+            "call_connected_at": call_connected_at,
+            "approved_at": approved_at,
+            "overall_score": overall,
+            "state": "finalized",
+            "source": db_source,
+            "era": era,
+            "models_used": MODELS_USED[era],
+            "formula_version": TEAM_FORMULA_VERSION[team_id],
+            "rubric_version": TEAM_RUBRIC_VERSION[team_id],
+            "key_strengths": cell(row, "Key Strengths") or None,
+            "opportunities": cell(row, "Opportunities") or None,
+            "call_summary": cell(row, "Call Summary") or None,
+            "caller_name": cell(row, "Caller Name") or None,
+            "caller_phone": cell(row, "Caller Phone") or None,
+            "annotations": annotations,
+            "import_blocked": import_blocked,
+            "sections": section_rows,
+        })
+
+    # ---- duplicate links (§8 D2): latest keeps the link ---------------------
+    by_link: dict[str, list[dict]] = {}
+    for s in staged:
+        if s["dialpad_link"]:
+            by_link.setdefault(s["dialpad_link"], []).append(s)
+    for link, group in by_link.items():
+        if len(group) < 2:
+            continue
+        counts["duplicate_link_groups"] += 1
+        group.sort(key=lambda s: s["approved_at"] or s["call_connected_at"] or "")
+        for older in group[:-1]:
+            older["annotations"]["superseded_dialpad_link"] = older["dialpad_link"]
+            older["dialpad_link"] = None
+            counts["superseded_links"] += 1
+
+    finalize_natural_keys(staged)
+    keys = [s["natural_key"] for s in staged]
+    if len(keys) != len(set(keys)):
+        raise SystemExit("structural: natural-key collision in staging output")
+
+    counts["rows_staged"] = len(staged)
+    counts["rows_excluded"] = len(excluded)
+    return {"staged": staged, "excluded": excluded, "counts": counts}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True, choices=sorted(TEAM_SECTIONS))
+    ap.add_argument("--csv", default=None)
+    ap.add_argument("--out-dir", default=str(_DEFAULT_OUT))
+    args = ap.parse_args()
+
+    csv_path = Path(args.csv) if args.csv else (
+        _REPO_ROOT / "database" / f"analyst_history_{args.team_id}.csv")
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with csv_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.reader(fh)
+        columns = next(reader)
+        rows = [dict(zip(columns, (r + [""] * len(columns))[: len(columns)]))
+                for r in reader]
+
+    result = stage_rows(args.team_id, rows, columns)
+    staged, excluded, counts = result["staged"], result["excluded"], result["counts"]
+
+    staging_path = out_dir / f"staging_{args.team_id}.jsonl"
+    with staging_path.open("w", encoding="utf-8") as fh:
+        for s in staged:
+            fh.write(json.dumps(s, ensure_ascii=False, sort_keys=True) + "\n")
+
+    exclusions_path = out_dir / f"backfill_exclusions_{args.team_id}.csv"
+    with exclusions_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["line", "agent", "dialpad_link", "reason"])
+        writer.writeheader()
+        writer.writerows(excluded)
+
+    # ---- expectation gates (§1/§2a inventory) -------------------------------
+    exp = TEAM_EXPECTATIONS[args.team_id]
+    gates = {
+        "rows_in_matches_plan": counts["rows_in"] == exp["rows"],
+        "excluded_matches_plan": counts["rows_excluded"] == exp["excluded"],
+        "anomalies_match_plan": counts["anomalies"] == exp["anomalies"],
+    }
+    report = {
+        "stage": "B0", "team_id": args.team_id, "csv": str(csv_path),
+        "counts": counts, "expected": exp, "gates": gates,
+        "outputs": {"staging": str(staging_path), "exclusions": str(exclusions_path)},
+        "exclusion_reasons": sorted({e["reason"].split(":")[0] for e in excluded}),
+    }
+    report_path = out_dir / f"report_{args.team_id}_b0.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print(f"[B0:{args.team_id}] in={counts['rows_in']} staged={counts['rows_staged']} "
+          f"excluded={counts['rows_excluded']} anomalies={counts['anomalies']}")
+    print(f"  binary cells normalized: {counts['binary_normalized_cells']}, "
+          f"confidence normalized: {counts['confidence_normalized_cells']}")
+    print(f"  broken timestamps: {counts['broken_timestamps']} (B2 repair queue), "
+          f"approval fallbacks: {counts['approval_clock_fallbacks']}, "
+          f"import-blocked (no clock): {counts['import_blocked_no_clock']}")
+    print(f"  dup-link groups: {counts['duplicate_link_groups']} "
+          f"({counts['superseded_links']} superseded)")
+    for gate, ok in gates.items():
+        print(f"  gate {gate}: {'OK' if ok else 'DRIFTED — review before B1'}")
+    print(f"  report: {report_path}")
+
+    return 0 if all(gates.values()) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/tests/test_backfill_b0.py
+++ b/qa-automation/AI-Scoring/tests/test_backfill_b0.py
@@ -1,0 +1,200 @@
+"""B0 sanitize+stage — BackfillPlan.md §4 rules on synthetic seed rows.
+
+Drives the pure core (`stage_rows`) with in-memory CSV rows; the real
+seed CSVs are gitignored PII and never touched by the suite. The two
+real-seed invariants (1,671 / 333 staged, 3 / 13 anomalies) live in the
+B0 run report, not here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "backfill_seed_b0.py"
+spec = importlib.util.spec_from_file_location("backfill_seed_b0", _SCRIPT)
+b0 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(b0)
+
+MS_SECTIONS = b0.TEAM_SECTIONS["member_support"]
+N = len(MS_SECTIONS)
+
+
+def ms_columns() -> list[str]:
+    names = ["Greeting", "Caller Identity Validation", "Purpose of the Call",
+             "Matching the Moment", "Process Adherence", "Call Resolution",
+             "Communication", "Efficiency & Call Handling", "Documentation",
+             "Customer Resolution Indicator"]
+    return (["Agent Name", "Agent Email", "Timestamp", "Evaluator Email",
+             "Dialpad Link", "Overall Score"]
+            + names + [f"{n} reasoning" for n in names]
+            + [f"{n} confidence" for n in names]
+            + ["Key Strengths", "Opportunities", "Call Summary",
+               "Caller Name", "Caller Phone", "Source", "Unnamed: 42"])
+
+
+def ms_row(*, agent="Jane Doe", ts="2026-05-01 10:00:00", link="https://d/c/1",
+           overall=None, scores=None, source="ai", approval="2026-05-02 09:00:00",
+           reasoning="because", confidence="high") -> dict:
+    """A consistent AI-era row. scores: dict section_name->cell; defaults
+    produce a row that matches the v0_sheet formula exactly."""
+    cols = ms_columns()
+    row = {c: "" for c in cols}
+    defaults = {"Greeting": "5", "Caller Identity Validation": "Yes",
+                "Purpose of the Call": "5", "Matching the Moment": "5",
+                "Process Adherence": "5", "Call Resolution": "5",
+                "Communication": "5", "Efficiency & Call Handling": "5",
+                "Documentation": "5", "Customer Resolution Indicator": "Yes"}
+    defaults.update(scores or {})
+    row.update({"Agent Name": agent, "Timestamp": ts, "Dialpad Link": link,
+                "Evaluator Email": "boss@landing.com", "Source": source,
+                "Unnamed: 42": approval})
+    for name, val in defaults.items():
+        row[name] = val
+        row[f"{name} reasoning"] = reasoning
+        row[f"{name} confidence"] = confidence
+    exact = b0.v0_sheet_score("member_support", {
+        sec_id: b0.normalize_cell(defaults[name], kind)
+        for (sec_id, kind), name in zip(MS_SECTIONS, defaults)
+    })
+    row["Overall Score"] = str(round(exact)) if overall is None else str(overall)
+    return row
+
+
+def run(rows):
+    return b0.stage_rows("member_support", rows, ms_columns())
+
+
+# ---------------------------------------------------------------------------
+
+def test_clean_row_stages_with_expected_shape():
+    out = run([ms_row()])
+    assert out["counts"]["rows_staged"] == 1 and not out["excluded"]
+    s = out["staged"][0]
+    assert s["state"] == "finalized"
+    assert s["source"] == "ai_reviewed"           # Source='ai' → ai_reviewed
+    assert s["formula_version"] == "member_support_v0_sheet"
+    assert s["rubric_version"] == "member_support_v1"
+    assert s["models_used"]["text"]["provider"] == "gemini"
+    assert len(s["sections"]) == N
+    assert not s["annotations"] and not s["import_blocked"]
+
+
+def test_binary_and_confidence_normalization():
+    out = run([ms_row(scores={"Caller Identity Validation": "Not Applicable",
+                              "Customer Resolution Indicator": "No"})])
+    by_id = {sec["section_id"]: sec for sec in out["staged"][0]["sections"]}
+    assert by_id["caller_identity_validation"]["value"] == {"na": True}
+    assert by_id["customer_resolution_indicator"]["value"] == {"binary": "N"}
+    assert by_id["greeting"]["confidence"] == "HIGH"   # 'high' → 'HIGH'
+
+
+def test_manual_era_never_fabricates_reasoning():
+    out = run([ms_row(source="", reasoning="stray text", confidence="high")])
+    s = out["staged"][0]
+    assert s["source"] == "manual"
+    assert s["models_used"]["text"] == {"provider": "human", "model": "human_brain"}
+    for sec in s["sections"]:
+        assert sec["reasoning"] is None and sec["confidence"] is None  # §7
+        assert sec["score_source"] == "manual"
+
+
+def test_hard_zero_override_excluded():
+    out = run([ms_row(overall=0)])
+    assert out["counts"]["rows_staged"] == 0
+    assert out["excluded"][0]["reason"] == "manual_hard_zero_override"
+
+
+def test_all_zero_no_agent_test_artifact_excluded():
+    zeros = {name: ("1" if kind in ("numeric", "manual") else "No")
+             for (sec_id, kind), name in zip(MS_SECTIONS, [
+                 "Greeting", "Caller Identity Validation", "Purpose of the Call",
+                 "Matching the Moment", "Process Adherence", "Call Resolution",
+                 "Communication", "Efficiency & Call Handling", "Documentation",
+                 "Customer Resolution Indicator"])}
+    # all-zero frac: ratings of 0 and binary No
+    zeros = {k: ("0" if v == "1" else "No") for k, v in zeros.items()}
+    out = run([ms_row(agent="", overall=0, scores=zeros)])
+    assert out["excluded"][0]["reason"] == "all_zero_test_artifact"
+
+
+def test_corrupt_section_value_excluded():
+    out = run([ms_row(scores={"Greeting": "banana"})])
+    assert out["counts"]["rows_staged"] == 0
+    assert out["excluded"][0]["reason"].startswith("corrupt_section_value")
+
+
+def test_hand_edit_gets_anomaly_annotation():
+    out = run([ms_row(overall=42)])  # formula-consistent default is 100
+    s = out["staged"][0]
+    assert "backfill_anomaly" in s["annotations"]
+    assert out["counts"]["anomalies"] == 1
+
+
+def test_na_redistribution_matches_formula():
+    # CRI (weight 1) goes NA — remaining weights rescale; all-5s still = 100.
+    out = run([ms_row(scores={"Customer Resolution Indicator": "Not Applicable"})])
+    assert out["counts"]["anomalies"] == 0
+
+
+def test_broken_timestamp_goes_to_repair_queue_not_exclusion():
+    out = run([ms_row(ts="12/31/1969 18:00:00")])
+    s = out["staged"][0]
+    assert s["call_connected_at"] is None
+    assert "backfill_broken_timestamp" in s["annotations"]
+    assert not s["import_blocked"]                 # approval clock still usable
+
+
+def test_no_usable_clock_blocks_import():
+    out = run([ms_row(ts="garbage", approval="")])
+    s = out["staged"][0]
+    assert s["import_blocked"] and s["approved_at"] is None
+    assert out["counts"]["import_blocked_no_clock"] == 1
+
+
+def test_missing_approval_clock_falls_back_to_timestamp():
+    out = run([ms_row(approval="")])
+    s = out["staged"][0]
+    assert s["approved_at"] == s["call_connected_at"]
+    assert s["annotations"]["backfill_approved_at_fallback"] == "timestamp_col"
+
+
+def test_duplicate_link_latest_keeps_it():
+    older = ms_row(approval="2026-05-02 09:00:00")
+    newer = ms_row(approval="2026-06-01 09:00:00")
+    out = run([older, newer])
+    assert out["counts"]["rows_staged"] == 2       # D2: import all
+    with_link = [s for s in out["staged"] if s["dialpad_link"]]
+    superseded = [s for s in out["staged"] if not s["dialpad_link"]]
+    assert len(with_link) == 1 and with_link[0]["approved_at"].startswith("2026-06-01")
+    assert superseded[0]["annotations"]["superseded_dialpad_link"] == "https://d/c/1"
+
+
+def test_reeval_rows_get_distinct_natural_keys():
+    # Same call clock + link + agent (post-PR-1 re-eval shape) but
+    # different approval clocks — keys must not collide.
+    rows = [ms_row(approval="2026-05-02 09:00:00"),
+            ms_row(approval="2026-06-01 09:00:00")]
+    out = run(rows)
+    keys = {s["natural_key"] for s in out["staged"]}
+    assert len(keys) == 2
+
+
+def test_identical_rows_get_ordinal_keys():
+    out = run([ms_row(), ms_row()])
+    keys = {s["natural_key"] for s in out["staged"]}
+    assert len(keys) == 2
+
+
+def test_migrated_source_maps_to_manual_with_provenance():
+    out = run([ms_row(source="migrated")])
+    s = out["staged"][0]
+    assert s["source"] == "manual"
+    assert s["annotations"]["backfill_source_raw"] == "migrated"
+
+
+def test_width_mismatch_is_structural_failure():
+    with pytest.raises(SystemExit, match="structural"):
+        b0.stage_rows("member_support", [], ms_columns()[:-1])


### PR DESCRIPTION
First slice of Backfill B0–B4 (BackfillPlan.md §5). B0 is deliberately **offline and pure**: seed CSV in → staging JSONL + exclusions CSV + run report out, byte-identical on re-run, nothing touches Railway. Review the staging file before B1 ever writes a row.

## What it implements
- Every §4 normalization rule + §8 decision: binary vocab (`Yes/No/Not Applicable→Y/N/NA`), confidence casing, epoch-zero/unparseable timestamps → B2 repair queue, **D1** approval-clock mapping with Timestamp fallback (rows with *no* usable clock stage as `import_blocked` — they'd violate the finalized CHECK — and wait for B2), **D2** duplicate-link supersede (latest by approval clock keeps the link, earlier rows stash `superseded_dialpad_link`), **D4** `human_brain` models_used, **D5** hard-zero exclusions, and §7's never-fabricate rule (manual-era reasonings/confidence forced NULL even if stray text exists).
- **v0_sheet formula recomputes** (both teams, from §2/§2a) annotate hand-edited rows with `backfill_anomaly` for the ε-sweep to segregate.
- **Run-report framework** for the overnight stages: JSON report with counts per transform + expectation gates from the plan's inventory; exit 0 = green, 2 = staged-but-drifted (human review before B1), 1 = structural (nothing written).

## Real-seed results (gates all green)
| | in | staged | excluded | anomalies | broken ts | import-blocked |
|---|---|---|---|---|---|---|
| member_support | 1,678 | **1,671** | 7 | 3 | 14 | 14 |
| sales | 334 | **333** | 1 | 13 | 5 | 5 |

Anomaly counts match the plan's least-squares analysis **exactly** (3 + 13) — independent validation of both formula implementations.

## Findings recorded
- **Natural keys**: link+call-clock+agent is NOT unique post-PR-1 (re-evaluations of the same call share col C; blank-link manual rows share date-only timestamps). Key = sha1(team|link|ts|agent|approval|overall|ordinal).
- **Sales CSV is a newer re-export** than the §2a analysis: the corrupted stray-value row was cleaned at source, and an approval-clock column appeared (~64 AI-era rows). Noted in BackfillPlan §2a; gates encode the corrected exclusion count.
- `database/backfill_staging/` gitignored — staging carries the seed's PII.

## Tests
16 new tests drive the pure core with synthetic rows (the PII seeds never enter the suite). Full suite: 746 passed, only the known task #7 date-flake failing.

Next: **B1** — staging → `qa.evaluations`/`qa.evaluation_sections` in one off-peak batch, shipping the two `v0_sheet` formula rows first (version_ship.py:154 explicitly defers those archives to B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)