### PR TITLE
feat(qa-automation): Pulpo P1–P3 — provider seam, shadow retrieval, coverage probe (99%/100%)

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -107,6 +107,9 @@ async def _lifespan(app: FastAPI):
     await close_pool()
     # Command Center webhook-ingest pool (lazy-created on first event).
     await cc_close_pool()
+    # RAG provider (Pulpo MCP session; lazy-created on first retrieval).
+    from backend.services.rag.factory import close_rag_provider
+    await close_rag_provider()
 
 
 app = FastAPI(

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -131,3 +131,7 @@ class ScorecardWithMeta(Scorecard):
     # by the per-leg id (the Stats export keys by ENTRY-POINT id).
     dialpad_entry_point_call_id: Optional[str] = None
     dialpad_master_call_id: Optional[str] = None
+    # PulpoConnection §4.2 step 6 — RAG retrieval provenance:
+    # [{id, title, score, score_kind, updated_at, open_flags}, ...].
+    # Stamped in shadow AND on modes; [] when retrieval was off/skipped.
+    pulpo_docs: List[dict] = []

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -189,6 +189,10 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
             # Full Dialpad marker set, typed + timestamped (DispositionDesign
             # C0: filtering is a prompt decision, never a storage decision).
             "moments": scorecard.moments_display,
+            # RAG retrieval provenance (PulpoConnection §4.2) — the
+            # corpus evolves, so the eval records exactly which docs
+            # (id + updated stamp + score) grounded its SOP context.
+            "pulpo_docs": scorecard.pulpo_docs,
         }),
     }
 

--- a/qa-automation/AI-Scoring/backend/services/rag/__init__.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/__init__.py
@@ -1,0 +1,19 @@
+"""RAG provider seam — PulpoConnection.md §4.1.
+
+The retrieval policy imports ONLY `provider` types and the `factory`
+accessor. Vendor-shaped code (today: Pulpo, an external platform) lives
+in exactly one module per vendor — swapping providers is one new module
+plus one env value, mirroring the `data_provider` factory seam.
+"""
+
+from backend.services.rag.factory import get_rag_provider, close_rag_provider
+from backend.services.rag.provider import RagDoc, RagFlag, RagHit, RagProvider
+
+__all__ = [
+    "RagDoc",
+    "RagFlag",
+    "RagHit",
+    "RagProvider",
+    "get_rag_provider",
+    "close_rag_provider",
+]

--- a/qa-automation/AI-Scoring/backend/services/rag/factory.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/factory.py
@@ -1,0 +1,49 @@
+"""RAG provider factory — RAG_PROVIDER env selects the vendor module.
+
+    pulpo   (default) PulpoProvider from PULPO_MCP_URL/PULPO_MCP_TOKEN
+    none    retrieval disabled (dev/tests; also any unknown value)
+
+Singleton per process (one httpx client, one MCP session); the FastAPI
+lifespan closes it via `close_rag_provider`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from backend.services.rag.provider import RagProvider
+
+logger = logging.getLogger(__name__)
+
+_provider: Optional[RagProvider] = None
+_resolved = False
+
+
+def get_rag_provider() -> Optional[RagProvider]:
+    global _provider, _resolved
+    if _resolved:
+        return _provider
+    mode = os.environ.get("RAG_PROVIDER", "pulpo").strip().lower()
+    if mode == "pulpo":
+        from backend.services.rag.pulpo import build_from_env
+        _provider = build_from_env()
+    elif mode != "none":
+        logger.error("rag: unknown RAG_PROVIDER=%r — retrieval disabled", mode)
+    _resolved = True
+    return _provider
+
+
+async def close_rag_provider() -> None:
+    """Lifespan teardown."""
+    global _provider, _resolved
+    if _provider is not None:
+        await _provider.aclose()
+    _provider, _resolved = None, False
+
+
+def reset_for_tests() -> None:
+    """Drop the cached provider so tests can re-point env."""
+    global _provider, _resolved
+    _provider, _resolved = None, False

--- a/qa-automation/AI-Scoring/backend/services/rag/provider.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/provider.py
@@ -1,0 +1,99 @@
+"""Neutral RAG-provider contract — PulpoConnection.md §4.1.
+
+NOTHING vendor-shaped belongs here: no Pulpo field names, no MCP
+concepts. Consumers (the SOP retrieval policy, the coverage probe, the
+migration script) program against these types only, so a vendor swap
+never touches policy code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RagHit:
+    """One search result. `score` semantics are provider-defined but
+    MUST be monotonic (higher = more relevant); `score_kind` names the
+    scale (e.g. 'cosine', 'rerank') for provenance, never for logic."""
+    id: str
+    title: str
+    excerpt: str
+    score: float
+    score_kind: str = ""
+    tags: tuple[str, ...] = ()
+    updated_at: str = ""          # provider-rendered; provenance only
+    flag_count: int = 0
+
+
+@dataclass(frozen=True)
+class RagFlag:
+    """An open review flag on an exact passage of a document."""
+    quote: str
+    note: str = ""
+    suggestion: str = ""
+
+
+@dataclass(frozen=True)
+class RagDoc:
+    """A full document body, ready for prompt injection."""
+    id: str
+    title: str
+    body: str
+    flags: tuple[RagFlag, ...] = ()
+    tags: tuple[str, ...] = ()
+    updated_at: str = ""
+
+
+class RagProviderError(Exception):
+    """Any provider-side failure (transport, auth, malformed payload).
+    Policy code catches THIS type — vendor exceptions never escape the
+    vendor module."""
+
+
+@dataclass
+class RagUpsertResult:
+    id: str
+    created: bool
+
+
+class RagProvider:
+    """Abstract provider. `search`/`get_document` are the required
+    surface; `flag_document`/`upsert_document` are OPTIONAL capabilities
+    — curation flows probe with `supports_*` before calling."""
+
+    name: str = "abstract"
+
+    async def search(
+        self, queries: list[str], *, limit: int = 5
+    ) -> list[list[RagHit]]:
+        """One result list PER query, order-aligned with `queries`."""
+        raise NotImplementedError
+
+    async def get_document(self, doc_id: str) -> Optional[RagDoc]:
+        """Full document, or None when the id doesn't resolve."""
+        raise NotImplementedError
+
+    # -- optional capabilities -------------------------------------------
+    @property
+    def supports_flagging(self) -> bool:
+        return False
+
+    async def flag_document(
+        self, doc_id: str, quote: str, *, note: str = "", suggestion: str = ""
+    ) -> None:
+        raise NotImplementedError(f"{self.name} does not support flagging")
+
+    @property
+    def supports_upsert(self) -> bool:
+        return False
+
+    async def upsert_document(
+        self, *, title: str, body: str, doc_id: Optional[str] = None
+    ) -> RagUpsertResult:
+        raise NotImplementedError(f"{self.name} does not support upsert")
+
+    async def aclose(self) -> None:
+        """Release transport resources; lifespan teardown calls this."""
+        return None

