### PR TITLE
feat(qa-automation): C3 — /score grounding block + eval-row stamps

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -120,3 +120,9 @@ class ScorecardWithMeta(Scorecard):
     future-project decision."""
     transcript_display: List[dict] = []  # [{timestamp, speaker, text}, ...]
     moments_display: List[dict] = []     # [{timestamp, time, type, agent}, ...]
+    # DispositionDesign §5 step 4 — verified CC facts stamped onto the
+    # qa.evaluations row at Stage 1. None = CC never saw the call, or the
+    # call was undispositioned (absence is expected-normal).
+    dialpad_disposition_category: Optional[str] = None
+    dialpad_disposition: Optional[str] = None
+    ai_csat: Optional[float] = None

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -119,4 +119,4 @@ class ScorecardWithMeta(Scorecard):
     `compute_call_duration` stub. Writing it to a dedicated column is a
     future-project decision."""
     transcript_display: List[dict] = []  # [{timestamp, speaker, text}, ...]
-    moments_display: List[dict] = []     # [{timestamp, type}, ...]
+    moments_display: List[dict] = []     # [{timestamp, time, type, agent}, ...]

--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -243,6 +243,7 @@ def build_prompt(
     sop_content: str = "",
     agent_name: str = "",
     extra_notes: str = "",
+    call_context_text: str = "",
 ) -> str:
     """Assemble the full user prompt for a scoring request."""
     parts = [build_scoring_rubric(config)]
@@ -257,6 +258,11 @@ def build_prompt(
         )
     else:
         parts.append(_build_sop_missing_note(config))
