### PR TITLE
feat(qa-automation): read-path flip F2–F5/W6 — dashboards & analytics from Postgres behind QA_READ_PATH

### DIFF
--- a/database/migrations/014_datapoint_lookup_index.sql
+++ b/database/migrations/014_datapoint_lookup_index.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- Migration 014: datapoint-lookup index (ReadPathFlip §3 W6, slice F5)
+--
+-- The /datapoints/{call_id} endpoint resolves a single evaluation by the
+-- call id parsed from its Dialpad link. On the Postgres read path that id
+-- equals dialpad_entry_point_call_id for the common case, but that column
+-- had no index — so PostgresProvider.get_by_eval_id would seq-scan the
+-- finalized-eval set on every datapoint-page load. dialpad_call_id is
+-- already covered by uq_eval_team_call_id (006); this adds the matching
+-- probe for the entry-point id so the lookup is a single indexed row hit.
+--
+-- Not CONCURRENTLY: same rationale as 008 — the runner wraps each
+-- migration in a transaction (CONCURRENTLY can't run there), and
+-- qa.evaluations is small (~2k finalized rows post-backfill), so the
+-- brief ACCESS EXCLUSIVE lock is a non-issue.
+-- ============================================================================
+
+CREATE INDEX idx_eval_entry_point_call_id
+    ON qa.evaluations (team_id, dialpad_entry_point_call_id)
+    WHERE dialpad_entry_point_call_id IS NOT NULL;

--- a/database/migrations/014_datapoint_lookup_index_down.sql
+++ b/database/migrations/014_datapoint_lookup_index_down.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- Migration 014 — DOWN
+--
+-- Drops the datapoint-lookup index. No-op for correctness (the provider
+-- falls back to the scan path); restores the pre-W6 index state.
+-- ============================================================================
+
+DROP INDEX IF EXISTS qa.idx_eval_entry_point_call_id;

--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -47,6 +47,11 @@ async def _lifespan(app: FastAPI):
         strict=os.environ.get("QA_VERSION_SHIP_STRICT", "") == "1",
     )
     yield
+    # Read-path flip (F3): close any connected PostgresProvider pools built
+    # by the get_provider factory under QA_READ_PATH=postgres. No-op for the
+    # default sheets path (SheetsProviders have no pool to close).
+    from backend.services.data_provider import close_all_providers
+    await close_all_providers()
     # Wave 2 Phase 4a: dual-write pool (lazy-created on first Stage 1 write).
     from backend.services.eval_store import close_pool
     await close_pool()

--- a/qa-automation/AI-Scoring/backend/routes/datapoints.py
+++ b/qa-automation/AI-Scoring/backend/routes/datapoints.py
@@ -16,8 +16,16 @@ async def get_datapoint(request: Request, call_id: str):
     """Return a single evaluation record by call_id (extracted from Dialpad link)."""
     team_id = team_id_from_path(request)
     provider = await get_provider(team_id)
-    all_records = await provider.get_all_history(days=365)
 
+    # W6 fast path: indexed single-eval lookup on the Postgres read path.
+    # Returns None on the sheets path (no index) or a junk-link miss, and
+    # we fall back to the 365-day scan below — identical result, and the
+    # scan still produces the diagnostic near-matches on a 404.
+    fast = await provider.get_by_eval_id(call_id)
+    if fast is not None:
+        return fast
+
+    all_records = await provider.get_all_history(days=365)
     for rec in all_records:
         if rec.eval_id == call_id:
             return rec

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime, time, timedelta, timezone
 
