### PR TITLE
fix(qa-automation): roster-script ergonomics — flag aliases, timeout, honest stays-NULL list

### DIFF
--- a/qa-automation/AI-Scoring/scripts/import_agents.py
+++ b/qa-automation/AI-Scoring/scripts/import_agents.py
@@ -99,7 +99,7 @@ async def _run(team_id: str, dry_run: bool) -> int:
             print(f"  {name} <{email}>" + (f" (canonical: {canonical})" if canonical else ""))
         if dsn and agents:
             import asyncpg
-            conn = await asyncpg.connect(dsn, timeout=10)
+            conn = await asyncpg.connect(dsn, timeout=30)
             try:
                 departed = await conn.fetch(_SELECT_DEPARTED, team_id, lower_names)
             finally:
@@ -123,7 +123,7 @@ async def _run(team_id: str, dry_run: bool) -> int:
 
     import asyncpg
 
-    conn = await asyncpg.connect(dsn, timeout=10)
+    conn = await asyncpg.connect(dsn, timeout=30)
     try:
         async with conn.transaction():
             for name, canonical, email, supervisor in agents:
@@ -143,7 +143,9 @@ async def _run(team_id: str, dry_run: bool) -> int:
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--team", required=True)
+    # --team-id accepted as an alias: the B-series / repair scripts use it,
+    # and the mismatch has already eaten one operator run.
+    ap.add_argument("--team", "--team-id", dest="team", required=True)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
     raise SystemExit(asyncio.run(_run(args.team, args.dry_run)))

--- a/qa-automation/AI-Scoring/scripts/repair_agent_identity.py
+++ b/qa-automation/AI-Scoring/scripts/repair_agent_identity.py
@@ -55,7 +55,7 @@ async def run(args) -> int:
 
     import asyncpg
 
-    conn = await asyncpg.connect(dsn, timeout=10)
+    conn = await asyncpg.connect(dsn, timeout=30)
     try:
         before = await conn.fetchrow(
             "SELECT COUNT(*) AS total, "
@@ -84,10 +84,13 @@ async def run(args) -> int:
             "FROM qa.evaluations e WHERE team_id = $1", args.team_id)
 
         # The stays-NULL list, explicit (departed agents — B3 §7 treatment).
+        # Excludes rows an apply-run would resolve, so a --dry-run doesn't
+        # mislabel resolvable rows as departed.
         unresolved_names = await conn.fetch(
-            "SELECT agent_name_raw, COUNT(*) AS n FROM qa.evaluations e "
-            "WHERE team_id = $1 AND agent_id IS NULL "
-            "GROUP BY 1 ORDER BY n DESC", args.team_id)
+            f"SELECT agent_name_raw, COUNT(*) AS n FROM qa.evaluations e "
+            f"WHERE team_id = $1 AND agent_id IS NULL "
+            f"AND NOT EXISTS (SELECT 1 FROM qa.agents a WHERE {_MATCH}) "
+            f"GROUP BY 1 ORDER BY n DESC", args.team_id)
     finally:
         await conn.close()
 
@@ -103,30 +106,33 @@ async def run(args) -> int:
             "email_missing_before": before["no_email"],
             "email_missing_after": after["no_email"],
         },
-        "unresolved_names": [{"name": r["agent_name_raw"], "rows": r["n"]}
+        "stays_null_names": [{"name": r["agent_name_raw"], "rows": r["n"]}
                              for r in unresolved_names],
     }
     report_path = _STAGING_DIR / f"report_{args.team_id}_identity_repair.json"
     report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     c = report["counts"]
+    stays_null_rows = sum(r["n"] for r in unresolved_names)
     tag = " [DRY RUN]" if args.dry_run else ""
     print(f"[identity-repair:{args.team_id}]{tag} rows={c['rows']} "
           f"unresolved={c['unresolved_before']} resolvable={resolvable} "
           f"resolved={c['resolved_this_run']}")
-    print(f"  remaining NULL: {c['unresolved_after']} rows across "
-          f"{len(report['unresolved_names'])} names (departed — stay NULL)")
-    for r in report["unresolved_names"][:10]:
+    print(f"  stays NULL: {stays_null_rows} rows across "
+          f"{len(report['stays_null_names'])} names (departed — no active "
+          f"roster match)")
+    for r in report["stays_null_names"][:10]:
         print(f"    {r['rows']:4d}  {r['name']}")
-    if len(report["unresolved_names"]) > 10:
-        print(f"    ... +{len(report['unresolved_names']) - 10} more (see report)")
+    if len(report["stays_null_names"]) > 10:
+        print(f"    ... +{len(report['stays_null_names']) - 10} more (see report)")
     print(f"  report: {report_path}")
     return 0
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--team-id", required=True)
+    # --team accepted as an alias (import_agents.py uses it).
+    ap.add_argument("--team-id", "--team", dest="team_id", required=True)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
     return asyncio.run(run(args))


### PR DESCRIPTION
## Summary

Three paper cuts surfaced by the first real operator run of the PR #114 scripts:

1. **Flag mismatch ate a run.** `import_agents.py` took `--team` while `repair_agent_identity.py` (and the B-series) take `--team-id`; the MS importer invocation errored on the wrong flag and the departure sync never executed — **Cassandra Cervantes is still `active=TRUE`** (see operator step below). Both scripts now accept both spellings.
2. **Connect timeout 10s → 30s.** The first repair invocation hit a `TimeoutError` against the Railway proxy; the immediate retry worked. 10s is too tight for the proxy's cold path.
3. **Misleading dry-run report.** The stays-NULL list included rows an apply-run would resolve — the sales `--dry-run` printed all 7 resolvable rows under "departed — stay NULL". The list now excludes active-roster matches in both modes (report key: `stays_null_names`).

Verified read-only against prod: `repair --team member_support` → 987 stays-NULL across 40 names, resolvable=0 (yesterday's 27 already stamped); `import_agents --team-id member_support` previews exactly `['Cassandra Cervantes']`.

## Operator step after merge (the one that got lost)

```bash
cd qa-automation/AI-Scoring
python3 scripts/import_agents.py --team member_support   # deactivates Cassandra for real
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)