--- a/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
@@ -1,0 +1,283 @@
+"""Pulpo provider — the ONLY Pulpo-shaped module (PulpoConnection §4.1).
+
+Speaks MCP over Streamable HTTP against `PULPO_MCP_URL`
+(https://plasticity.heypulpo.com/api/mcp): an `initialize` handshake,
+then `tools/call` JSON-RPC POSTs, Bearer-authenticated. No MCP SDK for
+four tool calls — a small client keeps the image lean and the Sandy
+port trivial (the TS side swaps this module for the native SDK).
+
+Streamable-HTTP servers may answer a POST either as plain JSON or as a
+short SSE stream; `_parse_rpc_response` handles both. A session id
+(`Mcp-Session-Id` response header) is captured at initialize and echoed
+on every later call; a 404 (expired session) re-initializes once.
+
+Pulpo shapes are mapped into the neutral provider types AT THIS
+BOUNDARY — `batches[].results[]`, `score_type`, `open_flags`,
+`anchor_status` never escape this file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+
+from backend.services.rag.provider import (
+    RagDoc,
+    RagFlag,
+    RagHit,
+    RagProvider,
+    RagProviderError,
+    RagUpsertResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROTOCOL_VERSION = "2025-03-26"
+_CLIENT_INFO = {"name": "landing-qa-scoring", "version": "1.0"}
+
+CONNECT_TIMEOUT_S = 3.0
+READ_TIMEOUT_S = 8.0
+
+
+def _parse_rpc_response(resp: httpx.Response) -> Optional[dict]:
+    """JSON-RPC response body → dict. Handles both plain JSON and SSE
+    (`data:` lines; the last data event carrying a JSON-RPC id wins).
+    Returns None for empty/accepted-only bodies (notifications)."""
+    content_type = resp.headers.get("content-type", "")
+    text = resp.text.strip()
+    if not text:
+        return None
+    if "text/event-stream" in content_type:
+        message = None
+        for line in text.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:"):].strip()
+            if not payload:
+                continue
+            try:
+                candidate = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(candidate, dict) and ("result" in candidate or "error" in candidate):
+                message = candidate
+        return message
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RagProviderError(f"pulpo: non-JSON response ({content_type}): {text[:200]}") from e
+
+
+class PulpoProvider(RagProvider):
+    name = "pulpo"
+
+    def __init__(self, url: str, token: str):
+        self._url = url
+        self._session_id: Optional[str] = None
+        self._initialized = False
+        self._next_id = 0
+        self._client = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json, text/event-stream",
+            },
+            timeout=httpx.Timeout(READ_TIMEOUT_S, connect=CONNECT_TIMEOUT_S),
+        )
+
+    # -- transport -----------------------------------------------------
+
+    async def _post(self, body: dict) -> httpx.Response:
+        headers = {}
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        try:
+            return await self._client.post(self._url, json=body, headers=headers)
+        except httpx.HTTPError as e:
+            raise RagProviderError(f"pulpo: transport error: {e}") from e
+
+    async def _initialize(self) -> None:
+        self._next_id += 1
+        resp = await self._post({
+            "jsonrpc": "2.0",
+            "id": self._next_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": _PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": _CLIENT_INFO,
+            },
+        })
+        if resp.status_code >= 400:
+            raise RagProviderError(
+                f"pulpo: initialize failed HTTP {resp.status_code}: {resp.text[:200]}"
+            )
+        message = _parse_rpc_response(resp)
+        if message is None or "error" in message:
+            raise RagProviderError(f"pulpo: initialize rejected: {message}")
+        self._session_id = resp.headers.get("mcp-session-id") or self._session_id
+        # Per spec the client acks with an initialized notification.
+        await self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        self._initialized = True
+
+    async def _tool_call(self, tool: str, arguments: dict) -> Any:
+        """tools/call → the tool's payload (structuredContent preferred,
+        else first text content block parsed as JSON, else raw text)."""
+        if not self._initialized:
+            await self._initialize()
+        self._next_id += 1
+        body = {
+            "jsonrpc": "2.0",
+            "id": self._next_id,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+        resp = await self._post(body)
+        if resp.status_code == 404 and self._session_id:
+            # Session expired server-side — re-handshake once and retry.
+            self._initialized, self._session_id = False, None
+            await self._initialize()
+            resp = await self._post(body)
+        if resp.status_code >= 400:
+            raise RagProviderError(
+                f"pulpo: {tool} failed HTTP {resp.status_code}: {resp.text[:200]}"
+            )
+        message = _parse_rpc_response(resp)
+        if message is None:
+            raise RagProviderError(f"pulpo: {tool} returned no response message")
+        if "error" in message:
+            raise RagProviderError(f"pulpo: {tool} error: {message['error']}")
+        result = message.get("result") or {}
+        if result.get("isError"):
+            raise RagProviderError(f"pulpo: {tool} tool error: {result}")
+        if "structuredContent" in result:
+            return result["structuredContent"]
+        for block in result.get("content", []):
+            if block.get("type") == "text":
+                text = block.get("text", "")
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+        return result
+
+    # -- shape mapping (Pulpo → neutral) -------------------------------
+
+    @staticmethod
+    def _map_hit(raw: dict) -> RagHit:
+        return RagHit(
+            id=str(raw.get("id", "")),
+            title=raw.get("title", "") or "",
+            excerpt=raw.get("excerpt", "") or "",
+            score=float(raw.get("score") or 0.0),
+            score_kind=raw.get("score_type", "") or "",
+            tags=tuple(raw.get("tags") or ()),
+            updated_at=str(raw.get("last_verified") or raw.get("updated_at") or ""),
+            flag_count=int(raw.get("open_flag_count") or 0),
+        )
+
+    @staticmethod
+    def _map_doc(raw: dict) -> RagDoc:
+        flags = tuple(
+            RagFlag(
+                quote=f.get("quote", "") or "",
+                note=f.get("body", "") or "",
+                suggestion=f.get("suggestion", "") or "",
+            )
+            for f in (raw.get("open_flags") or ())
+        )
+        return RagDoc(
+            id=str(raw.get("id", "")),
+            title=raw.get("title", "") or "",
+            body=raw.get("body", "") or "",
+            flags=flags,
+            tags=tuple(raw.get("tags") or ()),
+            updated_at=str(raw.get("last_verified") or raw.get("updated_at") or ""),
+        )
+
+    # -- RagProvider surface -------------------------------------------
+
+    async def search(
+        self, queries: list[str], *, limit: int = 5
+    ) -> list[list[RagHit]]:
+        if not queries:
+            return []
+        # rerank stays False by design (§4.2): Gemini reads full bodies,
+        # so Pulpo's precision pass is declined — their own guidance for
+        # agents that read the candidates themselves.
+        payload = await self._tool_call(
+            "search_knowledge_base",
+            {"queries": queries, "limit": limit, "rerank": False},
+        )
+        if not isinstance(payload, dict):
+            raise RagProviderError(f"pulpo: unexpected search payload: {payload!r:.200}")
+        batches = payload.get("batches") or []
+        by_query = {
+            b.get("query"): [self._map_hit(r) for r in (b.get("results") or [])]
+            for b in batches
+        }
+        # Order-align with the request; a query Pulpo dropped yields [].
+        return [by_query.get(q, []) for q in queries]
+
+    async def get_document(self, doc_id: str) -> Optional[RagDoc]:
+        try:
+            payload = await self._tool_call("get_document", {"id": doc_id})
+        except RagProviderError as e:
+            if "not found" in str(e).lower():
+                return None
+            raise
+        if not isinstance(payload, dict):
+            return None
+        # Live shape (verified 2026-07-22): the doc nests under "document".
+        raw = payload.get("document") if isinstance(payload.get("document"), dict) else payload
+        if not raw.get("id"):
+            return None
+        return self._map_doc(raw)
+
+    @property
+    def supports_flagging(self) -> bool:
+        return True
+
+    async def flag_document(
+        self, doc_id: str, quote: str, *, note: str = "", suggestion: str = ""
+    ) -> None:
+        args: dict = {"id": doc_id, "quote": quote}
+        if note:
+            args["body"] = note
+        if suggestion:
+            args["suggestion"] = suggestion
+        await self._tool_call("flag_document", args)
+
+    @property
+    def supports_upsert(self) -> bool:
+        return True
+
+    async def upsert_document(
+        self, *, title: str, body: str, doc_id: Optional[str] = None
+    ) -> RagUpsertResult:
+        args: dict = {"title": title, "body": body, "private": False}
+        if doc_id:
+            args["id"] = doc_id
+        payload = await self._tool_call("upsert_document", args)
+        new_id = str(payload.get("id", "")) if isinstance(payload, dict) else ""
+        return RagUpsertResult(id=new_id or (doc_id or ""), created=doc_id is None)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+def build_from_env(token_env: str = "PULPO_MCP_TOKEN") -> Optional[PulpoProvider]:
+    """None (with a loud log) when the env isn't configured — retrieval
+    is an enhancement, never a boot requirement."""
+    url = os.environ.get("PULPO_MCP_URL", "")
+    token = os.environ.get(token_env, "")
+    if not url or not token:
+        logger.warning(
+            "pulpo: PULPO_MCP_URL/%s unset — RAG retrieval disabled", token_env
+        )
+        return None
+    return PulpoProvider(url, token)

--- a/qa-automation/AI-Scoring/backend/services/rag/sop_retrieval.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/sop_retrieval.py
@@ -1,0 +1,189 @@
+"""SOP retrieval policy — PulpoConnection §4.2 (provider-agnostic).
+
+At Stage 1, alongside the CC grounding fetch: build a query from the
+verified disposition (the C3 retrieval key; transcript head as the
+absence fallback), search the RAG provider, threshold, fetch full
+bodies, and render the SOP context block + provenance stamps.
+
+Gated by PULPO_SOP_MODE (off | shadow | on, default OFF):
+  off     no retrieval at all
+  shadow  retrieve + log the would-be block + stamp provenance; the
+          prompt still uses the legacy Notion path
+  on      the rendered block replaces the Notion fetch entirely;
+          empty retrieval → the sop_context_missing conservative path
+
+Never raises: any provider failure logs and returns the empty context —
+retrieval is an enhancement, never a scoring blocker (the cc_context
+doctrine).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from backend.services.rag.factory import get_rag_provider
+from backend.services.rag.provider import RagDoc, RagHit
+
+logger = logging.getLogger(__name__)
+
+MAX_DOCS = 3                 # inject at most this many docs
+BLOCK_CHAR_CAP = 16_000      # ≈4k tokens; truncate lowest-scoring first
+CACHE_TTL_S = 3600           # per-query + per-doc TTL (finite label space
+                             # → steady state is a handful of queries/day)
+DEFAULT_THRESHOLD = 0.55     # τ — calibrated by the §6.1 coverage probe
+
+_search_cache: dict[str, tuple[float, list[RagHit]]] = {}
+_doc_cache: dict[str, tuple[float, Optional[RagDoc]]] = {}
+
+
+def pulpo_sop_mode() -> str:
+    """`off` | `shadow` | `on` (unknown values collapse to `off` —
+    retrieval is opt-in, unlike CC grounding's shadow default)."""
+    mode = os.environ.get("PULPO_SOP_MODE", "off").strip().lower()
+    return mode if mode in ("off", "shadow", "on") else "off"
+
+
+def score_threshold() -> float:
+    raw = os.environ.get("PULPO_SCORE_THRESHOLD", "").strip()
+    try:
+        return float(raw) if raw else DEFAULT_THRESHOLD
+    except ValueError:
+        return DEFAULT_THRESHOLD
+
+
+@dataclass
+class SopContext:
+    """What retrieval produced for one call. Empty (`docs=[]`) means the
+    prompt takes the sop_context_missing conservative path."""
+    query: str = ""
+    sop_title: str = ""          # top doc title — existing analytics slot
+    block_text: str = ""         # rendered multi-doc SOP context
+    provenance: list[dict] = field(default_factory=list)
+    skipped_reason: str = ""     # '' when retrieval ran and hit
+
+
+def build_sop_query(
+    disposition_category: Optional[str],
+    disposition: Optional[str],
+    transcript_text: str,
+) -> Optional[str]:
+    """The disposition IS the query (§3.3); absence falls back to the
+    transcript head; nothing at all → None (skip retrieval)."""
+    if disposition_category:
+        if disposition:
+            return f"{disposition_category} — {disposition}"
+        return disposition_category
+    head = (transcript_text or "").strip()[:600]
+    return head or None
+
+
+def render_sop_block(docs: list[tuple[RagDoc, RagHit]]) -> str:
+    """Pure renderer: numbered docs (title + body), flag cautions per
+    Pulpo's citation-warning convention, lowest-scoring truncated first
+    to honor BLOCK_CHAR_CAP."""
+    if not docs:
+        return ""
+    sections: list[str] = []
+    for i, (doc, hit) in enumerate(docs, start=1):
+        lines = [f"[SOP {i}] {doc.title}"]
+        for flag in doc.flags:
+            lines.append(
+                f"  NOTE: the passage \"{flag.quote[:120]}\" is under "
+                f"review — verify before treating it as current policy."
+            )
+        lines.append(doc.body.strip())
+        sections.append("\n".join(lines))
+
+    # Enforce the cap from the lowest-scoring doc up: truncate the tail
+    # once, then drop it if the block is still over. The retruncate
+    # guard (2_100) sits ABOVE the truncated size (~2_011) so a section
+    # is never re-truncated to the same length — that exact loop hung
+    # the first test run.
+    while sections and sum(len(s) for s in sections) > BLOCK_CHAR_CAP:
+        if len(sections[-1]) > 2_100:
+            sections[-1] = sections[-1][:2_000] + "\n[truncated]"
+        else:
+            sections.pop()
+    return "\n\n".join(sections)
+
+
+def _cache_get(cache: dict, key: str):
+    entry = cache.get(key)
+    if entry and entry[0] > time.monotonic():
+        return entry[1]
+    cache.pop(key, None)
+    return None
+
+
+def _cache_put(cache: dict, key: str, value) -> None:
+    cache[key] = (time.monotonic() + CACHE_TTL_S, value)
+
+
+def reset_caches_for_tests() -> None:
+    _search_cache.clear()
+    _doc_cache.clear()
+
+
+async def fetch_sop_context(
+    *,
+    disposition_category: Optional[str],
+    disposition: Optional[str],
+    transcript_text: str,
+) -> SopContext:
+    """Search → threshold → fetch bodies → render. Never raises."""
+    query = build_sop_query(disposition_category, disposition, transcript_text)
+    if query is None:
+        return SopContext(skipped_reason="no_query_material")
+
+    provider = get_rag_provider()
+    if provider is None:
+        return SopContext(query=query, skipped_reason="no_provider")
+
+    try:
+        hits = _cache_get(_search_cache, query)
+        if hits is None:
+            (hits,) = await provider.search([query], limit=5)
+            _cache_put(_search_cache, query, hits)
+
+        tau = score_threshold()
+        selected = [h for h in hits if h.score >= tau][:MAX_DOCS]
+        if not selected:
+            return SopContext(query=query, skipped_reason="below_threshold")
+
+        docs: list[tuple[RagDoc, RagHit]] = []
+        for hit in selected:
+            doc = _cache_get(_doc_cache, hit.id)
+            if doc is None:
+                doc = await provider.get_document(hit.id)
+                _cache_put(_doc_cache, hit.id, doc)
+            if doc is not None and doc.body.strip():
+                docs.append((doc, hit))
+        if not docs:
+            return SopContext(query=query, skipped_reason="no_bodies")
+
+        return SopContext(
+            query=query,
+            sop_title=docs[0][0].title,
+            block_text=render_sop_block(docs),
+            provenance=[
+                {
+                    "id": doc.id,
+                    "title": doc.title,
+                    "score": hit.score,
+                    "score_kind": hit.score_kind,
+                    "updated_at": doc.updated_at,
+                    "open_flags": len(doc.flags),
+                }
+                for doc, hit in docs
+            ],
+        )
+    except Exception:
+        logger.exception(
+            "sop_retrieval: failed for query=%r — scoring proceeds without SOP context",
+            query,
+        )
+        return SopContext(query=query, skipped_reason="provider_error")

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -109,6 +109,7 @@ from backend.services.dialpad_client import (
     get_transcript,
 )
 from backend.services.notion_service import fetch_sop_for_call
