### PR TITLE
fix(qa-automation): re-score returns the row to a clean draft (human_review_pair_check)

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -269,10 +269,36 @@ async def record_draft_evaluation(
         return None
 
 
+# Stage-1 re-score over an existing row must return it to a CLEAN draft.
+# build_draft_row only carries the Stage-1 columns, so without this reset
+# the previous approve/finalize cycle's outputs survive the overwrite:
+#
+# - human_review_completed_at outlives the fresh required_at=NULL →
+#   evaluations_human_review_pair_check violation (observed 2026-07-14
+#   re-scoring a v4-flagged, review-resolved eval under the new formula);
+# - the finalize writer COALESCEs evaluator_email/approved_at, so stale
+#   values would pin the OLD evaluator and approval clock on the re-eval;
+# - overall_score/formula_version/rubric_version are re-stamped by
+#   finalize_evaluation_scoring from the versions active at re-approval.
+#
+# needs_coaching/action_plan are deliberately NOT reset: no writer exists
+# yet (VP-review UI pending) — that re-score semantic belongs to its design.
+_RESCORE_RESET: dict[str, Any] = {
+    "evaluator_email": None,
+    "approved_at": None,
+    "finalized_at": None,
+    "overall_score": None,
+    "formula_version": None,
+    "rubric_version": None,
+    "human_review_completed_at": None,
+}
+
+
 async def _upsert_draft(conn: Any, row: dict[str, Any], sections: list[EvaluationSection]) -> int:
     """INSERT the draft, or UPDATE the existing row matched by
-    (team_id, dialpad_link) — the Stage-1 re-score overwrite. Section rows
-    are replaced wholesale either way, in one transaction."""
+    (team_id, dialpad_link) — the Stage-1 re-score overwrite, which also
+    resets the previous cycle's lifecycle columns (_RESCORE_RESET). Section
+    rows are replaced wholesale either way, in one transaction."""
     async with conn.transaction():
         evaluation_id = None
         if row["dialpad_link"]:
@@ -281,9 +307,9 @@ async def _upsert_draft(conn: Any, row: dict[str, Any], sections: list[Evaluatio
                 row["team_id"], row["dialpad_link"],
             )
 
-        columns = list(row)
-        values = [row[c] for c in columns]
         if evaluation_id is None:
+            columns = list(row)
+            values = [row[c] for c in columns]
             placeholders = ", ".join(f"${i + 1}" for i in range(len(columns)))
             evaluation_id = await conn.fetchval(
                 f"INSERT INTO qa.evaluations ({', '.join(columns)}) "
@@ -291,6 +317,9 @@ async def _upsert_draft(conn: Any, row: dict[str, Any], sections: list[Evaluatio
                 *values,
             )
         else:
+            merged = {**row, **_RESCORE_RESET}
+            columns = list(merged)
+            values = [merged[c] for c in columns]
             assignments = ", ".join(f"{c} = ${i + 2}" for i, c in enumerate(columns))
             await conn.execute(
                 f"UPDATE qa.evaluations SET {assignments} WHERE id = $1",

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -206,6 +206,7 @@ class FakeConn:
         self.existing_id = existing_id
         self.inserts: list[tuple] = []
         self.updates: list[tuple] = []
+        self.update_queries: list[str] = []
         self.deletes: list[tuple] = []
 
     @asynccontextmanager
@@ -222,6 +223,7 @@ class FakeConn:
     async def execute(self, query, *args):
         if query.startswith("UPDATE"):
             self.updates.append(args)
+            self.update_queries.append(query)
         elif query.startswith("DELETE"):
             self.deletes.append(args)
         else:
@@ -265,6 +267,41 @@ class TestRecordDraftEvaluation:
         assert len(self.conn.updates) == 1
         assert self.conn.deletes == [(77,)]
         assert not [i for i in self.conn.inserts if i[0] == "evaluations"]
+
+    async def test_rescore_resets_previous_cycle_lifecycle_columns(self, ms_config):
+        """Re-scoring an already-approved/finalized eval must return the row
+        to a CLEAN draft. Regression for the 2026-07-14 prod failure: the
+        old cycle's human_review_completed_at survived the overwrite while
+        the fresh draft set required_at=NULL → evaluations_human_review_
+        pair_check violation. The stale evaluator_email/approved_at were
+        worse than cosmetic — the finalize writer COALESCEs them, so the
+        re-eval would have kept the OLD approval clock and evaluator."""
+        self.conn.existing_id = 77
+        await record_draft_evaluation(_scorecard(ms_config), ms_config)
+
+        (query,) = self.conn.update_queries
+        (args,) = self.conn.updates
+        # parse "col = $N" assignments back into a column -> value map
+        import re
+        col_by_pos = {int(m.group(2)): m.group(1)
+                      for m in re.finditer(r"(\w+) = \$(\d+)", query)}
+        # $1 is the WHERE id; assignment params start at $2 == args[1]
+        values = {col: args[pos - 1] for pos, col in col_by_pos.items()}
+
+        for col in eval_store._RESCORE_RESET:
+            assert col in values, f"UPDATE must reset {col}"
+            assert values[col] is None, f"{col} must reset to NULL, got {values[col]!r}"
+        # the fresh Stage-1 columns still land
+        assert values["state"] == "draft"
+
+    async def test_insert_does_not_carry_reset_columns(self, ms_config):
+        """The reset is an UPDATE-arm concern: a fresh INSERT's dict stays
+        exactly build_draft_row's shape (no explicit NULL lifecycle cols)."""
+        row = eval_store.build_draft_row(_scorecard(ms_config), ms_config)
+        assert not set(eval_store._RESCORE_RESET) & set(row), (
+            "build_draft_row grew a column that _RESCORE_RESET overrides — "
+            "decide the re-score precedence explicitly"
+        )
 
     async def test_db_failure_is_swallowed(self, ms_config, monkeypatch):
         async def exploding_pool():


### PR DESCRIPTION
## Summary

Re-running a call whose previous eval was **flagged for human review and resolved** failed at Stage 1 with:

```
new row for relation "evaluations" violates check constraint "evaluations_human_review_pair_check"
```

### Root cause

`_upsert_draft`'s UPDATE arm (the re-score overwrite matched by `team_id, dialpad_link`) only sets the columns `build_draft_row` produces. The old cycle's `human_review_completed_at` survived the overwrite while the fresh draft set `human_review_required_at = NULL` (new formula doesn't flag) — completed-without-required, exactly what the 009 CHECK forbids. Postgres reports the post-UPDATE tuple as "new row", hence the confusing message; the failing row's old timestamps (created 07-01, scored 07-06 under `member_support_v4`) confirm it was the update arm, not an insert.

### Why the fix is broader than one column

The stale columns were worse than the constraint. `finalize_evaluation_scoring` **COALESCEs** `evaluator_email` and `approved_at` — so a re-scored eval would have silently kept the **old evaluator and old approval clock** through re-finalize. `overall_score` / `formula_version` / `rubric_version` also masqueraded on a `'draft'` row.

`_RESCORE_RESET` nulls the seven previous-cycle outputs on the UPDATE arm only:
`evaluator_email, approved_at, finalized_at, overall_score, formula_version, rubric_version, human_review_completed_at` — each re-produced by the next approve/finalize from the versions active at re-approval. `needs_coaching`/`action_plan` deliberately excluded (no writer exists yet; that semantic belongs to the VP-review design).

### Notes

- `agent_stat_points` keeps the point from the first finalize (UNIQUE `evaluation_id`, idempotent by design). If stat-point accuracy after re-scores ever matters (CC sparklines), `scripts/backfill_stat_points.py` replay rebuilds the series deterministically.
- Tests: UPDATE-arm reset asserted column-by-column (SQL parsed back into a col→value map); a tripwire pins that `build_draft_row` never grows a column the reset would silently override. Full suite: **585 passed, 0 failed**.

### Verify after deploy

Re-run the same call from the scoring UI (the one that errored on eval 71): Stage 1 should complete, the scorecard loads, and after re-approval the row should show a fresh `approved_at`/`evaluator_email` and the new formula's version stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)