### PR TITLE
docs(qa-automation): ReadPathFlip design + LateStageDesign registry

### DIFF
--- a/qa-automation/AI-Scoring/references/LateStageDesign.md
+++ b/qa-automation/AI-Scoring/references/LateStageDesign.md
@@ -1,0 +1,79 @@
+# Late-Stage Design Registry — features pending docs, decisions, or both
+
+> Single registry of everything the reference corpus mentions, promises,
+> or half-scopes that has **no design doc or implementation plan of its
+> own** — compiled 2026-07-12 from a full sweep of `references/`,
+> `database/SQLMigration.md`, and `landing-ai/LandGPT.md`. Future
+> sessions start here: pick an item, write its doc (design-doc-first for
+> anything > half a day), link it back, and strike the row.
+>
+> Ordered by silent-failure impact (data loss / launch block first, doc
+> hygiene last). Items already covered by a real design doc (ReadPathFlip,
+> SopRag/#99, HRBonusSheet, LandGPT, LandingOpsCommandCenter, CutoverDesign)
+> appear only where a *piece* of them is undecided.
+
+---
+
+## Tier 1 — owner-owed decisions blocking scoped work
+
+| Item | Where it's owed | Blocks | Notes |
+|---|---|---|---|
+| **13 default `na_applies_when` texts** | Sales spec §10a pre-flip checklist; Sales Mgmt | Sales rubric prose correctness (NA = full credit, so loose wording leaks score) | Pipeline live regardless; texts are operational defaults today |
+| **GLR v2 bullet points** (General Landing Rules) | Owner | August v6 bundle AND SopRag cascade Stage C prompt | Same deliverable feeds both — write once |
+| **HR bonus: Sales section subset** | HR + Sales Mgmt (HRBonusSheet §8) | Sales onboarding to the HR workbook | Config-only once decided (`hr_export` block in sales.json) |
+| **HR bonus P4** | Operator | first supervised run 2026-08-01 | clasp create → Script Properties → `installMonthlyTrigger()` (hr-bonus/README.md) |
+| **ε-sweep (Phase 6)** | Unblocked by B4 (2026-07-12) | leadership view of historic-compliance deltas | MUST ship with the BackfillPlan §2/§2a narrative attached — deltas are large by design |
+
+## Tier 2 — designed elsewhere, one undecided piece
+
+| Item | Doc | The undecided piece |
+|---|---|---|
+| SopRag R1–R6 | #99 (pending Ops VP) | bge-m3 hosting (container vs sidecar — decide in R3 with latency numbers); Stage-A prompt's lean on the Dialpad transcript hint; long-call embedding strategy |
+| Read-path flip F1–F5 | ReadPathFlip.md | none — ready to build |
+| Nightly `reproject` sweep | CutoverDesign (mentioned, never built) | projection-drift repair job: scope, cadence, alerting |
+| Analyst_History sheet retirement ("Phase D") | CutoverDesign §7 tab-retention rule | after read-path flip + one full bonus cycle: what (if anything) still reads the sheet? GAS email does — retirement needs an email-source decision |
+| LandGPT v1 pilot | LandGPT.md (living) | its own open-questions table: runtime (MLX/llama.cpp/Ollama), annotated-transcript schema fields, Stage-2 hardware, pilot go/no-go |
+
+## Tier 3 — recurring promises with NO design doc (each needs one)
+
+| Feature | Mentioned in | What the future doc must decide |
+|---|---|---|
+| **Manager version-ship / rubric / formula editor UI** | Section10 B1 (a signed **requirement**: rating curve reconfigurable in the same UI that ships versions); Wave2 §7; SQLMigration v1.3 (`POST /rubric_and_formula` atomic edit) | auth tier, edit surface, validation against archived versions, ship ceremony vs restart-loader |
+| **Cost tracking + admin dashboard** (Step 7 / PRD Phase D) | PhaseOne, PRD-MultiTeam | `qa.api_audit_log` already collects cost rows; needs `/api/admin/costs`, dashboard page, per-team budget caps + cutoff semantics. RAG cascade (§6 of SopRag) makes this urgent-adjacent: calls multiply |
+| **Dialpad webhook automation + stratified sampler** (Step 8) | PhaseOne, PhaseThree (`sampling_state`), CC Phase 5 (auto-score on `recording` webhook), roadmap "webhooks + 100% local AI" (August) | sampling policy (30–35/agent/week vs 100% Local-AI era), dedupe vs lookup-triggered scores, `sampling_status` column exists and is waiting |
+| **Assessment writer/reader + coaching workflow UI + tags apply/remove** | Wave2 §7; migrations 011 (assessments) and v1.2 (tags/coachings) shipped EMPTY schemas | R3 partially covers qa.assessments persistence for the one-pager; coaching/tags UI wholly undesigned |
+| **Per-evaluator session identity** | LookupToScore future-work; scoring.py comment ("Future: replace with authenticated session user") | replaces client-supplied `manager_email`; prerequisite for HR/MGMT role split |
+| **In-memory `_jobs` store** | PhaseOne tech debt (real: `routes/scoring.py` module dict) | restart loses in-flight scorecards; decide: table in qa.* vs accept (jobs are minutes-long) |
+| **Duplicate-call version picker** | PRD-MultiTeam §7 ("v1 shows all versions; future: choose which persists") | interacts with D2 re-eval semantics now in the DB |
+| **Call-duration analytics dimension** | CallTimeOnAnalystHistory (`compute_call_duration` wired, unconsumed); B2 backfilled `call_duration_ms` on ~1,900 rows | data now exists — a dashboard axis away |
+| **Explicit-NA vs missing in analytics** | NumericNAOption out-of-scope note; standing `xfail` in test_analytics | becomes tractable post-read-path-flip: the DB distinguishes `binary_value='NA'` from absent rows natively — fold into F5 or its own doc |
+| **TeamStatsBoard §11 extensions** | change-point detection, mixed-effects, predictive risk, GMM, CUSUM | park until Local-AI 100% coverage; `coverage_regime` per-row tagging is the prerequisite ([[project_predictive_groundwork]]) |
+| **LandGPT v2 employee surfaces** | LandGPT.md v2 (chat sessions, storage, RBAC, branded frontend) | post-v1-pilot only |
+| **CC Phases 2–5** | LandingOpsCommandCenter.md | wallboard, Slack call-management, profanity detection, MCP server — Wave 3 territory |
+
+## Tier 4 — small forgotten items (low ceremony, just do them)
+
+- **GAS email label** "Evaluation Date" → "Call Date" (CallTime doc; separate GAS-side PR + deploy, never made).
+- **Task #7 date-flake** (`test_monthly_summary_buckets_in_project_local_time`) — fails on DST-dependent dates; the suite's only red for weeks.
+- **Cell-notes retention + `rebuildHistory()` enrichment** (AgentProgressionDashboard open questions — GAS side).
+- **Tier-2 `improvements`→`opportunities` rename** (QAEntry.js/AnalystHistory.js) + `teams/sales/Branding.js` header typo + stale `Main.js` Mails comment.
+- **`score_destination` config blocks + sheet tabs cleanup** — after read-path flip + one bonus cycle (paired with Analyst_History retirement decision, Tier 2).
+- **`qa.score_audit` DB table usage** — schema exists; verify whether the writer still only appends to the sheet tab, and if so wire the dual-write or retire the table decision into the reproject/retirement doc.
+
+## Tier 5 — doc hygiene (stale status lines that mislead readers)
+
+| Doc | Correction needed |
+|---|---|
+| PhaseThree.md | **Superseded banner**: its unified-jsonb schema lost to SQLMigration's normalized `qa.*`; do not implement as written |
+| LookupToScore.md | Says "Design — not yet implemented"; shipped in PR #28 (+#30 gave `/score/batch` audit/auth/idempotency parity — its own future-work item, already done) |
+| NumericNAOption.md | Says "not yet implemented"; shipped in PR #33 |
+| LiveDashboard.md | Phases B–E marked unimplemented; shipped in PR #37 (+#38/#39) |
+| Wave2Plan.md | MS §10 checklist renders unchecked; closed 2026-07-04 per Section10SignoffBriefs |
+| SQLMigration.md | file the promised **v1.5** §3.8 update (Ops-signed formula shape) + note `annotated_transcript` no longer NULL-on-Gemini once the SopRag cascade ships (`gemini_annotate_v1`) |
+| PhaseOne.md | Tech-debt table: FR-AI "rewrites same draft row" is the *designed* idempotency now, not debt; job-store row stays (Tier 3) |
+
+---
+
+**Maintenance rule:** when an item here gains a real design doc, replace
+its row with a link; when it ships, delete the row in the same PR. This
+file should shrink.

--- a/qa-automation/AI-Scoring/references/ReadPathFlip.md
+++ b/qa-automation/AI-Scoring/references/ReadPathFlip.md
@@ -1,0 +1,160 @@
+# Read-Path Flip — Dashboards & Analytics from Postgres
+
+> Design for roadmap item 4: every read surface (dashboards, drill-downs,
+> datapoint pages, progression) sources from `qa.*` instead of the
+> Analyst_History sheet. Unblocked 2026-07-12 by Backfill B0–B4 (1,985
+> historic evaluations imported, enriched, identity-resolved, verified —
+> BackfillPlan §7.4 all green). Writes are NOT in scope: Stage-1 FR-AI
+> drafts, the Analyst_History projection (GAS email source), and
+> Score_Audit keep working exactly as today.
+
+| | |
+|---|---|
+| **Status** | v1 draft — 2026-07-12, from the frontend/backend read-path review |
+| **Owner constraint honored** | flip only AFTER backfill (done) — flipping earlier would have blanked history |
+| **Rollback** | flag flip back (reads only — no data is produced by this path) |
+| **Depends on** | PR #94 `PostgresProvider`; backfill complete; `qa.agent_stat_points` seed (F1, this doc) |
+
+---
+
+## 1. The two read paths (finding)
+
+The frontend consumes **two structurally different read paths**; only one
+flips via the provider factory.
+
+**Path 1 — provider-based.** `/agents`, `/agents/{name}/history`,
+`/agents/{name}/progression`, `/datapoints`, `/datapoints/{call_id}` go
+through the `DataProvider` ABC. `PostgresProvider` already implements the
+full contract with tested `EvaluationRecord` parity (sections keyed by
+history_id, naming bridges, YN_DISPLAY strings, tz-aware UTC) and serves
+the Mails-shaped roster from `qa.agents`. Flip = factory wiring + pool
+lifecycle (§5 F3).
+
+**Path 2 — the `/team` analytics trio.** `/team/stats`, `/team/evals`,
+`/team/long_form` bypass the provider: they call
+`provider._ws.get_all_values()` (a gspread-only attribute) and feed raw
+rows to `load_and_clean` + nine pandas `compute_*` functions. No factory
+swap can flip these — they need a Postgres **row-source** (§3 W1).
+
+**Keystone decision:** do NOT rewrite the nine battle-tested pandas
+computations (EWMA, SPC, modified-Z outliers, roster, sections, binary,
+supervisor, distribution, long-form) in SQL. Flip their *row source* and
+keep the math byte-identical, provable by a golden-parity harness (§5
+F2). Individual aggregations move into SQL later only where performance
+says so (§5 F5) — correctness first, optimization second.
+
+---
+
+## 2. Frontend windows inventory (what the pages actually need)
+
+From the full frontend review (2026-07-12). Endpoints → consumers:
+
+| Endpoint | Consumers | Window semantics |
+|---|---|---|
+| `/team/stats` | KPI row, month chiclets, SPC, distribution, EWMA chart, roster, outliers, section analysis, binary tiles, supervisor tab | `days`/`date_from..date_to` (≤730d); **chiclets+SPC bucket by call date in `America/Los_Angeles`, independent of the days filter** |
+| `/team/evals` | month drill-down page, Recent-Evals seed | single `year_month` bucket (call-date TZ bucketing); returns both call clock and `eval_approved_at` |
+| `/team/long_form` | predictive-analytics groundwork (July 2026 Local-AI cutover consumer — do not clean up) | `days`/range; `coverage_regime` envelope |
+| `/team/sections`, `/team/mails` | section metadata, supervisor dropdown | config / roster — no history read |
+| `/agents/{name}/history` | agent page tiles + trend + section bars (client-side aggregation), EWMA drill-down, datapoint mini-history (`days=90` hardcoded) | `days` OR range |
+| `/agents/{name}/progression` | AI assessment card | `days` only |
+| `/datapoints` (`bin`/`agent`) | distribution drill-down | `days` only (custom range deliberately not honored today — preserve) |
+| `/datapoints/{call_id}` | datapoint page | single eval by eval_id |
+| `/events/stream` (SSE) | toasts, Recent-Evals live buffer | unaffected by the flip (event bus, not storage) |
+
+Client-side-only aggregations (agent-page tiles/means, `/team/evals`
+mean±std, last-5 trend arrows, Recent-Evals ring buffer + today count)
+need **no server work** — they ride on the rows above.
+
+---
+
+## 3. Postgres windows to create
+
+- **W1 — history row-source** (the `load_and_clean` equivalent; new
+  `services/team_source.py`). Two queries per request, pandas assembles
+  the same DataFrame the sheet produced:
+  1. finalized evaluations ⋈ `qa.agents` (LEFT JOIN on `agent_id`):
+     `COALESCE(a.canonical_name, e.agent_name_raw)` as agent, call clock,
+     `approved_at`, `overall_score`, `evaluator_email`, `a.active` →
+     `is_active` (NULL agent → inactive — departed-agent parity),
+     `a.supervisor_email` → supervisor, eval_id (§4), dialpad_link;
+  2. `qa.evaluation_sections` long for those evals (numeric_score /
+     binary display) — pandas pivots to the per-section columns.
+- **W2 — monthly buckets view** (`qa.v_monthly_scores`): month label via
+  `call clock AT TIME ZONE <bucket_tz>` → count/mean/std per team.
+  Feeds chiclets + SPC + `/team/evals` month filter. Also the biggest
+  perf win: today every chiclet render loads the entire sheet.
+- **W3 — `qa.v_history_long`**: evaluations × sections — `/team/long_form`
+  is natively this shape; W1's query 2 is a parameterized slice of it.
+- **W4 — `qa.agent_stat_points` seed** (the CutoverDesign 4c gap —
+  CONFIRMED unimplemented: schema+indexes exist, zero writers, zero rows):
+  - finalize-time writer: one EWMA/SPC point per finalize, computed by
+    `team_stats.py` math (§9.2 — λ pinned per point);
+  - backfill replay over all ~2,100 evaluations ordered by
+    `approved_at` (SQLMigration §7.1 — EWMA is sequential);
+  - **semantics wrinkle (decided):** stat points are the *all-time
+    incremental* series for CC sparklines/PDF assessments; the
+    dashboard's *window-scoped* EWMA stays computed over W1 rows. They
+    are different numbers by design — neither impersonates the other.
+- **W5 — roster** — already done: `PostgresProvider._get_mails_sheet()`
+  serves `qa.agents` in Mails shape; `/team/mails`, supervisor dropdown,
+  and `/lookup/scoring-permission` ride it after F3.
+- **W6 — indexed eval-id lookup** for `/datapoints/{call_id}`: replaces
+  today's linear scan over 365 days of history with an indexed
+  `WHERE dialpad_entry_point_call_id = $1 OR dialpad_call_id = $1`
+  (B2 populated both on every enrichable row) with dialpad_link-suffix
+  fallback for pre-B2-junk rows. Ships in F5 (perf, not correctness).
+
+---
+
+## 4. Parity traps (each becomes a golden-parity test)
+
+1. **Naive vs tz-aware timestamps.** `load_and_clean` deliberately emits
+   naive bucket-TZ-comparable timestamps; the provider path emits aware
+   UTC. W1 must preserve the naive semantics or month boundaries shift.
+2. **eval_id derivation.** Everywhere (URLs, SSE dedupe, drill-down
+   links) eval_id = trailing segment of the dialpad_link *text*.
+   Superseded D2 re-eval rows have NULL links — W1 falls back to
+   `dialpad_call_metadata.backfill.superseded_dialpad_link`, then to
+   `dialpad_entry_point_call_id`. Rows with junk links (26 marked) parse
+   to whatever the sheet had — same as today.
+3. **Departed agents** (984 MS rows, `agent_id IS NULL`): must degrade
+   exactly as Mails-absence does today — inactive, blank supervisor,
+   raw name shown. The LEFT JOIN does this naturally; test it anyway.
+4. **`active_only` and supervisor filters** must consult `qa.agents`
+   with the same canonicalization (accent-stripped matching exists in
+   load_and_clean's canonical_map — W1 keeps it in pandas).
+5. **`coverage_regime`** stays hardcoded `manager_sample` until the
+   Local-AI cutover (predictive-groundwork constraint — do not touch).
+6. **Row-drop rules**: load_and_clean drops rows with unparseable
+   overall/timestamp/blank agent/test-agent names — W1 filters
+   equivalently (mostly moot post-B0, but the excluded_test_agents
+   config filter must stay).
+7. **`/datapoints` days-only window** (ignores custom range) is a
+   frontend contract today — preserve, don't "fix" during the flip.
+
+---
+
+## 5. Slice plan (each PR-able; shadow-tested like the write flip)
+
+| # | Slice | Checkpoint |
+|---|---|---|
+| F1 | `agent_stat_points` finalize writer + ordered backfill replay script (`backfill_stat_points.py`, B-series run-report conventions) | pytest: EWMA/λ pinning, replay ordering, idempotency (UNIQUE evaluation_id); replay report row-count == finalized evals |
+| F2 | W1/W2/W3 row-source (`team_source.py`) feeding unchanged pandas + **golden-parity harness**: same request served from sheet and Postgres, JSON-diffed | parity green on /team/stats, /team/evals, /team/long_form across days/range/supervisor/active_only permutations, both teams |
+| F3 | Path-1 factory flip: `get_provider()` returns connected `PostgresProvider` behind `QA_READ_PATH=postgres` env flag; pool lifecycle in main.py lifespan | existing provider-contract tests + route smoke; rollback = env flip |
+| F4 | `/team` trio flipped behind the same flag after a shadow window (both sources computed, diffs logged, on live traffic) | zero diffs over the window; operator smoke: roster, chiclets, SPC, drill-downs, datapoint, SSE |
+| F5 | Perf + cleanup: W6 indexed datapoint lookup, W2/W3 as real SQL views, delete the `_ws` back-door and sheet-read code from the trio (slice-5-style) | suite green; no gspread import in the /team read path |
+
+Flag semantics: one env var (`QA_READ_PATH`, default `sheets`) — reads
+are stateless so a redeploy-free per-team column isn't warranted; flip
+and rollback are single Railway env changes.
+
+## 6. Explicitly out of scope
+
+- Any write-path change (FR-AI drafts, Analyst_History projection,
+  Score_Audit tab, GAS email flow) — the sheet remains a projection
+  target and the email source.
+- Retiring the Analyst_History sheet itself (post-flip + one bonus
+  cycle, per CutoverDesign §7's tab-retention rule).
+- HR bonus endpoint (already reads qa.* — untouched).
+- `/lookup` Dialpad passthroughs (no history reads except
+  scoring-permission, which F3 covers via W5).


### PR DESCRIPTION
Two documents from the read-path review + full reference-corpus sweep (all 17 docs, SQLMigration §9–10, LandGPT.md).

## `references/ReadPathFlip.md` — the flip mini-project design
- **Finding:** two structurally different read paths. Provider-based routes (`/agents*`, `/datapoints*`, progression) flip via factory wiring — `PostgresProvider` (PR #94) already passes the contract. The `/team` trio (`stats`/`evals`/`long_form`) bypasses the provider through the gspread-only `_ws` attribute and needs a Postgres **row-source**.
- **W1–W6 windows** mapped from the frontend inventory: history row-source feeding the *unchanged* pandas pipeline, monthly-buckets view (bucket-TZ, and the biggest perf win — chiclets currently load the whole sheet per render), `v_history_long`, the **`agent_stat_points` gap** (CutoverDesign 4c confirmed unimplemented: schema + indexes exist, zero writers, zero rows — needs finalize-time writer + ordered backfill replay), roster (done), indexed eval-id lookup.
- **Seven parity traps** documented (naive-vs-aware timestamps, eval_id from D2-superseded rows, departed-agent degradation, coverage_regime freeze…) — each becomes a golden-parity test.
- **F1–F5 slice plan**, env-flag flip (`QA_READ_PATH`), shadow window before cutover, writes explicitly out of scope.
- Decided wrinkle: stat points are the all-time series for CC sparklines/PDF assessments; the dashboard's window-scoped EWMA stays computed over W1 rows — different numbers by design.

## `references/LateStageDesign.md` — the registry for future sessions
Everything mentioned/promised in the corpus with no design doc of its own, tiered by silent-failure impact: owner-owed decisions (the 13 `na_applies_when` texts, GLR v2 bullets — which feed BOTH the v6 bundle and the RAG cascade Stage C, HR Sales subset), undecided pieces of existing docs, features needing docs (the B1-**required** manager version-ship/editor UI, cost/admin dashboard, Step-8 webhook sampler, coaching/tags UI over the empty v1.2 schemas, session identity, in-memory job store…), quick wins, and **stale-doc corrections** — four docs still say "not yet implemented" for features that shipped (#28/#30/#33/#37), and PhaseThree's jsonb schema is superseded by `qa.*` (flagged so nobody implements it as-is).

Maintenance rule baked in: rows get replaced by doc links, then deleted on ship — the file should only shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)