+import pandas as pd
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
+from backend.services.data_provider import _read_path_mode, get_provider
+from backend.services.read_path_shadow import log_shadow
+from backend.services.team_source import fetch_history_frame
 from backend.models.team_stats import (
     LongFormResponse,
     LongFormRow,
@@ -18,7 +23,6 @@ from backend.models.team_stats import (
     TeamEvalsResponse,
     TeamStatsResponse,
 )
-from backend.services.data_provider import get_provider
 from backend.services.team_stats import (
     _months_in_bucket_tz,
     compute_agent_roster,
@@ -34,7 +38,38 @@ from backend.services.team_stats import (
     load_and_clean,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/team", tags=["team"])
+
+
+async def _team_history_frame(team_id: str, config) -> pd.DataFrame:
+    """The load_and_clean-shaped analytics frame for the /team trio,
+    sourced per QA_READ_PATH (ReadPathFlip §5 F4):
+
+    - ``sheets``   → read Analyst_History via the SheetsProvider (today).
+    - ``shadow``   → serve the SHEET frame but also build the Postgres
+      frame and log the delta on live traffic (validation window).
+    - ``postgres`` → serve the Postgres row-source (team_source), which
+      already joins qa.agents for is_active/supervisor — no _ws access,
+      so it works when get_provider hands back a PostgresProvider.
+    """
+    mode = _read_path_mode()
+    if mode == "postgres":
+        return await fetch_history_frame(config)
+
+    provider = await get_provider(team_id)
+    sheet_df = load_and_clean(
+        provider._ws.get_all_values(), provider._get_mails_sheet(), config)
+    if mode == "shadow":
+        try:
+            pg_df = await fetch_history_frame(config)
+        except Exception:  # noqa: BLE001 — shadow must not break the response
+            logger.warning("read-path shadow[%s]: pg fetch failed",
+                           team_id, exc_info=True)
+        else:
+            log_shadow(team_id, sheet_df, pg_df)
+    return sheet_df
 
 
 # Coverage regime is hardcoded until Local AI scores 100% of calls
@@ -91,12 +126,8 @@ async def team_stats(
     """Return all team-level statistical computations in one response."""
     team_id = team_id_from_path(request)
     config = get_team_config(team_id)
-    provider = await get_provider(team_id)
 
-    raw_history = provider._ws.get_all_values()
-    raw_mails = provider._get_mails_sheet()
-
-    df = load_and_clean(raw_history, raw_mails, config)
+    df = await _team_history_frame(team_id, config)
     window = _resolve_window(date_from, date_to)
     filters = {
         "days": days,
@@ -191,12 +222,8 @@ async def team_month_evals(
     """
     team_id = team_id_from_path(request)
     config = get_team_config(team_id)
-    provider = await get_provider(team_id)
 
-    raw_history = provider._ws.get_all_values()
-    raw_mails = provider._get_mails_sheet()
-
-    df = load_and_clean(raw_history, raw_mails, config)
+    df = await _team_history_frame(team_id, config)
     filters = {"active_only": active_only, "supervisor": supervisor}
 
     if df.empty:
@@ -221,8 +248,6 @@ async def team_month_evals(
 
     # Sort newest first — analysts skim the top to find recent calls.
     df = df.sort_values("timestamp", ascending=False)
-
-    import pandas as pd
 
     def _to_utc(ts):
         """Ensure outgoing ISO timestamps carry an explicit UTC marker.
@@ -308,12 +333,8 @@ async def team_long_form(
     """
     team_id = team_id_from_path(request)
     config = get_team_config(team_id)
-    provider = await get_provider(team_id)
 
-    raw_history = provider._ws.get_all_values()
-    raw_mails = provider._get_mails_sheet()
-
-    df = load_and_clean(raw_history, raw_mails, config)
+    df = await _team_history_frame(team_id, config)
     window = _resolve_window(date_from, date_to)
     filters = {
         "days": days,

--- a/qa-automation/AI-Scoring/backend/services/data_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/data_provider.py
@@ -53,6 +53,13 @@ class DataProvider(ABC):
     def _get_mails_sheet(self) -> list[list[str]]:
         ...
 
+    async def get_by_eval_id(self, call_id: str) -> EvaluationRecord | None:
+        """Fast single-eval lookup for /datapoints/{call_id} (ReadPathFlip
+        §3 W6). Default: unsupported — return None and let the caller fall
+        back to scanning get_all_history. PostgresProvider overrides this
+        with an indexed query; SheetsProvider has no index to exploit."""
+        return None
+
 
 # Per-team provider cache (keyed by team_id) + the read-path mode each
 # cached instance was built for, so a runtime flag flip rebuilds cleanly.

--- a/qa-automation/AI-Scoring/backend/services/data_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/data_provider.py
@@ -1,9 +1,35 @@
-"""Abstract data provider with factory for Sheets/Postgres fallback."""
+"""Abstract data provider with the Sheets↔Postgres read-path factory.
+
+The read path is selected by the ``QA_READ_PATH`` env var (ReadPathFlip
+§5), default ``sheets``:
+
+- ``sheets``   → ``SheetsProvider`` (today's path; reads Analyst_History).
+- ``postgres`` → ``PostgresProvider``, ``connect()``-ed before it is
+  handed out so its pool + roster snapshot are live.
+
+Flip and rollback are a single env change + redeploy — reads are
+stateless, so no per-team column is warranted. The factory re-checks the
+env on every call and rebuilds a team's provider if the mode changed, so
+the flag is honored without a process restart when Railway does an
+in-place env edit.
+
+NOTE (F3 scope): this flips **Path 1** (the provider-based endpoints —
+/agents, /datapoints, …). The /team analytics trio still reaches into
+``SheetsProvider._ws`` directly and is NOT yet safe under
+``QA_READ_PATH=postgres``; F4 makes that trio flag-aware via the Postgres
+row-source. Until F4 lands, keep the prod flag on ``sheets``.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import os
 from abc import ABC, abstractmethod
+
 from backend.models.dashboard import EvaluationRecord
+
+logger = logging.getLogger(__name__)
 
 
 class DataProvider(ABC):
@@ -28,18 +54,78 @@ class DataProvider(ABC):
         ...
 
 
-# Per-team provider cache (keyed by team_id)
+# Per-team provider cache (keyed by team_id) + the read-path mode each
+# cached instance was built for, so a runtime flag flip rebuilds cleanly.
 _providers: dict[str, DataProvider] = {}
+_provider_modes: dict[str, str] = {}
+_build_lock = asyncio.Lock()
+
+
+def _read_path_mode() -> str:
+    """Current read-path selection — ``postgres`` or ``sheets`` (default)."""
+    return os.environ.get("QA_READ_PATH", "sheets").strip().lower()
 
 
 async def get_provider(team_id: str = "member_support") -> DataProvider:
-    """Return a cached SheetsProvider for the given team.
+    """Return a cached, ready-to-use provider for *team_id*.
 
-    Reuses the same instance (and its sheet cache) across requests.
+    On the ``postgres`` path the returned instance is already
+    ``connect()``-ed (pool open, roster snapshot loaded). Reuses the same
+    instance across requests; rebuilds only when ``QA_READ_PATH`` changed
+    since the instance was cached.
     """
-    if team_id not in _providers:
+    mode = _read_path_mode()
+    cached = _providers.get(team_id)
+    if cached is not None and _provider_modes.get(team_id) == mode:
+        return cached
+
+    # Build under a lock so two concurrent first-hits don't each open a
+    # Postgres pool. Re-check inside — another coroutine may have won.
+    async with _build_lock:
+        cached = _providers.get(team_id)
+        if cached is not None and _provider_modes.get(team_id) == mode:
+            return cached
+
         from backend.config.team_config import get_team_config
-        from backend.services.history_service import SheetsProvider
         config = get_team_config(team_id)
-        _providers[team_id] = SheetsProvider(config=config)
-    return _providers[team_id]
+
+        if mode == "postgres":
+            from backend.services.db_provider import PostgresProvider
+            provider: DataProvider = PostgresProvider(config=config)
+            await provider.connect()
+        else:
+            from backend.services.history_service import SheetsProvider
+            provider = SheetsProvider(config=config)
+
+        previous = _providers.get(team_id)
+        _providers[team_id] = provider
+        _provider_modes[team_id] = mode
+        logger.info("get_provider[%s] → %s (QA_READ_PATH=%s)",
+                    team_id, provider.name, mode)
+
+        # Best-effort close of a superseded provider (e.g. a Postgres pool
+        # left over from a mode flip) so we don't leak connections.
+        if previous is not None and previous is not provider:
+            await _close_provider(previous)
+        return provider
+
+
+async def _close_provider(provider: DataProvider) -> None:
+    close = getattr(provider, "close", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception:  # noqa: BLE001 — teardown must not raise
+        logger.warning("provider %s close() failed", provider.name, exc_info=True)
+
+
+async def close_all_providers() -> None:
+    """Close every cached provider (Postgres pools) and clear the cache.
+
+    Called from the app lifespan on shutdown; safe to call when the cache
+    holds only SheetsProviders (which have no close())."""
+    for provider in list(_providers.values()):
+        await _close_provider(provider)
+    _providers.clear()
+    _provider_modes.clear()

--- a/qa-automation/AI-Scoring/backend/services/db_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/db_provider.py
@@ -100,6 +100,44 @@ class PostgresProvider(DataProvider):
     async def get_all_history(self, days: int = 90) -> list[EvaluationRecord]:
         return await self._fetch_records(days=days)
 
+    async def get_by_eval_id(self, call_id: str) -> EvaluationRecord | None:
+        """Indexed single-eval lookup for /datapoints/{call_id} (W6).
+
+        Fast path: probe the Dialpad id columns — the entry-point id is the
+        link's trailing segment in the common case (idx_eval_entry_point_
+        call_id, migration 014); dialpad_call_id covers the rest
+        (uq_eval_team_call_id). Replaces the 365-day get_all_history load +
+        Python scan with a single indexed row hit.
+
+        Returns None on a miss OR when the resolved row's link-derived
+        eval_id disagrees with call_id, so the route falls back to the scan
+        (junk-link rows whose stored ids don't match the link) — the result
+        is never a different record than the scan would have returned.
+        """
+        if not call_id:
+            return None
+        await self._refresh_roster_if_stale()
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_EVAL_COLUMNS} FROM qa.evaluations "
+                "WHERE team_id = $1 AND state = 'finalized' "
+                "AND (dialpad_entry_point_call_id = $2 OR dialpad_call_id = $2) "
+                # Match get_all_history's ascending order so a (rare)
+                # duplicate call_id resolves to the same row the scan picks.
+                "ORDER BY COALESCE(call_connected_at, created_at) LIMIT 1",
+                self._team_id, call_id,
+            )
+            if row is None:
+                return None
+            sections = await conn.fetch(
+                "SELECT evaluation_id, section_id, numeric_score, binary_value, "
+                "confidence, reasoning "
+                "FROM qa.evaluation_sections WHERE evaluation_id = $1",
+                row["id"],
+            )
+        record = self._record_from_rows(row, sections)
+        return record if record.eval_id == call_id else None
+
     # ------------------------------------------------------------------
     async def _fetch_records(
         self, days: int, agent_name: str | None = None

--- a/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
+++ b/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
@@ -38,11 +38,19 @@ def strip_accents(s: str) -> str:
 
 def key_series(df: pd.DataFrame) -> list[str]:
     """Row key eval_id|agent|ordinal — agent accent-stripped (roster
-    spellings drift), ordinal disambiguates D2 re-eval pairs
-    deterministically by (timestamp, overall_score)."""
+    spellings drift), ordinal disambiguates D2 re-eval pairs sharing an
+    eval_id.
+
+    The ordinal sorts by ``overall_score`` FIRST, timestamp second: the
+    two sources' clocks differ by up to ~a second (B2 repaired the DB
+    clock from Dialpad), so a timestamp-first tiebreak would flip the
+    order of a same-eval_id pair and mis-pair their rows across sources
+    (observed: two adjacent MS evals whose section scores looked swapped).
+    overall_score is identical across sources for a given eval, so it
+    pairs the rows stably; timestamp only breaks the rare same-score tie."""
     base = (df["eval_id"].astype(str) + "|"
             + df["agent"].str.strip().str.lower().map(strip_accents))
-    order = df.assign(_b=base).sort_values(["_b", "timestamp", "overall_score"])
+    order = df.assign(_b=base).sort_values(["_b", "overall_score", "timestamp"])
     ordinal = order.groupby("_b").cumcount()
     return (base + "|" + ordinal.reindex(df.index).astype(str)).tolist()
 

--- a/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
+++ b/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
@@ -36,21 +36,37 @@ def strip_accents(s: str) -> str:
                    if not unicodedata.combining(c))
 
 
+# Columns that legitimately differ between the two sources (see
+# classify_cell_diff): clocks were B2-repaired in the DB, roster fields go
+# stale in qa.agents, and agent spelling is accent-folded there. Everything
+# ELSE is expected byte-identical — those are the "stable content" columns.
+_CLOCK_COLS = {"timestamp", "eval_approved_at"}
+_ROSTER_COLS = {"is_active", "supervisor"}
+_JITTER_COLS = _CLOCK_COLS | _ROSTER_COLS | {"agent"}
+
+
 def key_series(df: pd.DataFrame) -> list[str]:
     """Row key eval_id|agent|ordinal — agent accent-stripped (roster
     spellings drift), ordinal disambiguates D2 re-eval pairs sharing an
     eval_id.
 
-    The ordinal sorts by ``overall_score`` FIRST, timestamp second: the
-    two sources' clocks differ by up to ~a second (B2 repaired the DB
-    clock from Dialpad), so a timestamp-first tiebreak would flip the
-    order of a same-eval_id pair and mis-pair their rows across sources
-    (observed: two adjacent MS evals whose section scores looked swapped).
-    overall_score is identical across sources for a given eval, so it
-    pairs the rows stably; timestamp only breaks the rare same-score tie."""
+    The ordinal orders same-key rows by their STABLE CONTENT (every shared
+    column except the known-jittery ones — clocks were B2-repaired in the
+    DB, roster/agent-spelling drift in qa.agents). Sorting by anything
+    jittery cross-pairs a D2 pair whose rows are otherwise tied: observed
+    twice on MS — first a pair tied on eval_id whose ±1s clock repair
+    flipped a timestamp tiebreak, then a pair ALSO tied on overall_score
+    and second-truncated timestamp, where sub-second jitter decided.
+
+    Pairing by content is sound, not self-fulfilling: within a same
+    (eval_id, agent) group every compute_* aggregates per-agent, so
+    intra-group order is analytically irrelevant — canonical ordering on
+    both sides pairs identical rows, and any REAL value difference still
+    has nowhere to hide (the multiset of rows differs)."""
     base = (df["eval_id"].astype(str) + "|"
             + df["agent"].str.strip().str.lower().map(strip_accents))
-    order = df.assign(_b=base).sort_values(["_b", "overall_score", "timestamp"])
+    stable = [c for c in sorted(df.columns) if c not in _JITTER_COLS]
+    order = df.assign(_b=base).sort_values(["_b", *stable])
     ordinal = order.groupby("_b").cumcount()
     return (base + "|" + ordinal.reindex(df.index).astype(str)).tolist()
 
@@ -97,12 +113,10 @@ def cell_diffs(sub_sheet: pd.DataFrame, sub_pg: pd.DataFrame) -> list[dict]:
     return diffs
 
 
-# Cell-diff classes for the read-path flip. The first three are KNOWN
-# source-of-truth differences between the sheet and qa.*, NOT row-source
-# bugs — so the sweep verdict (and the live-shadow alarm) key on 'other'.
-_CLOCK_COLS = {"timestamp", "eval_approved_at"}
-_ROSTER_COLS = {"is_active", "supervisor"}
-
+# Cell-diff classes for the read-path flip: clock / name_accent / roster
+# (the _JITTER_COLS above) are KNOWN source-of-truth differences between
+# the sheet and qa.*, NOT row-source bugs — so the sweep verdict (and the
+# live-shadow alarm) key on 'other'.
 
 def classify_cell_diff(d: dict) -> str:
     """Bucket one cell diff:

--- a/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
+++ b/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
@@ -1,0 +1,121 @@
+"""Shared sheet-vs-Postgres frame comparison (ReadPathFlip §5).
+
+ONE key derivation and ONE comparator, imported by both:
+
+- the offline F2 golden-parity harness (scripts/parity_readpath.py), which
+  layers the nine compute_* functions + the endpoint permutation grid on
+  top; and
+- the F4 live shadow window, which — while QA_READ_PATH=shadow — computes
+  the Postgres frame alongside the served sheet frame on real traffic and
+  logs the membership + cell deltas.
+
+Keeping them on the same code means "green offline" and "green in shadow"
+mean the same thing. The live path stops at membership + common-row cell
+diffs (bounded work per request); if the common rows are cell-identical
+the nine compute_* outputs are identical too, which the offline harness
+proves exhaustively.
+
+Membership deltas are EXPECTED and not failures: sheet-only rows (B0
+hard-zero exclusions) and db-only rows (backfilled history the sheet
+dropped). Only cell diffs on the common set signal a real divergence.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import unicodedata
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def strip_accents(s: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFD", str(s))
+                   if not unicodedata.combining(c))
+
+
+def key_series(df: pd.DataFrame) -> list[str]:
+    """Row key eval_id|agent|ordinal — agent accent-stripped (roster
+    spellings drift), ordinal disambiguates D2 re-eval pairs
+    deterministically by (timestamp, overall_score)."""
+    base = (df["eval_id"].astype(str) + "|"
+            + df["agent"].str.strip().str.lower().map(strip_accents))
+    order = df.assign(_b=base).sort_values(["_b", "timestamp", "overall_score"])
+    ordinal = order.groupby("_b").cumcount()
+    return (base + "|" + ordinal.reindex(df.index).astype(str)).tolist()
+
+
+def norm_cell(v):
+    """Canonicalize a cell for equality: NaN→None, datetimes→sec-ISO."""
+    if isinstance(v, float) and math.isnan(v):
+        return None
+    if hasattr(v, "isoformat"):
+        return v.isoformat(timespec="seconds")
+    return v
+
+
+def align(sheet_df: pd.DataFrame, pg_df: pd.DataFrame):
+    """Align on the row key; return (membership, sub_sheet, sub_pg).
+
+    The two sub-frames hold only the common rows, in identical (key-sorted)
+    order with a clean RangeIndex."""
+    s = sheet_df.assign(_k=key_series(sheet_df)).set_index("_k")
+    p = pg_df.assign(_k=key_series(pg_df)).set_index("_k")
+    sheet_only = sorted(set(s.index) - set(p.index))
+    db_only = sorted(set(p.index) - set(s.index))
+    common = sorted(set(s.index) & set(p.index))
+    membership = {
+        "sheet": len(s), "pg": len(p), "common": len(common),
+        "sheet_only": len(sheet_only), "db_only": len(db_only),
+        "sheet_only_keys": [k.split("|") for k in sheet_only[:25]],
+        "db_only_sample": [k.split("|") for k in db_only[:5]],
+    }
+    return membership, s.loc[common].reset_index(drop=True), p.loc[common].reset_index(drop=True)
+
+
+def cell_diffs(sub_sheet: pd.DataFrame, sub_pg: pd.DataFrame, limit: int = 50):
+    """Column-by-column diff of the aligned common rows (shared columns
+    only). Returns the full count plus up to *limit* samples."""
+    cols = [c for c in sub_sheet.columns if c in sub_pg.columns]
+    diffs = []
+    for i in range(len(sub_sheet)):
+        a, b = sub_sheet.iloc[i], sub_pg.iloc[i]
+        for c in cols:
+            va, vb = norm_cell(a[c]), norm_cell(b[c])
+            if va != vb:
+                diffs.append({"row": i, "col": c, "sheet": va, "pg": vb})
+    return len(diffs), diffs[:limit]
+
+
+def compare(sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> dict:
+    """Membership + common-row cell-diff summary (no compute_*)."""
+    membership, sub_sheet, sub_pg = align(sheet_df, pg_df)
+    count, samples = cell_diffs(sub_sheet, sub_pg)
+    return {"membership": membership, "cell_diff_count": count,
+            "cell_diff_sample": samples}
+
+
+def log_shadow(team_id: str, sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> None:
+    """F4 live shadow: log the sheet↔Postgres delta for one served request.
+
+    Never raises — a shadow-compare failure must not break the response
+    the sheet frame is about to serve.
+    """
+    try:
+        if sheet_df.empty or pg_df.empty:
+            logger.info("read-path shadow[%s]: skipped (sheet=%d pg=%d)",
+                        team_id, len(sheet_df), len(pg_df))
+            return
+        summary = compare(sheet_df, pg_df)
+        m = summary["membership"]
+        level = logging.WARNING if summary["cell_diff_count"] else logging.INFO
+        logger.log(
+            level,
+            "read-path shadow[%s]: common=%d sheet_only=%d db_only=%d cell_diffs=%d %s",
+            team_id, m["common"], m["sheet_only"], m["db_only"],
+            summary["cell_diff_count"], summary["cell_diff_sample"][:3] or "",
+        )
+    except Exception:  # noqa: BLE001 — shadow must never break the request
+        logger.warning("read-path shadow[%s] failed", team_id, exc_info=True)

--- a/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
+++ b/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
@@ -75,9 +75,9 @@ def align(sheet_df: pd.DataFrame, pg_df: pd.DataFrame):
     return membership, s.loc[common].reset_index(drop=True), p.loc[common].reset_index(drop=True)
 
 
-def cell_diffs(sub_sheet: pd.DataFrame, sub_pg: pd.DataFrame, limit: int = 50):
-    """Column-by-column diff of the aligned common rows (shared columns
-    only). Returns the full count plus up to *limit* samples."""
+def cell_diffs(sub_sheet: pd.DataFrame, sub_pg: pd.DataFrame) -> list[dict]:
+    """Full column-by-column diff of the aligned common rows (shared
+    columns only). Returns every differing cell — callers slice/classify."""
     cols = [c for c in sub_sheet.columns if c in sub_pg.columns]
     diffs = []
     for i in range(len(sub_sheet)):
@@ -86,15 +86,58 @@ def cell_diffs(sub_sheet: pd.DataFrame, sub_pg: pd.DataFrame, limit: int = 50):
             va, vb = norm_cell(a[c]), norm_cell(b[c])
             if va != vb:
                 diffs.append({"row": i, "col": c, "sheet": va, "pg": vb})
-    return len(diffs), diffs[:limit]
+    return diffs
+
+
+# Cell-diff classes for the read-path flip. The first three are KNOWN
+# source-of-truth differences between the sheet and qa.*, NOT row-source
+# bugs — so the sweep verdict (and the live-shadow alarm) key on 'other'.
+_CLOCK_COLS = {"timestamp", "eval_approved_at"}
+_ROSTER_COLS = {"is_active", "supervisor"}
+
+
+def classify_cell_diff(d: dict) -> str:
+    """Bucket one cell diff:
+
+    - ``clock``       timestamp column; B2 repaired the DB clock from
+      Dialpad while the sheet kept the stale value — DB is authoritative.
+    - ``name_accent`` the agent name is equal once accents are folded;
+      qa.agents stores the canonical (accent-stripped) spelling.
+    - ``roster``      is_active / supervisor; qa.agents roster is stale vs
+      the Mails tab — the one ACTIONABLE class (refresh qa.agents before
+      flipping so the dashboard's active/supervisor columns stay correct).
+    - ``other``       anything else: a genuine row-source divergence that
+      must be zero for parity.
+    """
+    col = d["col"]
+    if col in _CLOCK_COLS:
+        return "clock"
+    if col == "agent":
+        if (strip_accents(str(d["sheet"])).strip().lower()
+                == strip_accents(str(d["pg"])).strip().lower()):
+            return "name_accent"
+        return "other"
+    if col in _ROSTER_COLS:
+        return "roster"
+    return "other"
+
+
+def classify_diffs(diffs: list[dict]) -> dict:
+    """Group diffs by class → {class: [diffs]}."""
+    buckets: dict[str, list] = {"clock": [], "name_accent": [], "roster": [], "other": []}
+    for d in diffs:
+        buckets[classify_cell_diff(d)].append(d)
+    return buckets
 
 
 def compare(sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> dict:
-    """Membership + common-row cell-diff summary (no compute_*)."""
+    """Membership + classified common-row cell-diff summary (no compute_*)."""
     membership, sub_sheet, sub_pg = align(sheet_df, pg_df)
-    count, samples = cell_diffs(sub_sheet, sub_pg)
-    return {"membership": membership, "cell_diff_count": count,
-            "cell_diff_sample": samples}
+    diffs = cell_diffs(sub_sheet, sub_pg)
+    buckets = classify_diffs(diffs)
+    return {"membership": membership, "cell_diff_count": len(diffs),
+            "classified": {k: len(v) for k, v in buckets.items()},
+            "cell_diff_sample": diffs[:50]}
 
 
 def log_shadow(team_id: str, sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> None:
@@ -110,12 +153,19 @@ def log_shadow(team_id: str, sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> Non
             return
         summary = compare(sheet_df, pg_df)
         m = summary["membership"]
-        level = logging.WARNING if summary["cell_diff_count"] else logging.INFO
+        cls = summary["classified"]
+        # Only genuinely-unexplained ('other') diffs are an alarm; clock /
+        # name_accent / roster are known source-of-truth deltas.
+        others = [d for d in summary["cell_diff_sample"]
+                  if classify_cell_diff(d) == "other"]
+        level = logging.WARNING if cls["other"] else logging.INFO
         logger.log(
             level,
-            "read-path shadow[%s]: common=%d sheet_only=%d db_only=%d cell_diffs=%d %s",
+            "read-path shadow[%s]: common=%d sheet_only=%d db_only=%d "
+            "cell_diffs=%d (other=%d clock=%d name_accent=%d roster=%d) %s",
             team_id, m["common"], m["sheet_only"], m["db_only"],
-            summary["cell_diff_count"], summary["cell_diff_sample"][:3] or "",
+            summary["cell_diff_count"], cls["other"], cls["clock"],
+            cls["name_accent"], cls["roster"], others[:3] or "",
         )
     except Exception:  # noqa: BLE001 — shadow must never break the request
         logger.warning("read-path shadow[%s] failed", team_id, exc_info=True)

--- a/qa-automation/AI-Scoring/references/ReadPathFlip.md
+++ b/qa-automation/AI-Scoring/references/ReadPathFlip.md
@@ -146,7 +146,23 @@ need **no server work** — they ride on the rows above.
 
 Flag semantics: one env var (`QA_READ_PATH`, default `sheets`) — reads
 are stateless so a redeploy-free per-team column isn't warranted; flip
-and rollback are single Railway env changes.
+and rollback are single Railway env changes. **Three values** (refined in
+F4): `sheets` (today), `shadow` (serve the sheet but also build the
+Postgres frame and log the sheet↔pg delta on live traffic — the F4
+validation window), `postgres` (serve the row-source). `get_provider`
+treats `shadow` as `sheets` for Path-1 (the shadow window is a /team-trio
+concern); the promotion sequence is `sheets → shadow → postgres`, and
+rollback is any step leftward.
+
+**Implementation status (2026-07-14):** F2 ✅ (row-source + pytest +
+golden/endpoint parity harness), F3 ✅ (factory + lifecycle behind the
+flag), F4 ✅ (trio flag-aware + shadow, shared comparator in
+`services/read_path_shadow.py` used by both the harness and live shadow),
+F5 **partial** — W6 ✅ (indexed datapoint lookup, migration 014); the
+terminal cleanup (delete the trio's `_ws` sheet-read, drop gspread,
+W2/W3 as SQL views) is **deferred to post-cutover** — doing it now breaks
+the shadow window and the env-flip rollback (§6 sheet-retention). Prod
+flag stays `sheets` until the shadow window is validated on live traffic.
 
 ## 6. Explicitly out of scope
 

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -53,7 +53,8 @@ if str(_AI_SCORING) not in sys.path:
 from backend.config.team_config import get_team_config  # noqa: E402
 from backend.services import team_stats as ts  # noqa: E402
 from backend.services.read_path_shadow import (  # noqa: E402
-    align, cell_diffs as _cell_diffs, norm_cell as _norm,
+    align, cell_diffs as _cell_diffs, classify_cell_diff, classify_diffs,
+    norm_cell as _norm,
 )
 from backend.services.team_source import fetch_history_frame  # noqa: E402
 
@@ -64,8 +65,24 @@ _ALL_TEAMS = ["member_support", "sales"]
 # A. Frame parity — cell diffs + compute_* on the common subset
 # ---------------------------------------------------------------------------
 
-def frame_parity(sub_sheet, sub_pg, config) -> dict:
-    cell_diff_count, cell_diff_sample = _cell_diffs(sub_sheet, sub_pg)
+def reconcile_benign(sub_sheet, sub_pg, diffs):
+    """Return a copy of sub_pg with every KNOWN source-of-truth cell
+    (clock / name_accent / roster) overwritten by the sheet value, leaving
+    'other' cells intact. Running compute_* / endpoints on this isolates
+    genuine row-source divergence from the classified deltas — so the
+    verdict measures the flip's correctness, not qa.*'s clock/roster
+    currency (those are reported separately as data actions)."""
+    out = sub_pg.copy()
+    for d in diffs:
+        if classify_cell_diff(d) != "other":
+            out.at[d["row"], d["col"]] = sub_sheet.at[d["row"], d["col"]]
+    return out
+
+
+def frame_parity(sub_sheet, sub_pg_recon, config, diffs) -> dict:
+    """compute_* parity on the reconciled frames + the cell-diff
+    classification. `diffs` are the RAW (pre-reconcile) cell diffs."""
+    buckets = classify_diffs(diffs)
     stats = config.stats
     computations = {
         "monthly_summary": lambda d: ts.compute_monthly_summary(d),
@@ -81,11 +98,16 @@ def frame_parity(sub_sheet, sub_pg, config) -> dict:
     }
     compute_diffs = {}
     for name, fn in computations.items():
-        ja, jb = _safe(lambda: fn(sub_sheet)), _safe(lambda: fn(sub_pg))
+        ja, jb = _safe(lambda: fn(sub_sheet)), _safe(lambda: fn(sub_pg_recon))
         if ja != jb:
             compute_diffs[name] = {"sheet_len": len(ja), "pg_len": len(jb)}
-    return {"cell_diffs": cell_diff_sample, "cell_diff_count": cell_diff_count,
-            "compute_diffs": compute_diffs}
+    return {
+        "cell_diff_count": len(diffs),
+        "classified": {k: len(v) for k, v in buckets.items()},
+        "classified_samples": {k: v[:5] for k, v in buckets.items() if v},
+        "unexplained": buckets["other"][:50],
+        "compute_diffs": compute_diffs,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -240,26 +262,52 @@ async def run_team(team_id: str) -> int:
         return 2
 
     membership, sub_sheet, sub_pg = align(sheet_df, pg_df)
-    frame = frame_parity(sub_sheet, sub_pg, config)
+    diffs = _cell_diffs(sub_sheet, sub_pg)
+    # Reconcile the KNOWN source-of-truth deltas so compute_* + endpoint
+    # parity measure the FLIP's correctness, not qa.*'s clock/roster
+    # currency (reported separately below as data actions).
+    sub_pg_recon = reconcile_benign(sub_sheet, sub_pg, diffs)
+    frame = frame_parity(sub_sheet, sub_pg_recon, config, diffs)
     # Fixed reference time so both frames see the same days-cutoffs.
-    endpoints = endpoint_parity(sub_sheet, sub_pg, config, datetime.now())
+    endpoints = endpoint_parity(sub_sheet, sub_pg_recon, config, datetime.now())
 
-    report = {"membership": membership, "frame": frame, "endpoints": endpoints}
+    # Agents whose roster cells (is_active/supervisor) are stale in qa.* —
+    # the actionable list: import_agents.py --team <id> refreshes them.
+    roster_agents = sorted({
+        str(sub_sheet.at[d["row"], "agent"]) for d in diffs
+        if classify_cell_diff(d) == "roster"
+    })
+    cls = frame["classified"]
+
+    report = {"membership": membership, "frame": frame, "endpoints": endpoints,
+              "roster_stale_agents": roster_agents}
     report_path = _STAGING_DIR / f"report_{team_id}_parity.json"
     report_path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
 
     m = membership
     print(f"[parity:{team_id}] sheet={m['sheet']} pg={m['pg']} common={m['common']} "
           f"sheet_only={m['sheet_only']} db_only={m['db_only']}")
-    print(f"  A/frame:    cell_diffs={frame['cell_diff_count']} "
-          f"compute_diffs={list(frame['compute_diffs']) or 'NONE'}")
-    print(f"  B/endpoint: {endpoints['combos_run']} combos, "
+    print(f"  cell diffs: {frame['cell_diff_count']} → "
+          f"clock={cls['clock']} name_accent={cls['name_accent']} "
+          f"roster={cls['roster']} | OTHER (unexplained)={cls['other']}")
+    print(f"  A/frame (reconciled):    compute_diffs="
+          f"{list(frame['compute_diffs']) or 'NONE'}")
+    print(f"  B/endpoint (reconciled): {endpoints['combos_run']} combos, "
           f"{endpoints['failure_count']} failed "
           f"{[f['combo'] for f in endpoints['failures'][:6]] or ''}")
+    if roster_agents:
+        print(f"  ACTION — refresh qa.agents ({len(roster_agents)} stale): "
+              f"import_agents.py --team {team_id}  ⟶  {roster_agents[:8]}"
+              f"{' …' if len(roster_agents) > 8 else ''}")
+    if cls["other"]:
+        print(f"  UNEXPLAINED diffs (investigate): {frame['unexplained'][:5]}")
     print(f"  report: {report_path}")
 
-    ok = (not frame["cell_diff_count"] and not frame["compute_diffs"]
+    # Green = every divergence is a KNOWN class (clock/name_accent/roster)
+    # and the reconciled compute_* + endpoints agree exactly.
+    ok = (not cls["other"] and not frame["compute_diffs"]
           and not endpoints["failure_count"])
+    print(f"  verdict: {'GREEN — row-source correct' if ok else 'RED — unexplained divergence'}")
     return 0 if ok else 2
 
 

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -41,6 +41,7 @@ import sys
 from datetime import datetime, time, timedelta
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from dotenv import load_dotenv
 
@@ -101,25 +102,79 @@ def frame_parity(sub_sheet, sub_pg_recon, config, diffs) -> dict:
         ja, jb = _safe(lambda: fn(sub_sheet)), _safe(lambda: fn(sub_pg_recon))
         if ja != jb:
             compute_diffs[name] = {"sheet_len": len(ja), "pg_len": len(jb)}
-    return {
+
+    result = {
         "cell_diff_count": len(diffs),
         "classified": {k: len(v) for k, v in buckets.items()},
         "classified_samples": {k: v[:5] for k, v in buckets.items() if v},
         "unexplained": buckets["other"][:50],
+        # Column-set mismatch is invisible to cell diffs (they compare only
+        # shared columns) but drives compute_long_form (it emits per-column).
+        "col_only_sheet": sorted(set(sub_sheet.columns) - set(sub_pg_recon.columns)),
+        "col_only_pg": sorted(set(sub_pg_recon.columns) - set(sub_sheet.columns)),
         "compute_diffs": compute_diffs,
     }
+    if "long_form" in compute_diffs:
+        result["long_form_detail"] = _long_form_detail(sub_sheet, sub_pg_recon, config)
+    return result
+
+
+def _long_form_detail(sub_sheet, sub_pg, config) -> dict:
+    """Pinpoint the long_form divergence: row counts, the first differing
+    record as RAW json (so a number-vs-string serialization shows), and
+    the score-column dtypes per source (the dtype smoking gun)."""
+    ra = ts.compute_long_form(sub_sheet, config).to_dict("records")
+    rb = ts.compute_long_form(sub_pg, config).to_dict("records")
+    sec_ids = list(config.numeric_history_ids)
+    detail = {
+        "sheet_rows": len(ra), "pg_rows": len(rb),
+        "sheet_dtypes": {c: str(sub_sheet[c].dtype) for c in sec_ids if c in sub_sheet},
+        "pg_dtypes": {c: str(sub_pg[c].dtype) for c in sec_ids if c in sub_pg},
+    }
+    for i in range(min(len(ra), len(rb))):
+        ja = json.dumps(ra[i], default=_json_default, sort_keys=True)
+        jb = json.dumps(rb[i], default=_json_default, sort_keys=True)
+        if ja != jb:
+            detail["first_diff_index"] = i
+            detail["sheet_rec_json"] = ja
+            detail["pg_rec_json"] = jb
+            break
+    return detail
 
 
 # ---------------------------------------------------------------------------
 # B. Endpoint parity — mirror routes/team.py filter pipelines exactly
 # ---------------------------------------------------------------------------
 
+def _json_default(o):
+    """Serialization normalizer for the compute-parity comparison, matching
+    the cell comparison's granularity (read_path_shadow.norm_cell):
+
+    - datetimes/Timestamps → second-ISO. compute_long_form (the only
+      compute that emits RAW frame timestamps, unaggregated) otherwise
+      serializes the DB's microsecond value (e.g. ...:21.479) against the
+      sheet's strftime-truncated ...:21 → a spurious diff on every row,
+      even when cell_diffs (already second-granular) sees none. This is
+      the Sales long_form divergence: 0 cell diffs, yet long_form differed.
+    - numpy scalars → Python equivalents so np.float64(4.0) and float(4.0)
+      compare EQUAL rather than "4.0" (str) vs 4.0 (number).
+    """
+    if hasattr(o, "isoformat"):
+        try:
+            return o.isoformat(timespec="seconds")
+        except TypeError:  # a date (no timespec) — still stable
+            return o.isoformat()
+    if isinstance(o, np.generic):
+        return o.item()
+    return str(o)
+
+
 def _safe(thunk) -> str:
     """JSON-serialize a computation, capturing exceptions as a stable
     signature so an identical raise on both sides reads as parity, not a
     harness crash."""
     try:
-        return json.dumps(thunk(), default=str, sort_keys=True)
+        return json.dumps(thunk(), default=_json_default, sort_keys=True)
     except Exception as e:  # noqa: BLE001 — signature comparison, not handling
         return f"__exc__:{type(e).__name__}:{e}"
 
@@ -301,6 +356,21 @@ async def run_team(team_id: str) -> int:
               f"{' …' if len(roster_agents) > 8 else ''}")
     if cls["other"]:
         print(f"  UNEXPLAINED diffs (investigate): {frame['unexplained'][:5]}")
+    if frame["col_only_sheet"] or frame["col_only_pg"]:
+        print(f"  COLUMN MISMATCH — sheet-only={frame['col_only_sheet']} "
+              f"pg-only={frame['col_only_pg']}")
+    if "long_form_detail" in frame:
+        d = frame["long_form_detail"]
+        print(f"  long_form: sheet_rows={d['sheet_rows']} pg_rows={d['pg_rows']} "
+              f"first_diff@{d.get('first_diff_index')}")
+        if d["sheet_dtypes"] != d["pg_dtypes"]:
+            mism = {c: (d["sheet_dtypes"].get(c), d["pg_dtypes"].get(c))
+                    for c in d["sheet_dtypes"]
+                    if d["sheet_dtypes"].get(c) != d["pg_dtypes"].get(c)}
+            print(f"    DTYPE MISMATCH (sheet,pg): {mism}")
+        if "sheet_rec_json" in d:
+            print(f"    sheet_rec={d['sheet_rec_json']}")
+            print(f"    pg_rec   ={d['pg_rec_json']}")
     print(f"  report: {report_path}")
 
     # Green = every divergence is a KNOWN class (clock/name_accent/roster)

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import math
 import sys
 from datetime import datetime, time, timedelta
 from pathlib import Path
@@ -53,54 +52,12 @@ if str(_AI_SCORING) not in sys.path:
 
 from backend.config.team_config import get_team_config  # noqa: E402
 from backend.services import team_stats as ts  # noqa: E402
+from backend.services.read_path_shadow import (  # noqa: E402
+    align, cell_diffs as _cell_diffs, norm_cell as _norm,
+)
 from backend.services.team_source import fetch_history_frame  # noqa: E402
 
 _ALL_TEAMS = ["member_support", "sales"]
-
-
-def _strip_accents(s):
-    import unicodedata
-    return "".join(c for c in unicodedata.normalize("NFD", s)
-                   if not unicodedata.combining(c))
-
-
-def _key(df):
-    """String key eval_id|agent|ordinal — agent accent-stripped (roster
-    spellings drift), ordinal disambiguates D2 re-eval pairs
-    deterministically by (timestamp, overall_score)."""
-    base = (df["eval_id"].astype(str) + "|"
-            + df["agent"].str.strip().str.lower().map(_strip_accents))
-    order = df.assign(_b=base).sort_values(["_b", "timestamp", "overall_score"])
-    ordinal = order.groupby("_b").cumcount()
-    return (base + "|" + ordinal.reindex(df.index).astype(str)).tolist()
-
-
-def _norm(v):
-    if isinstance(v, float) and math.isnan(v):
-        return None
-    if hasattr(v, "isoformat"):
-        return v.isoformat(timespec="seconds")
-    return v
-
-
-def _common_subsets(sheet_df, pg_df):
-    """Align on the eval_id|agent|ordinal key; return the membership
-    classification plus the two common-subset frames (clean RangeIndex,
-    identical row order — sorted by key)."""
-    sheet_df = sheet_df.assign(_k=_key(sheet_df)).set_index("_k")
-    pg_df = pg_df.assign(_k=_key(pg_df)).set_index("_k")
-    sheet_only = sorted(set(sheet_df.index) - set(pg_df.index))
-    db_only = sorted(set(pg_df.index) - set(sheet_df.index))
-    common = sorted(set(sheet_df.index) & set(pg_df.index))
-    membership = {
-        "sheet": len(sheet_df), "pg": len(pg_df), "common": len(common),
-        "sheet_only": len(sheet_only), "db_only": len(db_only),
-        "sheet_only_keys": [k.split("|") for k in sheet_only[:25]],
-        "db_only_sample": [k.split("|") for k in db_only[:5]],
-    }
-    sub_sheet = sheet_df.loc[common].reset_index(drop=True)
-    sub_pg = pg_df.loc[common].reset_index(drop=True)
-    return membership, sub_sheet, sub_pg
 
 
 # ---------------------------------------------------------------------------
@@ -108,15 +65,7 @@ def _common_subsets(sheet_df, pg_df):
 # ---------------------------------------------------------------------------
 
 def frame_parity(sub_sheet, sub_pg, config) -> dict:
-    cols = [c for c in sub_sheet.columns if c in sub_pg.columns]
-    cell_diffs = []
-    for i in range(len(sub_sheet)):
-        a, b = sub_sheet.iloc[i], sub_pg.iloc[i]
-        for c in cols:
-            va, vb = _norm(a[c]), _norm(b[c])
-            if va != vb:
-                cell_diffs.append({"row": i, "col": c, "sheet": va, "pg": vb})
-
+    cell_diff_count, cell_diff_sample = _cell_diffs(sub_sheet, sub_pg)
     stats = config.stats
     computations = {
         "monthly_summary": lambda d: ts.compute_monthly_summary(d),
@@ -135,7 +84,7 @@ def frame_parity(sub_sheet, sub_pg, config) -> dict:
         ja, jb = _safe(lambda: fn(sub_sheet)), _safe(lambda: fn(sub_pg))
         if ja != jb:
             compute_diffs[name] = {"sheet_len": len(ja), "pg_len": len(jb)}
-    return {"cell_diffs": cell_diffs[:50], "cell_diff_count": len(cell_diffs),
+    return {"cell_diffs": cell_diff_sample, "cell_diff_count": cell_diff_count,
             "compute_diffs": compute_diffs}
 
 
@@ -290,7 +239,7 @@ async def run_team(team_id: str) -> int:
               f"(sheet={len(sheet_df)} pg={len(pg_df)})")
         return 2
 
-    membership, sub_sheet, sub_pg = _common_subsets(sheet_df, pg_df)
+    membership, sub_sheet, sub_pg = align(sheet_df, pg_df)
     frame = frame_parity(sub_sheet, sub_pg, config)
     # Fixed reference time so both frames see the same days-cutoffs.
     endpoints = endpoint_parity(sub_sheet, sub_pg, config, datetime.now())

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -3,23 +3,33 @@
 
 Read-only on both sides. Builds the analytics DataFrame from the
 Analyst_History sheet (today's path: raw rows → load_and_clean) and from
-qa.* (team_source.fetch_history_frame), then:
+qa.* (team_source.fetch_history_frame), aligns them on the common row
+set, then proves two things:
 
-1. aligns rows on (eval_id, agent-lower) and classifies membership
-   deltas — sheet-only rows (expected: the B0 hard-zero exclusions),
-   db-only rows (expected: backfilled history the sheet dropped, e.g.
-   the entire Sales pre-flip archive);
-2. cell-diffs the COMMON rows column by column (scores exact,
-   timestamps to the second, yn vocab verbatim);
-3. runs all nine compute_* functions on the common subset of BOTH
-   frames and deep-diffs their JSON.
+A. FRAME PARITY — the common rows are cell-identical (scores exact,
+   timestamps to the second, yn vocab verbatim) and all nine compute_*
+   functions agree on that common subset.
 
-Exit 0 = common-set parity exact; 2 = differences beyond the classified
-membership deltas (read the report).
+B. ENDPOINT PARITY — the /team/stats, /team/evals, /team/long_form
+   request pipelines (the exact filter order from routes/team.py) produce
+   identical output from either source across the full
+   days / range / supervisor / active_only permutation grid, plus every
+   month present in the data for the /evals drill-down. This is the F2
+   checkpoint: "parity green across days/range/supervisor/active_only
+   permutations, both teams."
+
+Membership deltas are expected and classified, NOT failures: sheet-only
+rows (B0 hard-zero exclusions) and db-only rows (backfilled history the
+sheet dropped, e.g. the Sales pre-flip archive). Parity is measured on
+the common subset — everything the two sources agree exists.
+
+Exit 0 = every checked team parity-exact; 2 = a real divergence (read the
+per-team report JSON).
 
 Usage:
     cd qa-automation/AI-Scoring
-    python3 scripts/parity_readpath.py --team-id member_support
+    python3 scripts/parity_readpath.py                 # both teams
+    python3 scripts/parity_readpath.py --team-id sales # one team
 """
 
 from __future__ import annotations
@@ -29,8 +39,10 @@ import asyncio
 import json
 import math
 import sys
+from datetime import datetime, time, timedelta
 from pathlib import Path
 
+import pandas as pd
 from dotenv import load_dotenv
 
 _AI_SCORING = Path(__file__).resolve().parent.parent
@@ -42,6 +54,8 @@ if str(_AI_SCORING) not in sys.path:
 from backend.config.team_config import get_team_config  # noqa: E402
 from backend.services import team_stats as ts  # noqa: E402
 from backend.services.team_source import fetch_history_frame  # noqa: E402
+
+_ALL_TEAMS = ["member_support", "sales"]
 
 
 def _strip_accents(s):
@@ -69,28 +83,41 @@ def _norm(v):
     return v
 
 
-def compare_frames(sheet_df, pg_df, config) -> dict:
+def _common_subsets(sheet_df, pg_df):
+    """Align on the eval_id|agent|ordinal key; return the membership
+    classification plus the two common-subset frames (clean RangeIndex,
+    identical row order — sorted by key)."""
     sheet_df = sheet_df.assign(_k=_key(sheet_df)).set_index("_k")
     pg_df = pg_df.assign(_k=_key(pg_df)).set_index("_k")
     sheet_only = sorted(set(sheet_df.index) - set(pg_df.index))
     db_only = sorted(set(pg_df.index) - set(sheet_df.index))
     common = sorted(set(sheet_df.index) & set(pg_df.index))
+    membership = {
+        "sheet": len(sheet_df), "pg": len(pg_df), "common": len(common),
+        "sheet_only": len(sheet_only), "db_only": len(db_only),
+        "sheet_only_keys": [k.split("|") for k in sheet_only[:25]],
+        "db_only_sample": [k.split("|") for k in db_only[:5]],
+    }
+    sub_sheet = sheet_df.loc[common].reset_index(drop=True)
+    sub_pg = pg_df.loc[common].reset_index(drop=True)
+    return membership, sub_sheet, sub_pg
 
-    cols = [c for c in sheet_df.columns if c in pg_df.columns]
+
+# ---------------------------------------------------------------------------
+# A. Frame parity — cell diffs + compute_* on the common subset
+# ---------------------------------------------------------------------------
+
+def frame_parity(sub_sheet, sub_pg, config) -> dict:
+    cols = [c for c in sub_sheet.columns if c in sub_pg.columns]
     cell_diffs = []
-    for k in common:
-        a, b = sheet_df.loc[k], pg_df.loc[k]
+    for i in range(len(sub_sheet)):
+        a, b = sub_sheet.iloc[i], sub_pg.iloc[i]
         for c in cols:
             va, vb = _norm(a[c]), _norm(b[c])
             if va != vb:
-                cell_diffs.append({"key": list(k), "col": c,
-                                   "sheet": va, "pg": vb})
+                cell_diffs.append({"row": i, "col": c, "sheet": va, "pg": vb})
 
-    # compute_* parity on the common subset
-    sub_sheet = sheet_df.loc[common].reset_index(drop=True)
-    sub_pg = pg_df.loc[common].reset_index(drop=True)
     stats = config.stats
-    compute_diffs = {}
     computations = {
         "monthly_summary": lambda d: ts.compute_monthly_summary(d),
         "monthly_spc": lambda d: ts.compute_monthly_spc(d, stats),
@@ -103,49 +130,200 @@ def compare_frames(sheet_df, pg_df, config) -> dict:
         "roster": lambda d: ts.compute_agent_roster(d, config),
         "long_form": lambda d: ts.compute_long_form(d, config).to_dict("records"),
     }
+    compute_diffs = {}
     for name, fn in computations.items():
-        ja = json.dumps(fn(sub_sheet), default=str, sort_keys=True)
-        jb = json.dumps(fn(sub_pg), default=str, sort_keys=True)
+        ja, jb = _safe(lambda: fn(sub_sheet)), _safe(lambda: fn(sub_pg))
         if ja != jb:
             compute_diffs[name] = {"sheet_len": len(ja), "pg_len": len(jb)}
-
-    return {"rows": {"sheet": len(sheet_df), "pg": len(pg_df),
-                     "common": len(common), "sheet_only": len(sheet_only),
-                     "db_only": len(db_only)},
-            "sheet_only_keys": [list(k) for k in sheet_only[:25]],
-            "db_only_sample": [list(k) for k in db_only[:5]],
-            "cell_diffs": cell_diffs[:50],
-            "cell_diff_count": len(cell_diffs),
+    return {"cell_diffs": cell_diffs[:50], "cell_diff_count": len(cell_diffs),
             "compute_diffs": compute_diffs}
 
 
-async def run(args) -> int:
-    config = get_team_config(args.team_id)
+# ---------------------------------------------------------------------------
+# B. Endpoint parity — mirror routes/team.py filter pipelines exactly
+# ---------------------------------------------------------------------------
+
+def _safe(thunk) -> str:
+    """JSON-serialize a computation, capturing exceptions as a stable
+    signature so an identical raise on both sides reads as parity, not a
+    harness crash."""
+    try:
+        return json.dumps(thunk(), default=str, sort_keys=True)
+    except Exception as e:  # noqa: BLE001 — signature comparison, not handling
+        return f"__exc__:{type(e).__name__}:{e}"
+
+
+def _stats_pipeline(df, config, *, active_only, supervisor, window, days, now):
+    if df.empty:
+        return {"empty": True}
+    d = df
+    if active_only:
+        d = d[d["is_active"]]
+    if supervisor:
+        d = d[d["supervisor"].str.lower() == supervisor.strip().lower()]
+    # Monthly chiclets honor active/supervisor but NOT days (team.py:139).
+    monthly = ts.compute_monthly_summary(d)
+    if window is not None:
+        d = d[(d["timestamp"] >= window[0]) & (d["timestamp"] <= window[1])]
+    elif days > 0:
+        d = d[d["timestamp"] >= now - timedelta(days=days)]
+    stats = config.stats
+    return {
+        "kpis": {
+            "total": len(d),
+            "avg": round(float(d["overall_score"].mean()), 1) if len(d) else 0,
+            "std": round(float(d["overall_score"].std(ddof=1)), 1) if len(d) > 1 else 0,
+            "analysts": int(d["agent"].nunique()),
+        },
+        "monthly": monthly,
+        "roster": ts.compute_agent_roster(d, config),
+        "outliers": ts.compute_outliers(d, stats),
+        "spc": ts.compute_monthly_spc(d, stats),
+        "section_analysis": ts.compute_section_analysis(d, config),
+        "binary_stats": ts.compute_binary_stats(d, config.yn_section_labels),
+        "supervisor_stats": ts.compute_supervisor_stats(d),
+        "ewma": ts.compute_ewma(d, stats),
+        "distribution": ts.compute_distribution(d),
+    }
+
+
+def _long_form_pipeline(df, config, *, active_only, supervisor, window, days, now):
+    if df.empty:
+        return []
+    d = df
+    # team.py:327 applies window/days BEFORE active/supervisor here.
+    if window is not None:
+        d = d[(d["timestamp"] >= window[0]) & (d["timestamp"] <= window[1])]
+    elif days > 0:
+        d = d[d["timestamp"] >= now - timedelta(days=days)]
+    if active_only:
+        d = d[d["is_active"]]
+    if supervisor:
+        d = d[d["supervisor"].str.lower() == supervisor.strip().lower()]
+    return ts.compute_long_form(d, config).to_dict("records")
+
+
+def _evals_pipeline(df, config, *, year_month, active_only, supervisor):
+    if df.empty:
+        return []
+    d = df
+    if active_only:
+        d = d[d["is_active"]]
+    if supervisor:
+        d = d[d["supervisor"].str.lower() == supervisor.strip().lower()]
+    months = ts._months_in_bucket_tz(d["timestamp"])
+    d = d[months == year_month].sort_values("timestamp", ascending=False)
+    return [
+        {"agent": r["agent"], "eval_id": r["eval_id"],
+         "timestamp": _norm(r["timestamp"]),
+         "overall_score": float(r["overall_score"]),
+         "supervisor": r.get("supervisor", ""),
+         "manager_email": r.get("manager_email", "")}
+        for r in d.to_dict("records")
+    ]
+
+
+def endpoint_parity(sub_sheet, sub_pg, config, now) -> dict:
+    """Run every request permutation against both frames and diff."""
+    # Representative supervisor: the one covering the most common rows.
+    sup_counts = sub_sheet[sub_sheet["supervisor"] != ""]["supervisor"].value_counts()
+    sup = str(sup_counts.index[0]) if len(sup_counts) else ""
+    supervisors = ["", sup] if sup else [""]
+
+    # Representative custom range: the middle 50% of the data span.
+    ts_min, ts_max = sub_sheet["timestamp"].min(), sub_sheet["timestamp"].max()
+    span = ts_max - ts_min
+    r_from = (ts_min + span * 0.25).date()
+    r_to = (ts_min + span * 0.75).date()
+    rng = (datetime.combine(r_from, time.min), datetime.combine(r_to, time.max))
+    windows = [("days30", None, 30), ("days90", None, 90),
+               ("days730", None, 730), ("range", rng, 0)]
+
+    combos, failures = [], []
+
+    def check(tag, fa, fb):
+        combos.append(tag)
+        ja, jb = _safe(fa), _safe(fb)
+        if ja != jb:
+            failures.append({"combo": tag, "sheet": ja[:240], "pg": jb[:240]})
+
+    for ao in (True, False):
+        for su in supervisors:
+            for wname, win, days in windows:
+                k = dict(active_only=ao, supervisor=su, window=win, days=days, now=now)
+                sfx = f"[active={ao},sup={bool(su)},{wname}]"
+                check("stats" + sfx,
+                      lambda k=k: _stats_pipeline(sub_sheet, config, **k),
+                      lambda k=k: _stats_pipeline(sub_pg, config, **k))
+                check("long_form" + sfx,
+                      lambda k=k: _long_form_pipeline(sub_sheet, config, **k),
+                      lambda k=k: _long_form_pipeline(sub_pg, config, **k))
+
+    months = sorted(set(ts._months_in_bucket_tz(sub_sheet["timestamp"])))
+    for ym in months:
+        for ao in (True, False):
+            for su in supervisors:
+                k = dict(year_month=ym, active_only=ao, supervisor=su)
+                check(f"evals[{ym},active={ao},sup={bool(su)}]",
+                      lambda k=k: _evals_pipeline(sub_sheet, config, **k),
+                      lambda k=k: _evals_pipeline(sub_pg, config, **k))
+
+    return {"supervisor_probe": sup, "range_probe": [str(r_from), str(r_to)],
+            "months": months, "combos_run": len(combos),
+            "failures": failures[:50], "failure_count": len(failures)}
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+async def run_team(team_id: str) -> int:
+    config = get_team_config(team_id)
     from backend.services.data_provider import get_provider
-    provider = await get_provider(args.team_id)
-    history_rows = provider._ws.get_all_values()
-    mails_rows = provider._get_mails_sheet()
-    sheet_df = ts.load_and_clean(history_rows, mails_rows, config)
+    provider = await get_provider(team_id)
+    sheet_df = ts.load_and_clean(
+        provider._ws.get_all_values(), provider._get_mails_sheet(), config)
     pg_df = await fetch_history_frame(config)
 
-    result = compare_frames(sheet_df, pg_df, config)
-    report_path = _STAGING_DIR / f"report_{args.team_id}_parity.json"
-    report_path.write_text(json.dumps(result, indent=2, default=str),
-                           encoding="utf-8")
+    if sheet_df.empty or pg_df.empty:
+        print(f"[parity:{team_id}] ABORT — empty frame "
+              f"(sheet={len(sheet_df)} pg={len(pg_df)})")
+        return 2
 
-    r = result["rows"]
-    print(f"[parity:{args.team_id}] sheet={r['sheet']} pg={r['pg']} "
-          f"common={r['common']} sheet_only={r['sheet_only']} "
-          f"db_only={r['db_only']}")
-    print(f"  common-set cell diffs: {result['cell_diff_count']}")
-    print(f"  compute_* diffs: {list(result['compute_diffs']) or 'NONE'}")
+    membership, sub_sheet, sub_pg = _common_subsets(sheet_df, pg_df)
+    frame = frame_parity(sub_sheet, sub_pg, config)
+    # Fixed reference time so both frames see the same days-cutoffs.
+    endpoints = endpoint_parity(sub_sheet, sub_pg, config, datetime.now())
+
+    report = {"membership": membership, "frame": frame, "endpoints": endpoints}
+    report_path = _STAGING_DIR / f"report_{team_id}_parity.json"
+    report_path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+
+    m = membership
+    print(f"[parity:{team_id}] sheet={m['sheet']} pg={m['pg']} common={m['common']} "
+          f"sheet_only={m['sheet_only']} db_only={m['db_only']}")
+    print(f"  A/frame:    cell_diffs={frame['cell_diff_count']} "
+          f"compute_diffs={list(frame['compute_diffs']) or 'NONE'}")
+    print(f"  B/endpoint: {endpoints['combos_run']} combos, "
+          f"{endpoints['failure_count']} failed "
+          f"{[f['combo'] for f in endpoints['failures'][:6]] or ''}")
     print(f"  report: {report_path}")
-    return 0 if not result["cell_diff_count"] and not result["compute_diffs"] else 2
+
+    ok = (not frame["cell_diff_count"] and not frame["compute_diffs"]
+          and not endpoints["failure_count"])
+    return 0 if ok else 2
+
+
+async def run(args) -> int:
+    teams = [args.team_id] if args.team_id else _ALL_TEAMS
+    codes = [await run_team(t) for t in teams]
+    return 0 if all(c == 0 for c in codes) else 2
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--team-id", required=True)
+    ap.add_argument("--team-id", default=None,
+                    help="one team; omit to sweep both (member_support, sales)")
     args = ap.parse_args()
     return asyncio.run(run(args))
 

--- a/qa-automation/AI-Scoring/tests/test_analytics.py
+++ b/qa-automation/AI-Scoring/tests/test_analytics.py
@@ -236,7 +236,7 @@ def test_monthly_summary_month_boundary_buckets_strictly():
     assert out["current"]["mean"] == 95.0
 
 
-def test_monthly_summary_buckets_in_project_local_time():
+def test_monthly_summary_buckets_in_project_local_time(monkeypatch):
     """The PR-3 smoke-test regression: a call that displays as May 31
     8:33 PM in the project bucket TZ (3:33 AM Jun 1 UTC) must bucket
     into May, not June. The previous tz-naive bucketing put it in June
@@ -245,7 +245,16 @@ def test_monthly_summary_buckets_in_project_local_time():
     from datetime import datetime as _dt
     from zoneinfo import ZoneInfo
     import pandas as pd
+    from backend.services import team_stats as _ts
     from backend.services.team_stats import _BUCKET_TZ
+
+    # Pin "now" so the last/current labels are deterministic: with now in
+    # June 2026, "current" = 2026-06 and "last" = 2026-05. Without this
+    # the test only passed while the real clock sat within a month of the
+    # hardcoded May boundary (it went red once the calendar reached July).
+    monkeypatch.setattr(
+        _ts, "_now_in_bucket_tz",
+        lambda: _dt(2026, 6, 15, 12, 0, 0, tzinfo=_BUCKET_TZ))
 
     # Construct a timestamp that is May 31 in the bucket TZ but Jun 1 UTC.
     # 31 May 23:30 LA = 06 Jun 1 06:30 UTC (LA is UTC-7 in DST).

--- a/qa-automation/AI-Scoring/tests/test_data_provider_factory.py
+++ b/qa-automation/AI-Scoring/tests/test_data_provider_factory.py
@@ -1,0 +1,103 @@
+"""F3 — Sheets↔Postgres read-path factory dispatch (ReadPathFlip §5).
+
+Verifies get_provider selects by QA_READ_PATH, connect()s the Postgres
+provider before handing it out, caches within a mode, rebuilds + closes
+the old instance on a flag flip, and that close_all_providers tears down
+pooled providers. Both providers are faked — no gspread creds, no live
+Postgres — so this pins the factory wiring in isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import backend.services.data_provider as dp
+
+
+class _FakeSheets:
+    name = "Google Sheets"
+
+    def __init__(self, config=None):
+        self.config = config
+        self.closed = False
+    # no close() — SheetsProvider has none; factory must tolerate that.
+
+
+class _FakePg:
+    name = "PostgreSQL"
+
+    def __init__(self, config=None):
+        self.config = config
+        self.connected = False
+        self.closed = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_and_fake(monkeypatch):
+    """Isolate each test: fresh caches, faked provider classes, no flag."""
+    monkeypatch.setattr(dp, "_providers", {})
+    monkeypatch.setattr(dp, "_provider_modes", {})
+    monkeypatch.delenv("QA_READ_PATH", raising=False)
+    import backend.services.history_service as hs
+    import backend.services.db_provider as db
+    monkeypatch.setattr(hs, "SheetsProvider", _FakeSheets)
+    monkeypatch.setattr(db, "PostgresProvider", _FakePg)
+
+
+def test_default_mode_returns_sheets():
+    p = asyncio.run(dp.get_provider("sales"))
+    assert isinstance(p, _FakeSheets)
+    assert dp._provider_modes["sales"] == "sheets"
+
+
+def test_postgres_mode_connects_before_return(monkeypatch):
+    monkeypatch.setenv("QA_READ_PATH", "postgres")
+    p = asyncio.run(dp.get_provider("sales"))
+    assert isinstance(p, _FakePg)
+    assert p.connected is True, "provider must be connect()-ed before hand-off"
+
+
+def test_caches_within_mode(monkeypatch):
+    monkeypatch.setenv("QA_READ_PATH", "postgres")
+
+    async def _twice():
+        a = await dp.get_provider("sales")
+        b = await dp.get_provider("sales")
+        return a, b
+
+    a, b = asyncio.run(_twice())
+    assert a is b  # same cached instance, connect() ran once
+
+
+def test_flag_flip_rebuilds_and_closes_previous(monkeypatch):
+    monkeypatch.setenv("QA_READ_PATH", "postgres")
+    pg = asyncio.run(dp.get_provider("sales"))
+    assert isinstance(pg, _FakePg)
+
+    monkeypatch.setenv("QA_READ_PATH", "sheets")
+    sheets = asyncio.run(dp.get_provider("sales"))
+    assert isinstance(sheets, _FakeSheets)
+    assert pg.closed is True, "superseded Postgres pool must be closed on flip"
+    assert dp._provider_modes["sales"] == "sheets"
+
+
+def test_close_all_providers_tears_down_pool(monkeypatch):
+    monkeypatch.setenv("QA_READ_PATH", "postgres")
+    pg = asyncio.run(dp.get_provider("sales"))
+    asyncio.run(dp.close_all_providers())
+    assert pg.closed is True
+    assert dp._providers == {} and dp._provider_modes == {}
+
+
+def test_close_all_tolerates_closeless_sheets():
+    asyncio.run(dp.get_provider("sales"))          # sheets path, no close()
+    asyncio.run(dp.close_all_providers())          # must not raise
+    assert dp._providers == {}

--- a/qa-automation/AI-Scoring/tests/test_datapoint_lookup.py
+++ b/qa-automation/AI-Scoring/tests/test_datapoint_lookup.py
@@ -1,0 +1,164 @@
+"""W6 — indexed /datapoints/{call_id} lookup (ReadPathFlip §3, slice F5).
+
+PostgresProvider.get_by_eval_id replaces the 365-day get_all_history load
++ Python scan with a single indexed row hit, but must never return a
+DIFFERENT record than the scan would: it verifies the resolved row's
+link-derived eval_id equals call_id, else returns None so the route falls
+back to the scan. All DB access is faked; no live Postgres.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from backend.services.data_provider import DataProvider
+from backend.services.db_provider import PostgresProvider
+from backend.services.history_service import _extract_eval_id
+from tests.conftest import load_test_config
+
+
+class _Conn:
+    def __init__(self, eval_rows, section_rows):
+        self.eval_rows = list(eval_rows)
+        self.section_rows = list(section_rows)
+        self.queries: list[str] = []
+
+    async def fetch(self, query, *params):
+        self.queries.append(query)
+        if "FROM qa.evaluation_sections" in query:
+            return [s for s in self.section_rows if s["evaluation_id"] == params[0]]
+        if "FROM qa.agents" in query:
+            return []
+        raise AssertionError(f"unexpected fetch: {query}")
+
+    async def fetchrow(self, query, *params):
+        self.queries.append(query)
+        _team_id, call_id = params
+        # Model the id-column probe as "the link's trailing segment matches".
+        for ev in self.eval_rows:
+            if _extract_eval_id(ev.get("dialpad_link") or "") == call_id:
+                return ev
+        return None
+
+    async def fetchval(self, query, *params):
+        return 1
+
+
+class _Acquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _Pool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _Acquire(self._conn)
+
+
+def _eval_row(eval_id=1, link="https://dialpad.com/launchpad/call/CALL123", **over):
+    row = {
+        "id": eval_id, "agent_name_raw": "Jane Doe", "agent_email": "jane@landing.com",
+        "evaluator_email": "boss@landing.com",
+        "ts": datetime(2026, 7, 2, 15, 30, tzinfo=timezone.utc),
+        "overall_score": 87.5, "dialpad_link": link, "key_strengths": "",
+        "opportunities": "", "call_summary": "", "caller_name": "", "caller_phone": "",
+        "source": "ai",
+    }
+    row.update(over)
+    return row
+
+
+def _sections(config, eval_id=1):
+    rows = []
+    for sec in config.sections_by_number:
+        binaryish = "binary" in str(sec.score_type) or str(sec.score_type) == "auto_value"
+        rows.append({
+            "evaluation_id": eval_id, "section_id": sec.id,
+            "numeric_score": None if binaryish else 4,
+            "binary_value": "Y" if binaryish else None,
+            "confidence": "high", "reasoning": f"r-{sec.id}",
+        })
+    return rows
+
+
+def _provider(eval_rows, section_rows):
+    config = load_test_config("sales_lite")
+    p = PostgresProvider(config=config)
+    p._roster = [["Name", "Email", "Supervisor", "Canonical Name"]]  # non-stale
+    import time
+    p._roster_at = time.monotonic()
+    p._pool = _Pool(_Conn(eval_rows, section_rows))
+    return p
+
+
+def test_lookup_hit_uses_indexed_column_and_returns_record():
+    config = load_test_config("sales_lite")
+    p = _provider([_eval_row()], _sections(config))
+    rec = asyncio.run(p.get_by_eval_id("CALL123"))
+    assert rec is not None
+    assert rec.eval_id == "CALL123"
+    assert rec.agent_name == "Jane Doe"
+    # the probe hit the entry-point id column (the W6 index target)
+    probe = next(q for q in p._pool._conn.queries if "FROM qa.evaluations" in q)
+    assert "dialpad_entry_point_call_id" in probe
+
+
+def test_lookup_miss_returns_none():
+    config = load_test_config("sales_lite")
+    p = _provider([_eval_row()], _sections(config))
+    assert asyncio.run(p.get_by_eval_id("NOPE")) is None
+
+
+def test_lookup_verifies_link_derived_id_matches():
+    """A row whose stored id matched but whose LINK parses to a different
+    eval_id must NOT be returned — the route falls back to the scan so the
+    result is byte-identical to today."""
+    config = load_test_config("sales_lite")
+    # Fake conn matches on the link segment; give it a row whose link says
+    # OTHER while we ask for CALL123 → fetchrow returns None here, but the
+    # verify guard is what protects the real id-column-match case. Assert
+    # the guard directly: a returned row with a mismatched link yields None.
+    p = _provider([_eval_row(link="https://dialpad.com/launchpad/call/OTHER")],
+                  _sections(config))
+
+    # Force fetchrow to return the OTHER-link row for ANY call_id, so only
+    # the eval_id verify can reject it.
+    conn = p._pool._conn
+    other_row = conn.eval_rows[0]
+
+    async def _always(query, *params):
+        conn.queries.append(query)
+        return other_row
+    conn.fetchrow = _always
+
+    assert asyncio.run(p.get_by_eval_id("CALL123")) is None
+
+
+def test_empty_call_id_short_circuits():
+    p = _provider([_eval_row()], [])
+    assert asyncio.run(p.get_by_eval_id("")) is None
+    # no DB query issued
+    assert p._pool._conn.queries == []
+
+
+def test_base_provider_default_is_none():
+    class _Stub(DataProvider):
+        async def list_agents(self):
+            return []
+        async def get_agent_history(self, agent_name, days=30):
+            return []
+        async def get_all_history(self, days=90):
+            return []
+        def _get_mails_sheet(self):
+            return []
+
+    assert asyncio.run(_Stub().get_by_eval_id("anything")) is None

--- a/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
+++ b/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
@@ -57,6 +57,26 @@ def test_cell_diff_detected_on_common_row():
     result = shadow.compare(sheet, pg)
     assert result["cell_diff_count"] == 1
     assert result["cell_diff_sample"][0]["col"] == "overall_score"
+    # a score divergence is genuinely unexplained → 'other'
+    assert result["classified"]["other"] == 1
+
+
+def test_classify_clock_and_roster_deltas():
+    """clock (±seconds on a timestamp col) and roster (is_active/supervisor)
+    are KNOWN source-of-truth deltas, not 'other' failures."""
+    sheet = pd.DataFrame([{
+        "eval_id": "A", "agent": "Star Rep",
+        "timestamp": datetime(2026, 4, 1, 9, 0, 0), "overall_score": 90.0,
+        "is_active": True, "supervisor": "Max",
+    }])
+    pg = sheet.copy()
+    pg.loc[0, "timestamp"] = datetime(2026, 4, 1, 9, 0, 1)   # B2 clock repair
+    pg.loc[0, "is_active"] = False                            # stale roster
+    pg.loc[0, "supervisor"] = ""
+    cls = shadow.compare(sheet, pg)["classified"]
+    assert cls["clock"] == 1
+    assert cls["roster"] == 2
+    assert cls["other"] == 0
 
 
 def test_accent_folded_key_aligns_then_surfaces_name_drift():
@@ -72,6 +92,9 @@ def test_accent_folded_key_aligns_then_surfaces_name_drift():
     assert result["membership"]["sheet_only"] == 0
     assert result["cell_diff_count"] == 1               # drift surfaced
     assert result["cell_diff_sample"][0]["col"] == "agent"
+    # classified as name_accent (canonicalization), NOT an unexplained fail
+    assert result["classified"]["name_accent"] == 1
+    assert result["classified"]["other"] == 0
 
 
 def test_log_shadow_never_raises_on_empty():

--- a/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
+++ b/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
@@ -1,0 +1,158 @@
+"""F4 — read-path shadow comparator + mode-aware /team frame helper.
+
+Two layers (ReadPathFlip §5 F4):
+- read_path_shadow.align/compare: key alignment, membership classification
+  (sheet-only / db-only / common are deltas, not failures), and common-row
+  cell diffing — the SAME comparator the offline harness uses.
+- routes.team._team_history_frame: QA_READ_PATH dispatch — postgres serves
+  the row-source (no provider._ws), shadow serves the sheet AND logs the
+  delta, sheets serves the sheet with no shadow work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from backend.services import read_path_shadow as shadow
+
+
+def _frame(rows):
+    """rows: list of (eval_id, agent, day, overall)."""
+    return pd.DataFrame([
+        {"eval_id": e, "agent": a,
+         "timestamp": datetime(2026, 4, d, 9, 0, 0), "overall_score": float(o)}
+        for e, a, d, o in rows
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Comparator
+# ---------------------------------------------------------------------------
+
+def test_membership_classification():
+    sheet = _frame([("A", "Star Rep", 1, 90), ("B", "Star Rep", 2, 80),
+                    ("C", "Decline Rep", 3, 70)])
+    pg = _frame([("B", "Star Rep", 2, 80), ("C", "Decline Rep", 3, 70),
+                 ("D", "Improve Rep", 4, 60)])
+    m = shadow.compare(sheet, pg)["membership"]
+    assert m["common"] == 2
+    assert m["sheet_only"] == 1  # A — a B0 exclusion analogue
+    assert m["db_only"] == 1     # D — backfilled-history analogue
+
+
+def test_identical_common_rows_zero_cell_diffs():
+    sheet = _frame([("A", "Star Rep", 1, 90), ("B", "Decline Rep", 2, 80)])
+    result = shadow.compare(sheet, sheet.copy())
+    assert result["cell_diff_count"] == 0
+
+
+def test_cell_diff_detected_on_common_row():
+    sheet = _frame([("A", "Star Rep", 1, 90), ("B", "Decline Rep", 2, 80)])
+    pg = sheet.copy()
+    pg.loc[pg["eval_id"] == "B", "overall_score"] = 81.0
+    result = shadow.compare(sheet, pg)
+    assert result["cell_diff_count"] == 1
+    assert result["cell_diff_sample"][0]["col"] == "overall_score"
+
+
+def test_accent_folded_key_aligns_then_surfaces_name_drift():
+    """The key folds accents so a roster-spelling drift still ALIGNS the
+    row (common, not an opaque sheet-only+db-only pair) — and then the
+    verbatim agent cell surfaces the drift as an informative diff. That
+    matters: compute_agent_roster groups on the raw agent string, so
+    differing spellings are a real analytics divergence, not cosmetic."""
+    sheet = _frame([("A", "José Peña", 1, 90)])
+    pg = _frame([("A", "Jose Pena", 1, 90)])
+    result = shadow.compare(sheet, pg)
+    assert result["membership"]["common"] == 1          # aligned, not split
+    assert result["membership"]["sheet_only"] == 0
+    assert result["cell_diff_count"] == 1               # drift surfaced
+    assert result["cell_diff_sample"][0]["col"] == "agent"
+
+
+def test_log_shadow_never_raises_on_empty():
+    # empty pg frame must not blow up the request path
+    shadow.log_shadow("sales", _frame([("A", "Star Rep", 1, 90)]), pd.DataFrame())
+
+
+# ---------------------------------------------------------------------------
+# Mode-aware /team frame helper
+# ---------------------------------------------------------------------------
+
+class _FakeSheetsProvider:
+    def __init__(self):
+        self._ws = self
+    def get_all_values(self):
+        return [["header"]]
+    def _get_mails_sheet(self):
+        return [["Agent Name"]]
+
+
+@pytest.fixture
+def _patch_team(monkeypatch):
+    import backend.routes.team as team
+
+    sheet_df = _frame([("S", "Star Rep", 1, 90)])
+    pg_df = _frame([("P", "Star Rep", 1, 90)])
+    calls = {"log_shadow": [], "fetch": 0, "get_provider": 0}
+
+    async def _fake_fetch(config):
+        calls["fetch"] += 1
+        return pg_df
+
+    async def _fake_get_provider(team_id):
+        calls["get_provider"] += 1
+        return _FakeSheetsProvider()
+
+    monkeypatch.setattr(team, "fetch_history_frame", _fake_fetch)
+    monkeypatch.setattr(team, "get_provider", _fake_get_provider)
+    monkeypatch.setattr(team, "load_and_clean", lambda *a, **k: sheet_df)
+    monkeypatch.setattr(team, "log_shadow",
+                        lambda tid, s, p: calls["log_shadow"].append((tid, len(s), len(p))))
+    monkeypatch.delenv("QA_READ_PATH", raising=False)
+    return team, sheet_df, pg_df, calls
+
+
+def test_helper_postgres_serves_rowsource(_patch_team, monkeypatch):
+    team, sheet_df, pg_df, calls = _patch_team
+    monkeypatch.setenv("QA_READ_PATH", "postgres")
+    df = asyncio.run(team._team_history_frame("sales", config=None))
+    assert df is pg_df
+    assert calls["fetch"] == 1
+    assert calls["get_provider"] == 0  # no _ws access on the postgres path
+    assert calls["log_shadow"] == []
+
+
+def test_helper_sheets_serves_sheet_no_shadow(_patch_team, monkeypatch):
+    team, sheet_df, pg_df, calls = _patch_team
+    monkeypatch.setenv("QA_READ_PATH", "sheets")
+    df = asyncio.run(team._team_history_frame("sales", config=None))
+    assert df is sheet_df
+    assert calls["fetch"] == 0
+    assert calls["log_shadow"] == []
+
+
+def test_helper_shadow_serves_sheet_and_logs(_patch_team, monkeypatch):
+    team, sheet_df, pg_df, calls = _patch_team
+    monkeypatch.setenv("QA_READ_PATH", "shadow")
+    df = asyncio.run(team._team_history_frame("sales", config=None))
+    assert df is sheet_df           # sheet is still the served source of truth
+    assert calls["fetch"] == 1      # but the pg frame was computed
+    assert calls["log_shadow"] == [("sales", 1, 1)]  # and the delta logged
+
+
+def test_helper_shadow_survives_pg_failure(_patch_team, monkeypatch):
+    team, sheet_df, pg_df, calls = _patch_team
+
+    async def _boom(config):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(team, "fetch_history_frame", _boom)
+    monkeypatch.setenv("QA_READ_PATH", "shadow")
+    df = asyncio.run(team._team_history_frame("sales", config=None))
+    assert df is sheet_df           # request still served despite pg failure
+    assert calls["log_shadow"] == []

--- a/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
+++ b/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
@@ -97,6 +97,27 @@ def test_accent_folded_key_aligns_then_surfaces_name_drift():
     assert result["classified"]["other"] == 0
 
 
+def test_key_ordinal_robust_to_clock_jitter():
+    """A same-eval_id D2 pair must align by overall_score, not timestamp:
+    the two sources' clocks differ by ~a second (B2 repair), so a
+    timestamp-first ordinal would flip the pair's order and cross-pair
+    their rows — the observed MS 'swapped section scores' artifact."""
+    sheet = pd.DataFrame([
+        {"eval_id": "X", "agent": "A", "overall_score": 95.0,
+         "timestamp": datetime(2026, 1, 1, 0, 0, 0)},
+        {"eval_id": "X", "agent": "A", "overall_score": 80.0,
+         "timestamp": datetime(2026, 1, 1, 0, 0, 1)},
+    ])
+    pg = pd.DataFrame([   # same evals, clocks repaired in opposite directions
+        {"eval_id": "X", "agent": "A", "overall_score": 95.0,
+         "timestamp": datetime(2026, 1, 1, 0, 0, 2)},
+        {"eval_id": "X", "agent": "A", "overall_score": 80.0,
+         "timestamp": datetime(2026, 1, 1, 0, 0, 0)},
+    ])
+    # both 95-overall rows (row 0 in each) must land on the same key
+    assert shadow.key_series(sheet)[0] == shadow.key_series(pg)[0]
+
+
 def test_log_shadow_never_raises_on_empty():
     # empty pg frame must not blow up the request path
     shadow.log_shadow("sales", _frame([("A", "Star Rep", 1, 90)]), pd.DataFrame())

--- a/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
+++ b/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
@@ -118,6 +118,43 @@ def test_key_ordinal_robust_to_clock_jitter():
     assert shadow.key_series(sheet)[0] == shadow.key_series(pg)[0]
 
 
+def test_key_ordinal_pairs_by_content_when_fully_tied():
+    """The prod-observed case the overall_score tiebreak missed: a D2 pair
+    tied on eval_id AND overall_score AND second-truncated timestamp, with
+    section values in opposite row order across sources (sub-second clock
+    jitter decided the old ordinal). Content ordering must pair (5,5) with
+    (5,5) — zero diffs."""
+    def rows(order):
+        return pd.DataFrame([
+            {"eval_id": "X", "agent": "A", "overall_score": 90.0,
+             "timestamp": datetime(2026, 1, 16, 20, 49, 40, us),
+             "matching_the_moment": v}
+            for us, v in order
+        ])
+    sheet = rows([(0, 5.0), (500000, 4.0)])
+    pg = rows([(600000, 4.0), (100000, 5.0)])   # opposite order, jittered µs
+    result = shadow.compare(sheet, pg)
+    assert result["membership"]["common"] == 2
+    assert result["cell_diff_count"] == 0
+
+
+def test_key_content_pairing_cannot_mask_real_divergence():
+    """Content ordering must NOT hide a genuine value difference inside a
+    same-key pair: sheet (5, 4) vs pg (5, 3) still shows exactly one diff."""
+    def rows(vals):
+        return pd.DataFrame([
+            {"eval_id": "X", "agent": "A", "overall_score": 90.0,
+             "timestamp": datetime(2026, 1, 16, 20, 49, 40),
+             "matching_the_moment": v}
+            for v in vals
+        ])
+    result = shadow.compare(rows([5.0, 4.0]), rows([3.0, 5.0]))
+    assert result["cell_diff_count"] == 1
+    d = result["cell_diff_sample"][0]
+    assert d["col"] == "matching_the_moment"
+    assert (d["sheet"], d["pg"]) == (4.0, 3.0)   # 5s paired; 4 vs 3 surfaces
+
+
 def test_log_shadow_never_raises_on_empty():
     # empty pg frame must not blow up the request path
     shadow.log_shadow("sales", _frame([("A", "Star Rep", 1, 90)]), pd.DataFrame())

--- a/qa-automation/AI-Scoring/tests/test_team_source.py
+++ b/qa-automation/AI-Scoring/tests/test_team_source.py
@@ -1,0 +1,232 @@
+"""Unit tests for the W1 Postgres row-source (ReadPathFlip §3/§4).
+
+Covers the pure assembly functions — no live Postgres. The golden-parity
+harness (scripts/parity_readpath.py) proves byte-identical compute_*
+output against the real sheet; these tests pin the individual parity
+traps in isolation so a regression names itself:
+
+- eval_id parse + fallback chain (link text → superseded metadata link →
+  entry-point call id);
+- schema parity: frame_from_rows emits EXACTLY load_and_clean's columns;
+- departed-agent LEFT-JOIN degradation (inactive, blank supervisor,
+  raw name);
+- excluded_test_agents filter, pre-2020 / null-timestamp row drops;
+- numeric-NA → NaN, Y/N vocab, missing-section defaults;
+- positional section-alias resolution across archived rubrics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from datetime import datetime
+
+import pytest
+
+from backend.services.team_source import (
+    _eval_id_from_link,
+    _section_alias_map,
+    frame_from_rows,
+)
+from backend.services.team_stats import load_and_clean
+
+from tests.conftest import make_history_sheet, make_mails_sheet
+
+
+# ---------------------------------------------------------------------------
+# Synthetic DB-row builders (asyncpg Records are dict-indexable; dicts stand in)
+# ---------------------------------------------------------------------------
+
+def _eval_row(**over) -> dict:
+    row = {
+        "id": 1,
+        "agent_name_raw": "Star Rep",
+        "agent_display": "Star Rep",
+        "evaluator_email": "eval@landing.com",
+        "overall_score": 92.0,
+        "dialpad_link": "https://dialpad.com/callhistory/callreview/123456",
+        "dialpad_entry_point_call_id": "ep-123",
+        "dialpad_call_metadata": None,
+        "ts": datetime(2026, 4, 1, 9, 0, 0),
+        "approved_at": datetime(2026, 4, 1, 10, 0, 0),
+        "is_active": True,
+        "supervisor": "Sup A",
+    }
+    row.update(over)
+    return row
+
+
+def _sec_row(eval_id, section_id, *, numeric=None, binary=None) -> dict:
+    return {
+        "evaluation_id": eval_id,
+        "section_id": section_id,
+        "numeric_score": numeric,
+        "binary_value": binary,
+    }
+
+
+def _identity_alias(config) -> dict[str, str]:
+    """Current-config slice of _section_alias_map — every live section_id
+    and history_id resolves to its own history_id."""
+    alias: dict[str, str] = {}
+    for s in config.sections_by_number:
+        alias[s.history_id] = s.history_id
+        alias[s.id] = s.history_id
+    return alias
+
+
+# ---------------------------------------------------------------------------
+# eval_id parsing (parity trap §4.2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("link,expected", [
+    ("https://dialpad.com/callhistory/callreview/123456", "123456"),
+    ("https://dialpad.com/callhistory/callreview/123456?foo=bar", "123456"),
+    ("https://dialpad.com/callhistory/callreview/123456 [LONG CALL]", "123456"),
+    ("https://dialpad.com/callhistory/callreview/123456/", "123456"),
+    ("", ""),
+])
+def test_eval_id_from_link(link, expected):
+    assert _eval_id_from_link(link) == expected
+
+
+def test_eval_id_fallback_chain(sales):
+    """link text → superseded metadata link → entry-point call id."""
+    alias = _identity_alias(sales)
+    a = _eval_row(id=1, dialpad_link="https://x/callhistory/callreview/AAA")
+    b = _eval_row(
+        id=2, dialpad_link=None,
+        dialpad_call_metadata=json.dumps(
+            {"backfill": {"superseded_dialpad_link": "https://x/callhistory/callreview/BBB"}}
+        ),
+    )
+    c = _eval_row(id=3, dialpad_link=None, dialpad_call_metadata=None,
+                  dialpad_entry_point_call_id="CCC")
+    df = frame_from_rows(sales, [a, b, c], [], alias).set_index("eval_id")
+    assert set(df.index) == {"AAA", "BBB", "CCC"}
+
+
+# ---------------------------------------------------------------------------
+# Schema parity — the load-bearing invariant for the flip
+# ---------------------------------------------------------------------------
+
+def test_frame_schema_matches_load_and_clean(config):
+    """The nine compute_* functions run unchanged only if frame_from_rows
+    emits the SAME column set load_and_clean derives from the sheet."""
+    history = make_history_sheet(config)
+    mails = make_mails_sheet(
+        ["Star Rep", "Decline Rep", "Improve Rep", "Steady Rep", "Junior Rep"])
+    sheet_df = load_and_clean(history, mails, config)
+
+    num = config.numeric_history_ids
+    yn = config.yn_history_ids
+    secs = []
+    if num:
+        secs.append(_sec_row(1, num[0], numeric=3.0))
+    if yn:
+        secs.append(_sec_row(1, yn[0], binary="Y"))
+    pg_df = frame_from_rows(config, [_eval_row(id=1)], secs, _identity_alias(config))
+
+    assert not sheet_df.empty and not pg_df.empty
+    assert set(pg_df.columns) == set(sheet_df.columns)
+
+
+# ---------------------------------------------------------------------------
+# Departed agents + roster filters (parity traps §4.3 / §4.4)
+# ---------------------------------------------------------------------------
+
+def test_departed_agent_degrades(sales):
+    """agent_id NULL (LEFT JOIN miss) → inactive, blank supervisor, raw name."""
+    ev = _eval_row(agent_display=None, agent_name_raw="Departed Person",
+                   is_active=False, supervisor="")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales))
+    assert len(df) == 1
+    r = df.iloc[0]
+    assert r["agent"] == "Departed Person"
+    assert bool(r["is_active"]) is False
+    assert r["supervisor"] == ""
+
+
+def test_excluded_test_agent_dropped(sales):
+    """Real Sales config excludes 'Maximiliano Perez'."""
+    ev = _eval_row(agent_display="Maximiliano Perez", agent_name_raw="Maximiliano Perez")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales))
+    assert df.empty
+
+
+# ---------------------------------------------------------------------------
+# Row-drop rules (parity trap §4.6)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_ts", [None, datetime(2019, 12, 31, 23, 59)])
+def test_bad_timestamp_dropped(sales, bad_ts):
+    ev = _eval_row(ts=bad_ts)
+    assert frame_from_rows(sales, [ev], [], _identity_alias(sales)).empty
+
+
+# ---------------------------------------------------------------------------
+# Section values: numeric NA → NaN, Y/N vocab, missing-section defaults
+# ---------------------------------------------------------------------------
+
+def test_numeric_na_becomes_nan(sales):
+    num = sales.numeric_history_ids
+    df = frame_from_rows(
+        sales, [_eval_row(id=5)], [_sec_row(5, num[0], numeric=None)],
+        _identity_alias(sales))
+    assert math.isnan(df.iloc[0][num[0]])
+
+
+def test_missing_numeric_section_is_nan(sales):
+    num = sales.numeric_history_ids
+    df = frame_from_rows(sales, [_eval_row(id=6)], [], _identity_alias(sales))
+    assert math.isnan(df.iloc[0][num[0]])
+
+
+def test_yn_vocab_and_missing_default(sales):
+    yn = sales.yn_history_ids
+    if not yn:
+        pytest.skip("Sales config has no Y/N sections")
+    df = frame_from_rows(
+        sales, [_eval_row(id=7)], [_sec_row(7, yn[0], binary="N")],
+        _identity_alias(sales))
+    assert df.iloc[0][yn[0]] == "N"
+    df2 = frame_from_rows(sales, [_eval_row(id=8)], [], _identity_alias(sales))
+    assert df2.iloc[0][yn[0]] == ""
+
+
+# ---------------------------------------------------------------------------
+# Timestamps: naive, tz stripped (parity trap §4.1)
+# ---------------------------------------------------------------------------
+
+def test_timestamps_are_naive(sales):
+    df = frame_from_rows(sales, [_eval_row(id=9)], [], _identity_alias(sales))
+    assert df["timestamp"].dt.tz is None
+    assert df["eval_approved_at"].dt.tz is None
+
+
+# ---------------------------------------------------------------------------
+# Positional section aliasing across archived rubrics (team_source docstring)
+# ---------------------------------------------------------------------------
+
+def test_section_alias_positional(sales):
+    """A renamed slot in an archived rubric aliases to the CURRENT section
+    occupying the same section_number — historic scores stay in-column."""
+    target = sales.sections_by_number[0]
+    archived = {"sections": [{
+        "id": "legacy_slot_id",
+        "section_number": target.section_number,
+        "history_id": "legacy_hist",
+    }]}
+
+    class _FakeConn:
+        async def fetch(self, _query, *_args):
+            return [{"rubric_json": json.dumps(archived)}]
+
+    alias = asyncio.run(_section_alias_map(_FakeConn(), sales))
+    # archived id + its history_id both resolve to the current slot's history_id
+    assert alias["legacy_slot_id"] == target.history_id
+    assert alias["legacy_hist"] == target.history_id
+    # current ids resolve to themselves
+    assert alias[target.history_id] == target.history_id
+    assert alias[target.id] == target.history_id


### PR DESCRIPTION
## Summary

Implements ReadPathFlip slices **F2–F4 + F5/W6** (`references/ReadPathFlip.md`, follows F1 in #108): every read surface can now source from `qa.*` instead of the Analyst_History sheet, selected by a single env var. **No behavior change ships enabled** — `QA_READ_PATH` defaults to `sheets`; flip and rollback are single Railway env edits.

### Slices

- **F2 — Postgres row-source + golden parity** (`services/team_source.py`, `scripts/parity_readpath.py`): the `/team` trio's `load_and_clean`-shaped DataFrame built from `qa.evaluations ⋈ qa.agents` + `qa.evaluation_sections`, honoring every §4 parity trap (naive timestamps, eval_id fallback chain, departed-agent degradation, positional rubric aliasing, excluded-agent filters). The nine pandas `compute_*` functions run **unchanged**.
- **F3 — provider factory + pool lifecycle** (`services/data_provider.py`): `get_provider()` selects by `QA_READ_PATH`; `postgres` hands out a `connect()`-ed `PostgresProvider`; providers rebuilt (old pool closed) on a runtime flag change; teardown in the app lifespan.
- **F4 — `/team` trio flag-aware + live shadow** (`routes/team.py`, `services/read_path_shadow.py`): the flag gained a third value `shadow` — serve the sheet, also build the Postgres frame, log the classified delta on live traffic. One shared key/comparator for the offline harness and the live shadow, so "green offline" and "green in shadow" mean the same thing. A pg failure in shadow never breaks the response.
- **F5/W6 — indexed datapoint lookup** (`db_provider.get_by_eval_id`, migration 014): replaces the 365-day load + linear scan on `/datapoints/{call_id}` with an indexed row hit; verifies the link-derived eval_id so it can never return a different record than the scan (falls back on miss/junk-link).
- Plus: pinned the date-sensitive monthly-bucket test (was red since July).

### Parity evidence (prod data, 2026-07-14)

| team | rows (sheet/pg/common) | unexplained | compute_* | endpoint combos |
|---|---|---|---|---|
| member_support | 1796 / 1780 / 1780 | **0** | exact | **104/104** |
| sales | 4 / 335 / 4 | **0** | exact | **40/40** |

All 102 MS cell deltas classify as known source-of-truth differences (clock=38 — B2 repaired DB clocks from Dialpad; name_accent=6; roster=58) and reconcile to exact compute/endpoint parity. Sales `db_only=331` is the designed gain: the backfilled pre-flip archive the sheet never had. Full unit suite: **583 passed, 0 failed**.

### Out of scope (deliberately)

- The F5 terminal cleanup (delete the trio's `_ws` sheet-read, drop gspread, W2/W3 SQL views) — would break the shadow window and env-flip rollback; deferred post-cutover per §6 sheet retention.
- Any write-path change: FR-AI drafts, Analyst_History projection, Score_Audit, GAS email flow all untouched.

### Cutover checklist (after merge)

1. Apply migration 014 (`idx_eval_entry_point_call_id`).
2. `import_agents.py --team member_support` — 8 stale roster rows (Alexis López, Fernanda Acosta, Fernanda Santillán, Ivan García, Jorge Barrón, Oswaldo Bautista, Rubio Rivera, Scarlet Muñoz) must refresh before serving `is_active`/`supervisor` from `qa.agents`.
3. Railway `QA_READ_PATH=shadow` → watch the shadow logs on live traffic (WARNs only on unexplained diffs).
4. Zero unexplained over the window → `QA_READ_PATH=postgres`. Rollback at any step = set the flag back.

Note: this PR touches nothing under `qa-automation/AI-Scoring/`'s Railway Watch Paths exclusions — the service deploy picks it up normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)