### PR TITLE
docs(qa-automation): trace the /lookup Score Call path in scoring_service

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -1,7 +1,94 @@
-"""
-Scoring pipeline orchestrator.
-Ties together: Dialpad transcript -> CC call context -> Notion SOP ->
-Gemini scoring.
+"""Scoring pipeline orchestrator — the full path of a scored call.
+
+`score_call` below is the heart of the pipeline. This docstring traces
+the WHOLE journey of the most common workflow — "Score Call" on the
+/lookup page — because the human trigger is about to be replaced by an
+automated process: everything DOWNSTREAM of the button is already
+automation, so the replacement only needs to reproduce the POST in
+step 2 and honor the constraints listed at the bottom.
+
+1. ENTRY — /lookup (frontend/lookup.html)
+   The operator searches an agent by email, sees their recent Dialpad
+   calls, and clicks "Score Call" (`scoreCall()`). The button is gated
+   by GET /lookup/scoring-permission (team keys need the agent in the
+   team's Mails roster; privileged keys may score anyone and pick the
+   target team via a modal when the agent is unrostered).
+
+2. SUBMIT — POST /api/{team_id}/score (backend/routes/scoring.py,
+   `score_single_call`)
+   Form fields: call_id, agent_email, manager_email (no audio file —
+   that is the legacy manual-upload mode). Synchronously, in order:
+     - identity: resolve agent name<->email via the Mails roster;
+     - auth: `check_scoring_access` (denials write a Score_Audit row);
+     - idempotency: job_id = f(call_id, agent_name); a re-POST while a
+       prior job is pending/scoring returns THAT job instead of
+       double-scoring (double-click safe — keep this in the automated
+       trigger);
+     - audio: `download_recording(call_id)` from Dialpad (422 when the
+       call has no recording, 503 on rate-limit);
+     - prefetch: `get_transcript` + `get_call_details` here, NOT in the
+       worker — fan-out background tasks would burst Dialpad into 429s;
+     - audit: Score_Audit "scored" row before the worker is scheduled,
+       so the action is logged even if the worker dies;
+     - spawn the background `run()` and return {job_id, "pending"}.
+
+3. SCORE — `score_call` (this module), inside a per-key semaphore:
+     Step 1    transcript text from the prefetched payload (C0: Dialpad
+               markers never reach the prompt; the full marker set rides
+               `moments_display` into eval metadata).
+     Step 1.5  CC grounding (DispositionDesign §5, cc_context.py):
+               triple-key match (entry-point -> per-leg -> master)
+               against command_center.calls, populated TODAY by the
+               half-hour Stats pull (disposition_pull.py; webhook
+               ingestion pending ops/engineering). Gated by
+               CC_GROUNDING_MODE: off | shadow (default: stamp + log
+               the would-be block, prompt untouched) | on (inject the
+               "CALL CONTEXT (VERIFIED SYSTEM DATA)" block ahead of the
+               transcript). Hold wording only for webhook-observed
+               calls (has_hold_truth); Spanish calls follow the
+               audio-is-SOT language rule (v2.1).
+     Step 2    SOP context: `fetch_sop_for_call` — keyword classify ->
+               Notion page text. INTERIM: the SopRag cascade (PR #99,
+               open) replaces this with disposition-keyed retrieval
+               over the coach-cards corpus after the Sandy re-platform.
+     Step 3    `score_audio`: upload audio to Gemini, build the prompt
+               (rubric + SOP + grounding + transcript, from TeamConfig
+               JSON), parse/validate the Scorecard.
+     Step 4    return ScorecardWithMeta: caller metadata, call clocks,
+               dialpad_link (entry-point id preferred), and the CC
+               stamps (dialpad_disposition*, ai_csat) for the eval row.
+
+4. PERSIST — back in the route worker `run()`:
+     - `write_draft_to_fr_ai`: FR-AI sheet projection (display side of
+       the dual-write);
+     - `record_draft_evaluation(strict=True)`: qa.evaluations draft +
+       sections — the DB row is truth (§7.3 Phase C), so DB failure
+       fails the JOB, deliberately;
+     - `_postgres_post_stage1` (CutoverDesign §2): the human-review
+       gate decides auto-finalize vs pause —
+         CLEAN   -> `stamp_and_finalize` (engine score + formula/rubric
+                    version stamps) -> Analyst_History projection ->
+                    SSE `evaluation_finalized` -> GAS scorecard email.
+                    Zero analyst touch.
+         FLAGGED -> row stays draft (scoring_status=
+                    'flagged_human_review'); an operator resolves it in
+                    the red editor and approves
+                    (POST /score/{job_id}/approve).
+
+5. OBSERVE — the frontend polls GET /score/{job_id} every 3s and links
+   to /scorecard/{team_id}/{job_id} (read-only when finalized, editor
+   when flagged).
+
+Constraints the automated trigger MUST keep in mind:
+   - `_jobs` is in-process memory: poll the same instance that accepted
+     the POST, and a restart forgets in-flight jobs (the eval row and
+     sheet write survive; the job status does not).
+   - Concurrency is capped per API key (semaphore) — queue, don't spray.
+   - The Gemini call is the expensive step; idempotency (step 2) is the
+     only guard against paying for it twice.
+   - Score AFTER the half-hour stats pull has covered the call, or the
+     prompt grounds without a disposition (absence path) — the eval's
+     disposition columns are still filled by a later pull.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Documentation-only. With the human-triggered pipeline about to be replaced by an automated process, `scoring_service.py`'s module docstring now carries the definitive end-to-end trace of the most common workflow — `/lookup` → "Score Call" — verified against the code as it runs today:

1. **Entry** — lookup permission gate (roster vs privileged team-pick)
2. **Submit** — `POST /api/{team_id}/score`: identity resolution, auth + denied-audit, double-click idempotency, Dialpad recording download, transcript/details prefetch (429 protection), pre-worker audit row
3. **Score** — `score_call`: C0 marker handling, C3 grounding (interim stats-pull source, `CC_GROUNDING_MODE` shadow gate, hold-truth, Spanish audio-SOT), interim keyword-SOP (until PR #99's SopRag cascade), Gemini
4. **Persist** — FR-AI sheet projection + strict `qa.evaluations` dual-write + CutoverDesign auto-finalize vs `flagged_human_review` (SSE + GAS email on the clean path)
5. **Observe** — 3s polling → `/scorecard` editor

Ends with the constraints the automated trigger must preserve: in-process `_jobs` store (same-instance polling, restart amnesia), per-key semaphore, idempotency as the only double-Gemini-spend guard, and score-after-the-half-hour-pull.

## Test plan

- Import + scoring test files pass (16 passed); no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)