### PR TITLE
fix(qa-automation): B2 — D2-consistent call-id ownership for re-evaluation groups

### DIFF
--- a/database/BackfillPlan.md
+++ b/database/BackfillPlan.md
@@ -207,11 +207,11 @@ as documentation output. Sales §11's 75.00 vector stays the Sales fixture until
   clearly marked as post-hoc.
 - **Agent emails** beyond Mails-tab coverage; **caller identity** where Dialpad no longer retains
   the call; the 22 agents who never appear with an email.
-- **The 15 no-clock, no-link rows (B2 finding, 2026-07-11):** 14 MS + 1 Sales rows have a broken
-  Timestamp, no approval-clock value, *and* no Dialpad link — there is no clock source anywhere,
-  and `state='finalized'` CHECKs require `approved_at`. They stay in staging as
-  `import_blocked` forever and appear in every B2 report as unresolvable (zero API cost —
-  they're linkless). The other 4 Sales blocked rows carry links and repair via B2 phase R.
+- **The 19 no-clock rows (B2 runs, 2026-07-12):** all 14 MS + 5 Sales `import_blocked` rows
+  are permanently unimportable. 15 are linkless outright; the 4 Sales rows that *appeared*
+  to carry links held junk values (`test`, `login`, …) that Dialpad rejects. No clock source
+  exists anywhere and `state='finalized'` CHECKs require `approved_at`. They stay in staging
+  as `import_blocked` forever and appear in every B2 report as unresolvable.
 
 ## 8. Decisions (locked 2026-07-01)
 

--- a/qa-automation/AI-Scoring/scripts/backfill_seed_b2.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_seed_b2.py
@@ -297,28 +297,72 @@ async def phase_enrich(db, team_id: str, batch_size: int,
                 row["call_connected_at"].isoformat())
             counts["clock_overwrites"] += 1
         metadata["dialpad_raw"] = details.get("raw") or {}
-        try:
-            # Idempotent single-row UPDATE — safe to retry blindly.
-            await b1.with_reconnect(db, lambda: db.conn.execute(
-                "UPDATE qa.evaluations SET "
-                "dialpad_call_id=$2, dialpad_master_call_id=$3, "
-                "dialpad_entry_point_call_id=$4, "
-                "call_connected_at=COALESCE($5, call_connected_at), "
-                "call_started_at=$6, call_ended_at=$7, call_duration_ms=$8, "
-                "call_type=$9, mos_score=$10, recording_urls=$11::jsonb, "
-                "caller_name=COALESCE(caller_name, $12), "
-                "caller_phone=COALESCE(caller_phone, $13), "
-                "dialpad_call_metadata=$14::jsonb "
-                "WHERE id=$1",
-                row["id"], fields["dialpad_call_id"],
-                fields["dialpad_master_call_id"],
-                fields["dialpad_entry_point_call_id"],
+
+        async def update_row(include_ids: bool):
+            """Idempotent single-row UPDATE — safe to retry blindly.
+            include_ids=False leaves the unique-indexed call-id columns
+            alone (they go to metadata instead — D2 semantics)."""
+            id_sql = ("dialpad_call_id=$12, dialpad_master_call_id=$13, "
+                      "dialpad_entry_point_call_id=$14, " if include_ids else "")
+            params = [
+                row["id"],
                 fields["call_connected_at"], fields["call_started_at"],
                 fields["call_ended_at"], fields["call_duration_ms"],
                 fields["call_type"], fields["mos_score"],
                 json.dumps(fields["recording_urls"]),
                 fields["caller_name"], fields["caller_phone"],
-                json.dumps(metadata)))
+                json.dumps(metadata),
+            ]
+            if include_ids:
+                params += [fields["dialpad_call_id"],
+                           fields["dialpad_master_call_id"],
+                           fields["dialpad_entry_point_call_id"]]
+            await b1.with_reconnect(db, lambda: db.conn.execute(
+                "UPDATE qa.evaluations SET " + id_sql +
+                "call_connected_at=COALESCE($2, call_connected_at), "
+                "call_started_at=$3, call_ended_at=$4, call_duration_ms=$5, "
+                "call_type=$6, mos_score=$7, recording_urls=$8::jsonb, "
+                "caller_name=COALESCE(caller_name, $9), "
+                "caller_phone=COALESCE(caller_phone, $10), "
+                "dialpad_call_metadata=$11::jsonb "
+                "WHERE id=$1",
+                *params))
+
+        try:
+            import asyncpg
+            try:
+                await update_row(include_ids=True)
+            except asyncpg.exceptions.UniqueViolationError:
+                # D2 re-evaluation group: another backfill row of the same
+                # call already holds (team_id, dialpad_call_id). The
+                # dialpad_link holder is the canonical owner of the call-id
+                # family; superseded rows stash theirs in metadata.
+                holder = await b1.with_reconnect(db, lambda: db.conn.fetchrow(
+                    "SELECT id, dialpad_link, dialpad_call_metadata "
+                    "FROM qa.evaluations WHERE team_id=$1 AND dialpad_call_id=$2",
+                    team_id, fields["dialpad_call_id"]))
+                if (row["dialpad_link"] is not None and holder is not None
+                        and holder["dialpad_link"] is None):
+                    # Wrong row got there first (CSV order): demote the
+                    # superseded holder, then claim the ids here.
+                    holder_meta = json.loads(holder["dialpad_call_metadata"])
+                    holder_meta["backfill"]["superseded_dialpad_call_id"] = (
+                        fields["dialpad_call_id"])
+                    await b1.with_reconnect(db, lambda: db.conn.execute(
+                        "UPDATE qa.evaluations SET dialpad_call_id=NULL, "
+                        "dialpad_master_call_id=NULL, "
+                        "dialpad_entry_point_call_id=NULL, "
+                        "dialpad_call_metadata=$2::jsonb WHERE id=$1",
+                        holder["id"], json.dumps(holder_meta)))
+                    await update_row(include_ids=True)
+                    counts["call_id_swaps"] += 1
+                else:
+                    # This row is the superseded one (or a same-call link
+                    # variant): keep ids off the unique columns.
+                    metadata["backfill"]["superseded_dialpad_call_id"] = (
+                        fields["dialpad_call_id"])
+                    await update_row(include_ids=False)
+                    counts["call_id_deferred"] += 1
             counts["enriched"] += 1
             if fields["caller_name"] and not row["caller_name"]:
                 counts["caller_fields_filled"] += 1
@@ -345,7 +389,8 @@ async def run(args) -> int:
         "repair_unresolvable", "repair_failed", "enrich_batch", "enriched",
         "enrich_failed_404", "enrich_failed_other", "clock_overwrites",
         "caller_fields_filled", "rate_limit_hits", "unenrichable_no_link",
-        "enrich_remaining_after", "reconnects")}
+        "enrich_remaining_after", "reconnects", "call_id_swaps",
+        "call_id_deferred")}
     counts["aborted_rate_limited"] = False
     failures: list[dict] = []
 
