### PR TITLE
docs(qa-automation): generalize the Spanish-audio SOT rule (DispositionDesign v2.1)

### DIFF
--- a/qa-automation/AI-Scoring/references/DispositionDesign.md
+++ b/qa-automation/AI-Scoring/references/DispositionDesign.md
@@ -12,7 +12,7 @@
 
 | | |
 |---|---|
-| **Status** | v2 — evidence complete (API probes, taxonomy payload, one-day Stats export analyzed) |
+| **Status** | v2.1 — MERGED 2026-07-19 (PR #120 + owner amendment: Spanish-call audio SOT). Build starts at C0 |
 | **Supersedes** | v1's phase gating (P2 Stats-interim / P3-August webhooks). Webhooks are NOW — they are this project |
 | **Related** | LandingOpsCommandCenter.md (CC phases; this implements the ingestion base), SQLMigration.md §4 (webhook_events / calls / the hold_intervals scrapping clause), [[project_rag_coach_cards]] |
 
@@ -126,6 +126,13 @@ At Stage 1, after the transcript fetch:
      (back-to-back handling) — score on transcript evidence alone
      OR audio content if call is in Spanish."*
 4. Stamp the three `qa.evaluations` columns in the same Stage-1 write.
+
+**Language rule (owner, 2026-07-19):** for Spanish calls the source of
+truth is the AUDIO, not the transcript (Dialpad transcription is
+English-biased). Every grounding-block sentence that references
+"transcript evidence" must carry the audio alternative — C3's prompt
+builder branches the wording on the eval's `language`, it does not
+hardcode transcript-first phrasing.
 
 This is deliberately plain-injection: the RAG rework (disposition keying
 into SopRag retrieval, coach-cards corpus) follows the Sandy re-platform


### PR DESCRIPTION
One-paragraph follow-up to the merge-time amendment on #120: the Spanish-call rule ("audio is SOT, not transcript") applies to the **whole grounding block**, so §5 now states it as a language rule — C3's prompt builder must branch wording on the eval's `language` instead of hardcoding transcript-first phrasing. Status row bumped to v2.1 / build-starts-at-C0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)