+from backend.services.rag.sop_retrieval import fetch_sop_context, pulpo_sop_mode
 
 if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
@@ -170,8 +171,31 @@ async def score_call(
                 call_id, cc_ctx.matched_by, rendered,
             )
 
-    # Step 2: Notion SOP
-    sop_data = await fetch_sop_for_call(transcript_text)
+    # Step 2: SOP context — PulpoConnection §4.2/§4.3. PULPO_SOP_MODE:
+    #   off     legacy Notion path only (default)
+    #   shadow  Pulpo retrieval runs + logs + stamps provenance; the
+    #           prompt still uses Notion (the log-only compare window)
+    #   on      Pulpo replaces Notion; empty retrieval falls through to
+    #           the sop_context_missing conservative path
+    sop_mode = pulpo_sop_mode()
+    sop_ctx = None
+    if sop_mode != "off":
+        sop_ctx = await fetch_sop_context(
+            disposition_category=cc_ctx.disposition_category if cc_ctx else None,
+            disposition=cc_ctx.disposition if cc_ctx else None,
+            transcript_text=transcript_text,
+        )
+        if sop_mode == "shadow":
+            logger.info(
+                "pulpo_sop[shadow] call=%s query=%r reason=%r would inject %d docs: %s",
+                call_id, sop_ctx.query, sop_ctx.skipped_reason,
+                len(sop_ctx.provenance),
+                [p["title"] for p in sop_ctx.provenance],
+            )
+    if sop_mode == "on" and sop_ctx is not None:
+        sop_data = {"sop_title": sop_ctx.sop_title, "sop_content": sop_ctx.block_text}
+    else:
+        sop_data = await fetch_sop_for_call(transcript_text)
 
     # Step 3: Score
     extra_notes = ""