+
+    # DispositionDesign §5: the verified-system-data grounding block rides
+    # AHEAD of the transcript.
+    if call_context_text:
+        parts.append(call_context_text)
 
     if transcript_text:
         parts.append(

--- a/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/qa_scoring_prompt.py
@@ -223,10 +223,6 @@ TRANSCRIPT_CONTEXT_BLOCK = """
 Use this alongside the audio to improve accuracy. Speaker labels and content are from Dialpad.
 
 {transcript_text}
-
-=== DIALPAD SIGNAL MOMENTS ===
-These are events automatically detected by Dialpad during the call:
-{moments_text}
 """
 
 
@@ -243,7 +239,6 @@ def _build_sop_missing_note(config: TeamConfig) -> str:
 def build_prompt(
     config: TeamConfig,
     transcript_text: str = "",
-    moments_text: str = "",
     sop_title: str = "",
     sop_content: str = "",
     agent_name: str = "",
@@ -264,11 +259,8 @@ def build_prompt(
         parts.append(_build_sop_missing_note(config))
 
     if transcript_text:
-        moments_str = moments_text if moments_text else "No moments detected."
         parts.append(
-            TRANSCRIPT_CONTEXT_BLOCK.format(
-                transcript_text=transcript_text, moments_text=moments_str
-            )
+            TRANSCRIPT_CONTEXT_BLOCK.format(transcript_text=transcript_text)
         )
 
     if agent_name:

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -66,6 +66,7 @@ async def score_audio(
     sop_content: str = "",
     agent_name: str = "",
     extra_notes: str = "",
+    call_context_text: str = "",
 ) -> Scorecard:
     """
     Upload audio to Gemini and score it.
@@ -92,6 +93,7 @@ async def score_audio(
             sop_content=sop_content,
             agent_name=agent_name,
             extra_notes=extra_notes,
+            call_context_text=call_context_text,
         )
 
         response = client.models.generate_content(

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -62,7 +62,6 @@ async def score_audio(
     filename: str,
     config: TeamConfig,
     transcript_text: str = "",
-    moments_text: str = "",
     sop_title: str = "",
     sop_content: str = "",
     agent_name: str = "",
@@ -89,7 +88,6 @@ async def score_audio(
         prompt = build_prompt(
             config=config,
             transcript_text=transcript_text,
-            moments_text=moments_text,
             sop_title=sop_title,
             sop_content=sop_content,
             agent_name=agent_name,

--- a/qa-automation/AI-Scoring/backend/services/cc_context.py
+++ b/qa-automation/AI-Scoring/backend/services/cc_context.py
@@ -1,0 +1,235 @@
+"""Command Center call-context for /score grounding — DispositionDesign §5.
+
+At Stage 1, after the transcript fetch: match the eval's call against
+`command_center.calls` by the triple key (entry-point id first — it's
+what the eval usually carries — then per-leg call id, then master), pull
+the verified facts (disposition pair, AI-CSAT, hold cycles), and render
+the EMPHASIZED `Call context (verified system data)` block that goes
+ahead of the transcript in the scoring prompt.
+
+Rollout gate — `CC_GROUNDING_MODE` env var, read per call:
+
+  off      no CC lookup at all
+  shadow   (default) lookup + stamp qa.evaluations, LOG the block that
+           would have been injected, but leave the prompt untouched —
+           the C3 shadow week's log-only compare
+  on       lookup + stamp + inject
+
+Language rule (owner, 2026-07-19 / v2.1): for Spanish calls the AUDIO is
+the source of truth (Dialpad transcription is English-biased). Every
+sentence referencing transcript evidence branches on the eval's
+language; when the language is not yet known at prompt-build time (the
+Stage-1 reality — Gemini detects it in-flight), the wording carries both
+alternatives.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from backend.services.eval_store import get_pool
+
+logger = logging.getLogger(__name__)
+
+
+def grounding_mode() -> str:
+    """`off` | `shadow` | `on` (unknown values collapse to `shadow`)."""
+    mode = os.environ.get("CC_GROUNDING_MODE", "shadow").strip().lower()
+    return mode if mode in ("off", "shadow", "on") else "shadow"
+
+
+@dataclass(frozen=True)
+class HoldCycle:
+    started_at: datetime
+    ended_at: datetime
+    seconds: int
+
+
+@dataclass(frozen=True)
+class CallContext:
+    """Verified per-call facts pulled from command_center.* (§5 step 2)."""
+    cc_call_id: int
+    matched_by: str                      # 'entry_point' | 'call_id' | 'master'
+    disposition_category: Optional[str]
+    disposition: Optional[str]
+    ai_csat: Optional[float]
+    total_hold_seconds: int
+    connected_at: Optional[datetime]
+    started_at: Optional[datetime]
+    holds: list[HoldCycle] = field(default_factory=list)
+
+
+_MATCH_KEYS = (
+    ("entry_point", "dialpad_entry_point_call_id"),
+    ("call_id", "dialpad_call_id"),
+    ("master", "dialpad_master_call_id"),
+)
+
+
+async def fetch_call_context(
+    team_id: str,
+    *,
+    entry_point_call_id: str = "",
+    dialpad_call_id: str = "",
+    master_call_id: str = "",
+) -> Optional[CallContext]:
+    """Triple-key match against command_center.calls; None when the CC has
+    never seen the call (webhook era predates it) or no DB is configured.
+    Read-only and non-fatal: any failure logs and returns None — grounding
+    is an enhancement, never a scoring blocker."""
+    ids = {
+        "entry_point": (entry_point_call_id or "").strip(),
+        "call_id": (dialpad_call_id or "").strip(),
+        "master": (master_call_id or "").strip(),
+    }
+    try:
+        pool = await get_pool()
+        if pool is None:
+            return None
+        async with pool.acquire() as conn:
+            row, matched_by = None, ""
+            for key, column in _MATCH_KEYS:
+                if not ids[key]:
+                    continue
+                row = await conn.fetchrow(
+                    f"""
+                    SELECT id, disposition_category, disposition, ai_csat,
+                           total_hold_seconds, connected_at, started_at
+                    FROM command_center.calls
+                    WHERE team_id = $1 AND {column} = $2
+                    """,
+                    team_id, ids[key],
+                )
+                if row is not None:
+                    matched_by = key
+                    break
+            if row is None:
+                return None
+            hold_rows = await conn.fetch(
+                "SELECT started_at, ended_at, seconds "
+                "FROM command_center.hold_intervals "
+                "WHERE call_id = $1 ORDER BY started_at",
+                row["id"],
+            )
+    except Exception:
+        logger.exception(
+            "cc_context: lookup failed for team=%s call=%s — scoring proceeds ungrounded",
+            team_id, ids["call_id"] or ids["entry_point"],
+        )
+        return None
+
+    return CallContext(
+        cc_call_id=row["id"],
+        matched_by=matched_by,
+        disposition_category=row["disposition_category"],
+        disposition=row["disposition"],
+        ai_csat=float(row["ai_csat"]) if row["ai_csat"] is not None else None,
+        total_hold_seconds=row["total_hold_seconds"] or 0,
+        connected_at=row["connected_at"],
+        started_at=row["started_at"],
+        holds=[
+            HoldCycle(r["started_at"], r["ended_at"], r["seconds"])
+            for r in hold_rows
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure rendering — the EMPHASIZED block (§5 step 3)
+# ---------------------------------------------------------------------------
+
+
+def _mmss(total_seconds: int) -> str:
+    mins, secs = divmod(max(0, int(total_seconds)), 60)
+    return f"{mins}:{secs:02d}"
+
+
+def _absence_sentence(language: Optional[str]) -> str:
+    if language == "es":
+        return (
+            "No disposition was captured for this call (back-to-back "
+            "handling) — score on the AUDIO content: for Spanish calls the "
+            "audio is the source of truth and the transcript is unreliable."
+        )
+    if language == "en":
+        return (
+            "No disposition was captured for this call (back-to-back "
+            "handling) — score on transcript evidence alone."
+        )
+    return (
+        "No disposition was captured for this call (back-to-back "
+        "handling) — score on transcript evidence alone, OR on the audio "
+        "content if the call is in Spanish (for Spanish calls the audio is "
+        "the source of truth)."
+    )
+
+
+def build_call_context_block(
+    ctx: Optional[CallContext], language: Optional[str] = None
+) -> str:
+    """Render the grounding block; "" when the CC never saw the call
+    (nothing verified to say — the prompt stays as it is today)."""
+    if ctx is None:
+        return ""
+
+    lines = [
+        "",
+        "=== CALL CONTEXT (VERIFIED SYSTEM DATA) ===",
+        "IMPORTANT: the facts below are verified Dialpad system records for "
+        "THIS call. They are ground truth — do not second-guess them from "
+        "the transcript or audio.",
+        "",
+    ]
+
+    if ctx.disposition_category:
+        label = ctx.disposition_category + (
+            f" — {ctx.disposition}" if ctx.disposition else ""
+        )
+        lines.append(
+            f"- The agent classified this call as: {label}. Score the call "
+            "within reason FOR that disposition — the expectations of each "
+            "section apply as they pertain to this call type."
+        )
+    else:
+        lines.append(f"- {_absence_sentence(language)}")
+
+    anchor = ctx.connected_at or ctx.started_at
+    if ctx.holds:
+        described = []
+        for hold in ctx.holds:
+            duration = _mmss(hold.seconds)
+            if anchor is not None:
+                offset = _mmss(int((hold.started_at - anchor).total_seconds()))
+                described.append(f"{duration} at {offset}")
+            else:
+                described.append(duration)
+        n = len(ctx.holds)
+        lines.append(
+            f"- Verified hold record: {n} hold{'s' if n != 1 else ''} "
+            f"({', '.join(described)}). Do NOT infer or report holds beyond "
+            "this record."
+        )
+    elif ctx.total_hold_seconds > 0:
+        # Backfill-era rows can carry the rollup without per-cycle detail.
+        lines.append(
+            f"- Verified total hold time: {_mmss(ctx.total_hold_seconds)}. "
+            "Do NOT infer additional holds beyond this total."
+        )
+    else:
+        lines.append(
+            "- Verified: no holds occurred on this call. Do NOT report or "
+            "penalize hold time."
+        )
+
+    if ctx.ai_csat is not None:
+        lines.append(
+            f"- Dialpad Ai CSAT estimate for this call: {ctx.ai_csat:g}/5 "
+            "(context only — do not let it anchor your section scores)."
+        )
+
+    lines.append("")
+    return "\n".join(lines)

--- a/qa-automation/AI-Scoring/backend/services/dialpad_client.py
+++ b/qa-automation/AI-Scoring/backend/services/dialpad_client.py
@@ -26,19 +26,6 @@ class DialpadRateLimited(Exception):
 class NoRecordingAvailable(Exception):
     """Raised when a call has no associated recording to download."""
 
-# Dialpad moment types to strip before passing to the scoring model (noise)
-FILTERED_MOMENT_TYPES = {
-    "whole_call_summary_fragment",
-    "whole_call_summary",
-    "ner",
-    "action_item_v2",
-    "ai_csat_reboot",
-    "call_disposition",
-    "call_purpose",
-    "question",
-}
-
-
 def _headers() -> Optional[dict]:
     token = os.getenv("DIALPAD_API_KEY")
     if not token:
@@ -507,17 +494,86 @@ async def get_call_details(call_id: str) -> dict:
 # Transcript + moments
 # ---------------------------------------------------------------------------
 
+def parse_transcript_payload(data: dict) -> dict:
+    """
+    Parse a GET /transcripts/{id} payload. Pure — testable without HTTP.
+
+    Moment lines are occurrence markers: the moment TYPE arrives in
+    `content` (`moment_type` is None in current payloads) and `name` is
+    the AGENT, not the type. Markers carry no values, so none reach the
+    scoring prompt; ALL of them are kept in `moments_display` for the
+    frontend and Stage-1 persistence to `dialpad_call_metadata.moments`
+    (filtering is a prompt decision, never a storage decision —
+    DispositionDesign §2).
+    """
+    lines = data.get("lines", [])
+    transcript_lines = []        # flat text for the prompt
+    transcript_display = []      # structured list for the frontend
+    moments_display = []         # full marker set: frontend + Stage-1 persistence
+    call_start = None            # first timestamp, used to compute relative mm:ss
+
+    def _mmss(ts_raw: str) -> str:
+        try:
+            ts_dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return ""
+        if call_start is None:
+            return ""
+        elapsed = (ts_dt - call_start).total_seconds()
+        mins, secs = divmod(int(elapsed), 60)
+        return f"{mins}:{secs:02d}"
+
+    for line in lines:
+        line_type = line.get("type", "")
+        ts_raw = line.get("time", "")
+
+        if line_type == "transcript":
+            name = line.get("name", "Unknown")
+            content = line.get("content", "").strip()
+            if not content:
+                continue
+
+            if ts_raw and call_start is None:
+                try:
+                    call_start = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    pass
+
+            transcript_lines.append(f"{name}: {content}")
+            transcript_display.append({
+                "timestamp": _mmss(ts_raw) if ts_raw else "",
+                "speaker": name,
+                "text": content,
+            })
+
+        elif line_type in ("moment", "real_time_moment", "custom_moment"):
+            moment_type = line.get("moment_type") or line.get("content", "").strip()
+            if not moment_type:
+                continue
+
+            moments_display.append({
+                "timestamp": _mmss(ts_raw) if ts_raw else "",
+                "time": ts_raw,
+                "type": moment_type,
+                "agent": line.get("name", ""),
+            })
+
+    return {
+        "transcript_text": "\n".join(transcript_lines),
+        "transcript_display": transcript_display,
+        "moments_display": moments_display,
+    }
+
+
 async def get_transcript(call_id: str) -> dict:
     """
-    Fetch the full transcript for a call.
-    Returns a dict with 'transcript_text' and 'moments_text' ready for the prompt.
-    Returns empty strings if DIALPAD_API_KEY is not configured.
+    Fetch the full transcript for a call and parse it via
+    `parse_transcript_payload`. On any failure (no API key, HTTP error,
+    network error) returns empty shapes — scoring proceeds from audio only.
     """
+    empty = {"transcript_text": "", "transcript_display": [], "moments_display": []}
     if not os.getenv("DIALPAD_API_KEY"):
-        return {
-            "transcript_text": "",
-            "moments_text": "Dialpad not configured — transcript unavailable.",
-        }
+        return empty
 
     try:
         async with _SEMAPHORE, httpx.AsyncClient() as client:
@@ -530,83 +586,12 @@ async def get_transcript(call_id: str) -> dict:
             data = response.json()
     except httpx.HTTPStatusError as e:
         print(f"[dialpad_client] Transcript fetch failed ({e.response.status_code}): {e}")
-        return {
-            "transcript_text": "",
-            "moments_text": f"Transcript unavailable (HTTP {e.response.status_code}). Scoring from audio only.",
-        }
+        return empty
     except httpx.RequestError as e:
         print(f"[dialpad_client] Transcript request error: {e}")
-        return {
-            "transcript_text": "",
-            "moments_text": "Transcript unavailable (network error). Scoring from audio only.",
-        }
+        return empty
 
-    lines = data.get("lines", [])
-    transcript_lines = []        # flat text for the prompt
-    transcript_display = []      # structured list for the frontend
-    moments = []                 # flat text for the prompt
-    moments_display = []         # structured list for the frontend
-    call_start = None            # first timestamp, used to compute relative mm:ss
-
-    for line in lines:
-        line_type = line.get("type", "")
-        ts_raw = line.get("time", "")
-
-        if line_type == "transcript":
-            name = line.get("name", "Unknown")
-            content = line.get("content", "").strip()
-            if not content:
-                continue
-
-            # Parse timestamp to compute mm:ss offset from call start
-            ts_display = ""
-            if ts_raw:
-                try:
-                    from datetime import datetime as dt
-                    ts_dt = dt.fromisoformat(ts_raw.replace("Z", "+00:00"))
-                    if call_start is None:
-                        call_start = ts_dt
-                    elapsed = (ts_dt - call_start).total_seconds()
-                    mins, secs = divmod(int(elapsed), 60)
-                    ts_display = f"{mins}:{secs:02d}"
-                except (ValueError, TypeError):
-                    ts_display = ""
-
-            transcript_lines.append(f"{name}: {content}")
-            transcript_display.append({
-                "timestamp": ts_display,
-                "speaker": name,
-                "text": content,
-            })
-
-        elif line_type in ("moment", "real_time_moment", "custom_moment"):
-            moment_type = line.get("moment_type") or line.get("name", "")
-            if not moment_type or moment_type in FILTERED_MOMENT_TYPES:
-                continue
-
-            ts_display = ""
-            if ts_raw and call_start is not None:
-                try:
-                    from datetime import datetime as dt
-                    ts_dt = dt.fromisoformat(ts_raw.replace("Z", "+00:00"))
-                    elapsed = (ts_dt - call_start).total_seconds()
-                    mins, secs = divmod(int(elapsed), 60)
-                    ts_display = f"{mins}:{secs:02d}"
-                except (ValueError, TypeError):
-                    ts_display = ""
-
-            moments.append(f"[{moment_type}] at {ts_raw}")
-            moments_display.append({
-                "timestamp": ts_display,
-                "type": moment_type,
-            })
-
-    return {
-        "transcript_text": "\n".join(transcript_lines),
-        "moments_text": "\n".join(moments) if moments else "No relevant moments detected.",
-        "transcript_display": transcript_display,
-        "moments_display": moments_display,
-    }
+    return parse_transcript_payload(data)
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -177,6 +177,9 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
         "dialpad_call_metadata": json.dumps({
             "sop_used": scorecard.sop_used,
             "stage1_flags": sorted({f for s in scorecard.sections for f in s.flags}),
+            # Full Dialpad marker set, typed + timestamped (DispositionDesign
+            # C0: filtering is a prompt decision, never a storage decision).
+            "moments": scorecard.moments_display,
         }),
     }
 

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -174,6 +174,12 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
         "ai_provider_primary": "gemini",
         "scoring_status": scoring_status,
         "human_review_required_at": datetime.now(timezone.utc) if flagged_review else None,
+        # DispositionDesign §5 step 4 — CC-match stamps (migration 016).
+        # Self-contained on the eval row for analytics/one-pagers, same
+        # reproducibility instinct as the formula/rubric stamps.
+        "dialpad_disposition_category": scorecard.dialpad_disposition_category,
+        "dialpad_disposition": scorecard.dialpad_disposition,
+        "ai_csat": scorecard.ai_csat,
         "dialpad_call_metadata": json.dumps({
             "sop_used": scorecard.sop_used,
             "stage1_flags": sorted({f for s in scorecard.sections for f in s.flags}),

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -1,14 +1,21 @@
 """
 Scoring pipeline orchestrator.
-Ties together: Dialpad transcript -> Notion SOP -> Gemini scoring.
+Ties together: Dialpad transcript -> CC call context -> Notion SOP ->
+Gemini scoring.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Optional
 
 from backend.models.scorecard import ScorecardWithMeta
 from backend.services.audio_service import score_audio
+from backend.services.cc_context import (
+    build_call_context_block,
+    fetch_call_context,
+    grounding_mode,
+)
 from backend.services.dialpad_client import (
     CALL_DURATION_FLAG_MS,
     _epoch_ms_to_utc_datetime,
@@ -20,6 +27,8 @@ from backend.services.notion_service import fetch_sop_for_call
 
 if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
+
+logger = logging.getLogger(__name__)
 
 
 async def score_call(
@@ -47,6 +56,34 @@ async def score_call(
     if transcript_data is None:
         transcript_data = await get_transcript(call_id)
     transcript_text = transcript_data["transcript_text"]
+
+    # Step 1.5: CC call context (DispositionDesign §5). call_details moves
+    # ahead of scoring because the triple-key match wants the entry-point
+    # and master ids. Non-fatal throughout — an unmatched call scores
+    # exactly as it does today.
+    if call_details is None:
+        call_details = await get_call_details(call_id)
+    cc_ctx = None
+    call_context_text = ""
+    mode = grounding_mode()
+    if mode != "off":
+        cc_ctx = await fetch_call_context(
+            config.team_id,
+            entry_point_call_id=call_details.get("entry_point_call_id", ""),
+            dialpad_call_id=call_id,
+            master_call_id=call_details.get("master_call_id", ""),
+        )
+    if cc_ctx is not None:
+        rendered = build_call_context_block(cc_ctx)
+        if mode == "on":
+            call_context_text = rendered
+        else:
+            # Shadow week: log-only compare — the block that WOULD have
+            # been injected, prompt untouched.
+            logger.info(
+                "cc_grounding[shadow] call=%s matched_by=%s would inject:\n%s",
+                call_id, cc_ctx.matched_by, rendered,
+            )
 
     # Step 2: Notion SOP
     sop_data = await fetch_sop_for_call(transcript_text)
@@ -86,11 +123,8 @@ async def score_call(
         sop_content=sop_data["sop_content"],
         agent_name=agent_name,
         extra_notes=extra_notes,
+        call_context_text=call_context_text,
     )
-
-    # Step 4: Caller metadata from Dialpad
-    if call_details is None:
-        call_details = await get_call_details(call_id)
 
     return ScorecardWithMeta(
         **scorecard.model_dump(),
@@ -108,4 +142,9 @@ async def score_call(
         call_ended_at_utc=_epoch_ms_to_utc_datetime(call_details.get("date_ended")),
         transcript_display=transcript_data.get("transcript_display", []),
         moments_display=transcript_data.get("moments_display", []),
+        # §5 step 4: Stage-1 stamps from the CC match (None when unmatched
+        # or undispositioned — absence is a first-class state).
+        dialpad_disposition_category=cc_ctx.disposition_category if cc_ctx else None,
+        dialpad_disposition=cc_ctx.disposition if cc_ctx else None,
+        ai_csat=cc_ctx.ai_csat if cc_ctx else None,
     )

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -47,7 +47,6 @@ async def score_call(
     if transcript_data is None:
         transcript_data = await get_transcript(call_id)
     transcript_text = transcript_data["transcript_text"]
-    moments_text = transcript_data["moments_text"]
 
     # Step 2: Notion SOP
     sop_data = await fetch_sop_for_call(transcript_text)
@@ -83,7 +82,6 @@ async def score_call(
         filename=filename,
         config=config,
         transcript_text=transcript_text,
-        moments_text=moments_text,
         sop_title=sop_data["sop_title"],
         sop_content=sop_data["sop_content"],
         agent_name=agent_name,

--- a/qa-automation/AI-Scoring/tests/integration/test_cc_context.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_cc_context.py
@@ -1,0 +1,148 @@
+"""fetch_call_context against a real Postgres — the §5 triple-key match
+(entry_point → call_id → master, in that order) + the holds pull."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from backend.services import eval_store
+from backend.services.cc_context import fetch_call_context
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+T0 = datetime(2026, 7, 15, 10, 0, 30, tzinfo=timezone.utc)
+
+
+def _at(seconds: int) -> datetime:
+    return datetime.fromtimestamp(T0.timestamp() + seconds, tz=timezone.utc)
+
+
+@pytest_asyncio.fixture
+async def pg_ctx(clean_pg: asyncpg.Connection, pg_dsn: str, monkeypatch):
+    """004/005/006/016 + the eval_store pool (cc_context reads through it)
+    pointed at the container DB."""
+    for name in (
+        "004_create_schemas_and_teams.sql",
+        "005_command_center_tables.sql",
+        "006_qa_tables.sql",
+        "016_cc_dispositions_ai_csat_holds.sql",
+    ):
+        await clean_pg.execute((MIGRATIONS_DIR / name).read_text(encoding="utf-8"))
+    monkeypatch.setenv("DATABASE_URL", pg_dsn)
+    monkeypatch.setattr(eval_store, "_pool", None)
+    monkeypatch.setattr(eval_store, "_pool_lock", None)
+    try:
+        yield clean_pg
+    finally:
+        await eval_store.close_pool()
+
+
+async def _seed_call(conn: asyncpg.Connection, **cols) -> int:
+    base = dict(
+        team_id="member_support",
+        dialpad_call_id="DP-LEG",
+        dialpad_entry_point_call_id="DP-ENTRY",
+        dialpad_master_call_id="DP-MASTER",
+        seen_via="webhook",
+        connected_at=T0,
+        total_hold_seconds=160,
+        disposition_category="Access & Entry",
+        disposition="Smart-lock failure",
+        disposition_source="webhook",
+        ai_csat=4.5,
+    )
+    base.update(cols)
+    names = ", ".join(base)
+    placeholders = ", ".join(f"${i + 1}" for i in range(len(base)))
+    return await conn.fetchval(
+        f"INSERT INTO command_center.calls ({names}) "
+        f"VALUES ({placeholders}) RETURNING id",
+        *base.values(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_prefers_entry_point(pg_ctx: asyncpg.Connection) -> None:
+    await _seed_call(pg_ctx)
+    ctx = await fetch_call_context(
+        "member_support",
+        entry_point_call_id="DP-ENTRY",
+        dialpad_call_id="DP-LEG",
+        master_call_id="DP-MASTER",
+    )
+    assert ctx is not None
+    assert ctx.matched_by == "entry_point"
+    assert ctx.disposition_category == "Access & Entry"
+    assert ctx.disposition == "Smart-lock failure"
+    assert ctx.ai_csat == 4.5
+    assert ctx.total_hold_seconds == 160
+
+
+@pytest.mark.asyncio
+async def test_match_falls_back_call_id_then_master(
+    pg_ctx: asyncpg.Connection,
+) -> None:
+    await _seed_call(pg_ctx)
+    by_leg = await fetch_call_context(
+        "member_support",
+        entry_point_call_id="NOT-A-MATCH",
+        dialpad_call_id="DP-LEG",
+        master_call_id="DP-MASTER",
+    )
+    assert by_leg is not None and by_leg.matched_by == "call_id"
+    by_master = await fetch_call_context(
+        "member_support",
+        entry_point_call_id="NOT-A-MATCH",
+        dialpad_call_id="ALSO-NOT",
+        master_call_id="DP-MASTER",
+    )
+    assert by_master is not None and by_master.matched_by == "master"
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_none(pg_ctx: asyncpg.Connection) -> None:
+    """Webhook era predates the call → ungrounded scoring, not an error."""
+    await _seed_call(pg_ctx)
+    ctx = await fetch_call_context(
+        "member_support",
+        entry_point_call_id="X", dialpad_call_id="Y", master_call_id="Z",
+    )
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_team_scoping(pg_ctx: asyncpg.Connection) -> None:
+    """A sales-team call never grounds a member_support eval."""
+    await _seed_call(pg_ctx, team_id="sales")
+    ctx = await fetch_call_context(
+        "member_support", dialpad_call_id="DP-LEG",
+    )
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_holds_pulled_in_order(pg_ctx: asyncpg.Connection) -> None:
+    cc_id = await _seed_call(pg_ctx)
+    for start, end, secs, ended_by in (
+        (662, 720, 58, "hangup"),
+        (195, 297, 102, "connected"),
+    ):
+        await pg_ctx.execute(
+            """
+            INSERT INTO command_center.hold_intervals
+                (team_id, dialpad_call_id, call_id, started_at, ended_at,
+                 seconds, ended_by)
+            VALUES ('member_support', 'DP-LEG', $1, $2, $3, $4, $5)
+            """,
+            cc_id, _at(start), _at(end), secs, ended_by,
+        )
+    ctx = await fetch_call_context("member_support", dialpad_call_id="DP-LEG")
+    assert ctx is not None
+    assert [(h.seconds,) for h in ctx.holds] == [(102,), (58,)]
+    assert ctx.holds[0].started_at == _at(195)

--- a/qa-automation/AI-Scoring/tests/test_cc_grounding.py
+++ b/qa-automation/AI-Scoring/tests/test_cc_grounding.py
@@ -1,0 +1,221 @@
+"""C3 checkpoint — prompt-build tests for the grounding block.
+
+DispositionDesign §5: disposition present / absent, holds / no-holds,
+the v2.1 language rule (audio SOT for Spanish), block placement ahead of
+the transcript, and the Stage-1 eval-row stamps.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.models.scorecard import ScorecardWithMeta
+from backend.prompts.qa_scoring_prompt import build_prompt
+from backend.services.cc_context import (
+    CallContext,
+    HoldCycle,
+    build_call_context_block,
+    grounding_mode,
+)
+from backend.services.eval_store import build_draft_row
+from tests.conftest import load_test_config
+
+T0 = datetime(2026, 7, 15, 10, 0, 30, tzinfo=timezone.utc)
+
+
+def _at(seconds: int) -> datetime:
+    return datetime.fromtimestamp(T0.timestamp() + seconds, tz=timezone.utc)
+
+
+def _ctx(**overrides) -> CallContext:
+    defaults = dict(
+        cc_call_id=1,
+        matched_by="entry_point",
+        disposition_category="Access & Entry",
+        disposition="Smart-lock failure",
+        ai_csat=4.5,
+        total_hold_seconds=160,
+        connected_at=T0,
+        started_at=_at(-30),
+        holds=[
+            HoldCycle(_at(195), _at(297), 102),
+            HoldCycle(_at(662), _at(720), 58),
+        ],
+    )
+    defaults.update(overrides)
+    return CallContext(**defaults)
+
+
+@pytest.fixture(scope="module")
+def config():
+    return load_test_config("member_support")
+
+
+# ---------------------------------------------------------------------------
+# build_call_context_block — disposition present / absent
+# ---------------------------------------------------------------------------
+
+
+def test_disposition_present_scores_for_the_disposition():
+    block = build_call_context_block(_ctx())
+    assert "CALL CONTEXT (VERIFIED SYSTEM DATA)" in block
+    assert "Access & Entry — Smart-lock failure" in block
+    assert "FOR that disposition" in block
+
+
+def test_bare_category_renders_without_sub():
+    block = build_call_context_block(_ctx(disposition=None))
+    assert "classified this call as: Access & Entry." in block
+
+
+def test_absence_path_language_unknown_carries_both():
+    """Stage-1 reality: language is detected in-flight, so the wording
+    carries the transcript AND audio alternatives (v2.1 rule)."""
+    block = build_call_context_block(
+        _ctx(disposition_category=None, disposition=None)
+    )
+    assert "No disposition was captured" in block
+    assert "transcript evidence alone" in block
+    assert "audio content if the call is in Spanish" in block
+
+
+def test_absence_path_spanish_is_audio_sot():
+    """v2.1: for Spanish calls the AUDIO is the source of truth — no
+    transcript-first phrasing anywhere in the sentence."""
+    block = build_call_context_block(
+        _ctx(disposition_category=None, disposition=None), language="es"
+    )
+    assert "AUDIO content" in block
+    assert "audio is the source of truth" in block
+    assert "transcript evidence alone" not in block
+
+
+def test_absence_path_english_is_transcript_evidence():
+    block = build_call_context_block(
+        _ctx(disposition_category=None, disposition=None), language="en"
+    )
+    assert "transcript evidence alone" in block
+    assert "AUDIO content" not in block
+
+
+# ---------------------------------------------------------------------------
+# build_call_context_block — holds / no-holds
+# ---------------------------------------------------------------------------
+
+
+def test_holds_render_duration_at_offset():
+    """`1:42 at 3:15` — cycle duration at its offset from connect (§5)."""
+    block = build_call_context_block(_ctx())
+    assert "Verified hold record: 2 holds (1:42 at 3:15, 0:58 at 11:02)" in block
+    assert "Do NOT infer" in block
+
+
+def test_no_holds_kills_the_hallucinated_hold_class():
+    block = build_call_context_block(_ctx(total_hold_seconds=0, holds=[]))
+    assert "Verified: no holds occurred on this call" in block
+
+
+def test_rollup_without_cycles_renders_total_only():
+    """Backfill-era rows (stats_pull) can carry the rollup without
+    per-cycle detail — state the total, never invent positions."""
+    block = build_call_context_block(_ctx(holds=[], total_hold_seconds=160))
+    assert "Verified total hold time: 2:40" in block
+    assert "hold record:" not in block
+
+
+def test_ai_csat_line_present_and_absent():
+    assert "Ai CSAT estimate for this call: 4.5/5" in build_call_context_block(_ctx())
+    assert "CSAT" not in build_call_context_block(_ctx(ai_csat=None))
+
+
+def test_no_context_renders_nothing():
+    """CC never saw the call → no block; the prompt stays as-is today."""
+    assert build_call_context_block(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# build_prompt — placement ahead of the transcript
+# ---------------------------------------------------------------------------
+
+
+def test_context_block_rides_ahead_of_transcript(config):
+    block = build_call_context_block(_ctx())
+    p = build_prompt(
+        config,
+        transcript_text="Speaker A: hello",
+        call_context_text=block,
+    )
+    assert p.index("CALL CONTEXT (VERIFIED SYSTEM DATA)") < p.index(
+        "DIALPAD TRANSCRIPT"
+    )
+
+
+def test_empty_context_leaves_prompt_unchanged(config):
+    with_none = build_prompt(config, transcript_text="Speaker A: hello")
+    with_empty = build_prompt(
+        config, transcript_text="Speaker A: hello", call_context_text=""
+    )
+    assert with_none == with_empty
+    assert "CALL CONTEXT" not in with_empty
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 eval-row stamps (§5 step 4)
+# ---------------------------------------------------------------------------
+
+
+def _scorecard(config, **overrides) -> ScorecardWithMeta:
+    defaults = dict(
+        sections=[],
+        key_strengths="",
+        opportunities="",
+        call_summary="",
+        call_id="DP123",
+        agent_name="Jane Agent",
+    )
+    defaults.update(overrides)
+    return ScorecardWithMeta(**defaults)
+
+
+def test_draft_row_carries_cc_stamps(config):
+    row = build_draft_row(
+        _scorecard(
+            config,
+            dialpad_disposition_category="Access & Entry",
+            dialpad_disposition="Smart-lock failure",
+            ai_csat=4.5,
+        ),
+        config,
+    )
+    assert row["dialpad_disposition_category"] == "Access & Entry"
+    assert row["dialpad_disposition"] == "Smart-lock failure"
+    assert row["ai_csat"] == 4.5
+
+
+def test_draft_row_stamps_null_when_unmatched(config):
+    row = build_draft_row(_scorecard(config), config)
+    assert row["dialpad_disposition_category"] is None
+    assert row["dialpad_disposition"] is None
+    assert row["ai_csat"] is None
+
+
+# ---------------------------------------------------------------------------
+# grounding_mode gate
+# ---------------------------------------------------------------------------
+
+
+def test_grounding_mode_default_is_shadow(monkeypatch):
+    monkeypatch.delenv("CC_GROUNDING_MODE", raising=False)
+    assert grounding_mode() == "shadow"
+
+
+def test_grounding_mode_values(monkeypatch):
+    for value, expected in (
+        ("off", "off"), ("ON", "on"), (" shadow ", "shadow"),
+        ("bogus", "shadow"),
+    ):
+        monkeypatch.setenv("CC_GROUNDING_MODE", value)
+        assert grounding_mode() == expected

--- a/qa-automation/AI-Scoring/tests/test_dialpad_client.py
+++ b/qa-automation/AI-Scoring/tests/test_dialpad_client.py
@@ -13,7 +13,151 @@ from backend.services.dialpad_client import (
     _epoch_ms_to_utc_datetime,
     build_dialpad_link,
     compute_call_duration,
+    parse_transcript_payload,
 )
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript_payload — DispositionDesign C0 moment parse.
+# Payload shape probed 2026-07-19: moment lines carry the TYPE in `content`
+# (`moment_type` is None) and the AGENT in `name`.
+# ---------------------------------------------------------------------------
+
+def _real_payload():
+    return {
+        "call_id": "DP123",
+        "lines": [
+            {
+                "type": "transcript",
+                "name": "Jane Agent",
+                "content": "Thank you for calling Landing, this is Jane.",
+                "time": "2026-07-15T10:00:00Z",
+            },
+            {
+                "type": "moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "call_purpose",
+                "time": "2026-07-15T10:00:30Z",
+            },
+            {
+                "type": "transcript",
+                "name": "Member",
+                "content": "Hi, my smart lock is not working.",
+                "time": "2026-07-15T10:00:42Z",
+            },
+            {
+                "type": "real_time_moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "whole_call_summary_fragment",
+                "time": "2026-07-15T10:01:00Z",
+            },
+            {
+                "type": "moment",
+                "moment_type": None,
+                "name": "Jane Agent",
+                "content": "call_disposition",
+                "time": "2026-07-15T10:05:12Z",
+            },
+        ],
+    }
+
+
+def test_moment_type_parsed_from_content_not_name():
+    """The rotted filter matched `moment_type`/`name`; current payloads put
+    the type in `content` and the agent in `name`. The agent's name must
+    never surface as a marker type again."""
+    out = parse_transcript_payload(_real_payload())
+    types = [m["type"] for m in out["moments_display"]]
+    assert types == ["call_purpose", "whole_call_summary_fragment", "call_disposition"]
+    assert all(m["agent"] == "Jane Agent" for m in out["moments_display"])
+
+
+def test_full_marker_set_kept_nothing_filtered():
+    """DispositionDesign §2: filtering is a prompt decision, never a storage
+    decision. Former FILTERED_MOMENT_TYPES members (call_disposition,
+    whole_call_summary_fragment) are kept — the full set feeds
+    dialpad_call_metadata.moments."""
+    out = parse_transcript_payload(_real_payload())
+    assert len(out["moments_display"]) == 3
+    kept = {m["type"] for m in out["moments_display"]}
+    assert "call_disposition" in kept
+    assert "whole_call_summary_fragment" in kept
+
+
+def test_markers_never_reach_prompt_text():
+    """C0 checkpoint: zero marker lines in the prompt. The parse emits no
+    moments_text at all — transcript_text is the only prompt-bound string,
+    and it carries no `[...] at <ts>` marker lines."""
+    out = parse_transcript_payload(_real_payload())
+    assert "moments_text" not in out
+    assert "] at " not in out["transcript_text"]
+    assert "call_disposition" not in out["transcript_text"]
+
+
+def test_moment_type_field_wins_when_populated():
+    """Older/other payload shapes populated `moment_type`; it takes
+    precedence over `content` when present."""
+    out = parse_transcript_payload({
+        "lines": [
+            {
+                "type": "moment",
+                "moment_type": "ai_csat_reboot",
+                "name": "Jane Agent",
+                "content": "ignored",
+                "time": "2026-07-15T10:00:00Z",
+            },
+        ],
+    })
+    assert [m["type"] for m in out["moments_display"]] == ["ai_csat_reboot"]
+
+
+def test_typeless_marker_skipped():
+    """No moment_type and no content → unclassifiable; skipped rather than
+    persisting an empty-string type."""
+    out = parse_transcript_payload({
+        "lines": [
+            {"type": "moment", "moment_type": None, "name": "Jane Agent",
+             "content": "", "time": "2026-07-15T10:00:00Z"},
+        ],
+    })
+    assert out["moments_display"] == []
+
+
+def test_marker_timestamps_relative_to_call_start():
+    """mm:ss offsets are computed from the first transcript line; the raw
+    ISO time is kept alongside for persistence."""
+    out = parse_transcript_payload(_real_payload())
+    disposition = out["moments_display"][-1]
+    assert disposition["timestamp"] == "5:12"
+    assert disposition["time"] == "2026-07-15T10:05:12Z"
+
+
+def test_marker_before_first_transcript_line_keeps_raw_time():
+    """A marker arriving before any transcript line has no call-start to
+    offset from — mm:ss stays blank but the raw time survives."""
+    out = parse_transcript_payload({
+        "lines": [
+            {"type": "moment", "moment_type": None, "name": "Jane Agent",
+             "content": "call_purpose", "time": "2026-07-15T10:00:00Z"},
+            {"type": "transcript", "name": "Jane Agent", "content": "Hello.",
+             "time": "2026-07-15T10:00:05Z"},
+        ],
+    })
+    marker = out["moments_display"][0]
+    assert marker["timestamp"] == ""
+    assert marker["time"] == "2026-07-15T10:00:00Z"
+
+
+def test_transcript_lines_unaffected_by_moment_fix():
+    out = parse_transcript_payload(_real_payload())
+    assert out["transcript_text"] == (
+        "Jane Agent: Thank you for calling Landing, this is Jane.\n"
+        "Member: Hi, my smart lock is not working."
+    )
+    assert out["transcript_display"][0]["timestamp"] == "0:00"
+    assert out["transcript_display"][1]["timestamp"] == "0:42"
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -109,6 +109,28 @@ class TestBuildDraftRow:
         assert meta["stage1_flags"] == ["long_hold"]
         assert meta["sop_used"] == "Billing SOP"
 
+    def test_full_marker_set_persisted_to_metadata(self, ms_config):
+        """DispositionDesign C0 checkpoint: dialpad_call_metadata.moments
+        carries the FULL marker set, including types the old prompt filter
+        used to strip — typed, timestamped, with the agent name."""
+        moments = [
+            {"timestamp": "0:30", "time": "2026-07-15T10:00:30Z",
+             "type": "call_purpose", "agent": "Jane Agent"},
+            {"timestamp": "1:00", "time": "2026-07-15T10:01:00Z",
+             "type": "whole_call_summary_fragment", "agent": "Jane Agent"},
+            {"timestamp": "5:12", "time": "2026-07-15T10:05:12Z",
+             "type": "call_disposition", "agent": "Jane Agent"},
+        ]
+        row = build_draft_row(_scorecard(ms_config, moments_display=moments), ms_config)
+        meta = json.loads(row["dialpad_call_metadata"])
+        assert meta["moments"] == moments
+
+    def test_no_markers_persists_empty_list(self, ms_config):
+        """Transcript-fetch failures hand the writer an empty marker list —
+        metadata records [] (we looked and found none), not a missing key."""
+        meta = json.loads(build_draft_row(_scorecard(ms_config), ms_config)["dialpad_call_metadata"])
+        assert meta["moments"] == []
+
 
 # ---------------------------------------------------------------------------
 # build_draft_sections

--- a/qa-automation/AI-Scoring/tests/test_prompt_build.py
+++ b/qa-automation/AI-Scoring/tests/test_prompt_build.py
@@ -150,6 +150,21 @@ def test_numeric_non_na_section_schema_unchanged(sales: TeamConfig):
     assert '"yn_value": null' in block
 
 
+def test_prompt_has_zero_dialpad_marker_lines(config: TeamConfig):
+    """DispositionDesign C0 checkpoint: Dialpad moments are occurrence
+    markers with no values — the SIGNAL MOMENTS block is gone from the
+    prompt entirely. Markers persist to dialpad_call_metadata.moments
+    instead (filtering is a prompt decision, never a storage decision)."""
+    p = build_prompt(
+        config,
+        transcript_text="Speaker A: hello\nSpeaker B: hi",
+        sop_title="",
+        sop_content="",
+    )
+    assert "SIGNAL MOMENTS" not in p
+    assert "] at " not in p
+
+
 def test_full_prompt_assembles_without_error(config: TeamConfig):
     p = build_prompt(
         config,


### PR DESCRIPTION
## Summary

Slice **C3** of DispositionDesign v2.1 — the scoring pipeline consumes the CC's verified per-call truth. **Stacked on #124 (C2); also merges #122 (C0)** since it extends the post-C0 prompt builder.

- **`backend/services/cc_context.py`** — `fetch_call_context` (triple-key match: entry-point → per-leg → master; read-only, non-fatal) + `build_call_context_block` (pure renderer).
- **The grounding block** rides ahead of the transcript, EMPHASIZED as verified system data: the agent's disposition (*"score within reason FOR that disposition"*), the verified hold record per cycle (`1:42 at 3:15, 0:58 at 11:02`) or *"no holds occurred"* (kills the hallucinated-hold class), and AI-CSAT flagged context-only. Backfill-era rows with a rollup but no cycles state the total without inventing positions.
- **v2.1 language rule**: the absence path branches on eval language — Spanish → audio is source of truth, English → transcript evidence, unknown (Stage-1 reality) carries both alternatives. No hardcoded transcript-first phrasing.
- **`CC_GROUNDING_MODE`** (`off`/`shadow`/`on`), **default `shadow`**: context is fetched, eval columns stamped, and the would-be block logged (`cc_grounding[shadow]` lines) — but the prompt is untouched. This is the shadow week's log-only compare; flip the Railway env var to `on` when it reads clean.
- **Stage-1 stamps**: `dialpad_disposition_category` / `dialpad_disposition` / `ai_csat` stamped on `qa.evaluations` in the same Stage-1 write (self-contained rows, same instinct as the formula/rubric stamps). NULL = unmatched or undispositioned — absence is first-class.

## Checkpoint (C3)

- [x] Prompt-build pytest: disposition present / absent × holds / no-holds + all three language branches + block-ahead-of-transcript placement — `tests/test_cc_grounding.py` (16)
- [x] Triple-key match order, team scoping, holds pull — `tests/integration/test_cc_context.py` (5)
- [ ] **Shadow week (operator)**: after merge+deploy, watch `cc_grounding[shadow]` logs for a week of scored calls, then set `CC_GROUNDING_MODE=on`.

⚠ Deploy ordering: migration 016 must be applied to prod **before** this deploys (the Stage-1 write now includes the 016 columns).

## Test plan

- `pytest tests/` — 911 passed, 6 skipped, 3 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)