### PR TITLE
feat(qa-automation): C0 — moment-parse fix + marker persistence

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -119,4 +119,4 @@ class ScorecardWithMeta(Scorecard):
     `compute_call_duration` stub. Writing it to a dedicated column is a
     future-project decision."""
     transcript_display: List[dict] = []  # [{timestamp, speaker, text}, ...]
-    moments_display: List[dict] = []     # [{timestamp, type}, ...]
+    moments_display: List[dict] = []     # [{timestamp, time, type, agent}, ...]

--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -223,10 +223,6 @@ TRANSCRIPT_CONTEXT_BLOCK = """
 Use this alongside the audio to improve accuracy. Speaker labels and content are from Dialpad.
 
 {transcript_text}
-
-=== DIALPAD SIGNAL MOMENTS ===
-These are events automatically detected by Dialpad during the call:
-{moments_text}
 """
 
 
@@ -243,7 +239,6 @@ def _build_sop_missing_note(config: TeamConfig) -> str:
 def build_prompt(
     config: TeamConfig,
     transcript_text: str = "",
-    moments_text: str = "",
     sop_title: str = "",
     sop_content: str = "",
     agent_name: str = "",
@@ -264,11 +259,8 @@ def build_prompt(
         parts.append(_build_sop_missing_note(config))
 
     if transcript_text:
-        moments_str = moments_text if moments_text else "No moments detected."
         parts.append(
-            TRANSCRIPT_CONTEXT_BLOCK.format(
-                transcript_text=transcript_text, moments_text=moments_str
-            )
+            TRANSCRIPT_CONTEXT_BLOCK.format(transcript_text=transcript_text)
         )
 
     if agent_name:

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -62,7 +62,6 @@ async def score_audio(
     filename: str,
     config: TeamConfig,
     transcript_text: str = "",
-    moments_text: str = "",
     sop_title: str = "",
     sop_content: str = "",
     agent_name: str = "",
@@ -89,7 +88,6 @@ async def score_audio(
         prompt = build_prompt(
             config=config,
             transcript_text=transcript_text,
-            moments_text=moments_text,
             sop_title=sop_title,
             sop_content=sop_content,
             agent_name=agent_name,

--- a/qa-automation/AI-Scoring/backend/services/dialpad_client.py
+++ b/qa-automation/AI-Scoring/backend/services/dialpad_client.py
@@ -26,19 +26,6 @@ class DialpadRateLimited(Exception):
 class NoRecordingAvailable(Exception):
     """Raised when a call has no associated recording to download."""
 
-# Dialpad moment types to strip before passing to the scoring model (noise)
-FILTERED_MOMENT_TYPES = {
-    "whole_call_summary_fragment",
-    "whole_call_summary",
-    "ner",
-    "action_item_v2",
-    "ai_csat_reboot",
-    "call_disposition",
-    "call_purpose",
-    "question",
-}
-
-
 def _headers() -> Optional[dict]:
     token = os.getenv("DIALPAD_API_KEY")
     if not token:
@@ -507,17 +494,86 @@ async def get_call_details(call_id: str) -> dict:
 # Transcript + moments
 # ---------------------------------------------------------------------------
 
+def parse_transcript_payload(data: dict) -> dict:
+    """
+    Parse a GET /transcripts/{id} payload. Pure — testable without HTTP.
+
+    Moment lines are occurrence markers: the moment TYPE arrives in
+    `content` (`moment_type` is None in current payloads) and `name` is
+    the AGENT, not the type. Markers carry no values, so none reach the
+    scoring prompt; ALL of them are kept in `moments_display` for the
+    frontend and Stage-1 persistence to `dialpad_call_metadata.moments`
+    (filtering is a prompt decision, never a storage decision —
+    DispositionDesign §2).
+    """
+    lines = data.get("lines", [])
+    transcript_lines = []        # flat text for the prompt
+    transcript_display = []      # structured list for the frontend
+    moments_display = []         # full marker set: frontend + Stage-1 persistence
+    call_start = None            # first timestamp, used to compute relative mm:ss
+
+    def _mmss(ts_raw: str) -> str:
+        try:
+            ts_dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return ""
+        if call_start is None:
+            return ""
+        elapsed = (ts_dt - call_start).total_seconds()
+        mins, secs = divmod(int(elapsed), 60)
+        return f"{mins}:{secs:02d}"
+
+    for line in lines:
+        line_type = line.get("type", "")
+        ts_raw = line.get("time", "")
+
+        if line_type == "transcript":
+            name = line.get("name", "Unknown")
+            content = line.get("content", "").strip()
+            if not content:
+                continue
+
+            if ts_raw and call_start is None:
+                try:
+                    call_start = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    pass
+
+            transcript_lines.append(f"{name}: {content}")
+            transcript_display.append({
+                "timestamp": _mmss(ts_raw) if ts_raw else "",
+                "speaker": name,
+                "text": content,
+            })
+
+        elif line_type in ("moment", "real_time_moment", "custom_moment"):
+            moment_type = line.get("moment_type") or line.get("content", "").strip()
+            if not moment_type:
+                continue
+
+            moments_display.append({
+                "timestamp": _mmss(ts_raw) if ts_raw else "",
+                "time": ts_raw,
+                "type": moment_type,
+                "agent": line.get("name", ""),
+            })
+
+    return {
+        "transcript_text": "\n".join(transcript_lines),
+        "transcript_display": transcript_display,
+        "moments_display": moments_display,
+    }
+
+
 async def get_transcript(call_id: str) -> dict:
     """
