### PR TITLE
feat(qa-automation): F5 terminal cleanup — delete sheet-read path, ship W2/W3 views

### DIFF
--- a/database/migrations/015_read_views.sql
+++ b/database/migrations/015_read_views.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Migration 015: analytics read views (ReadPathFlip §3 W2/W3, slice F5)
+--
+-- ⚠ ORDERING: apply BEFORE deploying the F5 code — team_source's section
+-- query reads qa.v_history_long; deploying first 500s the /team trio.
+--
+-- W3 — qa.v_history_long: finalized evaluations × sections, the canonical
+-- long-form shape. team_source's per-section query is a parameterized
+-- slice of it; future feature stores / cohort analyses start here instead
+-- of re-deriving the join.
+--
+-- W2 — qa.v_monthly_scores: per-team calendar-month rollup of finalized
+-- overall scores, bucketed in the project TZ. NOTE: this is the
+-- UNFILTERED aggregate (no active_only / supervisor awareness — those are
+-- per-request dashboard filters that a team-level view cannot honor), so
+-- the dashboard chiclets deliberately do NOT read it; it exists for
+-- consumers that want team-wide months without a frame load: Command
+-- Center, ad-hoc SQL, exports. The 'America/Los_Angeles' literal mirrors
+-- team_stats.BUCKET_TZ_NAME's default; if LANDING_BUCKET_TZ ever changes,
+-- ship a follow-up migration.
+-- ============================================================================
+
+CREATE VIEW qa.v_history_long AS
+SELECT e.team_id,
+       e.id AS evaluation_id,
+       e.agent_id,
+       e.agent_name_raw,
+       COALESCE(e.call_connected_at, e.approved_at) AS ts,
+       e.approved_at,
+       e.overall_score,
+       e.evaluator_email,
+       es.section_id,
+       es.section_number,
+       es.score_type,
+       es.numeric_score,
+       es.binary_value
+FROM qa.evaluations e
+JOIN qa.evaluation_sections es ON es.evaluation_id = e.id
+WHERE e.state = 'finalized';
+
+CREATE VIEW qa.v_monthly_scores AS
+SELECT e.team_id,
+       to_char(COALESCE(e.call_connected_at, e.approved_at)
+               AT TIME ZONE 'America/Los_Angeles', 'YYYY-MM') AS year_month,
+       COUNT(*)                      AS n,
+       AVG(e.overall_score)          AS mean_score,
+       STDDEV_SAMP(e.overall_score)  AS std_score
+FROM qa.evaluations e
+WHERE e.state = 'finalized'
+GROUP BY 1, 2;

--- a/database/migrations/015_read_views_down.sql
+++ b/database/migrations/015_read_views_down.sql
@@ -1,0 +1,10 @@
+-- ============================================================================
+-- Migration 015 — DOWN
+--
+-- Drops both read views. ⚠ team_source.fetch_history_frame reads
+-- qa.v_history_long since F5 — only roll back together with (or after)
+-- reverting the F5 code, or the /team trio 500s.
+-- ============================================================================
+
+DROP VIEW IF EXISTS qa.v_monthly_scores;
+DROP VIEW IF EXISTS qa.v_history_long;

--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -47,9 +47,7 @@ async def _lifespan(app: FastAPI):
         strict=os.environ.get("QA_VERSION_SHIP_STRICT", "") == "1",
     )
     yield
-    # Read-path flip (F3): close any connected PostgresProvider pools built
-    # by the get_provider factory under QA_READ_PATH=postgres. No-op for the
-    # default sheets path (SheetsProviders have no pool to close).
+    # Close the PostgresProvider pools built by the get_provider factory.
     from backend.services.data_provider import close_all_providers
     await close_all_providers()
     # Wave 2 Phase 4a: dual-write pool (lazy-created on first Stage 1 write).

--- a/qa-automation/AI-Scoring/backend/routes/team.py
+++ b/qa-automation/AI-Scoring/backend/routes/team.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import date, datetime, time, timedelta, timezone
 
 import pandas as pd
