### PR TITLE
fix(qa-automation): dashboard undercount — read-time identity fallback for orphaned evals

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/team_source.py
+++ b/qa-automation/AI-Scoring/backend/services/team_source.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from backend.services.data_normalization import strip_accents
 from backend.services.eval_store import get_pool
 
 if TYPE_CHECKING:
@@ -73,12 +74,49 @@ async def _section_alias_map(conn, config: "TeamConfig") -> dict[str, str]:
     return alias
 
 
+def _roster_maps(agent_rows: list) -> tuple[dict, dict, set]:
+    """Read-time identity maps from ACTIVE qa.agents rows, mirroring
+    load_and_clean's Mails canonical_map exactly (ReadPathFlip §4.4):
+    raw-name (verbatim + accent-stripped, lowered) → canonical display;
+    supervisor and active membership keyed by canonical-lower. Inactive
+    qa.agents rows are excluded — the Mails tab only lists active agents,
+    so an inactive match degrades identically to no match."""
+    canonical_map: dict[str, str] = {}
+    supervisor_map: dict[str, str] = {}
+    active_set: set[str] = set()
+    for a in agent_rows:
+        if not a["active"]:
+            continue
+        name = (a["name"] or "").strip()
+        if not name:
+            continue
+        canonical = (a["canonical_name"] or "").strip() or name
+        canonical_map[name.lower()] = canonical
+        canonical_map[strip_accents(name).lower()] = canonical
+        canonical_map[canonical.lower()] = canonical
+        canonical_map[strip_accents(canonical).lower()] = canonical
+        supervisor_map[canonical.lower()] = a["supervisor_email"] or ""
+        active_set.add(canonical.lower())
+    return canonical_map, supervisor_map, active_set
+
+
 def frame_from_rows(config: "TeamConfig", eval_rows: list, section_rows: list,
-                    alias_map: dict[str, str]) -> pd.DataFrame:
-    """Pure assembly: DB rows → the load_and_clean schema."""
+                    alias_map: dict[str, str],
+                    agent_rows: list = ()) -> pd.DataFrame:
+    """Pure assembly: DB rows → the load_and_clean schema.
+
+    Identity is two-tier: rows carry the finalize-time ``agent_id`` join
+    (display/is_active/supervisor pre-resolved in SQL), and rows the stamp
+    missed (``agent_id`` NULL — e.g. finalized while the agent's qa.agents
+    row was stale; 26 such rows caused the 2026-07-15 roster undercount)
+    fall back to READ-time name matching against the CURRENT roster, the
+    way the sheet path always resolved against the live Mails tab. Rows
+    matching nothing degrade as before: inactive, blank supervisor, raw
+    name (true departed agents — §4.3)."""
     numeric_ids = set(config.numeric_history_ids)
     yn_ids = set(config.yn_history_ids)
     excluded = {a.strip().lower() for a in config.excluded_test_agents}
+    canonical_map, supervisor_map, active_set = _roster_maps(list(agent_rows))
 
     # section values per evaluation, keyed by resolved history_id
     by_eval: dict[int, dict[str, object]] = {}
@@ -95,6 +133,16 @@ def frame_from_rows(config: "TeamConfig", eval_rows: list, section_rows: list,
     records = []
     for ev in eval_rows:
         agent = (ev["agent_display"] or ev["agent_name_raw"] or "").strip()
+        is_active = bool(ev["is_active"])
+        supervisor = ev["supervisor"] or ""
+        if ev["agent_id"] is None and agent:
+            # read-time fallback for identity-orphaned rows
+            canonical = (canonical_map.get(agent.lower())
+                         or canonical_map.get(strip_accents(agent).lower()))
+            if canonical is not None:
+                agent = canonical
+                is_active = canonical.lower() in active_set
+                supervisor = supervisor_map.get(canonical.lower(), "")
         if not agent or agent.lower() in excluded:
             continue
         ts = ev["ts"]
@@ -113,8 +161,8 @@ def frame_from_rows(config: "TeamConfig", eval_rows: list, section_rows: list,
                                  if approved is not None else pd.NaT),
             "overall_score": float(ev["overall_score"]),
             "manager_email": (ev["evaluator_email"] or "").lower(),
-            "is_active": bool(ev["is_active"]),
-            "supervisor": ev["supervisor"] or "",
+            "is_active": is_active,
+            "supervisor": supervisor,
             "eval_id": eval_id,
         }
         sections = by_eval.get(ev["id"], {})
