### PR TITLE
feat(qa-automation): July R2/R3 — EOM CSV exports, qa.assessments persistence, one-pager DB swap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ database/onepager_*.html
 # B0 staging outputs (backfill_seed_b0.py) — derived from the seed CSVs,
 # same PII surface. Reports included: exclusion rows carry agent names.
 database/backfill_staging/
+# EOM CSV exports (export_eom_csvs.py) — agent names + scores, operator
+# deliverables; never repo content.
+database/eom_exports/

--- a/qa-automation/AI-Scoring/backend/services/assessment_store.py
+++ b/qa-automation/AI-Scoring/backend/services/assessment_store.py
@@ -1,0 +1,186 @@
+"""qa.assessments writer — R3 persistence (JulyR2R3 §2).
+
+Persists every FRESH progression generation (placeholders never). The
+Wave-2 write-ban on qa.assessments is lifted per the July rollout
+directive; migration 011's immutability rule stands: rows are pure AI
+output, append-only — the ONLY mutation is flipping the prior row's
+``is_current`` when a successor lands in the same window.
+
+Window semantics: ``is_current`` flips among rows sharing
+(agent_id, team_id, time_range_days). A calendar-month window whose day
+count equals a rolling window (June = 30 = the dashboard default) can
+therefore trade the flag back and forth with it — harmless by design:
+readers that need a SPECIFIC window (the one-pager) match on the exact
+``range_start_at``/``range_end_at`` ordered by ``generated_at`` and
+ignore ``is_current`` entirely; ``is_current`` serves "latest for this
+window size" listings only.
+
+``estimated_cost_usd`` stays NULL until the cost-dashboard work ships a
+price table (LateStageDesign Tier 3) — the column is nullable for
+exactly this.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Optional
+
+from backend.services.eval_store import get_pool
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+    from backend.models.dashboard import ProgressionAssessment
+
+logger = logging.getLogger(__name__)
+
+_VALID_TRENDS = {"improving", "stable", "declining"}
+
+
+async def persist_assessment(
+    result: "ProgressionAssessment",
+    *,
+    agent_name: str,
+    config: "TeamConfig",
+    range_start: Optional[datetime] = None,
+    range_end: Optional[datetime] = None,
+) -> Optional[int]:
+    """Insert one assessment (+ section rows) and flip the predecessor's
+    ``is_current``. Returns the new assessment id, or None when
+    persistence was skipped (no DB, unknown agent, no rubric version).
+    Raises on real DB failures — callers choose the posture
+    (get_progression swallows+logs; the EOM path lets it propagate).
+
+    ``range_start``/``range_end`` override the window stamps for
+    calendar-month (EOM) runs; the default is the rolling window ending
+    now, matching the dashboard's ``days=N`` semantics.
+    """
+    pool = await get_pool()
+    if pool is None:
+        logger.info("assessment_store: no DATABASE_URL — skip persist")
+        return None
+
+    now = datetime.now(timezone.utc)
+    end = range_end or now
+    start = range_start or (end - timedelta(days=result.time_range_days))
+
+    async with pool.acquire() as conn:
+        agent_id = await conn.fetchval(
+            "SELECT id FROM qa.agents "
+            "WHERE team_id = $1 AND active "
+            "  AND (LOWER(name) = LOWER($2) OR LOWER(canonical_name) = LOWER($2)) "
+            "ORDER BY id LIMIT 1",
+            config.team_id, agent_name.strip(),
+        )
+        if agent_id is None:
+            logger.info(
+                "assessment_store: no active qa.agents match for %r (%s) — "
+                "skip persist (departed/unknown agents keep ephemeral cards)",
+                agent_name, config.team_id,
+            )
+            return None
+
+        from backend.services.score_compute import (
+            VersionNotArchivedError,
+            get_active_versions,
+        )
+        try:
+            versions = await get_active_versions(conn, config.team_id)
+        except VersionNotArchivedError:
+            logger.warning(
+                "assessment_store: no active rubric/formula version for %s — "
+                "skip persist (rubric_version is NOT NULL)", config.team_id,
+            )
+            return None
+
+        models_used = json.dumps({"text": {
+            "provider": "gemini", "model": config.gemini.progression_model,
+        }})
+
+        async with conn.transaction():
+            assessment_id = await conn.fetchval(
+                "INSERT INTO qa.assessments "
+                "(agent_id, team_id, time_range_days, range_start_at, "
+                " range_end_at, evaluations_included, overall_assessment, "
+                " rubric_version, formula_version, models_used, is_current) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, TRUE) "
+                "RETURNING id",
+                agent_id, config.team_id, result.time_range_days,
+                start, end, result.evaluation_count,
+                result.overall_assessment,
+                versions.rubric_version, versions.formula_version,
+                models_used,
+            )
+            # The one permitted mutation (migration 011 Q4.a): retire the
+            # predecessor(s) in this window. Content columns untouched.
+            await conn.execute(
+                "UPDATE qa.assessments SET is_current = FALSE "
+                "WHERE agent_id = $1 AND team_id = $2 "
+                "  AND time_range_days = $3 AND is_current AND id <> $4",
+                agent_id, config.team_id, result.time_range_days,
+                assessment_id,
+            )
+            for history_id, sa in result.section_assessments.items():
+                sec = config.history_id_to_section.get(history_id)
+                if sec is None:
+                    logger.warning(
+                        "assessment_store: unknown section key %r — row skipped",
+                        history_id,
+                    )
+                    continue
+                trend = (sa.trend or "").strip().lower()
+                if trend not in _VALID_TRENDS:
+                    logger.warning(
+                        "assessment_store: invalid trend %r for %s — row skipped",
+                        sa.trend, sec.id,
+                    )
+                    continue
+                await conn.execute(
+                    "INSERT INTO qa.assessment_sections "
+                    "(assessment_id, section_id, section_name, section_number, "
+                    " trend, summary, coaching_tip) "
+                    "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    assessment_id, sec.id, sec.name, sec.section_number,
+                    trend, sa.summary, sa.coaching_tip,
+                )
+    logger.info(
+        "assessment_store: persisted assessment %s for %r (%s, %sd window, "
+        "%s evals)", assessment_id, agent_name, config.team_id,
+        result.time_range_days, result.evaluation_count,
+    )
+    return assessment_id
+
+
+async def fetch_assessment_for_range(
+    config: "TeamConfig",
+    agent_name: str,
+    range_start: datetime,
+    range_end: datetime,
+) -> Optional[dict]:
+    """Latest persisted assessment matching this EXACT window (the
+    one-pager read path — deliberately ignores ``is_current``; see module
+    docstring). Returns the row + section rows as plain dicts, or None."""
+    pool = await get_pool()
+    if pool is None:
+        return None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT a.* FROM qa.assessments a "
+            "JOIN qa.agents ag ON ag.id = a.agent_id "
+            "WHERE a.team_id = $1 "
+            "  AND (LOWER(ag.name) = LOWER($2) OR LOWER(ag.canonical_name) = LOWER($2)) "
+            "  AND a.range_start_at = $3 AND a.range_end_at = $4 "
+            "ORDER BY a.generated_at DESC LIMIT 1",
+            config.team_id, agent_name.strip(), range_start, range_end,
+        )
+        if row is None:
+            return None
+        sections = await conn.fetch(
+            "SELECT section_id, section_name, section_number, trend, "
+            "       summary, coaching_tip "
+            "FROM qa.assessment_sections WHERE assessment_id = $1 "
+            "ORDER BY section_number",
+            row["id"],
+        )
+    return {**dict(row), "sections": [dict(s) for s in sections]}

--- a/qa-automation/AI-Scoring/backend/services/assessment_store.py
+++ b/qa-automation/AI-Scoring/backend/services/assessment_store.py
@@ -152,6 +152,61 @@ async def persist_assessment(
     return assessment_id
 
 
+def month_bounds(month: str) -> tuple[datetime, datetime, int]:
+    """[start, end) of a YYYY-MM calendar month in the project bucket TZ,
+    as aware UTC datetimes, plus the month's day count (time_range_days).
+    Same TZ seam as the dashboard's month bucketing."""
+    from backend.services.team_stats import _BUCKET_TZ
+    year, mon = (int(p) for p in month.split("-"))
+    start_local = datetime(year, mon, 1, tzinfo=_BUCKET_TZ)
+    end_local = (datetime(year + 1, 1, 1, tzinfo=_BUCKET_TZ) if mon == 12
+                 else datetime(year, mon + 1, 1, tzinfo=_BUCKET_TZ))
+    days = (end_local - start_local).days
+    return (start_local.astimezone(timezone.utc),
+            end_local.astimezone(timezone.utc), days)
+
+
+async def get_or_generate_month_assessment(
+    config: "TeamConfig",
+    agent_name: str,
+    month: str,
+    generate: bool = True,
+) -> Optional[dict]:
+    """The one-pager's assessment source (JulyR2R3 §3): the persisted row
+    for (agent, exact month window), generating + persisting one when
+    absent (``generate=False`` for cost-free re-renders). Returns the
+    fetch_assessment_for_range dict shape, or None."""
+    start, end, days = month_bounds(month)
+    existing = await fetch_assessment_for_range(config, agent_name, start, end)
+    if existing is not None or not generate:
+        return existing
+
+    from backend.services.data_provider import get_provider
+    from backend.services.progression_service import (
+        AssessmentParseError,
+        generate_from_records,
+    )
+    provider = await get_provider(config.team_id)
+    records = await provider.get_agent_history_range(agent_name, start, end)
+    if not records:
+        return None
+    try:
+        result = generate_from_records(records, agent_name, days, config)
+    except AssessmentParseError:
+        logger.warning(
+            "assessment_store: month generation unparseable for %r (%s %s) — "
+            "no row persisted", agent_name, config.team_id, month,
+        )
+        return None
+    persisted = await persist_assessment(
+        result, agent_name=agent_name, config=config,
+        range_start=start, range_end=end,
+    )
+    if persisted is None:
+        return None
+    return await fetch_assessment_for_range(config, agent_name, start, end)
+
+
 async def fetch_assessment_for_range(
     config: "TeamConfig",
     agent_name: str,

--- a/qa-automation/AI-Scoring/backend/services/db_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/db_provider.py
@@ -97,6 +97,39 @@ class PostgresProvider(DataProvider):
     async def get_agent_history(self, agent_name: str, days: int = 30) -> list[EvaluationRecord]:
         return await self._fetch_records(days=days, agent_name=agent_name)
 
+    async def get_agent_history_range(
+        self, agent_name: str, start: datetime, end: datetime
+    ) -> list[EvaluationRecord]:
+        """Explicit [start, end) window — the EOM one-pager's calendar-month
+        fetch (JulyR2R3 §3); the rolling `days` cutoff can't express a
+        closed month."""
+        await self._refresh_roster_if_stale()
+        async with self._pool.acquire() as conn:
+            evals = await conn.fetch(
+                f"SELECT {_EVAL_COLUMNS} FROM qa.evaluations "
+                "WHERE team_id = $1 AND state = 'finalized' "
+                "AND LOWER(agent_name_raw) = LOWER($2) "
+                "AND COALESCE(call_connected_at, created_at) >= $3 "
+                "AND COALESCE(call_connected_at, created_at) < $4 "
+                "ORDER BY COALESCE(call_connected_at, created_at)",
+                self._team_id, agent_name.strip(), start, end,
+            )
+            if not evals:
+                return []
+            sections = await conn.fetch(
+                "SELECT evaluation_id, section_id, numeric_score, binary_value, "
+                "confidence, reasoning "
+                "FROM qa.evaluation_sections WHERE evaluation_id = ANY($1::bigint[])",
+                [ev["id"] for ev in evals],
+            )
+        sections_by_eval: dict[int, list] = {}
+        for s in sections:
+            sections_by_eval.setdefault(s["evaluation_id"], []).append(s)
+        return [
+            self._record_from_rows(ev, sections_by_eval.get(ev["id"], []))
+            for ev in evals
+        ]
+
     async def get_all_history(self, days: int = 90) -> list[EvaluationRecord]:
         return await self._fetch_records(days=days)
 

--- a/qa-automation/AI-Scoring/backend/services/progression_service.py
+++ b/qa-automation/AI-Scoring/backend/services/progression_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import time
@@ -17,6 +18,8 @@ from backend.models.dashboard import (
     SectionAssessment,
 )
 from backend.prompts.progression_prompt import build_progression_prompt
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
@@ -177,6 +180,19 @@ async def get_progression(
         time_range_days=days,
         data_source=provider.name,
     )
+
+    # R3 (JulyR2R3 §2): persist every FRESH generation — cache hits above
+    # never reach here, and the two placeholder results return early, so
+    # only genuine AI output lands in qa.assessments. Failures are logged
+    # and swallowed: the dashboard card renders regardless.
+    try:
+        from backend.services.assessment_store import persist_assessment
+        await persist_assessment(result, agent_name=agent_name, config=config)
+    except Exception:  # noqa: BLE001 — persistence must not break the card
+        logger.exception(
+            "progression: assessment persist failed for %r — card served "
+            "without a durable row", agent_name,
+        )
 
     _set_cached(agent_name, days, result)
     return result

--- a/qa-automation/AI-Scoring/backend/services/progression_service.py
+++ b/qa-automation/AI-Scoring/backend/services/progression_service.py
@@ -127,6 +127,57 @@ async def get_progression(
         _set_cached(agent_name, days, result)
         return result
 
+    try:
+        result = generate_from_records(records, agent_name, days, config,
+                                       data_source=provider.name)
+    except AssessmentParseError:
+        # parse-failure placeholder — cached (avoids hammering Gemini) but
+        # never persisted (§Q4.a: only genuine AI output lands).
+        result = ProgressionAssessment(
+            overall_assessment=(
+                f"Assessment generation for {agent_name} produced a partial response. "
+                "Try a shorter time window or retry."
+            ),
+            section_assessments={},
+            evaluation_count=len(records),
+            time_range_days=days,
+            data_source=provider.name,
+        )
+        _set_cached(agent_name, days, result)
+        return result
+
+    # R3 (JulyR2R3 §2): persist every FRESH generation — cache hits above
+    # never reach here, and the two placeholder results return early, so
+    # only genuine AI output lands in qa.assessments. Failures are logged
+    # and swallowed: the dashboard card renders regardless.
+    try:
+        from backend.services.assessment_store import persist_assessment
+        await persist_assessment(result, agent_name=agent_name, config=config)
+    except Exception:  # noqa: BLE001 — persistence must not break the card
+        logger.exception(
+            "progression: assessment persist failed for %r — card served "
+            "without a durable row", agent_name,
+        )
+
+    _set_cached(agent_name, days, result)
+    return result
+
+
+class AssessmentParseError(Exception):
+    """Gemini's response wasn't valid JSON — no genuine assessment exists."""
+
+
+def generate_from_records(
+    records: list[EvaluationRecord],
+    agent_name: str,
+    days: int,
+    config: TeamConfig,
+    data_source: str = "PostgreSQL",
+) -> ProgressionAssessment:
+    """The generation core: serialize → prompt → Gemini → parse. Shared by
+    the dashboard path (get_progression, rolling window) and the EOM
+    one-pager (calendar-month records). No caching, no persistence —
+    callers own both. Raises AssessmentParseError on unparseable output."""
     evaluations_json = _serialize_records(records)
     prompt = build_progression_prompt(config, agent_name, evaluations_json, days)
 
@@ -147,19 +198,8 @@ async def get_progression(
     raw_text = _strip_markdown_fences(response.text)
     try:
         parsed = json.loads(raw_text)
-    except json.JSONDecodeError:
-        result = ProgressionAssessment(
-            overall_assessment=(
-                f"Assessment generation for {agent_name} produced a partial response. "
-                "Try a shorter time window or retry."
-            ),
-            section_assessments={},
-            evaluation_count=len(records),
-            time_range_days=days,
-            data_source=provider.name,
-        )
-        _set_cached(agent_name, days, result)
-        return result
+    except json.JSONDecodeError as exc:
+        raise AssessmentParseError(str(exc)) from exc
 
     # Convert list response to dict keyed by internal history IDs
     section_name_map = config.section_name_to_history_id
@@ -173,26 +213,10 @@ async def get_progression(
             coaching_tip=sa["coaching_tip"],
         )
 
-    result = ProgressionAssessment(
+    return ProgressionAssessment(
         overall_assessment=parsed["overall_assessment"],
         section_assessments=section_assessments,
         evaluation_count=len(records),
         time_range_days=days,
-        data_source=provider.name,
+        data_source=data_source,
     )
-
-    # R3 (JulyR2R3 §2): persist every FRESH generation — cache hits above
-    # never reach here, and the two placeholder results return early, so
-    # only genuine AI output lands in qa.assessments. Failures are logged
-    # and swallowed: the dashboard card renders regardless.
-    try:
-        from backend.services.assessment_store import persist_assessment
-        await persist_assessment(result, agent_name=agent_name, config=config)
-    except Exception:  # noqa: BLE001 — persistence must not break the card
-        logger.exception(
-            "progression: assessment persist failed for %r — card served "
-            "without a durable row", agent_name,
-        )
-
-    _set_cached(agent_name, days, result)
-    return result

--- a/qa-automation/AI-Scoring/references/JulyR2R3.md
+++ b/qa-automation/AI-Scoring/references/JulyR2R3.md
@@ -1,0 +1,113 @@
+# July R2/R3 — EOM CSV Exports & Assessment Persistence
+
+> Design for roadmap item 5 (tasks #12/#13 of the MS Director's July
+> rollout): R2 = end-of-month CSV exports with the sampling counter;
+> R3 = `qa.assessments` persistence (the Wave-2 write-ban is lifted per
+> the rollout directive) + the one-pager's CSV→DB source swap. Both ride
+> the completed read-path flip: every data read here sources `qa.*`
+> through the proven `team_source` row-source — no sheet reads.
+
+| | |
+|---|---|
+| **Status** | v1 — 2026-07-19 |
+| **Depends on** | ReadPathFlip complete (#108–#116); migration 011 (`qa.assessments`, shipped empty); `scripts/export_onepager.py` mockup (PR #93-era); identity repair (#114) — `qa.assessments.agent_id` is NOT NULL |
+| **Out of scope** | coaching/tags UI (LateStageDesign Tier 3); webhook sampler (August); Sales onboarding to exports (config-gated, same code) |
+
+---
+
+## 1. R2 — EOM CSV exports + sampling counter
+
+One operator-run script, B-series conventions:
+
+```
+python3 scripts/export_eom_csvs.py --team member_support --month 2026-07 \
+    [--target 20] [--out-dir ../../database/eom_exports]
+```
+
+**Source:** `team_source.fetch_history_frame` filtered to the month via
+`_months_in_bucket_tz` — the EXACT bucket-TZ semantics of the dashboard
+chiclets/drill-down, so the CSV row count always equals the month
+drill-down count. No new query shapes.
+
+**Outputs** (UTF-8-BOM CSVs so Excel opens them clean, under
+`<out-dir>/<team>/<YYYY-MM>/`):
+
+1. `team_summary.csv` — one row per agent:
+   `agent, supervisor, evals, sampling_target, pct_of_target, mean,
+   std, min, max, <numeric section means...>, <yn section pcts...>`.
+   Sorted by mean desc (roster convention). Includes ONLY active-roster
+   agents by default (`--include-departed` to widen) — matches the
+   dashboard's default lens.
+2. `agent_<slug>.csv` — one per agent, one row per eval:
+   `call_date (bucket TZ), overall_score, <per-section scores...>,
+   evaluator_email, dialpad_link`.
+3. `run_report.json` — counts, month, target, source row totals
+   (staging-report convention).
+
+**Sampling counter** = `evals` vs `--target` (default 20; the rollout
+band is 20–25/agent/month). A CLI arg, not config: the target is July
+rollout policy, likely obsolete by the August webhook sampler —
+config-schema churn isn't warranted.
+
+**Destination:** local files (gitignored dir). The Director receives
+files; no Sheet/email automation in R2.
+
+## 2. R3 — qa.assessments persistence
+
+**Writer location:** `progression_service.get_progression` — persist
+every FRESH generation (cache hits don't re-persist; identical windows
+re-served from memory don't duplicate rows). This is what migration 011
+was designed for: append-only rows, the `is_current` flip on the prior
+(agent, window) row being the only permitted mutation. Dashboard cards
+and EOM runs share one code path and one audit trail, and
+`estimated_cost_usd` accrues per real Gemini call.
+
+**Never persisted:** the two placeholder results (no-evaluations, JSON
+parse failure). They are error text, not AI output — persisting them
+would violate the §Q4.a "pure unadulterated AI output" rule and flip
+`is_current` off a valid predecessor in favor of garbage.
+
+**Identity:** resolve `agent_id` from `qa.agents` (active roster,
+case-insensitive name/canonical match — the Stage-4 semantics). No
+match → generate as today but SKIP persistence with a log line
+(departed/unknown agents keep working dashboards; nothing silently
+breaks). Post-#114/#115 the roster is current, so misses should be rare.
+
+**Stamps:** `rubric_version`/`formula_version` from
+`score_compute.get_active_versions` (same source finalize uses);
+`models_used` mirrors the eval-row shape
+(`{"text": {"provider": "gemini", "model": <progression_model>}}`);
+`estimated_cost_usd` from response usage metadata when available, NULL
+otherwise. `qa.assessment_sections` snapshots section_name/number at
+generation time (migration 011 Q3.a).
+
+**Failure posture:** persistence failures are logged and swallowed — the
+dashboard card must render even if the DB write fails (same §7.3 spirit
+as the old dual-write). The EOM script, by contrast, treats a persist
+failure as a hard error (its whole point is the durable row).
+
+## 3. One-pager DB swap
+
+`export_onepager.py` drops `--csv` for `--team/--month/--agent`:
+
+- Rows from `fetch_history_frame` (same month filter as R2) — the
+  layout's existing per-section/trend/sparkline logic keeps working on
+  the frame's columns.
+- The reserved AI-Assessment slot fills from the CURRENT
+  `qa.assessments` row for (agent, month window) — generated via the
+  R3 writer if absent (`--no-generate` to skip, e.g. for cost-free
+  re-renders).
+- Month window = calendar month in bucket TZ (`range_start_at`/
+  `range_end_at` stamped accordingly; `time_range_days` = days in
+  month) — distinct from the dashboard's rolling `days=30`, disjoint by
+  design, distinguished naturally by the window columns.
+
+## 4. Slices
+
+| # | Slice | Checkpoint |
+|---|---|---|
+| R3a | assessment writer (`assessment_store.py`: resolve identity, insert + sections, is_current flip, stamps) wired into `get_progression` | pytest: fresh-generation persists, cache-hit doesn't, placeholders never persist, unknown agent skips, is_current uniqueness |
+| R2 | `export_eom_csvs.py` + pure summarization helpers | pytest on summarize-from-frame (synthetic frames); prod dry-run row counts == month drill-down |
+| R3b | one-pager swap + EOM assessment generation | render MS 2026-06 + 2026-07 against prod read-only; layout unchanged vs mockup |
+
+Single PR; slices are commits.

--- a/qa-automation/AI-Scoring/scripts/export_eom_csvs.py
+++ b/qa-automation/AI-Scoring/scripts/export_eom_csvs.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""R2 — end-of-month CSV exports + sampling counter (JulyR2R3 §1).
+
+One operator-run pass per team+month. Sources qa.* through the SAME
+row-source + bucket-TZ month semantics as the dashboard
+(team_source.fetch_history_frame + _months_in_bucket_tz), so every CSV
+row count equals the month drill-down count.
+
+Outputs under <out-dir>/<team>/<YYYY-MM>/ (UTF-8-BOM so Excel opens
+them clean):
+  team_summary.csv   one row per agent — evals vs the sampling target
+                     (July band: 20–25/agent/month), mean/std/min/max,
+                     numeric-section means, Y/N-section pcts
+  agent_<slug>.csv   one per agent — one row per eval
+  run_report.json    counts + parameters (staging-report convention)
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/export_eom_csvs.py --team member_support --month 2026-07 \\
+        [--target 20] [--include-departed] [--out-dir ../../database/eom_exports]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_DEFAULT_OUT = _AI_SCORING.parent.parent / "database" / "eom_exports"
+load_dotenv(_AI_SCORING / ".env")
+if str(_AI_SCORING) not in sys.path:
+    sys.path.insert(0, str(_AI_SCORING))
+
+from backend.config.team_config import get_team_config  # noqa: E402
+from backend.services.data_normalization import strip_accents  # noqa: E402
+from backend.services.team_source import fetch_history_frame  # noqa: E402
+from backend.services.team_stats import (  # noqa: E402
+    _compute_binary_pct,
+    _months_in_bucket_tz,
+)
+
+_DIALPAD_URL = "https://dialpad.com/callhistory/callreview/{}"
+
+
+def agent_slug(name: str) -> str:
+    return "_".join(strip_accents(name).lower().split())
+
+
+def month_frame(df: pd.DataFrame, month: str, include_departed: bool) -> pd.DataFrame:
+    """Filter the analytics frame to one bucket-TZ month (+ active lens)."""
+    if df.empty:
+        return df
+    d = df[_months_in_bucket_tz(df["timestamp"]) == month]
+    if not include_departed:
+        d = d[d["is_active"]]
+    return d
+
+
+def team_summary(df_month: pd.DataFrame, config, target: int) -> pd.DataFrame:
+    """One row per agent — the sampling counter + score rollup."""
+    numeric_ids = [h for h in config.numeric_history_ids if h in df_month.columns]
+    yn_ids = [h for h in config.yn_history_ids if h in df_month.columns]
+    labels = config.section_labels
+    yn_labels = config.yn_section_labels
+
+    rows = []
+    for agent, g in df_month.groupby("agent"):
+        scores = g["overall_score"]
+        row = {
+            "agent": agent,
+            "supervisor": g["supervisor"].iloc[0],
+            "evals": len(g),
+            "sampling_target": target,
+            "pct_of_target": round(100.0 * len(g) / target, 1) if target else "",
+            "mean": round(float(scores.mean()), 1),
+            "std": round(float(scores.std(ddof=1)), 1) if len(scores) > 1 else "",
+            "min": round(float(scores.min()), 1),
+            "max": round(float(scores.max()), 1),
+        }
+        for h in numeric_ids:
+            vals = g[h].dropna()
+            row[labels.get(h, h)] = round(float(vals.mean()), 2) if len(vals) else ""
+        for h in yn_ids:
+            row[f"{yn_labels.get(h, h)} %"] = _compute_binary_pct(g[h])
+        rows.append(row)
+    out = pd.DataFrame(rows)
+    # roster convention: strongest first
+    return out.sort_values("mean", ascending=False).reset_index(drop=True) if len(out) else out
+
+
+def agent_detail(df_month: pd.DataFrame, agent: str, config) -> pd.DataFrame:
+    """One row per eval for one agent, call-date ordered."""
+    numeric_ids = [h for h in config.numeric_history_ids if h in df_month.columns]
+    yn_ids = [h for h in config.yn_history_ids if h in df_month.columns]
+    labels = {**config.section_labels, **config.yn_section_labels}
+
+    g = df_month[df_month["agent"] == agent].sort_values("timestamp")
+    rows = []
+    for r in g.to_dict("records"):
+        row = {
+            "call_date": r["timestamp"].strftime("%Y-%m-%d %H:%M"),
+            "overall_score": r["overall_score"],
+        }
+        for h in [*numeric_ids, *yn_ids]:
+            v = r.get(h, "")
+            row[labels.get(h, h)] = "" if pd.isna(v) else v
+        row["evaluator"] = r.get("manager_email", "")
+        row["dialpad_link"] = _DIALPAD_URL.format(r["eval_id"]) if r.get("eval_id") else ""
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+async def run(args) -> int:
+    config = get_team_config(args.team)
+    df = await fetch_history_frame(config)
+    dm = month_frame(df, args.month, args.include_departed)
+    if dm.empty:
+        print(f"[eom:{args.team}] no rows for {args.month} — nothing exported")
+        return 2
+
+    out_dir = Path(args.out_dir) / args.team / args.month
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = team_summary(dm, config, args.target)
+    summary.to_csv(out_dir / "team_summary.csv", index=False, encoding="utf-8-sig")
+
+    agents = sorted(dm["agent"].unique())
+    for agent in agents:
+        detail = agent_detail(dm, agent, config)
+        detail.to_csv(out_dir / f"agent_{agent_slug(agent)}.csv",
+                      index=False, encoding="utf-8-sig")
+
+    report = {
+        "stage": "eom_export", "team_id": args.team, "month": args.month,
+        "sampling_target": args.target,
+        "include_departed": args.include_departed,
+        "rows_in_month": int(len(dm)),
+        "agents": len(agents),
+        "below_target": [r["agent"] for r in summary.to_dict("records")
+                         if r["evals"] < args.target],
+        "out_dir": str(out_dir),
+    }
+    (out_dir / "run_report.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8")
+
+    print(f"[eom:{args.team}] {args.month}: {len(dm)} evals across "
+          f"{len(agents)} agents → {out_dir}")
+    below = report["below_target"]
+    print(f"  below target ({args.target}): {len(below)} agent(s)"
+          + (f" — {below[:8]}{' …' if len(below) > 8 else ''}" if below else ""))
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team", "--team-id", dest="team", required=True)
+    ap.add_argument("--month", required=True, help="YYYY-MM (bucket-TZ month)")
+    ap.add_argument("--target", type=int, default=20,
+                    help="sampling target per agent per month (July band 20–25)")
+    ap.add_argument("--include-departed", action="store_true")
+    ap.add_argument("--out-dir", default=str(_DEFAULT_OUT))
+    args = ap.parse_args()
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/scripts/export_onepager.py
+++ b/qa-automation/AI-Scoring/scripts/export_onepager.py
@@ -1,31 +1,38 @@
 #!/usr/bin/env python3
-"""Landing-branded agent one-pager — print-ready HTML (July R2/R3 groundwork).
+"""Landing-branded agent one-pager — print-ready HTML (JulyR2R3 §3).
 
-Reads an Analyst_History-shaped CSV export, filters to one agent + one month,
-and renders a single-page, print-to-PDF HTML artifact: overall score with
-call count and standard deviation, per-section averages and trends, and a
-per-call score sparkline. R3 swaps the CSV for qa.evaluations and enriches
-with the qa.assessments AI Assessment at end of month — the layout reserves
-its slot.
+Sources qa.evaluations through the post-flip row-source (same bucket-TZ
+month semantics as the dashboard) and fills the AI-Assessment slot from
+qa.assessments — generating + persisting a calendar-month assessment via
+the R3 writer when none exists (``--no-generate`` skips that for
+cost-free re-renders). One HTML per agent, print-to-PDF ready (Letter
+portrait).
 
 Usage:
     cd qa-automation/AI-Scoring
-    python scripts/export_onepager.py \
-        --csv ../../database/export_document_test_data.csv \
-        --month 2026-06 [--agent "Name"] [--out path.html]
-
-Print to PDF from any browser (the page is sized for Letter portrait).
+    python3 scripts/export_onepager.py --team member_support --month 2026-06 \\
+        [--agent "Name"] [--no-generate] [--include-departed] \\
+        [--out-dir ../../database/eom_exports]
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import html
 import statistics
+import sys
 from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_DEFAULT_OUT = _AI_SCORING.parent.parent / "database" / "eom_exports"
+load_dotenv(_AI_SCORING / ".env")
+if str(_AI_SCORING) not in sys.path:
+    sys.path.insert(0, str(_AI_SCORING))
 
 # Landing brand palette (qa-automation/teams/*/Branding.js)
 NAVY = "#15192D"
@@ -36,27 +43,58 @@ AMBER = "#E8A317"
 RED = "#D9534F"
 GRAY = "#4A4A4A"
 
-_PREFIX = 6          # agent, email, timestamp, evaluator, link, overall
-_N_SECTIONS = 10     # MS layout; sections occupy cols 6..15
-
 _YN_VALUES = {"Yes": 1.0, "Y": 1.0, "No": 0.0, "N": 0.0}
 
 
-def _parse(csv_path: Path, month: str, agent: str | None):
-    df = pd.read_csv(csv_path)
-    df.columns = [c.strip() for c in df.columns]
-    df["_ts"] = pd.to_datetime(df["Timestamp"], errors="coerce")
-    df = df[df["_ts"].dt.strftime("%Y-%m") == month]
-    if agent:
-        df = df[df["Agent Name"].str.strip().str.lower() == agent.strip().lower()]
-    else:
-        agent = df["Agent Name"].str.strip().mode().iat[0]
-        df = df[df["Agent Name"].str.strip() == agent]
-    if df.empty:
-        raise SystemExit(f"no rows for agent={agent!r} month={month}")
-    df = df.sort_values("_ts")
-    section_cols = list(df.columns[_PREFIX:_PREFIX + _N_SECTIONS])
-    return df, agent, section_cols
+def frame_to_render(df_month: pd.DataFrame, agent: str, config):
+    """One agent's month slice of the analytics frame → the render shape
+    (display-label columns, canonical section order). The frame's yn cells
+    are already the Y/N/NA/'' vocabulary _section_stats understands;
+    numeric NAs arrive as NaN (the frame collapses the sheet-era
+    'Not Applicable' string — the NA count column reflects yn sections
+    only, a known fidelity trade)."""
+    g = df_month[df_month["agent"] == agent].sort_values("timestamp")
+    out = pd.DataFrame({
+        "Agent Name": g["agent"].values,
+        "_ts": g["timestamp"].values,
+        "Overall Score": g["overall_score"].values,
+    })
+    section_cols = []
+    for sec in config.sections_by_number:
+        h = sec.history_id
+        if h in g.columns:
+            out[sec.name] = g[h].values
+            section_cols.append(sec.name)
+    return out, section_cols
+
+
+def assessment_html(assessment: dict | None) -> str:
+    """The AI-Assessment slot: the persisted qa.assessments row, or the
+    reserved-slot placeholder when none exists."""
+    if assessment is None:
+        return (
+            '<div class="assessment"><strong>AI Assessment</strong><br>'
+            '<span class="muted">No persisted assessment for this window — '
+            "run without --no-generate to create one.</span></div>"
+        )
+    lines = []
+    for s in assessment.get("sections", []):
+        arrow = {"improving": ("▲", GREEN), "declining": ("▼", RED)}.get(
+            s["trend"], ("→", GRAY))
+        lines.append(
+            f'<div class="a-sec"><span style="color:{arrow[1]}">{arrow[0]}</span> '
+            f"<strong>{html.escape(s['section_name'])}</strong> — "
+            f"{html.escape(s['coaching_tip'])}</div>"
+        )
+    gen = assessment.get("generated_at")
+    stamp = gen.strftime("%Y-%m-%d") if hasattr(gen, "strftime") else ""
+    return (
+        '<div class="assessment"><strong>AI Assessment</strong> '
+        f'<span class="muted">({assessment.get("evaluations_included", "?")} evaluations'
+        f'{" · " + stamp if stamp else ""} · {html.escape(str(assessment.get("rubric_version", "")))})</span>'
+        f'<p style="margin:6px 0 8px">{html.escape(assessment["overall_assessment"])}</p>'
+        f"{''.join(lines)}</div>"
+    )
 
 
 def _section_stats(df: pd.DataFrame, col: str) -> dict:
@@ -129,7 +167,8 @@ def _bar(stat: dict) -> str:
     )
 
 
-def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str]) -> str:
+def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str],
+           assessment: dict | None = None) -> str:
     overall = pd.to_numeric(df["Overall Score"], errors="coerce").dropna().tolist()
     n = len(overall)
     mean = statistics.fmean(overall)
@@ -185,6 +224,7 @@ def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str]) ->
   .fill {{ height: 100%; border-radius: 4px; }}
   .assessment {{ border: 1.5px dashed {BLUE}; border-radius: 10px; padding: 14px 16px;
                  margin-top: 16px; color: {NAVY}; background: #fbfcff; }}
+  .a-sec {{ font-size: 11.5px; margin: 2px 0; }}
   footer {{ margin-top: 18px; font-size: 10.5px; color: #9aa3af; }}
 </style></head><body>
 <header>
@@ -209,34 +249,67 @@ def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str]) ->
 {chr(10).join(rows)}
 </tbody></table>
 
-<div class="assessment">
-  <strong>AI Assessment</strong><br>
-  <span class="muted">Generated at end of month from the evaluation record —
-  per-section trends, coaching focus, and progression summary land here
-  automatically (arrives with the July close).</span>
-</div>
+{assessment_html(assessment)}
 
-<footer>Generated {datetime.now().strftime("%Y-%m-%d %H:%M")} · Source: Analyst_History
+<footer>Generated {datetime.now().strftime("%Y-%m-%d %H:%M")} · Source: qa.evaluations
 ({n} finalized evaluations, {month_label}) · Trend = second-half vs first-half average
 · Scores computed by the Landing QA engine</footer>
 </body></html>"""
 
 
-def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--csv", required=True)
-    ap.add_argument("--month", required=True, help="YYYY-MM")
-    ap.add_argument("--agent", default=None)
-    ap.add_argument("--out", default=None)
-    args = ap.parse_args()
+async def run(args) -> int:
+    from backend.config.team_config import get_team_config
+    from backend.services.assessment_store import get_or_generate_month_assessment
+    from backend.services.team_source import fetch_history_frame
+    from backend.services.team_stats import _months_in_bucket_tz
 
-    df, agent, section_cols = _parse(Path(args.csv), args.month, args.agent)
-    out = Path(args.out) if args.out else Path(args.csv).parent / (
-        f"onepager_{agent.replace(' ', '_')}_{args.month}.html"
-    )
-    out.write_text(render(df, agent, args.month, section_cols), encoding="utf-8")
-    print(f"wrote {out}  ({len(df)} evaluations for {agent}, {args.month})")
+    config = get_team_config(args.team)
+    df = await fetch_history_frame(config)
+    dm = df[_months_in_bucket_tz(df["timestamp"]) == args.month] if not df.empty else df
+    if not args.include_departed and not dm.empty:
+        dm = dm[dm["is_active"]]
+    if dm.empty:
+        print(f"[onepager:{args.team}] no rows for {args.month}")
+        return 2
+
+    agents = [args.agent] if args.agent else sorted(dm["agent"].unique())
+    out_dir = Path(args.out_dir) / args.team / args.month / "onepagers"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for agent in agents:
+        rdf, section_cols = frame_to_render(dm, agent, config)
+        if rdf.empty:
+            print(f"  {agent}: no rows — skipped")
+            continue
+        assessment = await get_or_generate_month_assessment(
+            config, agent, args.month, generate=not args.no_generate)
+        slug = "_".join(agent.replace("/", " ").split())
+        out = out_dir / f"onepager_{slug}_{args.month}.html"
+        out.write_text(render(rdf, agent, args.month, section_cols, assessment),
+                       encoding="utf-8")
+        written += 1
+        print(f"  {agent}: {len(rdf)} evals"
+              + (", assessment ✓" if assessment else ", assessment —")
+              + f" → {out.name}")
+
+    print(f"[onepager:{args.team}] {args.month}: {written} page(s) → {out_dir}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--team", "--team-id", dest="team", required=True)
+    ap.add_argument("--month", required=True, help="YYYY-MM (bucket-TZ month)")
+    ap.add_argument("--agent", default=None, help="one agent; omit for all")
+    ap.add_argument("--no-generate", action="store_true",
+                    help="never call Gemini — reserved slot shows a note when "
+                         "no assessment is persisted")
+    ap.add_argument("--include-departed", action="store_true")
+    ap.add_argument("--out-dir", default=str(_DEFAULT_OUT))
+    args = ap.parse_args()
+    return asyncio.run(run(args))
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/qa-automation/AI-Scoring/tests/test_assessment_store.py
+++ b/qa-automation/AI-Scoring/tests/test_assessment_store.py
@@ -1,0 +1,234 @@
+"""R3 — qa.assessments persistence (JulyR2R3 §2).
+
+Checkpoints from the design doc: a fresh generation persists (row +
+sections + is_current flip), placeholders never persist, an unknown/
+departed agent skips cleanly, invalid trends drop only their section
+row, and get_progression's wiring persists exactly once per fresh
+generation (cache hits and placeholders don't). All DB access faked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+
+import backend.services.assessment_store as astore
+from backend.models.dashboard import ProgressionAssessment, SectionAssessment
+from backend.services.score_compute import ActiveVersions
+from tests.conftest import load_test_config
+
+
+class FakeConn:
+    def __init__(self, agent_id=16):
+        self.agent_id = agent_id
+        self.inserted_assessment = None
+        self.section_inserts = []
+        self.flips = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+    async def fetchval(self, query, *args):
+        if "FROM qa.agents" in query:
+            return self.agent_id
+        assert "INSERT INTO qa.assessments" in query
+        self.inserted_assessment = args
+        return 501
+
+    async def execute(self, query, *args):
+        if "SET is_current = FALSE" in query:
+            self.flips.append(args)
+        else:
+            assert "INSERT INTO qa.assessment_sections" in query
+            self.section_inserts.append(args)
+
+    async def fetchrow(self, query, *args):  # pragma: no cover - unused here
+        return None
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+def _result(**over) -> ProgressionAssessment:
+    kw = dict(
+        overall_assessment="Solid month with improving adherence.",
+        section_assessments={},
+        evaluation_count=13,
+        time_range_days=30,
+        data_source="PostgreSQL",
+    )
+    kw.update(over)
+    return ProgressionAssessment(**kw)
+
+
+@pytest.fixture
+def store(monkeypatch):
+    conn = FakeConn()
+
+    async def fake_pool():
+        return FakePool(conn)
+
+    async def fake_versions(c, team_id):
+        return ActiveVersions(formula_version="sales_v2", rubric_version="sales_v2r")
+
+    monkeypatch.setattr(astore, "get_pool", fake_pool)
+    import backend.services.score_compute as sc
+    monkeypatch.setattr(sc, "get_active_versions", fake_versions)
+    return conn
+
+
+def test_fresh_generation_persists_row_flip_and_sections(store, monkeypatch):
+    config = load_test_config("sales")
+    sec = config.sections_by_number[0]
+    result = _result(section_assessments={
+        sec.history_id: SectionAssessment(
+            trend="Improving", summary="s", coaching_tip="c"),
+    })
+    aid = asyncio.run(astore.persist_assessment(
+        result, agent_name="Alexis López", config=config))
+    assert aid == 501
+    # row stamps
+    args = store.inserted_assessment
+    assert args[0] == 16                       # resolved agent_id
+    assert args[1] == config.team_id
+    assert args[2] == 30                       # time_range_days
+    assert args[5] == 13                       # evaluations_included
+    assert args[7] == "sales_v2r"              # rubric_version
+    assert json.loads(args[9])["text"]["model"]  # models_used shape
+    # predecessor flip scoped to (agent, team, window size), excluding self
+    assert store.flips == [(16, config.team_id, 30, 501)]
+    # section snapshot: short id + name + number, trend normalized
+    (sargs,) = store.section_inserts
+    assert sargs[1] == sec.id and sargs[2] == sec.name
+    assert sargs[3] == sec.section_number
+    assert sargs[4] == "improving"
+
+
+def test_unknown_agent_skips_persist(store):
+    store.agent_id = None
+    config = load_test_config("sales")
+    aid = asyncio.run(astore.persist_assessment(
+        _result(), agent_name="Ghost Agent", config=config))
+    assert aid is None
+    assert store.inserted_assessment is None
+
+
+def test_invalid_trend_drops_only_that_section(store):
+    config = load_test_config("sales")
+    s0, s1 = config.sections_by_number[0], config.sections_by_number[1]
+    result = _result(section_assessments={
+        s0.history_id: SectionAssessment(trend="skyrocketing", summary="s", coaching_tip="c"),
+        s1.history_id: SectionAssessment(trend="stable", summary="s", coaching_tip="c"),
+    })
+    aid = asyncio.run(astore.persist_assessment(
+        result, agent_name="A", config=config))
+    assert aid == 501                          # assessment row still lands
+    assert [s[1] for s in store.section_inserts] == [s1.id]
+
+
+def test_no_active_versions_skips(store, monkeypatch):
+    import backend.services.score_compute as sc
+
+    async def boom(c, team_id):
+        raise sc.VersionNotArchivedError("qa.rubric_versions", "x")
+
+    monkeypatch.setattr(sc, "get_active_versions", boom)
+    aid = asyncio.run(astore.persist_assessment(
+        _result(), agent_name="A", config=load_test_config("sales")))
+    assert aid is None
+    assert store.inserted_assessment is None
+
+
+def test_no_pool_skips(monkeypatch):
+    async def no_pool():
+        return None
+
+    monkeypatch.setattr(astore, "get_pool", no_pool)
+    aid = asyncio.run(astore.persist_assessment(
+        _result(), agent_name="A", config=load_test_config("sales")))
+    assert aid is None
+
+
+# ---------------------------------------------------------------------------
+# get_progression wiring — persists exactly once per FRESH generation
+# ---------------------------------------------------------------------------
+
+class _Provider:
+    name = "PostgreSQL"
+
+    def __init__(self, records):
+        self._records = records
+
+    async def get_agent_history(self, agent_name, days=30):
+        return self._records
+
+
+def _wire(monkeypatch, gemini_text):
+    import backend.services.progression_service as ps
+    calls = []
+
+    async def fake_persist(result, *, agent_name, config, **kw):
+        calls.append((agent_name, result.evaluation_count))
+        return 1
+
+    monkeypatch.setattr(ps, "_cache", {})
+    import backend.services.assessment_store as ast
+    monkeypatch.setattr(ast, "persist_assessment", fake_persist)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    class _Resp:
+        text = gemini_text
+
+    class _Models:
+        def generate_content(self, **kw):
+            return _Resp()
+
+    class _Client:
+        def __init__(self, api_key=None):
+            self.models = _Models()
+
+    monkeypatch.setattr(ps.genai, "Client", _Client)
+    return ps, calls
+
+
+def test_progression_persists_once_and_not_on_cache_hit(monkeypatch, sales):
+    good = json.dumps({"overall_assessment": "fine", "section_assessments": []})
+    ps, calls = _wire(monkeypatch, good)
+    from backend.models.dashboard import EvaluationRecord
+    rec = EvaluationRecord(
+        timestamp="2026-07-01T00:00:00Z", agent_name="A", agent_email="",
+        manager_email="", overall_score=90.0, sections={}, eval_id="E",
+        dialpad_link=None,
+    )
+    provider = _Provider([rec])
+    r1 = asyncio.run(ps.get_progression(provider, "A", days=30, config=sales))
+    r2 = asyncio.run(ps.get_progression(provider, "A", days=30, config=sales))
+    assert r1.evaluation_count == 1 and r2.evaluation_count == 1
+    assert calls == [("A", 1)]                 # once — cache hit didn't re-persist
+
+
+def test_progression_placeholders_never_persist(monkeypatch, sales):
+    # no records → placeholder
+    ps, calls = _wire(monkeypatch, "irrelevant")
+    asyncio.run(ps.get_progression(_Provider([]), "A", days=30, config=sales))
+    assert calls == []
+    # parse failure → placeholder
+    ps2, calls2 = _wire(monkeypatch, "NOT JSON {{{")
+    from backend.models.dashboard import EvaluationRecord
+    rec = EvaluationRecord(
+        timestamp="2026-07-01T00:00:00Z", agent_name="B", agent_email="",
+        manager_email="", overall_score=90.0, sections={}, eval_id="E",
+        dialpad_link=None,
+    )
+    asyncio.run(ps2.get_progression(_Provider([rec]), "B", days=30, config=sales))
+    assert calls2 == []

--- a/qa-automation/AI-Scoring/tests/test_eom_export.py
+++ b/qa-automation/AI-Scoring/tests/test_eom_export.py
@@ -1,0 +1,75 @@
+"""R2 — EOM CSV export summarization (JulyR2R3 §1).
+
+Pure-helper tests on a synthetic load_and_clean frame (the exact schema
+fetch_history_frame emits): month filtering matches the bucket-TZ
+drill-down semantics, the sampling counter counts per agent, active-lens
+default, summary/detail column shapes, and the slug.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from backend.services.team_stats import load_and_clean
+from tests.conftest import make_history_sheet, make_mails_sheet
+
+_spec = importlib.util.spec_from_file_location(
+    "export_eom_csvs",
+    Path(__file__).resolve().parent.parent / "scripts" / "export_eom_csvs.py")
+eom = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(eom)
+
+
+def _frame(sales):
+    history = make_history_sheet(sales)
+    mails = make_mails_sheet(
+        ["Star Rep", "Decline Rep", "Improve Rep", "Steady Rep", "Junior Rep"])
+    return load_and_clean(history, mails, sales)
+
+
+def test_month_frame_filters_month_and_active(sales):
+    df = _frame(sales)
+    dm = eom.month_frame(df, "2026-04", include_departed=False)
+    assert not dm.empty
+    assert dm["is_active"].all()
+    # Test Agent (not in Mails) is inactive → excluded by the active lens
+    assert "Test Agent" not in set(dm["agent"])
+    # widened lens brings the departed row back
+    wide = eom.month_frame(df, "2026-04", include_departed=True)
+    assert "Test Agent" in set(wide["agent"])
+    # a month with no data is empty, not an error
+    assert eom.month_frame(df, "1999-01", include_departed=False).empty
+
+
+def test_team_summary_counts_and_target(sales):
+    dm = eom.month_frame(_frame(sales), "2026-04", include_departed=False)
+    summary = eom.team_summary(dm, sales, target=20)
+    assert set(summary["agent"]) == set(dm["agent"].unique())
+    star = summary[summary["agent"] == "Star Rep"].iloc[0]
+    n_star = int((dm["agent"] == "Star Rep").sum())
+    assert star["evals"] == n_star                       # the sampling counter
+    assert star["sampling_target"] == 20
+    assert star["pct_of_target"] == round(100.0 * n_star / 20, 1)
+    # rollup sanity + roster convention (sorted by mean desc)
+    assert summary.iloc[0]["mean"] == summary["mean"].max()
+    # per-section columns present (labels, not history_ids)
+    first_label = list(sales.section_labels.values())[0]
+    assert first_label in summary.columns
+
+
+def test_agent_detail_rows_and_link(sales):
+    dm = eom.month_frame(_frame(sales), "2026-04", include_departed=False)
+    detail = eom.agent_detail(dm, "Star Rep", sales)
+    assert len(detail) == int((dm["agent"] == "Star Rep").sum())
+    assert list(detail.columns)[0] == "call_date"
+    assert detail["dialpad_link"].str.startswith(
+        "https://dialpad.com/callhistory/callreview/").all()
+    # call-date ordered
+    assert list(detail["call_date"]) == sorted(detail["call_date"])
+
+
+def test_agent_slug_accent_folding():
+    assert eom.agent_slug("Alexis López") == "alexis_lopez"
+    assert eom.agent_slug("  Fernanda   Santillán ") == "fernanda_santillan"

--- a/qa-automation/AI-Scoring/tests/test_onepager.py
+++ b/qa-automation/AI-Scoring/tests/test_onepager.py
@@ -1,0 +1,129 @@
+"""R3b — one-pager DB swap (JulyR2R3 §3).
+
+month_bounds bucket-TZ math, the frame→render adapter, the assessment
+slot HTML, and get_or_generate_month_assessment's fetch-first /
+no-generate flows (DB + Gemini faked).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import backend.services.assessment_store as astore
+from backend.services.team_stats import load_and_clean
+from tests.conftest import make_history_sheet, make_mails_sheet, load_test_config
+
+_spec = importlib.util.spec_from_file_location(
+    "export_onepager",
+    Path(__file__).resolve().parent.parent / "scripts" / "export_onepager.py")
+onepager = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(onepager)
+
+
+# ---------------------------------------------------------------------------
+# month_bounds — the TZ seam
+# ---------------------------------------------------------------------------
+
+def test_month_bounds_bucket_tz():
+    start, end, days = astore.month_bounds("2026-06")
+    assert days == 30
+    # June 1 00:00 in America/Los_Angeles (PDT, UTC-7) = 07:00 UTC
+    assert start == datetime(2026, 6, 1, 7, 0, tzinfo=timezone.utc)
+    assert end == datetime(2026, 7, 1, 7, 0, tzinfo=timezone.utc)
+
+
+def test_month_bounds_december_rollover():
+    start, end, days = astore.month_bounds("2026-12")
+    assert days == 31
+    assert end.year == 2027 and end.month == 1
+
+
+# ---------------------------------------------------------------------------
+# frame → render adapter
+# ---------------------------------------------------------------------------
+
+def _month_frame(sales):
+    df = load_and_clean(
+        make_history_sheet(sales),
+        make_mails_sheet(["Star Rep", "Decline Rep", "Improve Rep",
+                          "Steady Rep", "Junior Rep"]),
+        sales)
+    return df
+
+
+def test_frame_to_render_shape(sales):
+    df = _month_frame(sales)
+    rdf, section_cols = onepager.frame_to_render(df, "Star Rep", sales)
+    assert not rdf.empty
+    assert {"Agent Name", "_ts", "Overall Score"} <= set(rdf.columns)
+    # canonical order, display labels
+    expected = [s.name for s in sales.sections_by_number
+                if s.history_id in df.columns]
+    assert section_cols == expected
+    # render end-to-end on the adapted frame
+    html_out = onepager.render(rdf, "Star Rep", "2026-04", section_cols)
+    assert "Star Rep" in html_out and "qa.evaluations" in html_out
+
+
+# ---------------------------------------------------------------------------
+# assessment slot
+# ---------------------------------------------------------------------------
+
+def test_assessment_html_placeholder_and_content():
+    assert "No persisted assessment" in onepager.assessment_html(None)
+    filled = onepager.assessment_html({
+        "overall_assessment": "Strong month overall.",
+        "evaluations_included": 12,
+        "rubric_version": "ms_v2r",
+        "generated_at": datetime(2026, 7, 1, tzinfo=timezone.utc),
+        "sections": [
+            {"section_name": "Greeting", "trend": "improving",
+             "coaching_tip": "Keep the warm open."},
+            {"section_name": "Efficiency", "trend": "declining",
+             "coaching_tip": "Tighten wrap-up."},
+        ],
+    })
+    assert "Strong month overall." in filled
+    assert "Greeting" in filled and "▲" in filled and "▼" in filled
+    assert "ms_v2r" in filled
+
+
+# ---------------------------------------------------------------------------
+# get_or_generate flow
+# ---------------------------------------------------------------------------
+
+def test_get_or_generate_prefers_existing_row(monkeypatch):
+    config = load_test_config("sales")
+    existing = {"overall_assessment": "cached row", "sections": []}
+    calls = {"generated": 0}
+
+    async def fake_fetch(cfg, agent, start, end):
+        return existing
+
+    monkeypatch.setattr(astore, "fetch_assessment_for_range", fake_fetch)
+
+    def boom(*a, **k):
+        calls["generated"] += 1
+        raise AssertionError("must not generate when a row exists")
+
+    import backend.services.progression_service as ps
+    monkeypatch.setattr(ps, "generate_from_records", boom)
+    got = asyncio.run(astore.get_or_generate_month_assessment(
+        config, "A", "2026-06"))
+    assert got is existing
+    assert calls["generated"] == 0
+
+
+def test_get_or_generate_no_generate_returns_none(monkeypatch):
+    config = load_test_config("sales")
+
+    async def fake_fetch(cfg, agent, start, end):
+        return None
+
+    monkeypatch.setattr(astore, "fetch_assessment_for_range", fake_fetch)
+    got = asyncio.run(astore.get_or_generate_month_assessment(
+        config, "A", "2026-06", generate=False))
+    assert got is None


### PR DESCRIPTION
## Summary

Roadmap item 5 (the MS Director's July rollout, tasks #12/#13) — design in `references/JulyR2R3.md` (first commit). Everything sources `qa.*` through the proven post-flip row-source; no sheet reads. **No migration needed** — `qa.assessments` (011) has been waiting empty since Wave 2.

### R3a — `qa.assessments` writer (`services/assessment_store.py`)
- `get_progression` persists **every fresh generation** (owner decision): cache hits don't re-persist, the two placeholder results never persist (§Q4.a pure-AI-output rule), persist failures are logged + swallowed so the dashboard card always renders.
- Stamps: `agent_id` via the active-roster Stage-4 match (unknown/departed → skip + log), rubric/formula versions via `get_active_versions`, `models_used` in the eval-row shape, section rows snapshotted (name/number) per migration 011 Q3.a. The only mutation is the `is_current` flip on the predecessor in the same `(agent, team, window-size)` — content columns untouched.
- The June==rolling-30 window-size collision is documented and defused: exact-window readers ignore `is_current`.

### R2 — EOM CSV exports (`scripts/export_eom_csvs.py`)
- `--team X --month YYYY-MM [--target 20]` → `team_summary.csv` (per-agent: **sampling counter** vs target, mean/std/min/max, section means, Y/N pcts), `agent_<slug>.csv` per agent, `run_report.json` with the below-target list.
- Same bucket-TZ month semantics as the dashboard drill-down — **verified on prod: June unfiltered count (189) equals `qa.v_monthly_scores` exactly**. Outputs land in gitignored `database/eom_exports/` (agent PII).

### R3b — one-pager DB swap (`scripts/export_onepager.py`)
- `--csv` → `--team/--month[/--agent]`; one print-ready HTML per active agent; the reserved AI-Assessment slot fills from `qa.assessments` (exact-month window), **generating + persisting via the R3 writer when absent**; `--no-generate` for cost-free re-renders.
- Enablers: `generate_from_records` extracted from `get_progression` (typed `AssessmentParseError` replaces sentinel text), `month_bounds` (bucket-TZ month → UTC window), `PostgresProvider.get_agent_history_range`.

### Verification
- Suite: **599 passed, 0 failed** (17 new tests across the three slices).
- Prod (read-only): June export = 189 rows matching the monthly view; one-pager renders with every mockup section.

### Operator notes after merge
- **First real assessment-persisting run**: `python3 scripts/export_onepager.py --team member_support --month 2026-06` (no `--no-generate`) — ~20 Gemini calls, writes the first `qa.assessments` rows. July's official run happens at the Aug 1 close alongside `export_eom_csvs.py --team member_support --month 2026-07`.
- Dashboard progression cards start persisting automatically on deploy — watch for `assessment_store: persisted assessment` lines in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)