### PR TITLE
fix: boot without command_center when the build root excludes it (prod crash-loop)

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -26,15 +26,39 @@ logging.basicConfig(
 )
 
 # Command Center mount (LandingOpsCommandCenter.md §6): the top-level
-# command_center/ package lives at the repo root, two levels above this
-# app's import root — put the repo root on sys.path before importing it.
+# command_center/ package lives at the repo root — WALK UP to find it,
+# never count parents. The Railway service builds from the
+# qa-automation/AI-Scoring subtree (service Root Directory), so in that
+# container /app/backend/main.py has only three ancestors and the repo
+# root — command_center/ included — is not in the image at all;
+# parents[3] crash-looped the 2026-07-20 deploy. Until the service
+# builds from the repo root, the app must boot WITHOUT the CC webhook
+# routes, loudly.
 import sys
-_cc_repo_root = Path(__file__).resolve().parents[3]
-if str(_cc_repo_root) not in sys.path:
+_cc_repo_root = next(
+    (p for p in Path(__file__).resolve().parents
+     if (p / "command_center").is_dir()),
+    None,
+)
+if _cc_repo_root is not None and str(_cc_repo_root) not in sys.path:
     sys.path.insert(0, str(_cc_repo_root))
 
-from command_center.routes.webhooks import router as cc_webhooks_router
-from command_center.services.store import close_pool as cc_close_pool
+try:
+    from command_center.routes.webhooks import router as cc_webhooks_router
+    from command_center.services.store import close_pool as cc_close_pool
+except ImportError:
+    cc_webhooks_router = None
+
+    async def cc_close_pool() -> None:
+        return None
+
+    logging.getLogger(__name__).error(
+        "command_center package not found — /api/webhooks/dialpad NOT "
+        "mounted. The build root excludes the repo root (Railway Root "
+        "Directory = qa-automation/AI-Scoring); switch the service to "
+        "build from the repo root before going live with the Dialpad "
+        "subscription."
+    )
 
 from backend.services.version_ship import run_startup_ship
 from backend.routes.scoring import router as scoring_router
@@ -101,8 +125,10 @@ for r in (scoring_router, dashboard_router, team_router, datapoints_router, look
 
 # Command Center webhook ingress — NO API-key dependency: Dialpad is the
 # caller and the JWT body signature is the authentication (DispositionDesign
-# §4). Distinct URL space from the QA routers above.
-app.include_router(cc_webhooks_router)
+# §4). Distinct URL space from the QA routers above. Absent when the build
+# root excludes the top-level package (see the import guard above).
+if cc_webhooks_router is not None:
+    app.include_router(cc_webhooks_router)
 
 
 @app.get("/api/health")


### PR DESCRIPTION
## Summary

**Hotfix for the crash-looping Railway deploy.** Root cause: the Railway service's Root Directory is `qa-automation/AI-Scoring`, so in the container `main.py` is `/app/backend/main.py` — only three path ancestors — and the C2 mount's `Path(__file__).resolve().parents[3]` raises `IndexError: 3` at import, before uvicorn can bind. Additionally, with that build root the `command_center/` package isn't in the image at all, so a fixed index could never have worked.

The mount now **walks up** looking for `command_center/` and **degrades loudly** when the package isn't shipped: the app boots with all backend routes (scoring incl. C0/C3/C4 behavior, dashboards, /scorecard) and logs an ERROR that `/api/webhooks/dialpad` is not mounted.

Nothing is functionally lost by shipping without the receiver tonight — there is no Dialpad subscription yet (blocked on the 100-sub cap), and everything else from the C-series lives under `backend/` and deploys normally.

## Verified

- Simulated the Railway subtree build locally (copy of `AI-Scoring/` with no repo root above it): **app boots**, QA routes present, webhook route absent, ERROR logged.
- Full-repo import: webhook route mounted.
- `pytest tests/ --ignore=tests/integration` — 660 passed.

## Follow-up (deliberate, not tonight)

To actually serve the webhook receiver, the Railway service must build from the **repo root** (Root Directory change + start command `cd qa-automation/AI-Scoring && uvicorn backend.main:app …`). Sequence it together with the Dialpad subscription creation once engineering frees a slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)