### PR TITLE
feat(qa-automation): flip F2 part 1 — Postgres row-source + golden-parity harness (99.8% and classified)

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/team_source.py
+++ b/qa-automation/AI-Scoring/backend/services/team_source.py
@@ -1,0 +1,159 @@
+"""W1 — Postgres row-source for the /team analytics trio (ReadPathFlip §3).
+
+Produces a DataFrame with EXACTLY the schema `team_stats.load_and_clean`
+derives from the Analyst_History sheet, so the nine compute_* functions
+run unchanged on either source. Parity traps honored (ReadPathFlip §4):
+
+- naive timestamps (UTC wall-clock, tz stripped) — bucket-TZ math relies
+  on it;
+- eval_id = trailing segment of the dialpad_link text, falling back to
+  the D2 superseded link in metadata, then to dialpad_entry_point_call_id;
+- departed agents (agent_id NULL) degrade to inactive + blank supervisor
+  with the raw name shown;
+- excluded_test_agents config filter applied identically;
+- yn cells use the Y/N/NA/'' vocabulary `_parse_yn_cell` produces;
+  numeric NA (binary_value='NA' on a numeric section) lands NaN, same as
+  the sheet's "Not Applicable" failing float-parse.
+
+Section identity: backfilled rows stamp ARCHIVED rubric section ids
+(e.g. `caller_identity_validation`) while live engine rows stamp current
+short ids (`caller_id`). The pivot resolves every stored section_id to a
+history_id via an alias map built from qa.rubric_versions (all archived
+rubrics) + the live config — rubric pinning without column loss. Ids
+whose history_id has no column in the CURRENT config (e.g. MS v1
+`documentation` after the v2 HRR rename, Sales v1's 19 legacy sections)
+drop from section analytics by design — the rubric changed; the scores
+are not comparable. Overall-score analytics keep the full history.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from backend.services.eval_store import get_pool
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+
+
+def _eval_id_from_link(link: str) -> str:
+    if not link:
+        return ""
+    clean = link.split("[")[0].strip().split("?")[0].strip()
+    return clean.rstrip("/").split("/")[-1]
+
+
+async def _section_alias_map(conn, config: "TeamConfig") -> dict[str, str]:
+    """Every known section_id (current + all archived rubrics for the
+    team) → its history_id."""
+    alias = {}
+    for s in config.sections_by_number:  # current config wins on conflict
+        alias[s.history_id] = s.history_id
+        alias[s.id] = s.history_id
+    # Archived rubrics alias BY POSITION (section_number → the current
+    # section occupying that slot): the sheet reads cells positionally,
+    # so a renamed slot (MS v1 `documentation` → v2 `human_review_required`,
+    # both section 9) keeps its historic scores in the same analytics
+    # column. History_ids that still exist match themselves anyway.
+    current_by_number = {s.section_number: s.history_id
+                         for s in config.sections_by_number}
+    rows = await conn.fetch(
+        "SELECT rubric_json FROM qa.rubric_versions WHERE team_id = $1",
+        config.team_id)
+    for r in rows:
+        payload = json.loads(r["rubric_json"])
+        for s in payload.get("sections", []):
+            target = current_by_number.get(s.get("section_number"))
+            if target is not None:
+                alias.setdefault(s["id"], target)
+                alias.setdefault(s.get("history_id", s["id"]), target)
+    return alias
+
+
+def frame_from_rows(config: "TeamConfig", eval_rows: list, section_rows: list,
+                    alias_map: dict[str, str]) -> pd.DataFrame:
+    """Pure assembly: DB rows → the load_and_clean schema."""
+    numeric_ids = set(config.numeric_history_ids)
+    yn_ids = set(config.yn_history_ids)
+    excluded = {a.strip().lower() for a in config.excluded_test_agents}
+
+    # section values per evaluation, keyed by resolved history_id
+    by_eval: dict[int, dict[str, object]] = {}
+    for s in section_rows:
+        hid = alias_map.get(s["section_id"])
+        if hid is None or (hid not in numeric_ids and hid not in yn_ids):
+            continue
+        if hid in numeric_ids:
+            val = float(s["numeric_score"]) if s["numeric_score"] is not None else float("nan")
+        else:
+            val = s["binary_value"] or ""
+        by_eval.setdefault(s["evaluation_id"], {})[hid] = val
+
+    records = []
+    for ev in eval_rows:
+        agent = (ev["agent_display"] or ev["agent_name_raw"] or "").strip()
+        if not agent or agent.lower() in excluded:
+            continue
+        ts = ev["ts"]
+        if ts is None or ts.year < 2020:
+            continue
+        meta = json.loads(ev["dialpad_call_metadata"]) if ev["dialpad_call_metadata"] else {}
+        link = (ev["dialpad_link"]
+                or (meta.get("backfill") or {}).get("superseded_dialpad_link")
+                or "")
+        eval_id = _eval_id_from_link(link) or (ev["dialpad_entry_point_call_id"] or "")
+        approved = ev["approved_at"]
+        rec = {
+            "agent": agent,
+            "timestamp": pd.Timestamp(ts).tz_localize(None),      # naive UTC
+            "eval_approved_at": (pd.Timestamp(approved).tz_localize(None)
+                                 if approved is not None else pd.NaT),
+            "overall_score": float(ev["overall_score"]),
+            "manager_email": (ev["evaluator_email"] or "").lower(),
+            "is_active": bool(ev["is_active"]),
+            "supervisor": ev["supervisor"] or "",
+            "eval_id": eval_id,
+        }
+        sections = by_eval.get(ev["id"], {})
+        for hid in numeric_ids:
+            rec[hid] = sections.get(hid, float("nan"))
+        for hid in yn_ids:
+            rec[hid] = sections.get(hid, "")
+        records.append(rec)
+
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame.from_records(records)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df["eval_approved_at"] = pd.to_datetime(df["eval_approved_at"])
+    return df
+
+
+async def fetch_history_frame(config: "TeamConfig") -> pd.DataFrame:
+    """W1 entry point: the load_and_clean-equivalent DataFrame from qa.*."""
+    pool = await get_pool()
+    if pool is None:
+        raise RuntimeError("team_source: no DATABASE_URL configured")
+    async with pool.acquire() as conn:
+        alias_map = await _section_alias_map(conn, config)
+        eval_rows = await conn.fetch(
+            "SELECT e.id, e.agent_name_raw, e.evaluator_email, e.overall_score, "
+            "  e.dialpad_link, e.dialpad_entry_point_call_id, e.dialpad_call_metadata, "
+            "  COALESCE(e.call_connected_at, e.approved_at) AS ts, e.approved_at, "
+            "  COALESCE(a.canonical_name, a.name, e.agent_name_raw) AS agent_display, "
+            "  COALESCE(a.active, FALSE) AS is_active, "
+            "  COALESCE(a.supervisor_email, '') AS supervisor "
+            "FROM qa.evaluations e "
+            "LEFT JOIN qa.agents a ON a.id = e.agent_id "
+            "WHERE e.team_id = $1 AND e.state = 'finalized'",
+            config.team_id)
+        section_rows = await conn.fetch(
+            "SELECT es.evaluation_id, es.section_id, es.numeric_score, es.binary_value "
+            "FROM qa.evaluation_sections es "
+            "JOIN qa.evaluations e ON e.id = es.evaluation_id "
+            "WHERE e.team_id = $1 AND e.state = 'finalized'",
+            config.team_id)
+    return frame_from_rows(config, eval_rows, section_rows, alias_map)

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""F2 golden-parity harness — sheet vs Postgres row-source (ReadPathFlip §5).
+
+Read-only on both sides. Builds the analytics DataFrame from the
+Analyst_History sheet (today's path: raw rows → load_and_clean) and from
+qa.* (team_source.fetch_history_frame), then:
+
+1. aligns rows on (eval_id, agent-lower) and classifies membership
+   deltas — sheet-only rows (expected: the B0 hard-zero exclusions),
+   db-only rows (expected: backfilled history the sheet dropped, e.g.
+   the entire Sales pre-flip archive);
+2. cell-diffs the COMMON rows column by column (scores exact,
+   timestamps to the second, yn vocab verbatim);
+3. runs all nine compute_* functions on the common subset of BOTH
+   frames and deep-diffs their JSON.
+
+Exit 0 = common-set parity exact; 2 = differences beyond the classified
+membership deltas (read the report).
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/parity_readpath.py --team-id member_support
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_STAGING_DIR = _AI_SCORING.parent.parent / "database" / "backfill_staging"
+load_dotenv(_AI_SCORING / ".env")
+if str(_AI_SCORING) not in sys.path:
+    sys.path.insert(0, str(_AI_SCORING))
+
+from backend.config.team_config import get_team_config  # noqa: E402
+from backend.services import team_stats as ts  # noqa: E402
+from backend.services.team_source import fetch_history_frame  # noqa: E402
+
+
+def _strip_accents(s):
+    import unicodedata
+    return "".join(c for c in unicodedata.normalize("NFD", s)
+                   if not unicodedata.combining(c))
+
+
+def _key(df):
+    """String key eval_id|agent|ordinal — agent accent-stripped (roster
+    spellings drift), ordinal disambiguates D2 re-eval pairs
+    deterministically by (timestamp, overall_score)."""
+    base = (df["eval_id"].astype(str) + "|"
+            + df["agent"].str.strip().str.lower().map(_strip_accents))
+    order = df.assign(_b=base).sort_values(["_b", "timestamp", "overall_score"])
+    ordinal = order.groupby("_b").cumcount()
+    return (base + "|" + ordinal.reindex(df.index).astype(str)).tolist()
+
+
+def _norm(v):
+    if isinstance(v, float) and math.isnan(v):
+        return None
+    if hasattr(v, "isoformat"):
+        return v.isoformat(timespec="seconds")
+    return v
+
+
+def compare_frames(sheet_df, pg_df, config) -> dict:
+    sheet_df = sheet_df.assign(_k=_key(sheet_df)).set_index("_k")
+    pg_df = pg_df.assign(_k=_key(pg_df)).set_index("_k")
+    sheet_only = sorted(set(sheet_df.index) - set(pg_df.index))
+    db_only = sorted(set(pg_df.index) - set(sheet_df.index))
+    common = sorted(set(sheet_df.index) & set(pg_df.index))
+
+    cols = [c for c in sheet_df.columns if c in pg_df.columns]
+    cell_diffs = []
+    for k in common:
+        a, b = sheet_df.loc[k], pg_df.loc[k]
+        for c in cols:
+            va, vb = _norm(a[c]), _norm(b[c])
+            if va != vb:
+                cell_diffs.append({"key": list(k), "col": c,
+                                   "sheet": va, "pg": vb})
+
+    # compute_* parity on the common subset
+    sub_sheet = sheet_df.loc[common].reset_index(drop=True)
+    sub_pg = pg_df.loc[common].reset_index(drop=True)
+    stats = config.stats
+    compute_diffs = {}
+    computations = {
+        "monthly_summary": lambda d: ts.compute_monthly_summary(d),
+        "monthly_spc": lambda d: ts.compute_monthly_spc(d, stats),
+        "ewma": lambda d: ts.compute_ewma(d, stats),
+        "outliers": lambda d: ts.compute_outliers(d, stats),
+        "distribution": lambda d: ts.compute_distribution(d),
+        "section_analysis": lambda d: ts.compute_section_analysis(d, config),
+        "binary_stats": lambda d: ts.compute_binary_stats(d, config.yn_section_labels),
+        "supervisor_stats": lambda d: ts.compute_supervisor_stats(d),
+        "roster": lambda d: ts.compute_agent_roster(d, config),
+        "long_form": lambda d: ts.compute_long_form(d, config).to_dict("records"),
+    }
+    for name, fn in computations.items():
+        ja = json.dumps(fn(sub_sheet), default=str, sort_keys=True)
+        jb = json.dumps(fn(sub_pg), default=str, sort_keys=True)
+        if ja != jb:
+            compute_diffs[name] = {"sheet_len": len(ja), "pg_len": len(jb)}
+
+    return {"rows": {"sheet": len(sheet_df), "pg": len(pg_df),
+                     "common": len(common), "sheet_only": len(sheet_only),
+                     "db_only": len(db_only)},
+            "sheet_only_keys": [list(k) for k in sheet_only[:25]],
+            "db_only_sample": [list(k) for k in db_only[:5]],
+            "cell_diffs": cell_diffs[:50],
+            "cell_diff_count": len(cell_diffs),
+            "compute_diffs": compute_diffs}
+
+
+async def run(args) -> int:
+    config = get_team_config(args.team_id)
+    from backend.services.data_provider import get_provider
+    provider = await get_provider(args.team_id)
+    history_rows = provider._ws.get_all_values()
+    mails_rows = provider._get_mails_sheet()
+    sheet_df = ts.load_and_clean(history_rows, mails_rows, config)
+    pg_df = await fetch_history_frame(config)
+
+    result = compare_frames(sheet_df, pg_df, config)
+    report_path = _STAGING_DIR / f"report_{args.team_id}_parity.json"
+    report_path.write_text(json.dumps(result, indent=2, default=str),
+                           encoding="utf-8")
+
+    r = result["rows"]
+    print(f"[parity:{args.team_id}] sheet={r['sheet']} pg={r['pg']} "
+          f"common={r['common']} sheet_only={r['sheet_only']} "
+          f"db_only={r['db_only']}")
+    print(f"  common-set cell diffs: {result['cell_diff_count']}")
+    print(f"  compute_* diffs: {list(result['compute_diffs']) or 'NONE'}")
+    print(f"  report: {report_path}")
+    return 0 if not result["cell_diff_count"] and not result["compute_diffs"] else 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True)
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First half of ReadPathFlip F2: `team_source.py` (the W1 row-source feeding the unchanged pandas pipeline) + `parity_readpath.py` (the golden-parity harness, read-only on both sides).

**Prod parity status:**
- **Row membership is EXACT** on both teams once classified: MS `sheet_only=16` = precisely the B0 exclusions + permanently-blocked rows; Sales `db_only=331` = the designed history gain (the sheet dropped its pre-flip archive); zero unexplained rows either side.
- **MS cell parity 1,950 → 108 diffs of ~63k cells (99.8%)** through two real fixes: position-based aliasing of archived rubric sections (the sheet reads cells positionally — v1 `documentation` scores belong in the `human_review_required` column, and now land there), and a `qa.agents` roster refresh via `import_agents.py` (supervisor/canonical-name drift since June).
- **Residual 108, fully explained:** B2's *designed* authoritative clock repairs (timestamp/approved_at — the DB is more correct than the sheet), and a name-matching asymmetry (sheet canonicalization accent-strips; B3's SQL match is exact) touching `is_active`/`supervisor`/`agent` on a handful of rows.

**F2 part 2 (next session):** harness classification for designed clock diffs, accent-insensitive identity alignment, the Sales `long_form` NA-emission delta (pg emits more long rows than sheet on identical inputs — suspect NA/blank handling), and `team_source` unit tests. Then F3 (factory flip) per the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)