@@ -237,4 +261,7 @@ async def score_call(
         # carry every id it was scored under, not just the per-leg one.
         dialpad_entry_point_call_id=call_details.get("entry_point_call_id") or None,
         dialpad_master_call_id=call_details.get("master_call_id") or None,
+        # PulpoConnection §4.2 step 6 — retrieval provenance for the eval
+        # row (stamped in shadow AND on: the shadow window's compare data).
+        pulpo_docs=sop_ctx.provenance if sop_ctx else [],
     )

--- a/qa-automation/AI-Scoring/references/PulpoConnection.md
+++ b/qa-automation/AI-Scoring/references/PulpoConnection.md
@@ -292,6 +292,20 @@ label's best-hit score + title. Outputs:
   caveat): compare shadow logs' retrieved titles against what an
   analyst would consider the right SOP before flipping.
 
+**Probe results — 2026-07-22 (P3 checkpoint, benchmark token, τ=0.55):**
+74 distinct disposition labels observed in `command_center.calls`
+(43,323 calls, the 3-month backfill). **73/74 labels covered (99%);
+call-weighted coverage 43,288/43,323 (100%)**. Sole gap: *Unit Issues —
+Pests* (best hit 0.528 and topically wrong — "Replacing Missing &
+Damaged Items"): a genuine corpus gap, first entry on the curation
+worklist. Calibration notes: hits ≥0.7 are strongly on-topic (e.g.
+*OTA reservation change* → "OTA SOP - Shortenings and Cancellations"
+at 0.807); the 0.55–0.60 band contains a few semantically weak matches
+(*Routing & Operational* sub-labels landing on "Admin"/check-in docs) —
+candidates for raising τ to ~0.60 after the shadow window's real-call
+review. Rate-limit learning: the limiter rejects a batch exceeding the
+REMAINING minute allowance — the probe paces 10-query batches 12s apart.
+
 **6.2 Post-migration: trigger-phrase recall** (v1 §7, re-targeted) —
 after §5 lands the cards, the 1,549 labeled (member phrase → card)
 pairs benchmark properly: sampled ~300, batched 20/query-batch, rerank

--- a/qa-automation/AI-Scoring/scripts/pulpo_coverage_probe.py
+++ b/qa-automation/AI-Scoring/scripts/pulpo_coverage_probe.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""P3 — SOP coverage probe (PulpoConnection §6.1).
+
+One query per disposition-taxonomy label observed in
+command_center.calls, batched ≤20 against the RAG provider on the
+BENCHMARK token (separate quota pool): reports each label's best hit +
+score, split above/below τ. The report is the pre-flip acceptance
+artifact (τ calibration sample + curation gap worklist) — record the
+summary in PulpoConnection.md.
+
+Read-only against both Postgres and Pulpo.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/pulpo_coverage_probe.py [--team-id member_support]
+        [--threshold 0.55] [--markdown out.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_AI_SCORING))
+load_dotenv(_AI_SCORING / ".env")
+
+from backend.services.rag.pulpo import build_from_env  # noqa: E402
+from backend.services.rag.sop_retrieval import build_sop_query  # noqa: E402
+
+# 60 queries/min per token and the limiter rejects a batch that exceeds
+# the REMAINING minute allowance — smaller batches + pacing beat big
+# bursts (observed live 2026-07-22).
+BATCH = 10
+BATCH_PAUSE_S = 12
+RATE_LIMIT_WAIT_S = 65
+
+
+async def _labels(team_id: str) -> list[tuple[str, str | None, int]]:
+    """(category, subdisposition, call_count) observed in cc.calls."""
+    import asyncpg
+    conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT disposition_category, disposition, COUNT(*) AS n
+            FROM command_center.calls
+            WHERE team_id = $1 AND disposition_category IS NOT NULL
+            GROUP BY 1, 2 ORDER BY n DESC
+            """,
+            team_id,
+        )
+    finally:
+        await conn.close()
+    return [(r["disposition_category"], r["disposition"], r["n"]) for r in rows]
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--team-id", default="member_support")
+    parser.add_argument("--threshold", type=float, default=0.55)
+    parser.add_argument("--markdown", default=None,
+                        help="also write the full table to this file")
+    args = parser.parse_args()
+
+    provider = build_from_env("PULPO_MCP_BENCHMARK_TOKEN")
+    if provider is None:
+        print("ERROR: PULPO_MCP_BENCHMARK_TOKEN / PULPO_MCP_URL not set")
+        return 1
+
+    labels = await _labels(args.team_id)
+    if not labels:
+        print("No disposition labels found in command_center.calls")
+        return 1
+    queries = [build_sop_query(c, s, "") for c, s, _ in labels]
+    print(f"{len(labels)} distinct labels → {len(queries)} queries "
+          f"({(len(queries) + BATCH - 1) // BATCH} batches, rerank off)")
+
+    hits_per_query: list[list] = []
+    for i in range(0, len(queries), BATCH):
+        chunk = queries[i:i + BATCH]
+        try:
+            hits_per_query.extend(await provider.search(chunk, limit=3))
+        except Exception as e:
+            if "rate_limited" not in str(e):
+                raise
+            print(f"  rate-limited — waiting {RATE_LIMIT_WAIT_S}s (full window) and retrying")
+            await asyncio.sleep(RATE_LIMIT_WAIT_S)
+            hits_per_query.extend(await provider.search(chunk, limit=3))
+        print(f"  batch {i // BATCH + 1} done")
+        if i + BATCH < len(queries):
+            await asyncio.sleep(BATCH_PAUSE_S)
+    await provider.aclose()
+
+    rows = []
+    for (category, sub, n), query, hits in zip(labels, queries, hits_per_query):
+        best = hits[0] if hits else None
+        rows.append({
+            "label": query,
+            "calls": n,
+            "score": best.score if best else 0.0,
+            "title": best.title if best else "(no hits)",
+            "covered": bool(best and best.score >= args.threshold),
+        })
+
+    covered = [r for r in rows if r["covered"]]
+    uncovered = [r for r in rows if not r["covered"]]
+    call_total = sum(r["calls"] for r in rows)
+    call_covered = sum(r["calls"] for r in covered)
+
+    lines = [
+        f"# Pulpo SOP coverage probe — {args.team_id}, τ={args.threshold}",
+        "",
+        f"Labels covered: {len(covered)}/{len(rows)} "
+        f"({100 * len(covered) / len(rows):.0f}%)  ·  "
+        f"call-weighted: {call_covered}/{call_total} "
+        f"({100 * call_covered / call_total:.0f}%)",
+        "",
+        "| best score | calls | disposition label | best hit |",
+        "|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda r: -r["score"]):
+        mark = "" if r["covered"] else " ⚠"
+        lines.append(
+            f"| {r['score']:.3f}{mark} | {r['calls']} | {r['label']} | {r['title']} |"
+        )
+    report = "\n".join(lines)
+    print("\n" + report)
+    if args.markdown:
+        Path(args.markdown).write_text(report + "\n", encoding="utf-8")
+        print(f"\nwritten to {args.markdown}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/qa-automation/AI-Scoring/scripts/pulpo_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/pulpo_smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""P1 live smoke — PulpoConnection §10 P1 checkpoint.
+
+Searches the real Pulpo endpoint, prints titles + scores, fetches the
+top document, and verifies BOTH-audience minting by retrieving at least
+one Customer-audience doc (§9 A3: an Internal-only token can't see
+them). Read-only.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/pulpo_smoke.py ["optional custom query"]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_AI_SCORING))
+load_dotenv(_AI_SCORING / ".env")
+
+from backend.services.rag.factory import get_rag_provider  # noqa: E402
+
+
+async def main() -> int:
+    provider = get_rag_provider()
+    if provider is None:
+        print("ERROR: no RAG provider (check PULPO_MCP_URL / PULPO_MCP_TOKEN)")
+        return 1
+    print(f"provider: {provider.name}")
+
+    queries = [
+        sys.argv[1] if len(sys.argv) > 1
+        else "standby cancellation policy and refunds",
+        # Known Customer-audience doc (admin console, 2026-07-21):
+        # proves the token was minted with BOTH audiences (§9 A3).
+        "is Landing legit",
+    ]
+    batches = await provider.search(queries, limit=5)
+    for query, hits in zip(queries, batches):
+        print(f"\nquery: {query!r} — {len(hits)} hits")
+        for hit in hits:
+            flag_note = f" [{hit.flag_count} open flags]" if hit.flag_count else ""
+            tag_note = f" tags={list(hit.tags)}" if hit.tags else ""
+            print(f"  {hit.score:.3f} ({hit.score_kind or '?'}) "
+                  f"{hit.title}{tag_note}{flag_note}")
+
+    top = next((h for hits in batches for h in hits), None)
+    if top is None:
+        print("\nNo hits at all — corpus/token problem; smoke FAILED")
+        await provider.aclose()
+        return 1
+
+    doc = await provider.get_document(top.id)
+    if doc is None:
+        print(f"\nget_document({top.id}) returned None — smoke FAILED")
+        await provider.aclose()
+        return 1
+    print(f"\nget_document: {doc.title!r} — {len(doc.body)} chars, "
+          f"{len(doc.flags)} flags, tags={list(doc.tags)}")
+    for flag in doc.flags:
+        print(f"  OPEN FLAG on {flag.quote[:60]!r}: {flag.note[:80]}")
+
+    customer_hits = batches[1]
+    print(
+        "\nboth-audience check:",
+        "OK" if customer_hits else
+        "NO HITS for the Customer-audience probe — token may be Internal-only!",
+    )
+    await provider.aclose()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/qa-automation/AI-Scoring/tests/test_rag_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_rag_provider.py
@@ -1,0 +1,195 @@
+"""P1 — Pulpo provider against a mocked MCP transport (PulpoConnection
+§4.1): handshake, session echo, JSON + SSE response parsing, neutral
+shape mapping at the boundary, order-aligned batches, factory gating."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from backend.services.rag import factory
+from backend.services.rag.provider import RagProviderError
+from backend.services.rag.pulpo import PulpoProvider, _parse_rpc_response
+
+URL = "https://pulpo.test/api/mcp"
+
+_SEARCH_PAYLOAD = {
+    "batches": [
+        {
+            "query": "Access & Entry — Smart-lock failure",
+            "degraded": False,
+            "results": [
+                {
+                    "id": "doc-1", "title": "Smart Lock Troubleshooting",
+                    "excerpt": "When a member reports...", "tags": ["member_support"],
+                    "score": 0.81, "score_type": "cosine",
+                    "last_verified": "2026-07-01", "open_flag_count": 1,
+                },
+                {
+                    "id": "doc-2", "title": "Lockbox Fallback",
+                    "excerpt": "If the smart lock...", "tags": [],
+                    "score": 0.44, "score_type": "cosine",
+                },
+            ],
+        },
+    ],
+}
+
+# Live shape (verified 2026-07-22): get_document nests under "document".
+_DOC_PAYLOAD = {
+    "document": {
+        "id": "doc-1", "title": "Smart Lock Troubleshooting",
+        "body": "Step 1...", "tags": ["member_support"],
+        "open_flags": [
+            {"quote": "reboot the lock", "body": "outdated for gen-3 locks",
+             "suggestion": "replace with hub reset", "anchor_status": "anchored"},
+        ],
+    },
+}
+
+
+def _mcp_handler(request: httpx.Request) -> httpx.Response:
+    body = json.loads(request.content)
+    method = body.get("method")
+    if method == "initialize":
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": body["id"],
+                  "result": {"protocolVersion": "2025-03-26", "capabilities": {}}},
+            headers={"Mcp-Session-Id": "sess-42"},
+        )
+    if method == "notifications/initialized":
+        return httpx.Response(202)
+    if method == "tools/call":
+        # Every post-handshake call must echo the session id.
+        assert request.headers.get("Mcp-Session-Id") == "sess-42"
+        tool = body["params"]["name"]
+        args = body["params"]["arguments"]
+        if tool == "search_knowledge_base":
+            assert args["rerank"] is False  # §4.2 stance, enforced at transport
+            payload = _SEARCH_PAYLOAD
+        elif tool == "get_document":
+            payload = _DOC_PAYLOAD if args["id"] == "doc-1" else {"error": "not found"}
+        else:
+            payload = {"ok": True}
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": body["id"],
+                  "result": {"content": [{"type": "text", "text": json.dumps(payload)}]}},
+        )
+    return httpx.Response(400)
+
+
+@pytest.fixture
+def provider() -> PulpoProvider:
+    p = PulpoProvider(URL, "pk_test")
+    p._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_mcp_handler),
+        headers={"Authorization": "Bearer pk_test"},
+    )
+    return p
+
+
+@pytest.mark.asyncio
+async def test_search_maps_neutral_hits(provider: PulpoProvider):
+    (hits,) = await provider.search(["Access & Entry — Smart-lock failure"])
+    assert [h.id for h in hits] == ["doc-1", "doc-2"]
+    top = hits[0]
+    assert top.title == "Smart Lock Troubleshooting"
+    assert top.score == 0.81
+    assert top.score_kind == "cosine"
+    assert top.tags == ("member_support",)
+    assert top.flag_count == 1
+    # Nothing Pulpo-shaped escapes: neutral dataclass, no score_type attr.
+    assert not hasattr(top, "score_type")
+
+
+@pytest.mark.asyncio
+async def test_search_order_aligned_with_queries(provider: PulpoProvider):
+    """A query Pulpo dropped yields [] in ITS position, not a shifted list."""
+    batches = await provider.search(
+        ["no-batch-for-this", "Access & Entry — Smart-lock failure"]
+    )
+    assert batches[0] == []
+    assert [h.id for h in batches[1]] == ["doc-1", "doc-2"]
+
+
+@pytest.mark.asyncio
+async def test_get_document_maps_flags(provider: PulpoProvider):
+    doc = await provider.get_document("doc-1")
+    assert doc is not None
+    assert doc.body == "Step 1..."
+    (flag,) = doc.flags
+    assert flag.quote == "reboot the lock"
+    assert flag.note == "outdated for gen-3 locks"
+    assert flag.suggestion == "replace with hub reset"
+
+
+@pytest.mark.asyncio
+async def test_handshake_runs_once(provider: PulpoProvider):
+    await provider.search(["q"])
+    assert provider._initialized and provider._session_id == "sess-42"
+    await provider.search(["q"])  # second call: no re-handshake assertion trips
+
+
+def test_parse_rpc_response_sse():
+    """Streamable-HTTP servers may answer POSTs as short SSE streams."""
+    resp = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        text=(
+            "event: message\n"
+            'data: {"jsonrpc":"2.0","method":"ping"}\n\n'
+            'data: {"jsonrpc":"2.0","id":2,"result":{"ok":true}}\n\n'
+        ),
+    )
+    message = _parse_rpc_response(resp)
+    assert message == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+
+
+def test_parse_rpc_response_garbage_raises():
+    resp = httpx.Response(200, headers={"content-type": "text/html"}, text="<html>")
+    with pytest.raises(RagProviderError):
+        _parse_rpc_response(resp)
+
+
+@pytest.mark.asyncio
+async def test_tool_error_raises_provider_error(provider: PulpoProvider):
+    async def failing_post(body):
+        return httpx.Response(500, text="boom")
+    provider._initialized = True
+    provider._post = failing_post  # type: ignore[method-assign]
+    with pytest.raises(RagProviderError):
+        await provider.search(["q"])
+
+
+# -- factory gating ---------------------------------------------------------
+
+
+def test_factory_none_mode(monkeypatch):
+    factory.reset_for_tests()
+    monkeypatch.setenv("RAG_PROVIDER", "none")
+    assert factory.get_rag_provider() is None
+    factory.reset_for_tests()
+
+
+def test_factory_pulpo_without_env_disables(monkeypatch):
+    factory.reset_for_tests()
+    monkeypatch.delenv("RAG_PROVIDER", raising=False)
+    monkeypatch.delenv("PULPO_MCP_URL", raising=False)
+    monkeypatch.delenv("PULPO_MCP_TOKEN", raising=False)
+    assert factory.get_rag_provider() is None
+    factory.reset_for_tests()
+
+
+def test_factory_pulpo_with_env(monkeypatch):
+    factory.reset_for_tests()
+    monkeypatch.delenv("RAG_PROVIDER", raising=False)
+    monkeypatch.setenv("PULPO_MCP_URL", URL)
+    monkeypatch.setenv("PULPO_MCP_TOKEN", "pk_test")
+    provider = factory.get_rag_provider()
+    assert provider is not None and provider.name == "pulpo"
+    assert factory.get_rag_provider() is provider  # singleton
+    factory.reset_for_tests()

