### PR TITLE
feat(qa-automation): C4 — Stats-API disposition backfill puller

### DIFF
--- a/qa-automation/AI-Scoring/scripts/pull_dispositions.py
+++ b/qa-automation/AI-Scoring/scripts/pull_dispositions.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""C4 — Stats-API disposition backfill (DispositionDesign §7).
+
+Initiates a Dialpad Stats **records** export per call center + date
+range, polls, downloads the CSV, joins on ``call_id`` (same id-space as
+our ``dialpad_call_id``), and fills the disposition columns on BOTH
+tables with ``disposition_source='stats_pull'`` — only for rows the
+webhook era predates:
+
+- ``command_center.calls``: filled only where ``disposition_source IS
+  NULL`` (a live webhook stamp always wins the seam).
+- ``qa.evaluations``: filled only where ``dialpad_disposition_category
+  IS NULL``, joined by the triple key (per-leg / entry-point / master —
+  the eval usually carries the entry-point id).
+
+The 2026-07-15 sample export carries NO AI-CSAT column, so this script
+fills dispositions only; ``ai_csat`` stays webhook-sourced (§9 appendix).
+
+Also the catch-up sweep if the receiver ever drops events — re-runs are
+idempotent by construction (the NULL guards).
+
+Overnight contract (B-series): row failures are caught, logged, and
+reported; the run never dies mid-batch. Exit 0 = clean; 2 = ran with
+failures (read the report); 1 = structural (nothing written).
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/pull_dispositions.py --team-id member_support \
+        --days-start 30 --days-end 0 --dry-run
+    python3 scripts/pull_dispositions.py --team-id member_support \
+        --days-start 30 --days-end 0
+    python3 scripts/pull_dispositions.py --team-id member_support \
+        --csv /path/to/export.csv        # offline: skip the API
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import io
+import json
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _AI_SCORING.parent.parent
+load_dotenv(_AI_SCORING / ".env")
+
+import os  # noqa: E402
+
+import httpx  # noqa: E402
+
+BASE_URL = "https://dialpad.com/api/v2"
+_CC_CONFIG = _REPO_ROOT / "command_center" / "config" / "command_center.json"
+
+POLL_INTERVAL_S = 5
+POLL_TIMEOUT_S = 600
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — testable without API or DB
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StatsRecord:
+    call_id: str
+    disposition_category: Optional[str]
+    disposition: Optional[str]
+
+
+def split_disposition(label: str) -> tuple[Optional[str], Optional[str]]:
+    """`Category~Subdisposition` → pair; bare category → (category, None)."""
+    label = (label or "").strip()
+    if not label:
+        return (None, None)
+    category, _, sub = label.partition("~")
+    return (category.strip(), sub.strip() or None)
+
+
+def parse_export_csv(text: str) -> list[StatsRecord]:
+    """Rows of the Stats records export we act on. Rows without a call_id
+    are dropped (unjoinable); rows without a disposition are kept — they
+    are the coverage denominator (§1: absence is expected-normal)."""
+    records = []
+    for row in csv.DictReader(io.StringIO(text)):
+        call_id = (row.get("call_id") or "").strip()
+        if not call_id:
+            continue
+        category, sub = split_disposition(row.get("disposition") or "")
+        records.append(StatsRecord(call_id, category, sub))
+    return records
+
+
+def team_call_center_ids(team_id: str) -> list[str]:
+    config = json.loads(_CC_CONFIG.read_text(encoding="utf-8"))
+    team = config.get("teams", {}).get(team_id)
+    if not team:
+        sys.exit(f"ERROR: team '{team_id}' not in {_CC_CONFIG}")
+    ids = team.get("dialpad", {}).get("target_call_center_ids", [])
+    if not ids:
+        sys.exit(f"ERROR: no target_call_center_ids for '{team_id}'")
+    return [str(i) for i in ids]
+
+
+# ---------------------------------------------------------------------------
+# Stats API — initiate / poll / download
+# ---------------------------------------------------------------------------
+
+
+def fetch_export(call_center_id: str, days_start: int, days_end: int) -> str:
+    api_key = os.environ.get("DIALPAD_API_KEY", "")
+    if not api_key:
+        sys.exit("ERROR: DIALPAD_API_KEY not set (env or AI-Scoring/.env).")
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    with httpx.Client(headers=headers, timeout=30) as client:
+        resp = client.post(
+            f"{BASE_URL}/stats",
+            json={
+                "export_type": "records",
+                "stat_type": "calls",
+                "target_id": int(call_center_id),
+                "target_type": "callcenter",
+                "days_ago_start": days_start,
+                "days_ago_end": days_end,
+                "timezone": "UTC",
+            },
+        )
+        resp.raise_for_status()
+        request_id = resp.json()["request_id"]
+        print(f"stats export initiated: request_id={request_id}")
+
+        deadline = time.monotonic() + POLL_TIMEOUT_S
+        while True:
+            status = client.get(f"{BASE_URL}/stats/{request_id}")
+            status.raise_for_status()
+            body = status.json()
+            if body.get("status") == "complete":
+                url = body["download_url"]
+                break
+            if body.get("status") == "failed":
+                sys.exit(f"ERROR: export failed: {body}")
+            if time.monotonic() > deadline:
+                sys.exit(f"ERROR: export not complete after {POLL_TIMEOUT_S}s")
+            time.sleep(POLL_INTERVAL_S)
+
+        download = client.get(url, follow_redirects=True)
+        download.raise_for_status()
+        return download.text
+
+
+# ---------------------------------------------------------------------------
+# DB fill — NULL-guarded, idempotent
+# ---------------------------------------------------------------------------
+
+
+async def fill_tables(
+    team_id: str, records: list[StatsRecord], *, dry_run: bool
+) -> dict:
+    import asyncpg
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        sys.exit("ERROR: DATABASE_URL not set.")
+
+    report = {
+        "rows_in_export": len(records),
+        "with_disposition": 0,
+        "cc_calls_filled": 0,
+        "evals_filled": 0,
+        "row_failures": 0,
+    }
+    dispositioned = [r for r in records if r.disposition_category]
+    report["with_disposition"] = len(dispositioned)
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        for record in dispositioned:
+            try:
+                if dry_run:
+                    cc_hit = await conn.fetchval(
+                        "SELECT COUNT(*) FROM command_center.calls "
+                        "WHERE team_id = $1 AND dialpad_call_id = $2 "
+                        "  AND disposition_source IS NULL",
+                        team_id, record.call_id,
+                    )
+                    ev_hit = await conn.fetchval(
+                        "SELECT COUNT(*) FROM qa.evaluations "
+                        "WHERE team_id = $1 AND dialpad_disposition_category IS NULL "
+                        "  AND (dialpad_call_id = $2 "
+                        "       OR dialpad_entry_point_call_id = $2 "
+                        "       OR dialpad_master_call_id = $2)",
+                        team_id, record.call_id,
+                    )
+                    report["cc_calls_filled"] += cc_hit
+                    report["evals_filled"] += ev_hit
+                    continue
+
+                cc_result = await conn.execute(
+                    "UPDATE command_center.calls "
+                    "SET disposition_category = $3, disposition = $4, "
+                    "    disposition_source = 'stats_pull' "
+                    "WHERE team_id = $1 AND dialpad_call_id = $2 "
+                    "  AND disposition_source IS NULL",
+                    team_id, record.call_id,
+                    record.disposition_category, record.disposition,
+                )
+                ev_result = await conn.execute(
+                    "UPDATE qa.evaluations "
+                    "SET dialpad_disposition_category = $3, "
+                    "    dialpad_disposition = $4 "
+                    "WHERE team_id = $1 AND dialpad_disposition_category IS NULL "
+                    "  AND (dialpad_call_id = $2 "
+                    "       OR dialpad_entry_point_call_id = $2 "
+                    "       OR dialpad_master_call_id = $2)",
+                    team_id, record.call_id,
+                    record.disposition_category, record.disposition,
+                )
+                report["cc_calls_filled"] += int(cc_result.split()[-1])
+                report["evals_filled"] += int(ev_result.split()[-1])
+            except Exception as e:  # noqa: BLE001 — overnight contract
+                report["row_failures"] += 1
+                print(f"  ROW FAILURE call_id={record.call_id}: {e}", file=sys.stderr)
+    finally:
+        await conn.close()
+    return report
+
+
+def print_report(team_id: str, report: dict, *, dry_run: bool) -> None:
+    label = "DRY-RUN (would fill)" if dry_run else "filled"
+    total = report["rows_in_export"]
+    with_disp = report["with_disposition"]
+    pct = (100 * with_disp / total) if total else 0.0
+    print()
+    print(f"=== pull_dispositions report — {team_id} ===")
+    print(f"rows in export:        {total}")
+    print(f"with disposition:      {with_disp} ({pct:.0f}% coverage)")
+    print(f"cc.calls {label}:      {report['cc_calls_filled']}")
+    print(f"qa.evaluations {label}: {report['evals_filled']}")
+    print(f"row failures:          {report['row_failures']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--team-id", default="member_support")
+    parser.add_argument("--days-start", type=int, default=30,
+                        help="days ago the range STARTS (older bound)")
+    parser.add_argument("--days-end", type=int, default=0,
+                        help="days ago the range ENDS (newer bound)")
+    parser.add_argument("--csv", default=None,
+                        help="local export CSV — skip the Stats API")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if args.csv:
+        text = Path(args.csv).read_text(encoding="utf-8")
+        records = parse_export_csv(text)
+    else:
+        records = []
+        for cc_id in team_call_center_ids(args.team_id):
+            print(f"fetching Stats export for call center {cc_id} "
+                  f"(days {args.days_start} → {args.days_end}) ...")
+            records.extend(
+                parse_export_csv(
+                    fetch_export(cc_id, args.days_start, args.days_end)
+                )
+            )
+
+    report = asyncio.run(
+        fill_tables(args.team_id, records, dry_run=args.dry_run)
+    )
+    print_report(args.team_id, report, dry_run=args.dry_run)
+    return 2 if report["row_failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa-automation/AI-Scoring/tests/integration/test_pull_dispositions_fill.py
+++ b/qa-automation/AI-Scoring/tests/integration/test_pull_dispositions_fill.py
@@ -1,0 +1,127 @@
+"""C4 fill semantics against a real Postgres: stats_pull fills only rows
+the webhook era predates (NULL guards), joins evals by the triple key,
+and re-runs are idempotent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from scripts.pull_dispositions import StatsRecord, fill_tables
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATIONS_DIR = REPO_ROOT / "database" / "migrations"
+
+_MODELS = '{"text": {"provider": "gemini"}}'
+
+
+@pytest_asyncio.fixture
+async def pg_fill(clean_pg: asyncpg.Connection, pg_dsn: str, monkeypatch):
+    for name in (
+        "004_create_schemas_and_teams.sql",
+        "005_command_center_tables.sql",
+        "006_qa_tables.sql",
+        "016_cc_dispositions_ai_csat_holds.sql",
+    ):
+        await clean_pg.execute((MIGRATIONS_DIR / name).read_text(encoding="utf-8"))
+    monkeypatch.setenv("DATABASE_URL", pg_dsn)
+
+    # CC calls: one already webhook-stamped, one pre-webhook (NULL source).
+    await clean_pg.execute(
+        """
+        INSERT INTO command_center.calls
+            (team_id, dialpad_call_id, seen_via,
+             disposition_category, disposition, disposition_source)
+        VALUES
+            ('member_support', 'CALL-WEBHOOK', 'webhook',
+             'Billing', 'Refund', 'webhook'),
+            ('member_support', 'CALL-OLD', 'qa_backfill', NULL, NULL, NULL)
+        """
+    )
+    # Evals: one already stamped at Stage 1, one pre-C3 (NULL), the latter
+    # carrying the export's id in its ENTRY-POINT column (the usual case).
+    await clean_pg.execute(
+        f"""
+        INSERT INTO qa.evaluations
+            (team_id, agent_name_raw, state, source, models_used,
+             dialpad_call_id, dialpad_entry_point_call_id,
+             dialpad_disposition_category, dialpad_disposition)
+        VALUES
+            ('member_support', 'A', 'draft', 'ai', '{_MODELS}'::jsonb,
+             'CALL-WEBHOOK', NULL, 'Billing', 'Refund'),
+            ('member_support', 'B', 'draft', 'ai', '{_MODELS}'::jsonb,
+             'LEG-OLD', 'CALL-OLD', NULL, NULL)
+        """
+    )
+    return clean_pg
+
+
+_RECORDS = [
+    StatsRecord("CALL-WEBHOOK", "Access & Entry", "Lockout"),
+    StatsRecord("CALL-OLD", "Access & Entry", "Smart-lock failure"),
+    StatsRecord("CALL-UNKNOWN", "Billing", None),
+    StatsRecord("CALL-NODISP", None, None),
+]
+
+
+@pytest.mark.asyncio
+async def test_fill_respects_webhook_seam(pg_fill: asyncpg.Connection) -> None:
+    report = await fill_tables("member_support", _RECORDS, dry_run=False)
+    assert report["rows_in_export"] == 4
+    assert report["with_disposition"] == 3
+    assert report["cc_calls_filled"] == 1
+    assert report["evals_filled"] == 1
+    assert report["row_failures"] == 0
+
+    # The webhook-stamped CC row is untouched.
+    webhook_row = await pg_fill.fetchrow(
+        "SELECT disposition_category, disposition, disposition_source "
+        "FROM command_center.calls WHERE dialpad_call_id = 'CALL-WEBHOOK'"
+    )
+    assert webhook_row["disposition_category"] == "Billing"
+    assert webhook_row["disposition_source"] == "webhook"
+
+    # The pre-webhook row got the stats fill.
+    old_row = await pg_fill.fetchrow(
+        "SELECT disposition_category, disposition, disposition_source "
+        "FROM command_center.calls WHERE dialpad_call_id = 'CALL-OLD'"
+    )
+    assert old_row["disposition_category"] == "Access & Entry"
+    assert old_row["disposition"] == "Smart-lock failure"
+    assert old_row["disposition_source"] == "stats_pull"
+
+    # Eval joined via its entry-point id; the stamped one untouched.
+    stamped = await pg_fill.fetchrow(
+        "SELECT dialpad_disposition_category FROM qa.evaluations "
+        "WHERE agent_name_raw = 'A'"
+    )
+    assert stamped["dialpad_disposition_category"] == "Billing"
+    filled = await pg_fill.fetchrow(
+        "SELECT dialpad_disposition_category, dialpad_disposition "
+        "FROM qa.evaluations WHERE agent_name_raw = 'B'"
+    )
+    assert filled["dialpad_disposition_category"] == "Access & Entry"
+    assert filled["dialpad_disposition"] == "Smart-lock failure"
+
+
+@pytest.mark.asyncio
+async def test_rerun_is_idempotent(pg_fill: asyncpg.Connection) -> None:
+    await fill_tables("member_support", _RECORDS, dry_run=False)
+    report = await fill_tables("member_support", _RECORDS, dry_run=False)
+    assert report["cc_calls_filled"] == 0
+    assert report["evals_filled"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_nothing(pg_fill: asyncpg.Connection) -> None:
+    report = await fill_tables("member_support", _RECORDS, dry_run=True)
+    assert report["cc_calls_filled"] == 1
+    assert report["evals_filled"] == 1
+    row = await pg_fill.fetchrow(
+        "SELECT disposition_source FROM command_center.calls "
+        "WHERE dialpad_call_id = 'CALL-OLD'"
+    )
+    assert row["disposition_source"] is None

--- a/qa-automation/AI-Scoring/tests/test_pull_dispositions.py
+++ b/qa-automation/AI-Scoring/tests/test_pull_dispositions.py
@@ -1,0 +1,66 @@
+"""Unit tests for the C4 Stats-export parse (pure helpers)."""
+
+from __future__ import annotations
+
+from scripts.pull_dispositions import parse_export_csv, split_disposition
+
+# Mirrors the 2026-07-15 sample export header exactly.
+_HEADER = (
+    "date_started,call_id,operator_id,operator_name,operator_email,"
+    "disposition,direction,external_number,internal_number,date_rang,"
+    "date_queued,date_connected,date_ended,target_id,target_kind,"
+    "office_id,company_id,salesforce_activity_id,recording_url,note,timezone"
+)
+
+
+def _row(call_id: str, disposition: str) -> str:
+    return (
+        f"2026-07-15 00:05:54.388365,{call_id},58046,Andrei Trejo,"
+        f"a@hellolanding.com,{disposition},inbound,REDACTED,12058528798,"
+        "2026-07-15 00:06:02,,2026-07-15 00:06:04,2026-07-15 00:21:51,"
+        "56990,CallCenter,48396,47255,,https://dialpad.test/rec,,"
+        "America/Mexico_City"
+    )
+
+
+def test_split_category_and_sub():
+    assert split_disposition("Access & Entry~Smart-lock failure") == (
+        "Access & Entry", "Smart-lock failure",
+    )
+
+
+def test_split_bare_category():
+    """Agent stopped at level 1 — the 07-15 sample's dominant shape."""
+    assert split_disposition("Reservation & Stay Changes") == (
+        "Reservation & Stay Changes", None,
+    )
+
+
+def test_split_empty():
+    assert split_disposition("") == (None, None)
+    assert split_disposition("   ") == (None, None)
+
+
+def test_parse_keeps_undispositioned_rows_for_coverage():
+    """Rows without a disposition stay in the parse — they are the
+    coverage denominator (83% in the 07-15 sample); only unjoinable
+    rows (no call_id) drop."""
+    text = "\n".join([
+        _HEADER,
+        _row("111", "Billing~Refund"),
+        _row("222", ""),
+        _row("", "Billing"),
+    ])
+    records = parse_export_csv(text)
+    assert [r.call_id for r in records] == ["111", "222"]
+    assert records[0].disposition_category == "Billing"
+    assert records[0].disposition == "Refund"
+    assert records[1].disposition_category is None
+
+
+def test_parse_real_sample_shape():
+    text = "\n".join([_HEADER, _row("6529997769220096", "Reservation & Stay Changes")])
+    (record,) = parse_export_csv(text)
+    assert record.call_id == "6529997769220096"
+    assert record.disposition_category == "Reservation & Stay Changes"
+    assert record.disposition is None


### PR DESCRIPTION
## Summary

Slice **C4** of DispositionDesign v2.1 — `scripts/pull_dispositions.py`, the historic backfill + catch-up sweep. **Stacked on #125 (C3).**

- **Fetch**: initiates a Dialpad Stats *records* export per configured call center (ids from `command_center/config/command_center.json`) and days-ago range, polls to completion, downloads the CSV. `--csv <path>` runs offline from a saved export.
- **Fill**: joins on `call_id` (same id-space as our `dialpad_call_id`); fills `command_center.calls` (guarded by `disposition_source IS NULL` — a live webhook stamp always wins the backfill-vs-live seam) and `qa.evaluations` (guarded by `dialpad_disposition_category IS NULL`, joined by the triple key since evals usually carry the entry-point id), stamping `disposition_source='stats_pull'`. Re-runs are idempotent by construction.
- **B-series conventions**: `--dry-run` reports what would fill without writing; row failures are caught/logged/reported, never fatal mid-batch; exit 0 clean / 2 with failures.
- The 07-15 sample export has **no AI-CSAT column** → dispositions only; `ai_csat` stays webhook-sourced (appendix already notes the field catalog).

## Checkpoint (C4)

- [x] Coverage report — parsing the real 2026-07-15 sample reproduces the design-era analysis exactly: 229 rows, 191 with disposition (83%), 43 distinct labels
- [x] Seam correctness, triple-key eval join, idempotent re-run, dry-run writes nothing — `tests/integration/test_pull_dispositions_fill.py`
- [ ] **Operator**: after first live run, spot-check a handful of filled rows against the Dialpad UI

## Test plan

- `pytest tests/` — 919 passed, 6 skipped, 3 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)