### PR TITLE
feat(qa-automation): backfill B1 — staging import into qa.evaluations (resume-safe, §7.4-checked)

### DIFF
--- a/qa-automation/AI-Scoring/scripts/backfill_seed_b1.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_seed_b1.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""B1 — import the B0 staging file into qa.evaluations (BackfillPlan §5).
+
+One off-peak batch, no external calls. Ships the team's archived
+``v0_sheet`` formula row first (version_ship.py defers historic archives
+to B1 by design — the evaluations FK needs it), then upserts staged
+evaluations by natural key: already-imported rows are skipped, so
+re-runs after a partial failure resume instead of duplicating.
+
+Overnight contract: every row failure is caught, logged, and reported —
+the run never dies mid-batch. §7.4 correctness checks run at the end
+(counts + overall-score sum, DB vs staging). Exit 0 = clean; 2 = ran
+with skips/failures or check drift (read the report); 1 = structural
+(preflight failed, nothing written).
+
+Rows B0 marked ``import_blocked`` (no usable clock — they would violate
+the finalized CHECKs) are excluded here and wait for B2's Dialpad
+repair; they are counted in the report, not silently dropped.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/backfill_seed_b1.py --team-id member_support --dry-run
+    python3 scripts/backfill_seed_b1.py --team-id member_support
+    python3 scripts/backfill_seed_b1.py --team-id sales --limit 20   # smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _AI_SCORING.parent.parent
+_STAGING_DIR = _REPO_ROOT / "database" / "backfill_staging"
+load_dotenv(_AI_SCORING / ".env")
+
+import os  # noqa: E402
+
+V0_SHEET_JSON = {
+    "member_support": _AI_SCORING / "backend" / "config" / "scoring" / "member_support" / "v0_sheet.json",
+    "sales": _AI_SCORING / "backend" / "config" / "scoring" / "sales" / "v0_sheet.json",
+}
+FORMULA_VERSION = {
+    "member_support": "member_support_v0_sheet",
+    "sales": "sales_v0_sheet",
+}
+
+# staged (kind, era) -> qa.evaluation_sections.score_type
+SCORE_TYPE = {
+    ("numeric", "ai"): "numeric",
+    ("numeric", "manual"): "manual_numeric",
+    ("yn", "ai"): "binary",
+    ("yn", "manual"): "manual_binary",
+    ("manual", "ai"): "manual_numeric",
+    ("manual", "manual"): "manual_numeric",
+    ("manual_yn", "ai"): "manual_binary",
+    ("manual_yn", "manual"): "manual_binary",
+}
+
+_EVAL_INSERT = """
+INSERT INTO qa.evaluations (
+    team_id, agent_name_raw, agent_email, evaluator_email, state, source,
+    call_connected_at, dialpad_link, overall_score,
+    formula_version, rubric_version, models_used, ai_provider_primary,
+    key_strengths, opportunities, call_summary, caller_name, caller_phone,
+    dialpad_call_metadata, scoring_status, approved_at, finalized_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13,$14,$15,$16,$17,$18,
+          $19::jsonb,'complete',$20,$21)
+RETURNING id
+"""
+
+_SECTION_INSERT = """
+INSERT INTO qa.evaluation_sections (
+    evaluation_id, section_id, section_number, score_type,
+    numeric_score, binary_value, score_source, ai_provider, model,
+    confidence, reasoning
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+"""
+
+_NK_PATH_SQL = "dialpad_call_metadata #>> '{backfill,natural_key}'"
+
+
+def _ts(iso: str | None) -> datetime | None:
+    return datetime.fromisoformat(iso) if iso else None
+
+
+def _section_params(evaluation_id: int, staged_eval: dict) -> list[tuple]:
+    params = []
+    for number, sec in enumerate(staged_eval["sections"], start=1):
+        value = sec["value"]
+        numeric = value.get("numeric")
+        binary = value.get("binary") or ("NA" if value.get("na") else None)
+        is_ai = sec["score_source"] == "ai"
+        params.append((
+            evaluation_id, sec["section_id"], number,
+            SCORE_TYPE[(sec["kind"], sec["era"])],
+            numeric, binary, sec["score_source"],
+            "gemini" if is_ai else None,
+            "gemini-2.5-flash" if is_ai else None,
+            sec["confidence"], sec["reasoning"],
+        ))
+    return params
+
+
+async def ship_v0_sheet_formula(conn, team_id: str, staged: list[dict], dry_run: bool) -> str:
+    """Insert the archived legacy formula row if absent (FK prerequisite)."""
+    version = FORMULA_VERSION[team_id]
+    exists = await conn.fetchval(
+        "SELECT 1 FROM qa.formula_versions WHERE formula_version = $1", version)
+    if exists:
+        return "already_present"
+    payload = json.loads(V0_SHEET_JSON[team_id].read_text(encoding="utf-8"))
+    declared = payload.get("formula_id")
+    if declared != version:
+        raise SystemExit(
+            f"structural: {V0_SHEET_JSON[team_id]} declares formula_id="
+            f"{declared!r}, expected {version!r}")
+    clocks = sorted(s["approved_at"] for s in staged if s["approved_at"])
+    if dry_run:
+        return "would_insert"
+    await conn.execute(
+        "INSERT INTO qa.formula_versions "
+        "(formula_version, team_id, formula_json, effective_from, effective_until) "
+        "VALUES ($1,$2,$3::jsonb,$4,$5) ON CONFLICT (formula_version) DO NOTHING",
+        version, team_id, json.dumps(payload), _ts(clocks[0]), _ts(clocks[-1]),
+    )
+    return "inserted"
+
+
+async def run(args) -> int:
+    import asyncpg
+
+    staging_path = Path(args.staging_dir) / f"staging_{args.team_id}.jsonl"
+    if not staging_path.exists():
+        print(f"structural: staging file missing: {staging_path} — run B0 first")
+        return 1
+    staged_all = [json.loads(line) for line in staging_path.open(encoding="utf-8")]
+    blocked = [s for s in staged_all if s["import_blocked"]]
+    importable = [s for s in staged_all if not s["import_blocked"]]
+    if args.limit:
+        importable = importable[: args.limit]
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        print("structural: DATABASE_URL not set")
+        return 1
+    conn = await asyncpg.connect(dsn, timeout=15)
+
+    counts = {
+        "staged_total": len(staged_all), "import_blocked": len(blocked),
+        "candidates": len(importable), "already_imported": 0,
+        "link_collisions": 0, "inserted": 0, "failed": 0,
+    }
+    failures: list[dict] = []
+
+    try:
+        # ---- preflight -----------------------------------------------------
+        rubric = staged_all[0]["rubric_version"]
+        if not await conn.fetchval(
+                "SELECT 1 FROM qa.rubric_versions WHERE rubric_version = $1", rubric):
+            print(f"structural: rubric_version {rubric!r} not in qa.rubric_versions")
+            return 1
+        formula_state = await ship_v0_sheet_formula(conn, args.team_id, staged_all, args.dry_run)
+
+        existing_keys = {
+            r[0] for r in await conn.fetch(
+                f"SELECT {_NK_PATH_SQL} FROM qa.evaluations "
+                f"WHERE team_id = $1 AND {_NK_PATH_SQL} IS NOT NULL", args.team_id)
+        }
+        to_import = []
+        for s in importable:
+            if s["natural_key"] in existing_keys:
+                counts["already_imported"] += 1
+            else:
+                to_import.append(s)
+
+        staged_links = [s["dialpad_link"] for s in to_import if s["dialpad_link"]]
+        collisions = set()
+        if staged_links:
+            collisions = {
+                r["dialpad_link"] for r in await conn.fetch(
+                    "SELECT dialpad_link FROM qa.evaluations "
+                    "WHERE team_id = $1 AND dialpad_link = ANY($2::text[])",
+                    args.team_id, staged_links)
+            }
+        if collisions:
+            counts["link_collisions"] = len(collisions)
+            for s in [x for x in to_import if x["dialpad_link"] in collisions]:
+                failures.append({"natural_key": s["natural_key"], "line": s["line"],
+                                 "error": f"dialpad_link already on a live row: {s['dialpad_link']}"})
+            to_import = [x for x in to_import if x["dialpad_link"] not in collisions]
+
+        print(f"[B1:{args.team_id}] staged={counts['staged_total']} "
+              f"blocked={counts['import_blocked']} candidates={counts['candidates']} "
+              f"already_imported={counts['already_imported']} "
+              f"link_collisions={counts['link_collisions']} "
+              f"to_import={len(to_import)} formula_row={formula_state}"
+              + (" [DRY RUN]" if args.dry_run else ""))
+        if args.dry_run:
+            return 0
+
+        # ---- import loop: one transaction per evaluation --------------------
+        imported_at = datetime.now(timezone.utc).isoformat()
+        for i, s in enumerate(to_import, start=1):
+            metadata = {"backfill": {
+                **s["annotations"],
+                "natural_key": s["natural_key"],
+                "staged_line": s["line"],
+                "imported_at": imported_at,
+            }}
+            era_ai = s["era"] == "ai"
+            try:
+                async with conn.transaction():
+                    evaluation_id = await conn.fetchval(
+                        _EVAL_INSERT,
+                        s["team_id"], s["agent_name_raw"], s["agent_email"],
+                        s["evaluator_email"], s["state"], s["source"],
+                        _ts(s["call_connected_at"]), s["dialpad_link"],
+                        s["overall_score"], s["formula_version"], s["rubric_version"],
+                        json.dumps(s["models_used"]),
+                        "gemini" if era_ai else None,
+                        s["key_strengths"], s["opportunities"], s["call_summary"],
+                        s["caller_name"], s["caller_phone"],
+                        json.dumps(metadata),
+                        _ts(s["approved_at"]), _ts(s["approved_at"]),
+                    )
+                    await conn.executemany(_SECTION_INSERT, _section_params(evaluation_id, s))
+                counts["inserted"] += 1
+            except Exception as e:  # noqa: BLE001 — overnight contract: log, continue
+                counts["failed"] += 1
+                failures.append({"natural_key": s["natural_key"], "line": s["line"],
+                                 "error": f"{type(e).__name__}: {e}"})
+            if i % 200 == 0:
+                print(f"  {i}/{len(to_import)} imported "
+                      f"({counts['failed']} failed so far)")
+
+        # ---- §7.4 checks -----------------------------------------------------
+        db = await conn.fetchrow(
+            f"SELECT COUNT(*) AS n, COALESCE(SUM(overall_score), 0) AS score_sum, "
+            f"COUNT(*) FILTER (WHERE call_connected_at IS NULL) AS null_clock "
+            f"FROM qa.evaluations WHERE team_id = $1 AND {_NK_PATH_SQL} IS NOT NULL",
+            args.team_id)
+        section_count = await conn.fetchval(
+            f"SELECT COUNT(*) FROM qa.evaluation_sections es "
+            f"JOIN qa.evaluations e ON e.id = es.evaluation_id "
+            f"WHERE e.team_id = $1 AND e.{_NK_PATH_SQL} IS NOT NULL", args.team_id)
+        expected_rows = counts["already_imported"] + counts["inserted"]
+        if args.limit:
+            # Partial smoke run: DB may hold rows outside the truncated
+            # candidate list, so equality checks don't apply.
+            checks = {"skipped_partial_run": True}
+        else:
+            complete = counts["failed"] == 0 and counts["link_collisions"] == 0
+            checks = {
+                "db_rows_equal_imported": db["n"] == expected_rows,
+                "db_sections_equal_rows_x_n":
+                    section_count == expected_rows * len(staged_all[0]["sections"]),
+                "overall_sum_matches_staging": complete and float(db["score_sum"])
+                    == round(sum(s["overall_score"] for s in importable), 1),
+            }
+    finally:
+        await conn.close()
+
+    report = {
+        "stage": "B1", "team_id": args.team_id, "counts": counts,
+        "checks": checks, "failures": failures,
+        "db": {"rows": db["n"], "sections": section_count,
+               "overall_sum": float(db["score_sum"]),
+               "null_call_clock": db["null_clock"]},
+    }
+    report_path = Path(args.staging_dir) / f"report_{args.team_id}_b1.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print(f"[B1:{args.team_id}] inserted={counts['inserted']} "
+          f"failed={counts['failed']} already_imported={counts['already_imported']}")
+    print(f"  db rows={db['n']} sections={section_count} "
+          f"null-clock (B2 queue)={db['null_clock']}")
+    for name, ok in checks.items():
+        print(f"  check {name}: {'OK' if ok else 'DRIFTED'}")
+    print(f"  report: {report_path}")
+
+    clean = (counts["failed"] == 0 and counts["link_collisions"] == 0
+             and all(checks.values()))
+    return 0 if clean else 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True, choices=sorted(FORMULA_VERSION))
+    ap.add_argument("--staging-dir", default=str(_STAGING_DIR))
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Preflight + counts only; no writes at all")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Import at most N rows (smoke runs)")
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/tests/test_backfill_b1.py
+++ b/qa-automation/AI-Scoring/tests/test_backfill_b1.py
@@ -1,0 +1,89 @@
+"""B1 import mapping — staged rows → qa.* insert parameters.
+
+Covers the pure translation layer (score_type matrix, NA shapes per
+migration 012, ai_provider-iff-ai CHECK alignment). The asyncpg loop is
+deliberately thin; its behavior is exercised by dry-run/smoke runs
+against the real staging files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "backfill_seed_b1.py"
+spec = importlib.util.spec_from_file_location("backfill_seed_b1", _SCRIPT)
+b1 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(b1)
+
+
+def staged_eval(sections):
+    return {"sections": sections}
+
+
+def sec(kind, era, value, *, score_source="manual", confidence=None, reasoning=None):
+    return {"section_id": f"{kind}_{era}", "kind": kind, "era": era,
+            "value": value, "score_source": score_source,
+            "confidence": confidence, "reasoning": reasoning}
+
+
+def test_score_type_matrix():
+    rows = b1._section_params(1, staged_eval([
+        sec("numeric", "ai", {"numeric": 4}),
+        sec("numeric", "manual", {"numeric": 3}),
+        sec("yn", "ai", {"binary": "Y"}),
+        sec("yn", "manual", {"binary": "N"}),
+        sec("manual", "ai", {"numeric": 5}),
+        sec("manual_yn", "manual", {"binary": "Y"}),
+    ]))
+    assert [r[3] for r in rows] == [
+        "numeric", "manual_numeric", "binary", "manual_binary",
+        "manual_numeric", "manual_binary",
+    ]
+    assert [r[2] for r in rows] == [1, 2, 3, 4, 5, 6]  # section_number order
+
+
+def test_numeric_na_uses_migration_012_shape():
+    [row] = b1._section_params(1, staged_eval([
+        sec("numeric", "ai", {"na": True}),
+    ]))
+    numeric_score, binary_value = row[4], row[5]
+    assert numeric_score is None and binary_value == "NA"
+
+
+def test_binary_values_land_in_binary_column():
+    rows = b1._section_params(1, staged_eval([
+        sec("yn", "ai", {"binary": "Y"}),
+        sec("yn", "ai", {"na": True}),
+    ]))
+    assert [(r[4], r[5]) for r in rows] == [(None, "Y"), (None, "NA")]
+
+
+def test_ai_provider_iff_ai_score_source():
+    rows = b1._section_params(1, staged_eval([
+        sec("numeric", "ai", {"numeric": 4}, score_source="ai",
+            confidence="HIGH", reasoning="because"),
+        sec("manual", "ai", {"numeric": 2}, score_source="manual"),
+    ]))
+    ai_row, manual_row = rows
+    assert (ai_row[7], ai_row[8]) == ("gemini", "gemini-2.5-flash")
+    assert (manual_row[7], manual_row[8]) == (None, None)
+    assert ai_row[9] == "HIGH" and ai_row[10] == "because"
+
+
+def test_ts_roundtrip():
+    dt = b1._ts("2026-05-01T10:00:00+00:00")
+    assert dt.tzinfo is not None and dt.year == 2026
+    assert b1._ts(None) is None
+
+
+def test_v0_sheet_formula_files_declare_expected_ids():
+    for team, version in b1.FORMULA_VERSION.items():
+        import json
+        payload = json.loads(b1.V0_SHEET_JSON[team].read_text(encoding="utf-8"))
+        assert payload.get("formula_id") == version, (
+            f"{team}: v0_sheet.json declares {payload.get('formula_id')!r}; "
+            f"B1's FK ship step expects {version!r}"
+        )


### PR DESCRIPTION
Second slice of Backfill B0–B4: the B0 staging file → `qa.evaluations` + `qa.evaluation_sections`, one off-peak batch, no external calls.

## Order of operations
1. **Preflight** (all read-only): staging file present, rubric row exists, existing natural keys loaded (resume), staged links checked against live rows (`uq_eval_team_link` guard).
2. **Ship the archived formula** — inserts `member_support_v0_sheet` / `sales_v0_sheet` into `qa.formula_versions` from `config/scoring/*/v0_sheet.json` (the step `version_ship.py` explicitly defers to B1), validating the JSON's declared `formula_id` and stamping the effective window from the seed's approval clocks.
3. **Import loop** — one transaction per evaluation (eval row + its sections), so any failure rolls back that row alone, gets logged to the report, and the batch continues. Progress lines every 200.
4. **§7.4 checks** — DB row/section counts and overall-score sum vs staging (skipped on `--limit` smoke runs).

## Overnight contract
- Idempotent resume: natural keys live at `dialpad_call_metadata.backfill.natural_key`; re-runs skip imported rows.
- B0's `import_blocked` rows (14 MS + 5 Sales, no usable clock) are counted and deferred to B2 — never silently dropped.
- JSON report with per-row failures; exit 0 = clean, 2 = review the report, 1 = structural preflight failure (nothing written).
- `--dry-run` (zero writes) and `--limit N` (smoke) for staged rollout.

## Mapping details
- kind×era `score_type` matrix (`numeric`/`manual_numeric`/`binary`/`manual_binary`); NA on numeric sections uses migration 012's `binary_value='NA'` shape (251 Sales rows need it); `ai_provider`/`model` set iff `score_source='ai'` (CHECK-aligned).
- `ai_provider_primary='gemini'` on AI-era rows, NULL for `human_brain` manual era, per §8.1.

## Validation
- **Dry-runs against prod are green**: MS `staged=1671 blocked=14 to_import=1657`, Sales `staged=333 blocked=5 to_import=328`, zero link collisions, both formula rows pending insert.
- 6 mapping tests; full suite **752 passed** (pre-existing task #7 flake only).

Suggested execution: merge → `--limit 20` smoke on MS → verify report → full runs off-peak tonight → B2 nightly enrichment next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)