@@ -140,7 +188,8 @@ async def fetch_history_frame(config: "TeamConfig") -> pd.DataFrame:
     async with pool.acquire() as conn:
         alias_map = await _section_alias_map(conn, config)
         eval_rows = await conn.fetch(
-            "SELECT e.id, e.agent_name_raw, e.evaluator_email, e.overall_score, "
+            "SELECT e.id, e.agent_id, e.agent_name_raw, e.evaluator_email, "
+            "  e.overall_score, "
             "  e.dialpad_link, e.dialpad_entry_point_call_id, e.dialpad_call_metadata, "
             "  COALESCE(e.call_connected_at, e.approved_at) AS ts, e.approved_at, "
             "  COALESCE(a.canonical_name, a.name, e.agent_name_raw) AS agent_display, "
@@ -156,4 +205,8 @@ async def fetch_history_frame(config: "TeamConfig") -> pd.DataFrame:
             "JOIN qa.evaluations e ON e.id = es.evaluation_id "
             "WHERE e.team_id = $1 AND e.state = 'finalized'",
             config.team_id)
-    return frame_from_rows(config, eval_rows, section_rows, alias_map)
+        agent_rows = await conn.fetch(
+            "SELECT name, canonical_name, active, supervisor_email "
+            "FROM qa.agents WHERE team_id = $1",
+            config.team_id)
+    return frame_from_rows(config, eval_rows, section_rows, alias_map, agent_rows)

--- a/qa-automation/AI-Scoring/tests/test_team_source.py
+++ b/qa-automation/AI-Scoring/tests/test_team_source.py
@@ -41,6 +41,7 @@ from tests.conftest import make_history_sheet, make_mails_sheet
 def _eval_row(**over) -> dict:
     row = {
         "id": 1,
+        "agent_id": 1,
         "agent_name_raw": "Star Rep",
         "agent_display": "Star Rep",
         "evaluator_email": "eval@landing.com",
@@ -138,7 +139,8 @@ def test_frame_schema_matches_load_and_clean(config):
 
 def test_departed_agent_degrades(sales):
     """agent_id NULL (LEFT JOIN miss) → inactive, blank supervisor, raw name."""
-    ev = _eval_row(agent_display=None, agent_name_raw="Departed Person",
+    ev = _eval_row(agent_id=None, agent_display=None,
+                   agent_name_raw="Departed Person",
                    is_active=False, supervisor="")
     df = frame_from_rows(sales, [ev], [], _identity_alias(sales))
     assert len(df) == 1
@@ -146,6 +148,64 @@ def test_departed_agent_degrades(sales):
     assert r["agent"] == "Departed Person"
     assert bool(r["is_active"]) is False
     assert r["supervisor"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Read-time identity fallback (ReadPathFlip §4.4 — the 2026-07-15 roster
+# undercount: rows finalized while qa.agents was stale carry agent_id NULL
+# forever; the CURRENT roster must resolve them at read time, like the
+# sheet path always did against the live Mails tab)
+# ---------------------------------------------------------------------------
+
+def _roster_row(name="Alexis López", canonical="", active=True, sup="max@x.com"):
+    return {"name": name, "canonical_name": canonical,
+            "active": active, "supervisor_email": sup}
+
+
+def test_orphaned_row_resolves_via_current_roster(sales):
+    ev = _eval_row(agent_id=None, agent_display=None,
+                   agent_name_raw="Alexis López", is_active=False, supervisor="")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales),
+                         agent_rows=[_roster_row()])
+    r = df.iloc[0]
+    assert r["agent"] == "Alexis López"
+    assert bool(r["is_active"]) is True          # active at READ time
+    assert r["supervisor"] == "max@x.com"
+
+
+def test_orphaned_row_matches_accent_stripped(sales):
+    """Dialpad drift: raw name lost the accents; the roster still claims it."""
+    ev = _eval_row(agent_id=None, agent_display=None,
+                   agent_name_raw="Alexis Lopez", is_active=False, supervisor="")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales),
+                         agent_rows=[_roster_row(name="Alexis López")])
+    r = df.iloc[0]
+    assert r["agent"] == "Alexis López"          # canonical spelling wins
+    assert bool(r["is_active"]) is True
+
+
+def test_orphaned_row_ignores_inactive_roster_entry(sales):
+    """An INACTIVE qa.agents row is not in the Mails tab — the fallback must
+    degrade exactly like no match (raw name, inactive), not resurrect them."""
+    ev = _eval_row(agent_id=None, agent_display=None,
+                   agent_name_raw="Gone Person", is_active=False, supervisor="")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales),
+                         agent_rows=[_roster_row(name="Gone Person", active=False)])
+    r = df.iloc[0]
+    assert r["agent"] == "Gone Person"
+    assert bool(r["is_active"]) is False
+    assert r["supervisor"] == ""
+
+
+def test_joined_rows_ignore_roster_fallback(sales):
+    """Rows with agent_id keep their SQL-joined identity — the fallback is
+    only for orphans (a conflicting roster row must not override the join)."""
+    ev = _eval_row(agent_id=7, agent_display="Star Rep",
+                   is_active=True, supervisor="joined@x.com")
+    df = frame_from_rows(sales, [ev], [], _identity_alias(sales),
+                         agent_rows=[_roster_row(name="Star Rep", sup="other@x.com")])
+    r = df.iloc[0]
+    assert r["supervisor"] == "joined@x.com"
 
 
 def test_excluded_test_agent_dropped(sales):


