### PR TITLE
fix(qa-automation): importer departure sync + agent_id identity repair script

### DIFF
--- a/qa-automation/AI-Scoring/scripts/import_agents.py
+++ b/qa-automation/AI-Scoring/scripts/import_agents.py
@@ -15,6 +15,14 @@ Usage:
 Upserts on the uq_agents_team_lower_name index — re-running refreshes
 emails/supervisors without duplicating rows. Rows without an email are
 skipped (qa.agents.email is NOT NULL).
+
+Departures: an agent absent from the Mails tab is marked ``active=FALSE``
+— never deleted; their evals keep the identity link and the dashboards
+degrade them to the departed treatment. (Temporary flow: qa.agents CRUD
+moves to the dashboard frontend later; until then the Mails tab remains
+the roster source and this script is the sync.) As a safety rail, a
+non-dry run REFUSES to proceed when the Mails read comes back empty —
+an empty read would otherwise deactivate the whole team.
 """
 
 from __future__ import annotations
@@ -45,6 +53,20 @@ ON CONFLICT (team_id, LOWER(name)) DO UPDATE SET
     updated_at       = NOW()
 """
 
+# Departure sync: active rows whose name no longer appears in the Mails tab.
+# Soft-deactivate only — deleting would orphan evals' agent_id links.
+_SELECT_DEPARTED = """
+SELECT name FROM qa.agents
+WHERE team_id = $1 AND active AND LOWER(name) != ALL($2::text[])
+ORDER BY name
+"""
+
+_DEACTIVATE = """
+UPDATE qa.agents SET active = FALSE, updated_at = NOW()
+WHERE team_id = $1 AND active AND LOWER(name) != ALL($2::text[])
+RETURNING name
+"""
+
 
 def _read_mails_rows(team_id: str) -> list[tuple[str, str | None, str, str | None]]:
     config = get_team_config(team_id)