--- a/qa-automation/AI-Scoring/tests/test_sop_retrieval.py
+++ b/qa-automation/AI-Scoring/tests/test_sop_retrieval.py
@@ -1,0 +1,200 @@
+"""P2 — SOP retrieval policy (PulpoConnection §4.2): query build,
+threshold, caching, block rendering with flag cautions, provenance
+shape, mode gating, and never-raises failure semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.rag import factory
+from backend.services.rag import sop_retrieval
+from backend.services.rag.provider import RagDoc, RagFlag, RagHit, RagProvider
+from backend.services.rag.sop_retrieval import (
+    SopContext,
+    build_sop_query,
+    fetch_sop_context,
+    pulpo_sop_mode,
+    render_sop_block,
+    score_threshold,
+)
+
+
+class FakeProvider(RagProvider):
+    name = "fake"
+
+    def __init__(self, hits, docs, fail=False):
+        self._hits, self._docs, self._fail = hits, docs, fail
+        self.search_calls = 0
+        self.doc_calls = 0
+
+    async def search(self, queries, *, limit=5):
+        if self._fail:
+            raise RuntimeError("provider exploded")
+        self.search_calls += 1
+        return [list(self._hits) for _ in queries]
+
+    async def get_document(self, doc_id):
+        self.doc_calls += 1
+        return self._docs.get(doc_id)
+
+
+def _hit(doc_id, score, flags=0):
+    return RagHit(id=doc_id, title=f"T-{doc_id}", excerpt="…",
+                  score=score, score_kind="cosine", flag_count=flags)
+
+
+def _doc(doc_id, body="Policy body.", flags=()):
+    return RagDoc(id=doc_id, title=f"T-{doc_id}", body=body,
+                  flags=flags, updated_at="2026-07-01")
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    sop_retrieval.reset_caches_for_tests()
+    factory.reset_for_tests()
+    monkeypatch.delenv("PULPO_SOP_MODE", raising=False)
+    monkeypatch.delenv("PULPO_SCORE_THRESHOLD", raising=False)
+    yield
+    sop_retrieval.reset_caches_for_tests()
+    factory.reset_for_tests()
+
+
+def _install(monkeypatch, provider):
+    monkeypatch.setattr(factory, "_provider", provider)
+    monkeypatch.setattr(factory, "_resolved", True)
+
+
+# -- pure helpers -----------------------------------------------------------
+
+
+def test_query_prefers_disposition():
+    assert build_sop_query("Access & Entry", "Smart-lock failure", "hello") == \
+        "Access & Entry — Smart-lock failure"
+    assert build_sop_query("Billing", None, "hello") == "Billing"
+
+
+def test_query_falls_back_to_transcript_head():
+    q = build_sop_query(None, None, "A" * 1000)
+    assert q == "A" * 600
+
+
+def test_query_none_without_material():
+    assert build_sop_query(None, None, "   ") is None
+
+
+def test_mode_gating(monkeypatch):
+    assert pulpo_sop_mode() == "off"          # default: opt-in
+    for value, expected in (("shadow", "shadow"), ("ON", "on"), ("bogus", "off")):
+        monkeypatch.setenv("PULPO_SOP_MODE", value)
+        assert pulpo_sop_mode() == expected
+
+
+def test_threshold_env_override(monkeypatch):
+    assert score_threshold() == 0.55
+    monkeypatch.setenv("PULPO_SCORE_THRESHOLD", "0.7")
+    assert score_threshold() == 0.7
+    monkeypatch.setenv("PULPO_SCORE_THRESHOLD", "junk")
+    assert score_threshold() == 0.55
+
+
+def test_render_flag_caution():
+    doc = _doc("d1", flags=(RagFlag(quote="reboot the lock", note="outdated"),))
+    block = render_sop_block([(doc, _hit("d1", 0.8, flags=1))])
+    assert "[SOP 1] T-d1" in block
+    assert "under review" in block and "reboot the lock" in block
+
+
+def test_render_caps_block_size():
+    docs = [(_doc(f"d{i}", body="x" * 9000), _hit(f"d{i}", 0.9 - i * 0.1))
+            for i in range(3)]
+    block = render_sop_block(docs)
+    assert len(block) <= sop_retrieval.BLOCK_CHAR_CAP + 100
+    # Highest-scoring doc survives intact; the tail got truncated/dropped.
+    assert "[SOP 1] T-d0" in block
+
+
+# -- fetch_sop_context ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_happy_path(monkeypatch):
+    provider = FakeProvider(
+        hits=[_hit("d1", 0.81), _hit("d2", 0.61), _hit("d3", 0.40)],
+        docs={"d1": _doc("d1"), "d2": _doc("d2")},
+    )
+    _install(monkeypatch, provider)
+    ctx = await fetch_sop_context(
+        disposition_category="Access & Entry",
+        disposition="Smart-lock failure",
+        transcript_text="",
+    )
+    assert ctx.sop_title == "T-d1"
+    assert "[SOP 1] T-d1" in ctx.block_text and "[SOP 2] T-d2" in ctx.block_text
+    # d3 fell below τ=0.55 — never fetched.
+    assert provider.doc_calls == 2
+    assert [p["id"] for p in ctx.provenance] == ["d1", "d2"]
+    assert ctx.provenance[0]["score"] == 0.81
+    assert ctx.skipped_reason == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_below_threshold_is_conservative(monkeypatch):
+    _install(monkeypatch, FakeProvider(hits=[_hit("d1", 0.30)], docs={}))
+    ctx = await fetch_sop_context(
+        disposition_category="Rare Category", disposition=None, transcript_text="",
+    )
+    assert ctx.block_text == "" and ctx.provenance == []
+    assert ctx.skipped_reason == "below_threshold"
+
+
+@pytest.mark.asyncio
+async def test_fetch_caches_by_query(monkeypatch):
+    provider = FakeProvider(hits=[_hit("d1", 0.9)], docs={"d1": _doc("d1")})
+    _install(monkeypatch, provider)
+    for _ in range(3):
+        await fetch_sop_context(
+            disposition_category="Billing", disposition="Refund",
+            transcript_text="",
+        )
+    assert provider.search_calls == 1  # finite label space → cached
+    assert provider.doc_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_error_never_raises(monkeypatch):
+    _install(monkeypatch, FakeProvider(hits=[], docs={}, fail=True))
+    ctx = await fetch_sop_context(
+        disposition_category="Billing", disposition=None, transcript_text="",
+    )
+    assert isinstance(ctx, SopContext)
+    assert ctx.skipped_reason == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_fetch_no_provider(monkeypatch):
+    _install(monkeypatch, None)
+    ctx = await fetch_sop_context(
+        disposition_category="Billing", disposition=None, transcript_text="",
+    )
+    assert ctx.skipped_reason == "no_provider"
+
+
+# -- eval-row provenance ----------------------------------------------------
+
+
+def test_draft_row_carries_pulpo_docs():
+    from backend.services.eval_store import build_draft_row
+    from backend.models.scorecard import ScorecardWithMeta
+    from tests.conftest import load_test_config
+
+    config = load_test_config("member_support")
+    provenance = [{"id": "d1", "title": "T-d1", "score": 0.81,
+                   "score_kind": "cosine", "updated_at": "2026-07-01",
+                   "open_flags": 0}]
+    sc = ScorecardWithMeta(
+        sections=[], key_strengths="", opportunities="", call_summary="",
+        call_id="DP1", agent_name="Jane", pulpo_docs=provenance,
+    )
+    import json
+    meta = json.loads(build_draft_row(sc, config)["dialpad_call_metadata"])
+    assert meta["pulpo_docs"] == provenance


### PR DESCRIPTION
## Summary

The first three PulpoConnection slices, all zero-scoring-path-risk (everything ships dark behind `PULPO_SOP_MODE`, default off). One commit per slice.

**P1 — provider seam + Pulpo transport** (`backend/services/rag/`): neutral `RagProvider` contract (`RagHit`/`RagFlag`/`RagDoc`, optional flag/upsert capabilities), `pulpo.py` as the *only* Pulpo-shaped module (MCP over Streamable HTTP: initialize handshake, `Mcp-Session-Id` echo with one re-handshake on 404, JSON-or-SSE response parsing, `rerank` pinned false, boundary shape-mapping — live finding: `get_document` nests under `"document"`), and a `RAG_PROVIDER` factory singleton mirroring the `data_provider` seam. **Live smoke passed**: real titles + scores, full doc fetch, and the both-audience check (§9 A3) proved by retrieving a Customer-audience doc.

**P2 — retrieval policy in shadow** (`sop_retrieval.py` + wiring): disposition-keyed query (transcript-head absence fallback), τ threshold (`PULPO_SCORE_THRESHOLD`, default 0.55), top-3 body fetch, flag cautions, 16k-char block cap, 60-min TTL caches, never-raises semantics. `score_call` branches on the mode; provenance (`pulpo_docs`) stamps `dialpad_call_metadata` in shadow *and* on, so the shadow window accumulates its own compare data. Lifespan closes the MCP session.

**P3 — coverage probe, executed live** (`scripts/pulpo_coverage_probe.py`, benchmark token): **74 disposition labels across 43,323 backfilled calls → 73/74 covered at τ=0.55 (99%), call-weighted 100%.** Sole genuine gap: *Unit Issues — Pests* (0.528, wrong doc) — first entry on the curation worklist. Results + τ→0.60 calibration note recorded in PulpoConnection.md §6.1. Rate-limit learning baked in: Pulpo rejects batches larger than the remaining minute allowance → 10-query batches paced 12s apart.

## Test plan

- `pytest tests/` — **951 passed**, 6 skipped, 3 xfailed (23 new: mocked-MCP transport + policy)
- Live: `pulpo_smoke.py` green (search/doc/both-audience); coverage probe green (8 paced batches)

## After merge

1. Set `PULPO_SOP_MODE=shadow` in Railway env → watch `pulpo_sop[shadow]` logs on scored calls (retrieved titles vs analyst judgment).
2. When the shadow reads clean (and τ is settled): P4 = flip `on` + Notion decommission. P5 (coach-cards migration) stays owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)