### PR TITLE
feat(qa-automation): backfill B3 + B4 — identity resolution and verification (executed, all green)

### DIFF
--- a/qa-automation/AI-Scoring/scripts/backfill_seed_b3.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_seed_b3.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""B3 — agent identity resolution for backfilled rows (BackfillPlan §5).
+
+One set-based pass after B2 settles: resolve ``agent_id`` via qa.agents
+using exactly the Stage-4 matching semantics (active roster rows,
+case-insensitive on name OR canonical_name), and repair missing historic
+``agent_email`` where the roster covers it. Names the roster doesn't
+know stay NULL forever — accepted per plan §7, and reported here so the
+list is explicit, not implicit.
+
+Idempotent: only touches backfill rows where ``agent_id IS NULL``.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/backfill_seed_b3.py --team-id member_support --dry-run
+    python3 scripts/backfill_seed_b3.py --team-id member_support
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_STAGING_DIR = _AI_SCORING.parent.parent / "database" / "backfill_staging"
+load_dotenv(_AI_SCORING / ".env")
+
+_b1_spec = importlib.util.spec_from_file_location(
+    "backfill_seed_b1", Path(__file__).resolve().parent / "backfill_seed_b1.py")
+b1 = importlib.util.module_from_spec(_b1_spec)
+_b1_spec.loader.exec_module(b1)
+
+_NK = "dialpad_call_metadata #>> '{backfill,natural_key}'"
+
+_MATCH = ("a.team_id = e.team_id AND a.active "
+          "AND (LOWER(a.name) = LOWER(e.agent_name_raw) "
+          "     OR LOWER(a.canonical_name) = LOWER(e.agent_name_raw))")
+
+
+async def run(args) -> int:
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        print("structural: DATABASE_URL not set")
+        return 1
+    db = b1.DbSession(dsn)
+    await db.connect()
+    try:
+        before = await b1.with_reconnect(db, lambda: db.conn.fetchrow(
+            f"SELECT COUNT(*) AS total, "
+            f"COUNT(*) FILTER (WHERE agent_id IS NULL) AS unresolved, "
+            f"COUNT(*) FILTER (WHERE agent_email IS NULL) AS no_email "
+            f"FROM qa.evaluations e "
+            f"WHERE team_id = $1 AND {_NK} IS NOT NULL", args.team_id))
+
+        resolvable = await b1.with_reconnect(db, lambda: db.conn.fetchval(
+            f"SELECT COUNT(*) FROM qa.evaluations e "
+            f"WHERE e.team_id = $1 AND {_NK} IS NOT NULL AND e.agent_id IS NULL "
+            f"AND EXISTS (SELECT 1 FROM qa.agents a WHERE {_MATCH})", args.team_id))
+
+        if not args.dry_run and resolvable:
+            await b1.with_reconnect(db, lambda: db.conn.execute(
+                f"UPDATE qa.evaluations e SET "
+                f"agent_id = a.id, "
+                f"agent_email = COALESCE(e.agent_email, a.email) "
+                f"FROM qa.agents a "
+                f"WHERE e.team_id = $1 AND e.{_NK} IS NOT NULL "
+                f"AND e.agent_id IS NULL AND {_MATCH}", args.team_id))
+
+        after = await b1.with_reconnect(db, lambda: db.conn.fetchrow(
+            f"SELECT COUNT(*) FILTER (WHERE agent_id IS NULL) AS unresolved, "
+            f"COUNT(*) FILTER (WHERE agent_email IS NULL) AS no_email "
+            f"FROM qa.evaluations e "
+            f"WHERE team_id = $1 AND {_NK} IS NOT NULL", args.team_id))
+
+        # The accepted-NULL-forever list, made explicit (plan §7).
+        unresolved_names = await b1.with_reconnect(db, lambda: db.conn.fetch(
+            f"SELECT agent_name_raw, COUNT(*) AS n FROM qa.evaluations e "
+            f"WHERE team_id = $1 AND {_NK} IS NOT NULL AND agent_id IS NULL "
+            f"GROUP BY 1 ORDER BY n DESC", args.team_id))
+    finally:
+        await db.close()
+
+    report = {
+        "stage": "B3", "team_id": args.team_id, "dry_run": args.dry_run,
+        "counts": {
+            "backfill_rows": before["total"],
+            "unresolved_before": before["unresolved"],
+            "resolvable": resolvable,
+            "unresolved_after": after["unresolved"],
+            "resolved_this_run": before["unresolved"] - after["unresolved"],
+            "email_missing_before": before["no_email"],
+            "email_missing_after": after["no_email"],
+            "emails_repaired": before["no_email"] - after["no_email"],
+        },
+        "unresolved_names": [{"name": r["agent_name_raw"], "rows": r["n"]}
+                             for r in unresolved_names],
+    }
+    report_path = _STAGING_DIR / f"report_{args.team_id}_b3.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    c = report["counts"]
+    tag = " [DRY RUN]" if args.dry_run else ""
+    print(f"[B3:{args.team_id}]{tag} rows={c['backfill_rows']} "
+          f"resolved={c['resolved_this_run']} (resolvable={c['resolvable']}) "
+          f"emails repaired={c['emails_repaired']}")
+    print(f"  remaining unresolved: {c['unresolved_after']} rows across "
+          f"{len(report['unresolved_names'])} names (NULL forever — plan §7)")
+    for r in report["unresolved_names"][:10]:
+        print(f"    {r['rows']:4d}  {r['name']}")
+    if len(report["unresolved_names"]) > 10:
+        print(f"    ... +{len(report['unresolved_names']) - 10} more (see report)")
+    print(f"  report: {report_path}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True, choices=sorted(b1.FORMULA_VERSION))
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/scripts/backfill_seed_b4.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_seed_b4.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""B4 — backfill verification + ε-sweep handoff (BackfillPlan §5, §7.4).
+
+Read-only. Compares the database's backfilled rows against the B0
+staging file (the reviewed source of truth) across every §7.4 axis:
+
+  - row + section counts (permanently-blocked rows excluded)
+  - overall-score sum, exact
+  - per-month row counts + score means (bucketed by approved_at — the
+    clock B2's authoritative-overwrite never touches)
+  - per-agent row counts
+  - anomaly annotations present (the §2/§2a hand-edit rows)
+  - v0_sheet formula rows archived; natural keys unique
+  - identity coverage after B3 (informational)
+
+Exit 0 = every check green (ε sweep may proceed — attach the §2
+narrative before showing leadership any deltas); 2 = drift, read the
+report before going further.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/backfill_seed_b4.py --team-id member_support
+    python3 scripts/backfill_seed_b4.py --team-id sales
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_STAGING_DIR = _AI_SCORING.parent.parent / "database" / "backfill_staging"
+load_dotenv(_AI_SCORING / ".env")
+
+_b1_spec = importlib.util.spec_from_file_location(
+    "backfill_seed_b1", Path(__file__).resolve().parent / "backfill_seed_b1.py")
+b1 = importlib.util.module_from_spec(_b1_spec)
+_b1_spec.loader.exec_module(b1)
+
+_NK = "dialpad_call_metadata #>> '{backfill,natural_key}'"
+_ANOM = "dialpad_call_metadata #>> '{backfill,backfill_anomaly}'"
+
+
+def staging_aggregates(staged: list[dict]) -> dict:
+    """Expected values from the reviewed B0 staging file."""
+    months = Counter()
+    month_sums: dict[str, float] = defaultdict(float)
+    agents = Counter()
+    anomalies = 0
+    total_sum = 0.0
+    for s in staged:
+        month = (s["approved_at"] or "")[:7]
+        months[month] += 1
+        month_sums[month] += s["overall_score"]
+        agents[s["agent_name_raw"].strip().lower()] += 1
+        total_sum += s["overall_score"]
+        if "backfill_anomaly" in s["annotations"]:
+            anomalies += 1
+    return {
+        "rows": len(staged),
+        "sections": sum(len(s["sections"]) for s in staged),
+        "score_sum": round(total_sum, 1),
+        "months": dict(months),
+        "month_means": {m: round(month_sums[m] / n, 2) for m, n in months.items()},
+        "agents": dict(agents),
+        "anomalies": anomalies,
+    }
+
+
+async def db_aggregates(db, team_id: str) -> dict:
+    row = await b1.with_reconnect(db, lambda: db.conn.fetchrow(
+        f"SELECT COUNT(*) AS rows, COALESCE(SUM(overall_score),0) AS score_sum, "
+        f"COUNT(*) FILTER (WHERE {_ANOM} IS NOT NULL) AS anomalies, "
+        f"COUNT(*) FILTER (WHERE agent_id IS NOT NULL) AS with_agent_id, "
+        f"COUNT(DISTINCT {_NK}) AS distinct_keys "
+        f"FROM qa.evaluations WHERE team_id = $1 AND {_NK} IS NOT NULL", team_id))
+    sections = await b1.with_reconnect(db, lambda: db.conn.fetchval(
+        f"SELECT COUNT(*) FROM qa.evaluation_sections es "
+        f"JOIN qa.evaluations e ON e.id = es.evaluation_id "
+        f"WHERE e.team_id = $1 AND e.{_NK} IS NOT NULL", team_id))
+    months = await b1.with_reconnect(db, lambda: db.conn.fetch(
+        f"SELECT to_char(approved_at AT TIME ZONE 'UTC', 'YYYY-MM') AS m, "
+        f"COUNT(*) AS n, ROUND(AVG(overall_score), 2) AS mean "
+        f"FROM qa.evaluations WHERE team_id = $1 AND {_NK} IS NOT NULL "
+        f"GROUP BY 1", team_id))
+    agents = await b1.with_reconnect(db, lambda: db.conn.fetch(
+        f"SELECT LOWER(TRIM(agent_name_raw)) AS a, COUNT(*) AS n "
+        f"FROM qa.evaluations WHERE team_id = $1 AND {_NK} IS NOT NULL "
+        f"GROUP BY 1", team_id))
+    formula = await b1.with_reconnect(db, lambda: db.conn.fetchval(
+        "SELECT 1 FROM qa.formula_versions WHERE formula_version = $1",
+        b1.FORMULA_VERSION[team_id]))
+    return {
+        "rows": row["rows"], "sections": sections,
+        "score_sum": round(float(row["score_sum"]), 1),
+        "anomalies": row["anomalies"],
+        "with_agent_id": row["with_agent_id"],
+        "distinct_keys": row["distinct_keys"],
+        "months": {r["m"]: r["n"] for r in months},
+        "month_means": {r["m"]: float(r["mean"]) for r in months},
+        "agents": {r["a"]: r["n"] for r in agents},
+        "formula_archived": bool(formula),
+    }
+
+
+async def run(args) -> int:
+    staging_path = _STAGING_DIR / f"staging_{args.team_id}.jsonl"
+    if not staging_path.exists():
+        print(f"structural: staging file missing: {staging_path}")
+        return 1
+    staged = [json.loads(line) for line in staging_path.open(encoding="utf-8")]
+    importable = [s for s in staged if not s["import_blocked"]]
+    expected = staging_aggregates(importable)
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        print("structural: DATABASE_URL not set")
+        return 1
+    db = b1.DbSession(dsn)
+    await db.connect()
+    try:
+        actual = await db_aggregates(db, args.team_id)
+    finally:
+        await db.close()
+
+    month_drift = {m: (expected["months"].get(m), actual["months"].get(m))
+                   for m in set(expected["months"]) | set(actual["months"])
+                   if expected["months"].get(m) != actual["months"].get(m)}
+    mean_drift = {m: (expected["month_means"].get(m), actual["month_means"].get(m))
+                  for m in expected["month_means"]
+                  if abs((expected["month_means"].get(m) or 0)
+                         - (actual["month_means"].get(m) or 0)) > 0.01}
+    agent_drift = {a: (expected["agents"].get(a), actual["agents"].get(a))
+                   for a in set(expected["agents"]) | set(actual["agents"])
+                   if expected["agents"].get(a) != actual["agents"].get(a)}
+
+    checks = {
+        "rows": actual["rows"] == expected["rows"],
+        "sections": actual["sections"] == expected["sections"],
+        "score_sum_exact": actual["score_sum"] == expected["score_sum"],
+        "natural_keys_unique": actual["distinct_keys"] == actual["rows"],
+        "anomalies_annotated": actual["anomalies"] == expected["anomalies"],
+        "per_month_counts": not month_drift,
+        "per_month_means": not mean_drift,
+        "per_agent_counts": not agent_drift,
+        "v0_sheet_formula_archived": actual["formula_archived"],
+    }
+    report = {
+        "stage": "B4", "team_id": args.team_id, "checks": checks,
+        "expected": {k: v for k, v in expected.items() if k not in ("agents",)},
+        "actual": {k: v for k, v in actual.items() if k not in ("agents",)},
+        "drift": {"months": month_drift, "month_means": mean_drift,
+                  "agents": agent_drift},
+        "identity_coverage": f"{actual['with_agent_id']}/{actual['rows']}",
+        "epsilon_sweep_handoff": (
+            "Backfill verified — the Phase 6 sweep may run compute_overall_score() "
+            "under the current formula. Attach the BackfillPlan §2/§2a narrative "
+            "before presenting deltas: large deltas are BY DESIGN (the sheet "
+            "ignored sections the new formulas weight heavily)."),
+    }
+    report_path = _STAGING_DIR / f"report_{args.team_id}_b4.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print(f"[B4:{args.team_id}] rows {actual['rows']}/{expected['rows']} | "
+          f"sections {actual['sections']}/{expected['sections']} | "
+          f"score_sum {actual['score_sum']} vs {expected['score_sum']} | "
+          f"anomalies {actual['anomalies']}/{expected['anomalies']}")
+    print(f"  identity coverage (post-B3): {report['identity_coverage']}")
+    for name, ok in checks.items():
+        print(f"  check {name}: {'OK' if ok else 'DRIFTED'}")
+    print(f"  report: {report_path}")
+    return 0 if all(checks.values()) else 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True, choices=sorted(b1.FORMULA_VERSION))
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Final two slices of Backfill B0–B4 — built and **already executed** (both are idempotent; B4 is read-only).