@@ -10,8 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
-from backend.services.data_provider import _read_path_mode, get_provider
-from backend.services.read_path_shadow import log_shadow
+from backend.services.data_provider import get_provider
 from backend.services.team_source import fetch_history_frame
 from backend.models.team_stats import (
     LongFormResponse,
@@ -35,41 +33,20 @@ from backend.services.team_stats import (
     compute_outliers,
     compute_section_analysis,
     compute_supervisor_stats,
-    load_and_clean,
 )
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/team", tags=["team"])
 
 
 async def _team_history_frame(team_id: str, config) -> pd.DataFrame:
     """The load_and_clean-shaped analytics frame for the /team trio,
-    sourced per QA_READ_PATH (ReadPathFlip §5 F4):
-
-    - ``sheets``   → read Analyst_History via the SheetsProvider (today).
-    - ``shadow``   → serve the SHEET frame but also build the Postgres
-      frame and log the delta on live traffic (validation window).
-    - ``postgres`` → serve the Postgres row-source (team_source), which
-      already joins qa.agents for is_active/supervisor — no _ws access,
-      so it works when get_provider hands back a PostgresProvider.
-    """
-    mode = _read_path_mode()
-    if mode == "postgres":
-        return await fetch_history_frame(config)
-
-    provider = await get_provider(team_id)
-    sheet_df = load_and_clean(
-        provider._ws.get_all_values(), provider._get_mails_sheet(), config)
-    if mode == "shadow":
-        try:
-            pg_df = await fetch_history_frame(config)
-        except Exception:  # noqa: BLE001 — shadow must not break the response
-            logger.warning("read-path shadow[%s]: pg fetch failed",
-                           team_id, exc_info=True)
-        else:
-            log_shadow(team_id, sheet_df, pg_df)
-    return sheet_df
+    from the Postgres row-source (ReadPathFlip §5, flipped 2026-07-15).
+    The sheet-read path and its QA_READ_PATH/shadow machinery were
+    deleted in F5 — rollback is git revert, not an env flip. The
+    Analyst_History sheet remains a write-side projection until its
+    retirement window closes; scripts/parity_readpath.py can still
+    compare the two sources on demand."""
+    return await fetch_history_frame(config)
 
 
 # Coverage regime is hardcoded until Local AI scores 100% of calls

--- a/qa-automation/AI-Scoring/backend/services/data_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/data_provider.py
@@ -1,30 +1,18 @@
-"""Abstract data provider with the Sheets↔Postgres read-path factory.
+"""Abstract data provider + the Postgres provider factory.
 
-The read path is selected by the ``QA_READ_PATH`` env var (ReadPathFlip
-§5), default ``sheets``:
-
-- ``sheets``   → ``SheetsProvider`` (today's path; reads Analyst_History).
-- ``postgres`` → ``PostgresProvider``, ``connect()``-ed before it is
-  handed out so its pool + roster snapshot are live.
-
-Flip and rollback are a single env change + redeploy — reads are
-stateless, so no per-team column is warranted. The factory re-checks the
-env on every call and rebuilds a team's provider if the mode changed, so
-the flag is honored without a process restart when Railway does an
-in-place env edit.
-
-NOTE (F3 scope): this flips **Path 1** (the provider-based endpoints —
-/agents, /datapoints, …). The /team analytics trio still reaches into
-``SheetsProvider._ws`` directly and is NOT yet safe under
-``QA_READ_PATH=postgres``; F4 makes that trio flag-aware via the Postgres
-row-source. Until F4 lands, keep the prod flag on ``sheets``.
+Every read serves from qa.* via a ``connect()``-ed ``PostgresProvider``
+(pool open, roster snapshot loaded). The flip completed 2026-07-15; the
+``QA_READ_PATH`` flag and its Sheets/shadow branches were deleted in F5
+(ReadPathFlip §5) — rollback is git revert + redeploy, and the
+Analyst_History sheet remains a write-side projection until retirement.
+``SheetsProvider`` survives in history_service for the parity harness,
+which instantiates it directly; the factory never returns it.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from abc import ABC, abstractmethod
 
 from backend.models.dashboard import EvaluationRecord
@@ -61,59 +49,31 @@ class DataProvider(ABC):
         return None
 
 
-# Per-team provider cache (keyed by team_id) + the read-path mode each
-# cached instance was built for, so a runtime flag flip rebuilds cleanly.
+# Per-team provider cache (keyed by team_id).
 _providers: dict[str, DataProvider] = {}
-_provider_modes: dict[str, str] = {}
 _build_lock = asyncio.Lock()
 
 
-def _read_path_mode() -> str:
-    """Current read-path selection — ``postgres`` or ``sheets`` (default)."""
-    return os.environ.get("QA_READ_PATH", "sheets").strip().lower()
-
-
 async def get_provider(team_id: str = "member_support") -> DataProvider:
-    """Return a cached, ready-to-use provider for *team_id*.
-
-    On the ``postgres`` path the returned instance is already
-    ``connect()``-ed (pool open, roster snapshot loaded). Reuses the same
-    instance across requests; rebuilds only when ``QA_READ_PATH`` changed
-    since the instance was cached.
-    """
-    mode = _read_path_mode()
+    """Return the cached, ``connect()``-ed PostgresProvider for *team_id*
+    (pool open, roster snapshot loaded), building it on first use."""
     cached = _providers.get(team_id)
-    if cached is not None and _provider_modes.get(team_id) == mode:
+    if cached is not None:
         return cached
 
     # Build under a lock so two concurrent first-hits don't each open a
     # Postgres pool. Re-check inside — another coroutine may have won.
     async with _build_lock:
         cached = _providers.get(team_id)
-        if cached is not None and _provider_modes.get(team_id) == mode:
+        if cached is not None:
             return cached
 
         from backend.config.team_config import get_team_config
-        config = get_team_config(team_id)
-
-        if mode == "postgres":
-            from backend.services.db_provider import PostgresProvider
-            provider: DataProvider = PostgresProvider(config=config)
-            await provider.connect()
-        else:
-            from backend.services.history_service import SheetsProvider
-            provider = SheetsProvider(config=config)
-
-        previous = _providers.get(team_id)
+        from backend.services.db_provider import PostgresProvider
+        provider = PostgresProvider(config=get_team_config(team_id))
+        await provider.connect()
         _providers[team_id] = provider
-        _provider_modes[team_id] = mode
-        logger.info("get_provider[%s] → %s (QA_READ_PATH=%s)",
-                    team_id, provider.name, mode)
-
-        # Best-effort close of a superseded provider (e.g. a Postgres pool
-        # left over from a mode flip) so we don't leak connections.
-        if previous is not None and previous is not provider:
-            await _close_provider(previous)
+        logger.info("get_provider[%s] → %s", team_id, provider.name)
         return provider
 
 
@@ -135,4 +95,3 @@ async def close_all_providers() -> None:
     for provider in list(_providers.values()):
         await _close_provider(provider)
     _providers.clear()
-    _provider_modes.clear()

--- a/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
+++ b/qa-automation/AI-Scoring/backend/services/read_path_shadow.py
@@ -1,19 +1,12 @@
-"""Shared sheet-vs-Postgres frame comparison (ReadPathFlip §5).
+"""Sheet-vs-Postgres frame comparison (ReadPathFlip §5).
 
-ONE key derivation and ONE comparator, imported by both:
-
-- the offline F2 golden-parity harness (scripts/parity_readpath.py), which
-  layers the nine compute_* functions + the endpoint permutation grid on
-  top; and
-- the F4 live shadow window, which — while QA_READ_PATH=shadow — computes
-  the Postgres frame alongside the served sheet frame on real traffic and
-  logs the membership + cell deltas.
-
-Keeping them on the same code means "green offline" and "green in shadow"
-mean the same thing. The live path stops at membership + common-row cell
-diffs (bounded work per request); if the common rows are cell-identical
-the nine compute_* outputs are identical too, which the offline harness
-proves exhaustively.
+Key derivation + comparator for the golden-parity harness
+(scripts/parity_readpath.py), which layers the nine compute_* functions
+and the endpoint permutation grid on top. During the F4 shadow window
+this module also drove the live per-request compare; the flip completed
+2026-07-15 and F5 deleted the shadow path, so the harness — still useful
+while the Analyst_History sheet is written as a projection — is the sole
+consumer.
 
 Membership deltas are EXPECTED and not failures: sheet-only rows (B0
 hard-zero exclusions) and db-only rows (backfilled history the sheet
@@ -22,13 +15,10 @@ dropped). Only cell diffs on the common set signal a real divergence.
 
 from __future__ import annotations
 
-import logging
 import math
 import unicodedata
 
 import pandas as pd
-
-logger = logging.getLogger(__name__)
 
 
 def strip_accents(s: str) -> str:
@@ -161,33 +151,3 @@ def compare(sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> dict:
             "classified": {k: len(v) for k, v in buckets.items()},
             "cell_diff_sample": diffs[:50]}
 
-
-def log_shadow(team_id: str, sheet_df: pd.DataFrame, pg_df: pd.DataFrame) -> None:
-    """F4 live shadow: log the sheet↔Postgres delta for one served request.
-
-    Never raises — a shadow-compare failure must not break the response
-    the sheet frame is about to serve.
-    """
-    try:
-        if sheet_df.empty or pg_df.empty:
-            logger.info("read-path shadow[%s]: skipped (sheet=%d pg=%d)",
-                        team_id, len(sheet_df), len(pg_df))
-            return
-        summary = compare(sheet_df, pg_df)
-        m = summary["membership"]
-        cls = summary["classified"]
-        # Only genuinely-unexplained ('other') diffs are an alarm; clock /
-        # name_accent / roster are known source-of-truth deltas.
-        others = [d for d in summary["cell_diff_sample"]
-                  if classify_cell_diff(d) == "other"]
-        level = logging.WARNING if cls["other"] else logging.INFO
-        logger.log(
-            level,
-            "read-path shadow[%s]: common=%d sheet_only=%d db_only=%d "
-            "cell_diffs=%d (other=%d clock=%d name_accent=%d roster=%d) %s",
-            team_id, m["common"], m["sheet_only"], m["db_only"],
-            summary["cell_diff_count"], cls["other"], cls["clock"],
-            cls["name_accent"], cls["roster"], others[:3] or "",
-        )
-    except Exception:  # noqa: BLE001 — shadow must never break the request
-        logger.warning("read-path shadow[%s] failed", team_id, exc_info=True)

--- a/qa-automation/AI-Scoring/backend/services/team_source.py
+++ b/qa-automation/AI-Scoring/backend/services/team_source.py
@@ -199,11 +199,11 @@ async def fetch_history_frame(config: "TeamConfig") -> pd.DataFrame:
             "LEFT JOIN qa.agents a ON a.id = e.agent_id "
             "WHERE e.team_id = $1 AND e.state = 'finalized'",
             config.team_id)
+        # W3: a parameterized slice of qa.v_history_long (migration 015) —
+        # the view owns the finalized-evals × sections join.
         section_rows = await conn.fetch(
-            "SELECT es.evaluation_id, es.section_id, es.numeric_score, es.binary_value "
-            "FROM qa.evaluation_sections es "
-            "JOIN qa.evaluations e ON e.id = es.evaluation_id "
-            "WHERE e.team_id = $1 AND e.state = 'finalized'",
+            "SELECT evaluation_id, section_id, numeric_score, binary_value "
+            "FROM qa.v_history_long WHERE team_id = $1",
             config.team_id)
         agent_rows = await conn.fetch(
             "SELECT name, canonical_name, active, supervisor_email "

--- a/qa-automation/AI-Scoring/references/ReadPathFlip.md
+++ b/qa-automation/AI-Scoring/references/ReadPathFlip.md
@@ -154,15 +154,23 @@ treats `shadow` as `sheets` for Path-1 (the shadow window is a /team-trio
 concern); the promotion sequence is `sheets → shadow → postgres`, and
 rollback is any step leftward.
 
-**Implementation status (2026-07-14):** F2 ✅ (row-source + pytest +
-golden/endpoint parity harness), F3 ✅ (factory + lifecycle behind the
-flag), F4 ✅ (trio flag-aware + shadow, shared comparator in
-`services/read_path_shadow.py` used by both the harness and live shadow),
-F5 **partial** — W6 ✅ (indexed datapoint lookup, migration 014); the
-terminal cleanup (delete the trio's `_ws` sheet-read, drop gspread,
-W2/W3 as SQL views) is **deferred to post-cutover** — doing it now breaks
-the shadow window and the env-flip rollback (§6 sheet-retention). Prod
-flag stays `sheets` until the shadow window is validated on live traffic.
+**Implementation status (2026-07-16): ALL SLICES COMPLETE.** F2 ✅, F3 ✅,
+F4 ✅ (flipped to `postgres` in prod 2026-07-15 after a clean shadow
+window — silent cutover), F5 ✅: W6 (indexed datapoint lookup, migration
+014) + terminal cleanup — the trio's `_ws` sheet-read, the `QA_READ_PATH`
+flag, and the shadow machinery are DELETED (rollback = git revert +
+redeploy; reads produce no data), `get_provider` is Postgres-only, no
+gspread in the /team read path — + W2/W3 as real views (migration 015):
+`qa.v_history_long` backs team_source's section query; `qa.v_monthly_scores`
+is the UNFILTERED month rollup for CC/ad-hoc/export consumers — the
+dashboard chiclets deliberately keep the pandas path because they honor
+per-request active_only/supervisor filters, which a team-level view
+cannot. Post-flip fixes folded in: read-time identity fallback (§4.4,
+PR #113), importer departure sync + identity repair (PRs #114–115).
+`SheetsProvider` survives only for `scripts/parity_readpath.py`, which
+stays runnable while the sheet is written as a projection (§6). Remaining
+sheet retirement (stop the write-side projection) is out of scope here —
+CutoverDesign §7's retention rule, post one bonus cycle.
 
 ## 6. Explicitly out of scope
 

--- a/qa-automation/AI-Scoring/scripts/parity_readpath.py
+++ b/qa-automation/AI-Scoring/scripts/parity_readpath.py
@@ -305,8 +305,12 @@ def endpoint_parity(sub_sheet, sub_pg, config, now) -> dict:
 
 async def run_team(team_id: str) -> int:
     config = get_team_config(team_id)
-    from backend.services.data_provider import get_provider
-    provider = await get_provider(team_id)
+    # Direct SheetsProvider — the get_provider factory is Postgres-only
+    # since F5; the sheet side of this comparison is exactly the retired
+    # read path, kept alive here while the sheet is still written as a
+    # projection.
+    from backend.services.history_service import SheetsProvider
+    provider = SheetsProvider(config=config)
     sheet_df = ts.load_and_clean(
         provider._ws.get_all_values(), provider._get_mails_sheet(), config)
     pg_df = await fetch_history_frame(config)

--- a/qa-automation/AI-Scoring/tests/test_data_provider_factory.py
+++ b/qa-automation/AI-Scoring/tests/test_data_provider_factory.py
@@ -1,10 +1,9 @@
-"""F3 — Sheets↔Postgres read-path factory dispatch (ReadPathFlip §5).
+"""Provider factory — always-Postgres since F5 (ReadPathFlip §5).
 
-Verifies get_provider selects by QA_READ_PATH, connect()s the Postgres
-provider before handing it out, caches within a mode, rebuilds + closes
-the old instance on a flag flip, and that close_all_providers tears down
-pooled providers. Both providers are faked — no gspread creds, no live
-Postgres — so this pins the factory wiring in isolation.
+The QA_READ_PATH flag and Sheets/shadow branches were deleted after the
+2026-07-15 flip; get_provider builds one connect()-ed PostgresProvider per
+team, caches it, and close_all_providers tears the pools down at shutdown.
+PostgresProvider is faked — no live DB.
 """
 
 from __future__ import annotations
@@ -14,15 +13,6 @@ import asyncio
 import pytest
 
 import backend.services.data_provider as dp
-
-
-class _FakeSheets:
-    name = "Google Sheets"
-
-    def __init__(self, config=None):
-        self.config = config
-        self.closed = False
-    # no close() — SheetsProvider has none; factory must tolerate that.
 
 
 class _FakePg:
@@ -40,64 +30,45 @@ class _FakePg:
         self.closed = True
 
 
+class _CloselessProvider:
+    """A provider without close() — close_all must tolerate it."""
+    name = "closeless"
+
+
 @pytest.fixture(autouse=True)
 def _reset_and_fake(monkeypatch):
-    """Isolate each test: fresh caches, faked provider classes, no flag."""
     monkeypatch.setattr(dp, "_providers", {})
-    monkeypatch.setattr(dp, "_provider_modes", {})
-    monkeypatch.delenv("QA_READ_PATH", raising=False)
-    import backend.services.history_service as hs
     import backend.services.db_provider as db
-    monkeypatch.setattr(hs, "SheetsProvider", _FakeSheets)
     monkeypatch.setattr(db, "PostgresProvider", _FakePg)
 
 
-def test_default_mode_returns_sheets():
-    p = asyncio.run(dp.get_provider("sales"))
-    assert isinstance(p, _FakeSheets)
-    assert dp._provider_modes["sales"] == "sheets"
-
-
-def test_postgres_mode_connects_before_return(monkeypatch):
-    monkeypatch.setenv("QA_READ_PATH", "postgres")
+def test_returns_connected_postgres_provider():
     p = asyncio.run(dp.get_provider("sales"))
     assert isinstance(p, _FakePg)
     assert p.connected is True, "provider must be connect()-ed before hand-off"
 
 
-def test_caches_within_mode(monkeypatch):
-    monkeypatch.setenv("QA_READ_PATH", "postgres")
-
-    async def _twice():
+def test_caches_per_team():
+    async def _calls():
         a = await dp.get_provider("sales")
         b = await dp.get_provider("sales")
-        return a, b
+        c = await dp.get_provider("member_support")
+        return a, b, c
 
-    a, b = asyncio.run(_twice())
-    assert a is b  # same cached instance, connect() ran once
-
-
-def test_flag_flip_rebuilds_and_closes_previous(monkeypatch):
-    monkeypatch.setenv("QA_READ_PATH", "postgres")
-    pg = asyncio.run(dp.get_provider("sales"))
-    assert isinstance(pg, _FakePg)
-
-    monkeypatch.setenv("QA_READ_PATH", "sheets")
-    sheets = asyncio.run(dp.get_provider("sales"))
-    assert isinstance(sheets, _FakeSheets)
-    assert pg.closed is True, "superseded Postgres pool must be closed on flip"
-    assert dp._provider_modes["sales"] == "sheets"
+    a, b, c = asyncio.run(_calls())
+    assert a is b                    # same cached instance, connect() once
+    assert c is not a                # per-team instances
+    assert set(dp._providers) == {"sales", "member_support"}
 
 
-def test_close_all_providers_tears_down_pool(monkeypatch):
-    monkeypatch.setenv("QA_READ_PATH", "postgres")
-    pg = asyncio.run(dp.get_provider("sales"))
+def test_close_all_providers_tears_down_pools():
+    p = asyncio.run(dp.get_provider("sales"))
     asyncio.run(dp.close_all_providers())
-    assert pg.closed is True
-    assert dp._providers == {} and dp._provider_modes == {}
+    assert p.closed is True
+    assert dp._providers == {}
 
 
-def test_close_all_tolerates_closeless_sheets():
-    asyncio.run(dp.get_provider("sales"))          # sheets path, no close()
-    asyncio.run(dp.close_all_providers())          # must not raise
+def test_close_all_tolerates_closeless_provider():
+    dp._providers["x"] = _CloselessProvider()
+    asyncio.run(dp.close_all_providers())     # must not raise
     assert dp._providers == {}

--- a/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
+++ b/qa-automation/AI-Scoring/tests/test_read_path_shadow.py
@@ -1,21 +1,17 @@
-"""F4 — read-path shadow comparator + mode-aware /team frame helper.
+"""Parity comparator tests (read_path_shadow).
 
-Two layers (ReadPathFlip §5 F4):
-- read_path_shadow.align/compare: key alignment, membership classification
-  (sheet-only / db-only / common are deltas, not failures), and common-row
-  cell diffing — the SAME comparator the offline harness uses.
-- routes.team._team_history_frame: QA_READ_PATH dispatch — postgres serves
-  the row-source (no provider._ws), shadow serves the sheet AND logs the
-  delta, sheets serves the sheet with no shadow work.
+read_path_shadow.align/compare: key alignment, membership classification
+(sheet-only / db-only / common are deltas, not failures), and common-row
+cell diffing — the comparator the golden-parity harness layers compute_*
+and endpoint permutations on. The F4 shadow-dispatch tests were deleted
+with the shadow path in F5.
 """
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime
 
 import pandas as pd
-import pytest
 
 from backend.services import read_path_shadow as shadow
 
@@ -153,87 +149,3 @@ def test_key_content_pairing_cannot_mask_real_divergence():
     d = result["cell_diff_sample"][0]
     assert d["col"] == "matching_the_moment"
     assert (d["sheet"], d["pg"]) == (4.0, 3.0)   # 5s paired; 4 vs 3 surfaces
-
-
-def test_log_shadow_never_raises_on_empty():
-    # empty pg frame must not blow up the request path
-    shadow.log_shadow("sales", _frame([("A", "Star Rep", 1, 90)]), pd.DataFrame())
-
-
-# ---------------------------------------------------------------------------
-# Mode-aware /team frame helper
-# ---------------------------------------------------------------------------
-
-class _FakeSheetsProvider:
-    def __init__(self):
-        self._ws = self
-    def get_all_values(self):
-        return [["header"]]
-    def _get_mails_sheet(self):
-        return [["Agent Name"]]
-
-
-@pytest.fixture
-def _patch_team(monkeypatch):
-    import backend.routes.team as team
-
-    sheet_df = _frame([("S", "Star Rep", 1, 90)])
-    pg_df = _frame([("P", "Star Rep", 1, 90)])
-    calls = {"log_shadow": [], "fetch": 0, "get_provider": 0}
-
-    async def _fake_fetch(config):
-        calls["fetch"] += 1
-        return pg_df
-
-    async def _fake_get_provider(team_id):
-        calls["get_provider"] += 1
-        return _FakeSheetsProvider()
-
-    monkeypatch.setattr(team, "fetch_history_frame", _fake_fetch)
-    monkeypatch.setattr(team, "get_provider", _fake_get_provider)
-    monkeypatch.setattr(team, "load_and_clean", lambda *a, **k: sheet_df)
-    monkeypatch.setattr(team, "log_shadow",
-                        lambda tid, s, p: calls["log_shadow"].append((tid, len(s), len(p))))
-    monkeypatch.delenv("QA_READ_PATH", raising=False)
-    return team, sheet_df, pg_df, calls
-
-
-def test_helper_postgres_serves_rowsource(_patch_team, monkeypatch):
-    team, sheet_df, pg_df, calls = _patch_team
-    monkeypatch.setenv("QA_READ_PATH", "postgres")
-    df = asyncio.run(team._team_history_frame("sales", config=None))
-    assert df is pg_df
-    assert calls["fetch"] == 1
-    assert calls["get_provider"] == 0  # no _ws access on the postgres path
-    assert calls["log_shadow"] == []
-
-
-def test_helper_sheets_serves_sheet_no_shadow(_patch_team, monkeypatch):
-    team, sheet_df, pg_df, calls = _patch_team
-    monkeypatch.setenv("QA_READ_PATH", "sheets")
-    df = asyncio.run(team._team_history_frame("sales", config=None))
-    assert df is sheet_df
-    assert calls["fetch"] == 0
-    assert calls["log_shadow"] == []
-
-
-def test_helper_shadow_serves_sheet_and_logs(_patch_team, monkeypatch):
-    team, sheet_df, pg_df, calls = _patch_team
-    monkeypatch.setenv("QA_READ_PATH", "shadow")
-    df = asyncio.run(team._team_history_frame("sales", config=None))
-    assert df is sheet_df           # sheet is still the served source of truth
-    assert calls["fetch"] == 1      # but the pg frame was computed
-    assert calls["log_shadow"] == [("sales", 1, 1)]  # and the delta logged
-
-
-def test_helper_shadow_survives_pg_failure(_patch_team, monkeypatch):
-    team, sheet_df, pg_df, calls = _patch_team
-
-    async def _boom(config):
-        raise RuntimeError("db down")
-
-    monkeypatch.setattr(team, "fetch_history_frame", _boom)
-    monkeypatch.setenv("QA_READ_PATH", "shadow")
-    df = asyncio.run(team._team_history_frame("sales", config=None))
-    assert df is sheet_df           # request still served despite pg failure
-    assert calls["log_shadow"] == []


### PR DESCRIPTION
## ⚠ Deploy order — read first

**Apply migration 015 BEFORE merging this PR.** `team_source` reads `qa.v_history_long`; if the code deploys before the view exists, the `/team` trio 500s.

```bash
cd ~/Dev/Landing-scripts && python3 database/runner.py up   # applies 015 (runner auto-loads .env since #111)
```

After merge: the `QA_READ_PATH` variable in Railway is now ignored — delete it at your leisure.

## Summary

Completes ReadPathFlip §5 — **all slices done**. The flip has run clean in prod since 07-15; this deletes the machinery that validated it and ships the W2/W3 views.

### Deleted (rollback = git revert + redeploy, slice-5 precedent)
- The `/team` trio's `_ws` sheet-read, `QA_READ_PATH` dispatch, and shadow branches — `_team_history_frame` is the Postgres row-source, full stop. **No gspread in the `/team` read path** (the F5 checkpoint).
- Factory mode logic — `get_provider` always builds one `connect()`-ed `PostgresProvider` per team.
- `log_shadow` (the live per-request compare). The comparator survives as the parity harness's foundation; `SheetsProvider` survives solely for the harness, which instantiates it directly and stays runnable while the sheet is written as a projection (§6).

### Migration 015 — the views
- **`qa.v_history_long`** — finalized evals × sections. `team_source`'s section query is now a parameterized slice of it. Verified byte-equivalent against prod: 18,620 (MS) / 6,337 (Sales) rows match the old join exactly.
- **`qa.v_monthly_scores`** — unfiltered per-team month rollup in the project TZ, for Command Center / ad-hoc SQL / exports. The dashboard chiclets **deliberately keep the pandas path**: they honor per-request `active_only`/`supervisor` filters, which a team-level view cannot (design note in the migration header).

### Verification
- Suite: **582 passed, 0 failed** (shadow-dispatch tests deleted with the shadow path; factory tests rewritten).
- View SQL equivalence proven read-only against prod (counts above).
- Post-merge smoke: dashboards for both teams, a datapoint page, `/team/evals` drill-down — then optionally `python3 scripts/parity_readpath.py` (both teams should stay GREEN; the harness now builds its own SheetsProvider).

### Out of scope
Sheet **write**-side retirement (Analyst_History projection + GAS email source) — CutoverDesign §7 retention, post one bonus cycle (~Aug).

This closes the packaging item before the Sandy migration: one read path, one row-source, no dual-source machinery for the TS rewrite to carry over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)