@@ -68,15 +90,35 @@ def _read_mails_rows(team_id: str) -> list[tuple[str, str | None, str, str | Non
 async def _run(team_id: str, dry_run: bool) -> int:
     agents = _read_mails_rows(team_id)
     print(f"team={team_id}: {len(agents)} agent row(s) from the Mails tab")
+    lower_names = [name.lower() for name, _, _, _ in agents]
+
+    dsn = os.environ.get("DATABASE_URL", "")
+
     if dry_run:
         for name, canonical, email, supervisor in agents[:10]:
             print(f"  {name} <{email}>" + (f" (canonical: {canonical})" if canonical else ""))
+        if dsn and agents:
+            import asyncpg
+            conn = await asyncpg.connect(dsn, timeout=10)
+            try:
+                departed = await conn.fetch(_SELECT_DEPARTED, team_id, lower_names)
+            finally:
+                await conn.close()
+            if departed:
+                print(f"would deactivate {len(departed)} departed agent(s): "
+                      f"{[r['name'] for r in departed]}")
         print("dry-run: nothing written")
         return 0
 
-    dsn = os.environ.get("DATABASE_URL", "")
     if not dsn:
         print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+    if not agents:
+        # An empty Mails read + the departure sync below would deactivate
+        # the entire team. Whatever caused it (wrong tab, API hiccup),
+        # nothing good comes from proceeding.
+        print("Mails tab read came back EMPTY — refusing to sync "
+              "(would deactivate every agent)", file=sys.stderr)
         return 2
 
     import asyncpg
@@ -86,11 +128,15 @@ async def _run(team_id: str, dry_run: bool) -> int:
         async with conn.transaction():
             for name, canonical, email, supervisor in agents:
                 await conn.execute(_UPSERT, team_id, name, canonical, email, supervisor)
+            departed = await conn.fetch(_DEACTIVATE, team_id, lower_names)
         total = await conn.fetchval(
             "SELECT COUNT(*) FROM qa.agents WHERE team_id = $1 AND active", team_id
         )
     finally:
         await conn.close()
+    if departed:
+        print(f"deactivated {len(departed)} departed agent(s): "
+              f"{[r['name'] for r in departed]}")
     print(f"qa.agents upserted; {total} active agent(s) for {team_id}")
     return 0
 

--- a/qa-automation/AI-Scoring/scripts/repair_agent_identity.py
+++ b/qa-automation/AI-Scoring/scripts/repair_agent_identity.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Repair agent_id on identity-orphaned evaluations (any origin).
+
+Evals finalized while the agent's qa.agents row was stale/missing carry
+``agent_id IS NULL`` forever — the finalize-time identity stamp is never
+revisited, and a roster re-import can't retro-stamp (observed 2026-07-15:
+26 orphaned member_support rows undercounting the dashboard roster,
+PR #113). The READ paths self-heal via the read-time roster fallback;
+this script repairs the column itself for the write-side consumers
+(qa.assessments FK, stat points, future CC joins).
+
+Same Stage-4 matching semantics as the finalize stamp and B3
+(backfill_seed_b3.py): ACTIVE roster rows, case-insensitive on name OR
+canonical_name. Names the active roster doesn't know stay NULL —
+departed agents keep the §7 treatment; run import_agents.py first so the
+roster is current.
+
+Unlike B3 this covers ALL rows (not just backfilled ones) and any state —
+a draft stamped early is simply ahead of its finalize. Idempotent: only
+touches rows where agent_id IS NULL.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/repair_agent_identity.py --team-id member_support --dry-run
+    python3 scripts/repair_agent_identity.py --team-id member_support
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_STAGING_DIR = _AI_SCORING.parent.parent / "database" / "backfill_staging"
+load_dotenv(_AI_SCORING / ".env")
+
+# Stage-4 / B3 matching semantics — keep in lockstep with
+# eval_store.finalize_evaluation_scoring's identity UPDATE.
+_MATCH = ("a.team_id = e.team_id AND a.active "
+          "AND (LOWER(a.name) = LOWER(e.agent_name_raw) "
+          "     OR LOWER(a.canonical_name) = LOWER(e.agent_name_raw))")
+
+
+async def run(args) -> int:
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        before = await conn.fetchrow(
+            "SELECT COUNT(*) AS total, "
+            "COUNT(*) FILTER (WHERE agent_id IS NULL) AS unresolved, "
+            "COUNT(*) FILTER (WHERE agent_email IS NULL) AS no_email "
+            "FROM qa.evaluations e WHERE team_id = $1", args.team_id)
+
+        resolvable = await conn.fetchval(
+            f"SELECT COUNT(*) FROM qa.evaluations e "
+            f"WHERE e.team_id = $1 AND e.agent_id IS NULL "
+            f"AND EXISTS (SELECT 1 FROM qa.agents a WHERE {_MATCH})",
+            args.team_id)
+
+        if not args.dry_run and resolvable:
+            await conn.execute(
+                f"UPDATE qa.evaluations e SET "
+                f"agent_id = a.id, "
+                f"agent_email = COALESCE(e.agent_email, a.email) "
+                f"FROM qa.agents a "
+                f"WHERE e.team_id = $1 AND e.agent_id IS NULL AND {_MATCH}",
+                args.team_id)
+
+        after = await conn.fetchrow(
+            "SELECT COUNT(*) FILTER (WHERE agent_id IS NULL) AS unresolved, "
+            "COUNT(*) FILTER (WHERE agent_email IS NULL) AS no_email "
+            "FROM qa.evaluations e WHERE team_id = $1", args.team_id)
+
+        # The stays-NULL list, explicit (departed agents — B3 §7 treatment).
+        unresolved_names = await conn.fetch(
+            "SELECT agent_name_raw, COUNT(*) AS n FROM qa.evaluations e "
+            "WHERE team_id = $1 AND agent_id IS NULL "
+            "GROUP BY 1 ORDER BY n DESC", args.team_id)
+    finally:
+        await conn.close()
+
+    report = {
+        "stage": "identity_repair", "team_id": args.team_id,
+        "dry_run": args.dry_run,
+        "counts": {
+            "rows": before["total"],
+            "unresolved_before": before["unresolved"],
+            "resolvable": resolvable,
+            "unresolved_after": after["unresolved"],
+            "resolved_this_run": before["unresolved"] - after["unresolved"],
+            "email_missing_before": before["no_email"],
+            "email_missing_after": after["no_email"],
+        },
+        "unresolved_names": [{"name": r["agent_name_raw"], "rows": r["n"]}
+                             for r in unresolved_names],
+    }
+    report_path = _STAGING_DIR / f"report_{args.team_id}_identity_repair.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    c = report["counts"]
+    tag = " [DRY RUN]" if args.dry_run else ""
+    print(f"[identity-repair:{args.team_id}]{tag} rows={c['rows']} "
+          f"unresolved={c['unresolved_before']} resolvable={resolvable} "
+          f"resolved={c['resolved_this_run']}")
+    print(f"  remaining NULL: {c['unresolved_after']} rows across "
+          f"{len(report['unresolved_names'])} names (departed — stay NULL)")
+    for r in report["unresolved_names"][:10]:
+        print(f"    {r['rows']:4d}  {r['name']}")
+    if len(report["unresolved_names"]) > 10:
+        print(f"    ... +{len(report['unresolved_names']) - 10} more (see report)")
+    print(f"  report: {report_path}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team-id", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two follow-ups from the PR #113 roster-undercount investigation.

### 1. `import_agents.py` — departure sync

An agent absent from the Mails tab is now marked **`active=FALSE`** on import — never deleted; their evals keep the `agent_id` identity link and dashboards degrade them to the departed treatment. Previously the importer only upserted what was present, so departed agents stayed `active=TRUE` forever (observed: Cassandra Cervantes).

Safety rails:
- **Dry-run previews deactivations**: `would deactivate 1 departed agent(s): ['Cassandra Cervantes']` (verified against prod).
- A non-dry run **refuses on an empty Mails read** — an empty read would otherwise deactivate the entire team.

Per owner direction this is the temporary flow: qa.agents CRUD moves to the dashboard frontend later; until then the Mails tab remains the roster source and this script is the sync.

### 2. `scripts/repair_agent_identity.py` — stamp orphaned `agent_id`

Evals finalized while the agent's qa.agents row was stale carry `agent_id IS NULL` forever (the finalize stamp is never revisited). Read paths self-heal since #113; this repairs the column itself for **write-side consumers** (qa.assessments FK, stat points, future CC joins).

- Same Stage-4 matching semantics as the finalize stamp and B3 (active roster, case-insensitive name OR canonical_name) — kept in lockstep, minus B3's backfill-rows scope.
- Names the active roster doesn't know **stay NULL** (departed agents — the B3 §7 treatment).
- Idempotent, `--dry-run` flag, B-series run-report to `database/backfill_staging/`.

Prod dry-run: 1,844 MS rows · 1,014 NULL (B3-departed by design) · **27 resolvable**.

## Operator steps after merge

```bash
cd qa-automation/AI-Scoring
python3 scripts/import_agents.py --team member_support          # deactivates Cassandra
python3 scripts/repair_agent_identity.py --team-id member_support --dry-run
python3 scripts/repair_agent_identity.py --team-id member_support
python3 scripts/repair_agent_identity.py --team-id sales --dry-run   # then apply if clean
```

(Order doesn't matter for correctness — identity ≠ active status — but importer-first keeps the reports tidy.)

Suite: **589 passed, 0 failed** (scripts verified via read-only prod dry-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)