## B3 — identity resolution
Set-based pass with Stage-4's exact matching semantics (active roster, case-insensitive `name` OR `canonical_name`), `agent_email` repaired via COALESCE. Results:
- **member_support: 673/1,657 resolved**, 2 emails repaired. The remaining 984 rows across 39 names are departed agents absent from `qa.agents` — the plan-§7 accepted-NULL-forever set, now explicit in the report instead of implicit.
- **sales: 328/328 resolved** — full identity coverage.

## B4 — §7.4 verification (read-only)
DB vs the reviewed B0 staging file, every axis:

| check | MS | Sales |
|---|---|---|
| rows | 1,657/1,657 | 328/328 |
| sections | 16,570 | 6,232 |
| score sum (exact) | 135,254.0 ✓ | 26,389.0 ✓ |
| per-month counts + means | ✓ | ✓ |
| per-agent counts | ✓ | ✓ |
| anomalies annotated | 3/3 | 12/12 |
| natural keys unique / formula archived | ✓ | ✓ |

**All 18 checks green → the Phase 6 ε sweep is formally unblocked**, and the report embeds the §2 reminder: sweep deltas are large *by design* (the legacy sheet ignored sections the new formulas weight heavily) — leadership sees the narrative before the numbers.

With this, **Backfill B0–B4 is complete**: 1,985 historic evaluations imported, enriched, identity-resolved, and verified. The read-path flip (roadmap item 4) is now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)