### PR DESCRIPTION
## Summary

Post-flip bug: the dashboard Agent Roster undercounted evaluations vs the agent page (Alexis López: **9 vs 13**, same `days=30` window).

### Root cause

26 in-window rows carry `agent_id IS NULL` — they were finalized while the agent's `qa.agents` row was stale/missing (cutover week), and the finalize-time identity stamp is never revisited. Re-importing the roster fixes `qa.agents` but cannot retro-stamp evals. W1's LEFT JOIN rendered those rows `is_active=FALSE`, so every `/team` surface with `active_only=true` silently dropped them; the agent page matches by raw name with no active filter, so it showed all 13.

This was specced and missed: **ReadPathFlip §4.4** requires read-time canonicalization against the current roster in pandas — exactly how `load_and_clean` resolved raw names against the live Mails tab on every request. W1 shipped with the write-time join only.

### Fix

`frame_from_rows` now receives the current `qa.agents` rows and, **for orphaned rows only**, resolves raw name → canonical/active/supervisor via accent-stripped maps mirroring the sheet's `canonical_map`. Inactive roster entries are excluded from the maps (the Mails tab only lists active agents), so no-match and inactive-match both degrade exactly as before: raw name, inactive — true departed agents (§4.3) are not resurrected. Joined rows are untouched.

### Verification

- Prod (read-only): Alexis **13/13 active** in-window; team-wide window rows 187 → **208** active (21/26 orphans resolve; 5 truly departed).
- Golden parity sweep: **both teams GREEN**, `name_accent` diffs eliminated (6→0), stale-agent action list 8→1 (`Cassandra Cervantes` — run `import_agents.py --team member_support` again to mark her departed/current).
- Unit suite: **589 passed, 0 failed** (4 new fallback tests incl. inactive-entry degrade + joined-row precedence).

### After merge

1. Deploy picks it up via Watch Paths; dashboard roster counts should match agent pages immediately.
2. Re-run `import_agents.py --team member_support` for the Cassandra Cervantes staleness the sweep flagged.
3. Optional follow-up (not in this PR): a one-time repair script to stamp `agent_id` on the orphaned rows — read paths no longer need it, but write-side consumers (assessments FK, stat points) benefit. Can add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)