-    Fetch the full transcript for a call.
-    Returns a dict with 'transcript_text' and 'moments_text' ready for the prompt.
-    Returns empty strings if DIALPAD_API_KEY is not configured.
+    Fetch the full transcript for a call and parse it via
+    `parse_transcript_payload`. On any failure (no API key, HTTP error,
+    network error) returns empty shapes — scoring proceeds from audio only.
     """
+    empty = {"transcript_text": "", "transcript_display": [], "moments_display": []}
     if not os.getenv("DIALPAD_API_KEY"):
-        return {
-            "transcript_text": "",
-            "moments_text": "Dialpad not configured — transcript unavailable.",
-        }
+        return empty
 
     try:
         async with _SEMAPHORE, httpx.AsyncClient() as client:
@@ -530,83 +586,12 @@ async def get_transcript(call_id: str) -> dict:
             data = response.json()
     except httpx.HTTPStatusError as e:
         print(f"[dialpad_client] Transcript fetch failed ({e.response.status_code}): {e}")
-        return {
-            "transcript_text": "",
-            "moments_text": f"Transcript unavailable (HTTP {e.response.status_code}). Scoring from audio only.",
-        }
+        return empty
     except httpx.RequestError as e:
         print(f"[dialpad_client] Transcript request error: {e}")
-        return {
-            "transcript_text": "",
-            "moments_text": "Transcript unavailable (network error). Scoring from audio only.",
-        }
+        return empty
 
-    lines = data.get("lines", [])
-    transcript_lines = []        # flat text for the prompt
-    transcript_display = []      # structured list for the frontend
-    moments = []                 # flat text for the prompt
-    moments_display = []         # structured list for the frontend
-    call_start = None            # first timestamp, used to compute relative mm:ss
-
-    for line in lines:
-        line_type = line.get("type", "")
-        ts_raw = line.get("time", "")
-
-        if line_type == "transcript":
-            name = line.get("name", "Unknown")
-            content = line.get("content", "").strip()
-            if not content:
-                continue
-
-            # Parse timestamp to compute mm:ss offset from call start
-            ts_display = ""
-            if ts_raw:
-                try:
-                    from datetime import datetime as dt
-                    ts_dt = dt.fromisoformat(ts_raw.replace("Z", "+00:00"))
-                    if call_start is None:
-                        call_start = ts_dt
-                    elapsed = (ts_dt - call_start).total_seconds()
-                    mins, secs = divmod(int(elapsed), 60)
-                    ts_display = f"{mins}:{secs:02d}"
-                except (ValueError, TypeError):
-                    ts_display = ""
-
-            transcript_lines.append(f"{name}: {content}")
-            transcript_display.append({
-                "timestamp": ts_display,
-                "speaker": name,
-                "text": content,
-            })
-
-        elif line_type in ("moment", "real_time_moment", "custom_moment"):
-            moment_type = line.get("moment_type") or line.get("name", "")
-            if not moment_type or moment_type in FILTERED_MOMENT_TYPES:
-                continue
-
-            ts_display = ""
-            if ts_raw and call_start is not None:
-                try:
-                    from datetime import datetime as dt
-                    ts_dt = dt.fromisoformat(ts_raw.replace("Z", "+00:00"))
-                    elapsed = (ts_dt - call_start).total_seconds()
-                    mins, secs = divmod(int(elapsed), 60)
-                    ts_display = f"{mins}:{secs:02d}"
-                except (ValueError, TypeError):
-                    ts_display = ""
-
-            moments.append(f"[{moment_type}] at {ts_raw}")
-            moments_display.append({
-                "timestamp": ts_display,
-                "type": moment_type,
-            })
-
-    return {
-        "transcript_text": "\n".join(transcript_lines),
-        "moments_text": "\n".join(moments) if moments else "No relevant moments detected.",
-        "transcript_display": transcript_display,
-        "moments_display": moments_display,
-    }
+    return parse_transcript_payload(data)
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -177,6 +177,9 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
         "dialpad_call_metadata": json.dumps({
             "sop_used": scorecard.sop_used,
             "stage1_flags": sorted({f for s in scorecard.sections for f in s.flags}),
+            # Full Dialpad marker set, typed + timestamped (DispositionDesign
+            # C0: filtering is a prompt decision, never a storage decision).
+            "moments": scorecard.moments_display,
         }),
     }
 

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -47,7 +47,6 @@ async def score_call(
     if transcript_data is None:
         transcript_data = await get_transcript(call_id)
     transcript_text = transcript_data["transcript_text"]
-    moments_text = transcript_data["moments_text"]
 
     # Step 2: Notion SOP
     sop_data = await fetch_sop_for_call(transcript_text)
@@ -83,7 +82,6 @@ async def score_call(
         filename=filename,
         config=config,
         transcript_text=transcript_text,
-        moments_text=moments_text,
         sop_title=sop_data["sop_title"],
         sop_content=sop_data["sop_content"],
         agent_name=agent_name,

--- a/qa-automation/AI-Scoring/tests/test_dialpad_client.py
+++ b/qa-automation/AI-Scoring/tests/test_dialpad_client.py
@@ -13,7 +13,151 @@ from backend.services.dialpad_client import (
     _epoch_ms_to_utc_datetime,
     build_dialpad_link,
     compute_call_duration,
+    parse_transcript_payload,
 )
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript_payload — DispositionDesign C0 moment parse.
+# Payload shape probed 2026-07-19: moment lines carry the TYPE in `content`
+# (`moment_type` is None) and the AGENT in `name`.
+# ---------------------------------------------------------------------------
+
+def _real_payload():
+    return {
+        "call_id": "DP123",
+        "lines": [
+            {
+                "type": "transcript",
+                "name": "Jane Agent",
+                "content": "Thank you for calling Landing, this is Jane.",
+                "time": "2026-07-15T10:00:00Z",
+            },
+            {
+                "type": "moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "call_purpose",
+                "time": "2026-07-15T10:00:30Z",
+            },
+            {
+                "type": "transcript",
+                "name": "Member",
+                "content": "Hi, my smart lock is not working.",
+                "time": "2026-07-15T10:00:42Z",
+            },
+            {
+                "type": "real_time_moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "whole_call_summary_fragment",
+                "time": "2026-07-15T10:01:00Z",
+            },
+            {
+                "type": "moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "call_disposition",
+                "time": "2026-07-15T10:05:12Z",
+            },
+        ],
+    }
+
+
+def test_moment_type_parsed_from_content_not_name():
+    """The rotted filter matched `moment_type`/`name`; current payloads put
+    the type in `content` and the agent in `name`. The agent's name must
+    never surface as a marker type again."""
+    out = parse_transcript_payload(_real_payload())
+    types = [m["type"] for m in out["moments_display"]]
+    assert types == ["call_purpose", "whole_call_summary_fragment", "call_disposition"]
+    assert all(m["agent"] == "Jane Agent" for m in out["moments_display"])
+
+
+def test_full_marker_set_kept_nothing_filtered():
+    """DispositionDesign §2: filtering is a prompt decision, never a storage
+    decision. Former FILTERED_MOMENT_TYPES members (call_disposition,
+    whole_call_summary_fragment) are kept — the full set feeds
+    dialpad_call_metadata.moments."""
+    out = parse_transcript_payload(_real_payload())
+    assert len(out["moments_display"]) == 3
+    kept = {m["type"] for m in out["moments_display"]}
+    assert "call_disposition" in kept
+    assert "whole_call_summary_fragment" in kept
+
+
+def test_markers_never_reach_prompt_text():
+    """C0 checkpoint: zero marker lines in the prompt. The parse emits no
+    moments_text at all — transcript_text is the only prompt-bound string,
+    and it carries no `[...] at <ts>` marker lines."""
+    out = parse_transcript_payload(_real_payload())
+    assert "moments_text" not in out
+    assert "] at " not in out["transcript_text"]
+    assert "call_disposition" not in out["transcript_text"]
+
+
+def test_moment_type_field_wins_when_populated():
+    """Older/other payload shapes populated `moment_type`; it takes
+    precedence over `content` when present."""
+    out = parse_transcript_payload({
+        "lines": [
+            {
+                "type": "moment",
+                "moment_type": "ai_csat_reboot",
+                "name": "Jane Agent",
+                "content": "ignored",
+                "time": "2026-07-15T10:00:00Z",
+            },
+        ],
+    })
+    assert [m["type"] for m in out["moments_display"]] == ["ai_csat_reboot"]
+
+
+def test_typeless_marker_skipped():
+    """No moment_type and no content → unclassifiable; skipped rather than
+    persisting an empty-string type."""
+    out = parse_transcript_payload({
+        "lines": [
+            {"type": "moment", "moment_type": None, "name": "Jane Agent",
+             "content": "", "time": "2026-07-15T10:00:00Z"},
+        ],
+    })
+    assert out["moments_display"] == []
+
+
+def test_marker_timestamps_relative_to_call_start():
+    """mm:ss offsets are computed from the first transcript line; the raw
+    ISO time is kept alongside for persistence."""
+    out = parse_transcript_payload(_real_payload())
+    disposition = out["moments_display"][-1]
+    assert disposition["timestamp"] == "5:12"
+    assert disposition["time"] == "2026-07-15T10:05:12Z"
+
+
+def test_marker_before_first_transcript_line_keeps_raw_time():
+    """A marker arriving before any transcript line has no call-start to
+    offset from — mm:ss stays blank but the raw time survives."""
+    out = parse_transcript_payload({
+        "lines": [
+            {"type": "moment", "moment_type": None, "name": "Jane Agent",
+             "content": "call_purpose", "time": "2026-07-15T10:00:00Z"},
+            {"type": "transcript", "name": "Jane Agent", "content": "Hello.",
+             "time": "2026-07-15T10:00:05Z"},
+        ],
+    })
+    marker = out["moments_display"][0]
+    assert marker["timestamp"] == ""
+    assert marker["time"] == "2026-07-15T10:00:00Z"
+
+
+def test_transcript_lines_unaffected_by_moment_fix():
+    out = parse_transcript_payload(_real_payload())
+    assert out["transcript_text"] == (
+        "Jane Agent: Thank you for calling Landing, this is Jane.\n"
+        "Member: Hi, my smart lock is not working."
+    )
+    assert out["transcript_display"][0]["timestamp"] == "0:00"
+    assert out["transcript_display"][1]["timestamp"] == "0:42"
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -109,6 +109,28 @@ class TestBuildDraftRow:
         assert meta["stage1_flags"] == ["long_hold"]
         assert meta["sop_used"] == "Billing SOP"
 
+    def test_full_marker_set_persisted_to_metadata(self, ms_config):
+        """DispositionDesign C0 checkpoint: dialpad_call_metadata.moments
+        carries the FULL marker set, including types the old prompt filter
+        used to strip — typed, timestamped, with the agent name."""
+        moments = [
+            {"timestamp": "0:30", "time": "2026-07-15T10:00:30Z",
+             "type": "call_purpose", "agent": "Jane Agent"},
+            {"timestamp": "1:00", "time": "2026-07-15T10:01:00Z",
+             "type": "whole_call_summary_fragment", "agent": "Jane Agent"},
+            {"timestamp": "5:12", "time": "2026-07-15T10:05:12Z",
+             "type": "call_disposition", "agent": "Jane Agent"},
+        ]
+        row = build_draft_row(_scorecard(ms_config, moments_display=moments), ms_config)
+        meta = json.loads(row["dialpad_call_metadata"])
+        assert meta["moments"] == moments
+
+    def test_no_markers_persists_empty_list(self, ms_config):
+        """Transcript-fetch failures hand the writer an empty marker list —
+        metadata records [] (we looked and found none), not a missing key."""
+        meta = json.loads(build_draft_row(_scorecard(ms_config), ms_config)["dialpad_call_metadata"])
+        assert meta["moments"] == []
+
 
 # ---------------------------------------------------------------------------
 # build_draft_sections

--- a/qa-automation/AI-Scoring/tests/test_prompt_build.py
+++ b/qa-automation/AI-Scoring/tests/test_prompt_build.py
@@ -150,6 +150,21 @@ def test_numeric_non_na_section_schema_unchanged(sales: TeamConfig):
     assert '"yn_value": null' in block
 
 
+def test_prompt_has_zero_dialpad_marker_lines(config: TeamConfig):
+    """DispositionDesign C0 checkpoint: Dialpad moments are occurrence
+    markers with no values — the SIGNAL MOMENTS block is gone from the
+    prompt entirely. Markers persist to dialpad_call_metadata.moments
+    instead (filtering is a prompt decision, never a storage decision)."""
+    p = build_prompt(
+        config,
+        transcript_text="Speaker A: hello\nSpeaker B: hi",
+        sop_title="",
+        sop_content="",
+    )
+    assert "SIGNAL MOMENTS" not in p
+    assert "] at " not in p
+
+
 def test_full_prompt_assembles_without_error(config: TeamConfig):
     p = build_prompt(
         config,


### PR DESCRIPTION
## Summary

First build slice of **DispositionDesign v2 (Command Center v1)** — C0, the prompt-hygiene fix carried over from v1's D1.

**The bug:** current `GET /transcripts/{id}` payloads put the moment TYPE in `content` (`moment_type` is None) and the AGENT in `name`. `FILTERED_MOMENT_TYPES` matched `moment_type`/`name`, so it filtered nothing — every marker sailed into the scoring prompt as `[<AgentName>] at <timestamp>` lines (~10–40 per call of pure noise, agent name repeated throughout).

**The fix, per §2's principle** (*filtering is a prompt decision, never a storage decision*):

- **Prompt keeps nothing** — markers carry no values, so the `DIALPAD SIGNAL MOMENTS` block is removed entirely; `moments_text` plumbing dropped from `build_prompt` / `score_audio` / `score_call`.
- **Storage keeps everything** — `parse_transcript_payload` (new pure function, extracted for testability) captures the FULL marker set `{timestamp, time, type, agent}`; Stage-1 draft writes it to `dialpad_call_metadata.moments`. `FILTERED_MOMENT_TYPES` deleted.
- `moment_type` still wins when populated (legacy payload shapes); frontend `moments_display` now shows correct type names instead of agent names.

## Checkpoint (C0)

- [x] Prompt has zero marker lines — `test_prompt_build.py::test_prompt_has_zero_dialpad_marker_lines`
- [x] Parse pytest against the REAL payload shape — 8 new tests in `test_dialpad_client.py`
- [x] `dialpad_call_metadata.moments` carries the full set — `test_eval_store.py`

## Test plan

- `pytest tests/` — 838 passed, 6 skipped, 3 xfailed (skips/xfails pre-existing)

Next slice: C1 (migration 016).

🤖 Generated with [Claude Code](https://claude.com/claude-code)