@@ -373,6 +418,8 @@ async def run(args) -> int:
           f"{counts['enrich_failed_404']} marked 404, "
           f"{counts['clock_overwrites']} clock overwrites, "
           f"{counts['caller_fields_filled']} caller fields filled")
+    print(f"  D2 re-eval call-id resolution: {counts['call_id_swaps']} swaps, "
+          f"{counts['call_id_deferred']} deferred to holder")
     print(f"  remaining after this run: {counts['enrich_remaining_after']} "
           f"(no-link unenrichable: {counts['unenrichable_no_link']})")
     print(f"  report: {report_path}")


### PR DESCRIPTION
Second field fix from tonight's enrichment run. MS's first full pass enriched **1,585/1,654** with 26 junk-link 404s (manual-era cells containing `edit`, `viewform`, `conversationhistory`… — permanently marked, never retried) and **43 `uq_eval_team_call_id` violations**.

## Root cause
D2 re-evaluation groups: both rows of a duplicate-link group are the *same Dialpad call*, so both lookups return the same `dialpad_call_id` — and only one row may hold `(team_id, dialpad_call_id)`. CSV order meant the **superseded row usually enriched first and claimed the id**, locking out the canonical link-holder.

## Fix — extend D2's link policy to the call-id family
- The `dialpad_link` **holder owns** `dialpad_call_id`/master/entry_point.
- Superseded rows stash theirs in `backfill.superseded_dialpad_call_id` (mirroring `superseded_dialpad_link`).
- On conflict: if the current id-holder is a superseded row → **demote it** (ids to metadata) and let the link-holder claim; otherwise → defer this row's ids to metadata.
- Either way the row still gets clocks/recordings/caller fields and `enriched_at` — no enrichment value lost. New counters: `call_id_swaps` / `call_id_deferred`.

The 43 rows carried no cursor marks, so the retry run (running now) picks them up automatically — the resume design doing its job. Also note for ops: multi-team invocations should chain with `;` not `&&` — exit 2 means "review report", not "abort the next team".

🤖 Generated with [Claude Code](https://claude.com/claude-code)