### PR TITLE
SOP reference footnotes + Call Metadata (site + agent email) & ModelProviderDesign v1

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/history_layout.py
+++ b/qa-automation/AI-Scoring/backend/config/history_layout.py
@@ -21,11 +21,14 @@ Layout (0-indexed columns)::
     6+3N+3      caller_name
     6+3N+4      caller_phone
     6+3N+5      source
-    6+3N+6      eval_approved_at        (NEW — see semantic note)
+    6+3N+6      eval_approved_at        (see semantic note)
+    6+3N+7      disposition             (display string "Category — Sub")
+    6+3N+8      ai_csat                 (Dialpad Ai estimate, 1-5)
+    6+3N+9      sop_references          (newline-joined "SOP n: Title")
 
-Total width: 6 + 3N + 7 columns.
+Total width: 6 + 3N + 10 columns.
 
-For Sales (N=19) → 70 cols (A–BR). For MS (N=10) → 43 cols (A–AQ).
+For Sales (N=19) → 73 cols (A–BU). For MS (N=10) → 46 cols (A–AT).
 
 ----------------------------------------------------------------------
 Timestamp semantic — see references/CallTimeOnAnalystHistory.md
@@ -60,7 +63,7 @@ COL_DIALPAD_LINK = 4
 COL_OVERALL_SCORE = 5
 
 PREFIX_WIDTH = 6
-TRAILING_WIDTH = 7          # bumped 6 → 7 to seat col_eval_approved_at
+TRAILING_WIDTH = 10         # 7 → 10: disposition, ai_csat, sop_references
 
 
 class HistoryLayout:
@@ -148,6 +151,29 @@ class HistoryLayout:
         rows until PR-2's backfill script runs; ``load_and_clean``
         falls back to col C during that window."""
         return self.confidence_end + 6
+
+    @property
+    def col_disposition(self) -> int:
+        """Verified Dialpad disposition as one display cell
+        ("Category — Sub", or just the category). Blank when the CC
+        match found none — absence is a first-class state
+        (DispositionDesign §5)."""
+        return self.confidence_end + 7
+
+    @property
+    def col_ai_csat(self) -> int:
+        """Dialpad Ai CSAT estimate (1-5, one decimal). A model
+        estimate, NOT a member survey — label it as such wherever
+        rendered (DispositionDesign §6)."""
+        return self.confidence_end + 8
+
+    @property
+    def col_sop_references(self) -> int:
+        """Newline-joined "SOP n: Title" footnotes for the RAG docs that
+        grounded the scoring prompt (PulpoConnection §4.2 provenance).
+        Numbering matches the [SOP n] citations inside the AI's
+        reasoning text."""
+        return self.confidence_end + 9
 
     @property
     def total_width(self) -> int:

--- a/qa-automation/AI-Scoring/backend/models/dashboard.py
+++ b/qa-automation/AI-Scoring/backend/models/dashboard.py
@@ -24,6 +24,18 @@ class EvaluationRecord(BaseModel):
     caller_name: Optional[str] = None
     caller_phone: Optional[str] = None
     source: str = "manual"  # "manual", "ai", or "backfilled"
+    # Call metadata (DispositionDesign §5 / PulpoConnection §4.2) — served
+    # by PostgresProvider only; the SheetsProvider parity path leaves the
+    # defaults, so parity comparisons must exclude these fields.
+    dialpad_disposition_category: Optional[str] = None
+    dialpad_disposition: Optional[str] = None
+    ai_csat: Optional[float] = None      # Dialpad Ai estimate, NOT a survey
+    call_duration_ms: Optional[int] = None
+    dialpad_call_id: Optional[str] = None
+    dialpad_entry_point_call_id: Optional[str] = None
+    dialpad_master_call_id: Optional[str] = None
+    sop_used: Optional[str] = None       # top SOP title injected at scoring
+    pulpo_docs: list[dict] = []          # retrieval provenance footnotes
 
 class SectionAssessment(BaseModel):
     """Gemini's assessment of a single section's progression."""

--- a/qa-automation/AI-Scoring/backend/services/db_provider.py
+++ b/qa-automation/AI-Scoring/backend/services/db_provider.py
@@ -13,6 +13,7 @@ are served here.
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -30,7 +31,13 @@ _EVAL_COLUMNS = (
     "id, agent_name_raw, agent_email, evaluator_email, "
     "COALESCE(call_connected_at, created_at) AS ts, "
     "overall_score, dialpad_link, key_strengths, opportunities, "
-    "call_summary, caller_name, caller_phone, source"
+    "call_summary, caller_name, caller_phone, source, "
+    # Call metadata for the /datapoint drill-down (DispositionDesign §5,
+    # PulpoConnection §4.2): CC stamps, clocks, the id triple, and the
+    # metadata JSONB carrying sop_used + pulpo_docs provenance.
+    "dialpad_disposition_category, dialpad_disposition, ai_csat, "
+    "call_duration_ms, dialpad_call_id, dialpad_entry_point_call_id, "
+    "dialpad_master_call_id, dialpad_call_metadata"
 )
 
 
@@ -228,6 +235,18 @@ class PostgresProvider(DataProvider):
             ts = ts.replace(tzinfo=timezone.utc)
 
         dialpad_link = ev["dialpad_link"] or None
+        # dialpad_call_metadata is JSONB; asyncpg returns it as a JSON
+        # string without a custom codec. Tolerate str, dict, or NULL —
+        # `.get` works on both asyncpg Records and dict test fixtures.
+        metadata = ev.get("dialpad_call_metadata")
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except ValueError:
+                metadata = {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        pulpo_docs = metadata.get("pulpo_docs")
         return EvaluationRecord(
             timestamp=ts,
             agent_name=ev["agent_name_raw"],
@@ -248,6 +267,15 @@ class PostgresProvider(DataProvider):
             caller_name=ev["caller_name"] or None,
             caller_phone=ev["caller_phone"] or None,
             source=ev["source"] or "manual",
+            dialpad_disposition_category=ev.get("dialpad_disposition_category") or None,
+            dialpad_disposition=ev.get("dialpad_disposition") or None,
+            ai_csat=float(ev["ai_csat"]) if ev.get("ai_csat") is not None else None,
+            call_duration_ms=ev.get("call_duration_ms"),
+            dialpad_call_id=ev.get("dialpad_call_id") or None,
+            dialpad_entry_point_call_id=ev.get("dialpad_entry_point_call_id") or None,
+            dialpad_master_call_id=ev.get("dialpad_master_call_id") or None,
+            sop_used=metadata.get("sop_used") or None,
+            pulpo_docs=pulpo_docs if isinstance(pulpo_docs, list) else [],
         )
 
     # ------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/backend/services/sheets_projection.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_projection.py
@@ -21,6 +21,7 @@ retryable — callers log and continue; the nightly reproject sweep
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -58,6 +59,43 @@ def _render_section_value(section: dict[str, Any]) -> str:
 
 def _render_ts(value: Any) -> str:
     return value.strftime(_SHEET_TS_FORMAT) if value else ""
+
+
+def _metadata_dict(evaluation: Any) -> dict:
+    """dialpad_call_metadata JSONB → dict (asyncpg returns a JSON string
+    without a custom codec; tolerate str, dict, or NULL). ``.get`` works
+    on both asyncpg Records and plain-dict test fixtures."""
+    raw = evaluation.get("dialpad_call_metadata")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _render_disposition(evaluation: Any) -> str:
+    """"Category — Sub" display cell; blank when the CC match found none."""
+    category = evaluation.get("dialpad_disposition_category") or ""
+    sub = evaluation.get("dialpad_disposition") or ""
+    if category and sub:
+        return f"{category} — {sub}"
+    return category or sub
+
+
+def _render_sop_references(metadata: dict) -> str:
+    """Newline-joined "SOP n: Title" footnotes from the pulpo_docs
+    provenance — numbering matches the [SOP n] citations the scoring
+    prompt used. Falls back to the bare sop_used title for rows written
+    before provenance existed."""
+    docs = metadata.get("pulpo_docs")
+    if isinstance(docs, list) and docs:
+        return "\n".join(
+            f"SOP {i}: {doc.get('title', '')}"
+            for i, doc in enumerate(docs, start=1)
+            if isinstance(doc, dict) and doc.get("title")
+        )
+    return metadata.get("sop_used") or ""
 
 
 def _render_overall(value: Any) -> str:
@@ -100,6 +138,14 @@ def build_projection_row(
     row[L.col_caller_phone] = evaluation["caller_phone"] or ""
     row[L.col_source] = evaluation["source"] or ""
     row[L.col_eval_approved_at] = _render_ts(evaluation["approved_at"])
+    # Call-metadata trailing columns (DispositionDesign §5 / PulpoConnection
+    # §4.2) — the GAS email reads these to render the disposition line and
+    # the SOP-reference footnotes.
+    metadata = _metadata_dict(evaluation)
+    ai_csat = evaluation.get("ai_csat")
+    row[L.col_disposition] = _render_disposition(evaluation)
+    row[L.col_ai_csat] = str(ai_csat) if ai_csat is not None else ""
+    row[L.col_sop_references] = _render_sop_references(metadata)
     return row
 
 

--- a/qa-automation/AI-Scoring/frontend/datapoint.html
+++ b/qa-automation/AI-Scoring/frontend/datapoint.html
@@ -80,15 +80,42 @@
       font-size: 0.95rem;
     }
 
-    /* Call info grid */
-    .info-grid {
+    /* Call Metadata — grouped grid */
+    .meta-groups {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 8px;
-      font-size: 0.8rem;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 16px;
     }
-    .info-item { color: var(--muted); }
+    .meta-group {
+      background: var(--bg);
+      border-radius: 10px;
+      padding: 12px 14px;
+    }
+    .meta-group-title {
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+    .info-item { color: var(--muted); font-size: 0.78rem; padding: 2px 0; overflow-wrap: anywhere; }
     .info-item strong { color: var(--text); }
+    .csat-badge {
+      display: inline-block; font-size: 0.72rem; padding: 2px 8px;
+      background: #d0ddf0; border-radius: 12px; color: var(--text);
+    }
+
+    /* SOP reference footnotes */
+    .reference-item {
+      display: grid; grid-template-columns: 56px 1fr; gap: 8px;
+      padding: 6px 0; font-size: 0.78rem; line-height: 1.5;
+      border-bottom: 1px solid var(--border);
+    }
+    .reference-item:last-child { border-bottom: none; }
+    .reference-num { color: var(--muted); font-variant-numeric: tabular-nums; }
+    .reference-meta { color: var(--muted); font-size: 0.68rem; }
+    .reference-flag { color: var(--amber); font-size: 0.68rem; }
 
     /* Call summary */
     .call-summary {
@@ -226,7 +253,8 @@
     <div id="placeholder" class="placeholder">Loading evaluation...</div>
 
     <div id="infoCard" class="card" style="display:none;">
-      <div class="info-grid" id="infoGrid"></div>
+      <h2>Call Metadata</h2>
+      <div class="meta-groups" id="metaGroups"></div>
     </div>
 
     <div id="summaryCard" class="card" style="display:none;">
@@ -249,6 +277,15 @@
         <div class="feedback-label">Opportunities for Improvement</div>
         <div id="improvements"></div>
       </div>
+    </div>
+
+    <div id="referencesCard" class="card" style="display:none;">
+      <h2>References</h2>
+      <div style="font-size:0.7rem; color:var(--muted); margin-bottom:8px;">
+        Internal SOPs the AI evaluator consulted when scoring this call —
+        numbering matches the [SOP n] citations in the reasoning above.
+      </div>
+      <div id="referencesList"></div>
     </div>
 
     <div id="dialpadCard" style="display:none; text-align:center; padding:8px 0;">
@@ -345,6 +382,103 @@
       }
     }
 
+    function escHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str == null ? '' : String(str);
+      return div.innerHTML;
+    }
+
+    function formatDuration(ms) {
+      if (!ms || ms <= 0) return null;
+      const totalSec = Math.round(ms / 1000);
+      const m = Math.floor(totalSec / 60);
+      const s = totalSec % 60;
+      return `${m}:${String(s).padStart(2, '0')} min`;
+    }
+
+    function metaGroup(title, items) {
+      const rows = items
+        .filter(i => i.html || (i.value !== null && i.value !== undefined && i.value !== ''))
+        .map(i => `<div class="info-item"><strong>${escHtml(i.label)}:</strong> ${i.html || escHtml(i.value)}</div>`)
+        .join('');
+      if (!rows) return '';
+      return `<div class="meta-group"><div class="meta-group-title">${escHtml(title)}</div>${rows}</div>`;
+    }
+
+    function renderCallMetadata(eval_) {
+      const disposition = eval_.dialpad_disposition_category
+        ? (eval_.dialpad_disposition
+            ? `${eval_.dialpad_disposition_category} — ${eval_.dialpad_disposition}`
+            : eval_.dialpad_disposition_category)
+        : null;
+      const csatHtml = (eval_.ai_csat !== null && eval_.ai_csat !== undefined)
+        ? `<span class="csat-badge" title="Dialpad Ai CSAT — model estimate, not a member survey">${escHtml(eval_.ai_csat)}/5 Ai (estimate)</span>`
+        : null;
+
+      const groups = [
+        metaGroup('Call', [
+          { label: 'Date', value: new Date(eval_.timestamp).toLocaleString() },
+          { label: 'Duration', value: formatDuration(eval_.call_duration_ms) },
+          { label: 'Entry-point ID', value: eval_.dialpad_entry_point_call_id },
+          { label: 'Call ID', value: eval_.dialpad_call_id },
+          { label: 'Master ID',
+            value: eval_.dialpad_master_call_id !== eval_.dialpad_call_id
+              ? eval_.dialpad_master_call_id : null },
+        ]),
+        metaGroup('Outcome', [
+          { label: 'Disposition', value: disposition },
+          { label: 'Ai CSAT', html: csatHtml },
+          { label: 'SOP grounding',
+            value: (eval_.pulpo_docs && eval_.pulpo_docs.length)
+              ? `${eval_.pulpo_docs.length} SOP${eval_.pulpo_docs.length > 1 ? 's' : ''} (see References)`
+              : (eval_.sop_used || null) },
+        ]),
+        metaGroup('Member', [
+          { label: 'Caller', value: eval_.caller_name },
+          { label: 'Phone', value: eval_.caller_phone },
+        ]),
+        metaGroup('Evaluation', [
+          { label: 'Agent', value: eval_.agent_name },
+          { label: 'Evaluator', value: eval_.manager_email },
+          { label: 'Source', value: eval_.source },
+        ]),
+      ].join('');
+
+      document.getElementById('metaGroups').innerHTML = groups;
+      document.getElementById('infoCard').style.display = '';
+    }
+
+    function renderReferences(eval_) {
+      const docs = Array.isArray(eval_.pulpo_docs) ? eval_.pulpo_docs : [];
+      let items = '';
+      if (docs.length > 0) {
+        items = docs.map((d, i) => {
+          const metaBits = [];
+          if (d.score != null) metaBits.push(`match ${Number(d.score).toFixed(2)}`);
+          if (d.updated_at) metaBits.push(`updated ${String(d.updated_at).slice(0, 10)}`);
+          const meta = metaBits.length ? `<span class="reference-meta"> — ${metaBits.join(', ')}</span>` : '';
+          const flagNote = d.open_flags > 0
+            ? `<div class="reference-flag">⚑ ${d.open_flags} open flag${d.open_flags > 1 ? 's' : ''} — passages under review; verify before treating as current policy.</div>`
+            : '';
+          return `
+            <div class="reference-item">
+              <div class="reference-num">[SOP ${i + 1}]</div>
+              <div>${escHtml(d.title || d.id || '')}${meta}${flagNote}</div>
+            </div>`;
+        }).join('');
+      } else if (eval_.sop_used) {
+        // Evals scored before provenance existed carry only the title.
+        items = `
+          <div class="reference-item">
+            <div class="reference-num">[SOP 1]</div>
+            <div>${escHtml(eval_.sop_used)}</div>
+          </div>`;
+      }
+      if (!items) return;
+      document.getElementById('referencesList').innerHTML = items;
+      document.getElementById('referencesCard').style.display = '';
+    }
+
     async function loadDataPoint() {
       if (!callId) {
         document.getElementById('placeholder').textContent = 'No call ID in URL.';
@@ -366,21 +500,13 @@
         `Call ${callId}  |  ${new Date(eval_.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}  |  Evaluator: ${eval_.manager_email}`;
       document.getElementById('agentLink').href = `/dashboard/${TEAM_ID}/agent/${encodeURIComponent(eval_.agent_name)}`;
 
-      // Info grid
-      const infoCard = document.getElementById('infoCard');
-      const items = [
-        { label: 'Agent', value: eval_.agent_name },
-        { label: 'Evaluator', value: eval_.manager_email },
-        { label: 'Date', value: new Date(eval_.timestamp).toLocaleString() },
-        { label: 'Source', value: eval_.source },
-      ];
-      if (eval_.caller_name) items.push({ label: 'Caller', value: eval_.caller_name });
-      if (eval_.caller_phone) items.push({ label: 'Phone', value: eval_.caller_phone });
+      // Call Metadata — everything the pipeline captured for this call,
+      // grouped: verified Dialpad facts (DispositionDesign §5), member
+      // info, call clocks/ids, and the evaluation trail.
+      renderCallMetadata(eval_);
 
-      document.getElementById('infoGrid').innerHTML = items.map(i =>
-        `<div class="info-item"><strong>${i.label}:</strong> ${i.value}</div>`
-      ).join('');
-      infoCard.style.display = '';
+      // SOP reference footnotes (PulpoConnection §4.2 provenance).
+      renderReferences(eval_);
 
       // Call summary
       if (eval_.call_summary) {

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -151,6 +151,24 @@
       color: var(--muted); margin-bottom: 0.35rem;
     }
 
+    /* SOP reference footnotes — numbering matches the [SOP n] citations
+       inside the AI reasoning text above. */
+    .references-section {
+      padding: 1rem 1.25rem; background: #f9fafe; border-top: 1px solid var(--border);
+      font-size: 0.75rem;
+    }
+    .reference-item {
+      display: grid; grid-template-columns: 52px 1fr; gap: 0.5rem;
+      padding: 0.3rem 0; line-height: 1.5;
+    }
+    .reference-num { color: var(--muted); font-variant-numeric: tabular-nums; }
+    .reference-meta { color: var(--muted); font-size: 0.68rem; }
+    .reference-flag { color: var(--warning); font-size: 0.68rem; }
+    .disposition-chip {
+      font-size: 0.7rem; padding: 0.2rem 0.6rem; background: #d0ddf0;
+      color: var(--text); border-radius: 20px;
+    }
+
     .transcript-panel { border-top: 2px solid var(--navy); margin-top: 0.5rem; }
     .transcript-toggle {
       display: flex; align-items: center; justify-content: space-between;
@@ -408,6 +426,16 @@ function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
 
   const sheetsNote = sheetsRow > 0 ? `<span>Sheets row ${sheetsRow}</span>` : '';
 
+  // Verified Dialpad disposition (DispositionDesign §5) — the same fact
+  // the grounding block fed the scoring prompt. Absent = CC never saw
+  // the call or it was undispositioned; render nothing.
+  const dispositionChip = sc.dialpad_disposition_category
+    ? `<span class="disposition-chip" title="Verified Dialpad disposition">${escHtml(
+        sc.dialpad_disposition
+          ? `${sc.dialpad_disposition_category} — ${sc.dialpad_disposition}`
+          : sc.dialpad_disposition_category)}</span>`
+    : '';
+
   const header = `
     <div class="scorecard-header">
       <div>
@@ -415,6 +443,7 @@ function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
         <div class="header-meta">
           <span>Call ${callId || ''}</span>
           <span class="status-badge status-complete">complete</span>
+          ${dispositionChip}
           ${sheetsNote}
         </div>
       </div>
@@ -571,8 +600,52 @@ function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
     `;
   }
 
-  panel.innerHTML = header + sectionRows.join('') + approveBar + notes + transcriptPanel;
+  panel.innerHTML = header + sectionRows.join('') + approveBar + notes
+    + buildReferencesSection(sc) + transcriptPanel;
   return panel;
+}
+
+function escHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str == null ? '' : String(str);
+  return div.innerHTML;
+}
+
+// SOP reference footnotes (PulpoConnection §4.2 provenance). The AI's
+// reasoning cites "[SOP n]" — pulpo_docs preserves the injection order,
+// so footnote numbering lines up with those citations. Falls back to the
+// bare sop_used title for evals scored before provenance existed.
+function buildReferencesSection(sc) {
+  const docs = Array.isArray(sc.pulpo_docs) ? sc.pulpo_docs : [];
+  let items = '';
+  if (docs.length > 0) {
+    items = docs.map((d, i) => {
+      const metaBits = [];
+      if (d.score != null) metaBits.push(`match ${Number(d.score).toFixed(2)}`);
+      if (d.updated_at) metaBits.push(`updated ${String(d.updated_at).slice(0, 10)}`);
+      const meta = metaBits.length ? `<span class="reference-meta"> — ${metaBits.join(', ')}</span>` : '';
+      const flagNote = d.open_flags > 0
+        ? `<div class="reference-flag">⚑ ${d.open_flags} open flag${d.open_flags > 1 ? 's' : ''} — passages under review; verify before treating as current policy.</div>`
+        : '';
+      return `
+        <div class="reference-item">
+          <div class="reference-num">[SOP ${i + 1}]</div>
+          <div>${escHtml(d.title || d.id || '')}${meta}${flagNote}</div>
+        </div>`;
+    }).join('');
+  } else if (sc.sop_used) {
+    items = `
+      <div class="reference-item">
+        <div class="reference-num">[SOP 1]</div>
+        <div>${escHtml(sc.sop_used)}</div>
+      </div>`;
+  }
+  if (!items) return '';
+  return `
+    <div class="references-section">
+      <div class="notes-label">References — SOPs consulted by the AI evaluator</div>
+      ${items}
+    </div>`;
 }
 
 function checkManualScores(jobId) {

--- a/qa-automation/AI-Scoring/references/ModelProviderDesign.md
+++ b/qa-automation/AI-Scoring/references/ModelProviderDesign.md
@@ -1,0 +1,152 @@
+# ModelProviderDesign — abstracting the AI model behind the pipeline
+
+**Status:** v1 draft — design only, no code yet (design-doc-first).
+**Date:** 2026-07-23
+**Prompted by:** "Our system abstracts Gemini config in the team JSON, but
+how are we abstracting the AI model itself? I want to try Claude models
+(not Fable — overkill) via API either for scoring itself or progression
+services."
+
+---
+
+## 1. Where we actually stand
+
+The honest answer: the **model name** is abstracted; the **provider** is
+not.
+
+| Layer | State today |
+|---|---|
+| Team JSON | `gemini.scoring_model`, `gemini.progression_model` + temperature/token knobs — swap `gemini-2.5-flash` for `gemini-2.5-pro` without touching code. |
+| `audio_service.score_audio` | Hardcodes `google.genai.Client`, Gemini file-upload for audio, Gemini response parsing. |
+| `progression_service` | Hardcodes `google.genai.Client` + `GEMINI_API_KEY`, Gemini generate_content, manual JSON-fence stripping. |
+| `eval_store` | Stamps `ai_provider_primary = "gemini"` as a literal; `models_used` JSONB already carries `{provider, model}` per leg (§8.1) — the *schema* anticipated multi-provider, the writer doesn't. |
+
+So we can change *which Gemini* per team, but trying Claude means editing
+two service modules. That's exactly the state the RAG layer was in before
+the `rag/` seam — and the fix is the same shape.
+
+## 2. The constraint that decides "scoring vs progression"
+
+**The Claude API has no audio input modality** (text, images, PDFs — no
+audio files). Our scoring pipeline is audio-first by doctrine:
+
+- Spanish calls: **audio is SOT** (owner rule 2026-07-19) — transcript-first
+  scoring is explicitly forbidden wording;
+- audio-dependent sections (tone, hold handling, pacing) are scored FROM
+  the recording, with the transcript as a supplement.
+
+A Claude scoring lane would therefore be transcript-only scoring — a
+*doctrine change*, not a provider swap. Recommendation: **do not point
+Claude at `score_audio`**. The natural first consumer is the
+**progression / assessment service**: pure text in (serialized eval
+history), JSON out, no audio anywhere — the same "first consumer" role
+the scoring prompt played for Pulpo. The monthly one-pager
+(`assessment_store`) is the second consumer, same shape.
+
+(If LandGPT v2 ever splits scoring into an audio leg + text leg, the text
+leg plugs into this same seam — `models_used.audio` / `.text` already
+model that split.)
+
+## 3. Design — `backend/services/llm/`, mirroring `rag/`
+
+Same three-file pattern that made Pulpo swappable:
+
+```
+backend/services/llm/
+  provider.py     # neutral contract — no vendor imports
+  gemini.py       # the ONLY google-genai-shaped module (moves the
+                  # client code out of progression_service)
+  anthropic.py    # the ONLY anthropic-SDK-shaped module
+  factory.py      # env/config-keyed singleton, mirrors get_rag_provider
+```
+
+### provider.py — the neutral contract
+
+```python
+@dataclass
+class LlmResult:
+    text: str                 # raw model text
+    provider: str             # "gemini" | "anthropic" — for models_used
+    model: str
+
+class TextModelProvider(Protocol):
+    async def generate(
+        self, prompt: str, *,
+        model: str,
+        max_output_tokens: int,
+        json_schema: dict | None = None,   # structured output when supported
+    ) -> LlmResult: ...
+```
+
+Deliberately text-only (`generate(prompt) -> text`): that covers
+progression + assessments today without inventing an audio interface
+nobody can implement twice. Temperature stays OUT of the contract —
+current Claude models reject sampling params; each provider module maps
+its own knobs.
+
+### anthropic.py — Claude specifics
+
+- Official `anthropic` SDK (async client), `ANTHROPIC_API_KEY` env.
+- **Model:** `claude-opus-4-8` as the quality default (the current Opus;
+  Fable excluded per owner call — overkill/pricing). Cost lever if
+  needed later: `claude-sonnet-5`. Exact IDs, no date suffixes.
+- Adaptive thinking on (`thinking={"type": "adaptive"}`); **no
+  temperature/top_p** (removed on Opus 4.8 — 400 if sent).
+- Structured output via `output_config={"format": {"type": "json_schema",
+  "schema": ...}}` — this **replaces** progression's markdown-fence
+  stripping entirely on the Claude path (guaranteed-valid JSON), and is
+  the main quality-of-life win of the trial.
+- Long histories: fine — 1M context; keep `max_tokens` ≈ current
+  `progression_max_output_tokens`.
+
+### factory.py + config
+
+- Team JSON grows a per-stage provider knob, defaulting to today's
+  behavior:
+
+  ```jsonc
+  "models": {
+    "progression": { "provider": "gemini", "model": "gemini-2.5-flash" }
+    // "scoring" stays implicitly gemini/audio until a doctrine change
+  }
+  ```
+
+  Back-compat: when `models` is absent, synthesize it from the existing
+  `gemini.*` block so no team JSON has to change on day one.
+- Env override for the trial, house-pattern-gated:
+  `PROGRESSION_MODEL_PROVIDER=anthropic` flips it fleet-wide without a
+  config edit (same off-by-default instinct as `PULPO_SOP_MODE`).
+
+### Call-site changes
+
+- `progression_service` / `assessment_store`: replace the inline
+  `genai.Client` block with `provider = get_llm_provider(stage="progression",
+  config=config)` + `provider.generate(...)`; stamp `result.provider` /
+  `result.model` into any persisted assessment metadata.
+- `eval_store`: `ai_provider_primary` and `ModelsUsed.text.provider`
+  read from the scorecard's actual provider instead of the `"gemini"`
+  literal (no behavior change until a non-Gemini stage exists).
+- `audio_service`: untouched.
+
+## 4. Rollout
+
+1. **P1** — seam + `gemini.py` extraction (pure refactor; progression
+   output byte-identical; pytest checkpoint).
+2. **P2** — `anthropic.py` + live smoke script (one real progression
+   assessment for one agent, printed side-by-side with Gemini's).
+3. **P3** — trial: flip `PROGRESSION_MODEL_PROVIDER=anthropic` on
+   Railway for a week; compare assessments qualitatively (they're
+   advisory prose, not scores — no formula risk); pick per-team defaults.
+4. **Not in scope:** Claude in the scoring path (audio doctrine, §2) and
+   any change to formula/score computation (progression output never
+   feeds scores).
+
+## 5. Open questions for the owner
+
+1. Progression first, or the EOM assessment one-pager first? (Same seam;
+   one-pager is lower-frequency → cheaper trial, but progression gives
+   faster feedback.)
+2. Billing: new Anthropic org/key under Landing, or existing account?
+   Railway needs `ANTHROPIC_API_KEY` either way.
+3. Comfortable with Opus-tier pricing ($5/$25 per MTok) for the trial, or
+   start on Sonnet 5 ($3/$15, intro $2/$10 through 2026-08-31)?

--- a/qa-automation/AI-Scoring/tests/test_config_load.py
+++ b/qa-automation/AI-Scoring/tests/test_config_load.py
@@ -66,15 +66,16 @@ def test_score_destination_columns_reference_real_sections(config: TeamConfig):
 
 
 def test_history_layout_width_matches_formula(config: TeamConfig):
-    """Derived layout width follows the canonical 6 + 3N + 7 formula.
+    """Derived layout width follows the canonical 6 + 3N + 10 formula.
 
-    Trailing width is 7 since the call-time initiative landed
-    `col_eval_approved_at` as a trailing column (see
-    references/CallTimeOnAnalystHistory.md).
+    Trailing width grew 6 → 7 with the call-time initiative
+    (`col_eval_approved_at`, references/CallTimeOnAnalystHistory.md) and
+    7 → 10 with the call-metadata columns (disposition, ai_csat,
+    sop_references — DispositionDesign §5 / PulpoConnection §4.2).
     """
     L = config.history_layout
     n = len(config.sections)
-    assert L.total_width == 6 + 3 * n + 7
+    assert L.total_width == 6 + 3 * n + 10
     # Range invariants: scores → reasoning → confidence are contiguous, each width N
     assert L.scores_end - L.scores_start == n
     assert L.reasoning_end - L.reasoning_start == n
@@ -84,12 +85,16 @@ def test_history_layout_width_matches_formula(config: TeamConfig):
     # Trailing fixed cells immediately follow confidence range
     assert L.col_key_strengths == L.confidence_end
     assert L.col_source == L.confidence_end + 5
-    # New trailing column for the call-time initiative
     assert L.col_eval_approved_at == L.confidence_end + 6
-    # eval_approved_at is the LAST trailing column — total_width math
+    # Call-metadata trailing columns (append-only — positions of every
+    # earlier cell must never shift)
+    assert L.col_disposition == L.confidence_end + 7
+    assert L.col_ai_csat == L.confidence_end + 8
+    assert L.col_sop_references == L.confidence_end + 9
+    # sop_references is the LAST trailing column — total_width math
     # would silently break if a future trailing cell landed without
     # bumping TRAILING_WIDTH here.
-    assert L.col_eval_approved_at == L.total_width - 1
+    assert L.col_sop_references == L.total_width - 1
 
 
 def test_history_layout_eval_approved_at_does_not_collide_with_existing_trailing_cells(
@@ -123,8 +128,8 @@ def test_history_layout_eval_approved_at_indices_at_n_boundaries():
             f"N={n}: col_eval_approved_at expected at index {expected}, "
             f"got {L.col_eval_approved_at}"
         )
-        # And it's the last column.
-        assert L.total_width == L.col_eval_approved_at + 1
+        # Three call-metadata columns follow it; sop_references is last.
+        assert L.total_width == L.col_sop_references + 1
 
 
 def test_section_numbers_are_unique(config: TeamConfig):

--- a/qa-automation/AI-Scoring/tests/test_db_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_db_provider.py
@@ -243,3 +243,50 @@ def test_roster_rows_work_with_history_service_helpers():
     assert rows[0] == ["Name", "Email", "Supervisor", "Canonical Name"]
     assert _email_in_mails_rows("JANE@landing.com", rows)
     assert _agent_email_for_name_in_rows("Jane Doe", rows) == "jane@landing.com"
+
+
+# ---------------------------------------------------------------------------
+# Call-metadata fields (DispositionDesign §5 / PulpoConnection §4.2)
+# ---------------------------------------------------------------------------
+
+def test_call_metadata_fields_flow_through_record():
+    """/datapoint reads disposition, CSAT, clocks, the id triple, and the
+    pulpo_docs footnotes off the record — asyncpg hands JSONB back as a
+    JSON string, so the builder must parse it."""
+    provider = make_provider()
+    row = make_eval_row(
+        dialpad_disposition_category="Unit Issues",
+        dialpad_disposition="Lockouts",
+        ai_csat=4.5,
+        call_duration_ms=312_000,
+        dialpad_call_id="111",
+        dialpad_entry_point_call_id="222",
+        dialpad_master_call_id="333",
+        dialpad_call_metadata=(
+            '{"sop_used": "Lockout SOP", "pulpo_docs": ['
+            '{"id": "a", "title": "Lockout SOP", "score": 0.91}]}'
+        ),
+    )
+    rec = provider._record_from_rows(row, make_section_rows(provider._config))
+    assert rec.dialpad_disposition_category == "Unit Issues"
+    assert rec.dialpad_disposition == "Lockouts"
+    assert rec.ai_csat == 4.5
+    assert rec.call_duration_ms == 312_000
+    assert rec.dialpad_call_id == "111"
+    assert rec.dialpad_entry_point_call_id == "222"
+    assert rec.dialpad_master_call_id == "333"
+    assert rec.sop_used == "Lockout SOP"
+    assert rec.pulpo_docs == [{"id": "a", "title": "Lockout SOP", "score": 0.91}]
+
+
+def test_call_metadata_absent_defaults_are_benign():
+    """Rows scored before the CC/Pulpo era (and the SheetsProvider parity
+    path) leave every metadata field at its default — never raise."""
+    provider = make_provider()
+    rec = provider._record_from_rows(
+        make_eval_row(), make_section_rows(provider._config)
+    )
+    assert rec.dialpad_disposition_category is None
+    assert rec.ai_csat is None
+    assert rec.sop_used is None
+    assert rec.pulpo_docs == []

--- a/qa-automation/AI-Scoring/tests/test_sheets_projection.py
+++ b/qa-automation/AI-Scoring/tests/test_sheets_projection.py
@@ -106,6 +106,45 @@ class TestBuildProjectionRow:
         assert row[history_layout.COL_TIMESTAMP] == ""
         assert row[L.col_eval_approved_at] == ""
 
+    def test_call_metadata_trailing_columns(self, ms_config):
+        """Disposition/CSAT/SOP-reference cells the GAS email reads —
+        pulpo_docs footnote numbering must match the [SOP n] citations
+        in the reasoning text (injection order preserved)."""
+        evaluation = _evaluation(
+            dialpad_disposition_category="Unit Issues",
+            dialpad_disposition="Lockouts",
+            ai_csat=4.5,
+            dialpad_call_metadata=(
+                '{"sop_used": "Lockout SOP", "pulpo_docs": ['
+                '{"id": "a", "title": "Lockout SOP", "score": 0.91},'
+                '{"id": "b", "title": "Latch Troubleshooting", "score": 0.72}]}'
+            ),
+        )
+        row = build_projection_row(evaluation, _sections(), ms_config)
+        L = ms_config.history_layout
+        assert row[L.col_disposition] == "Unit Issues — Lockouts"
+        assert row[L.col_ai_csat] == "4.5"
+        assert row[L.col_sop_references] == (
+            "SOP 1: Lockout SOP\nSOP 2: Latch Troubleshooting"
+        )
+
+    def test_call_metadata_absent_renders_blank(self, ms_config):
+        """Fixture without the metadata keys (and rows scored before the
+        CC/Pulpo era) render blank cells, never raise."""
+        row = build_projection_row(_evaluation(), _sections(), ms_config)
+        L = ms_config.history_layout
+        assert row[L.col_disposition] == ""
+        assert row[L.col_ai_csat] == ""
+        assert row[L.col_sop_references] == ""
+
+    def test_sop_references_falls_back_to_sop_used(self, ms_config):
+        """Pre-provenance rows carry only the bare title."""
+        evaluation = _evaluation(
+            dialpad_call_metadata='{"sop_used": "Lockout SOP", "pulpo_docs": []}',
+        )
+        row = build_projection_row(evaluation, _sections(), ms_config)
+        assert row[ms_config.history_layout.col_sop_references] == "Lockout SOP"
+
 
 class TestOverallRendering:
 

--- a/qa-automation/scripts/build_config.py
+++ b/qa-automation/scripts/build_config.py
@@ -75,6 +75,9 @@ def _render_history_layout(config: TeamConfig) -> str:
         f"  COL_CALLER_NAME:    {L.col_caller_name},",
         f"  COL_CALLER_PHONE:   {L.col_caller_phone},",
         f"  COL_SOURCE:         {L.col_source},",
+        f"  COL_DISPOSITION:    {L.col_disposition},",
+        f"  COL_AI_CSAT:        {L.col_ai_csat},",
+        f"  COL_SOP_REFERENCES: {L.col_sop_references},",
         "};",
     ]
     return "\n".join(lines)

--- a/qa-automation/src/FeedbackCard.js
+++ b/qa-automation/src/FeedbackCard.js
@@ -60,6 +60,13 @@ class FeedbackCard {
     );
     html += '</td></tr>';
 
+    // ── SOP reference footnotes (only when retrieval grounded the eval) ──
+    if (this.entry.sopReferences && this.entry.sopReferences.length) {
+      html += '<tr><td style="padding:8px 16px 16px 16px;font-family:Arial,sans-serif;">';
+      html += this._renderReferences();
+      html += '</td></tr>';
+    }
+
     // ── Dialpad call link ─────────────────────────────────────────
     if (this.entry.dialpadLink) {
       html += '<tr><td style="padding:0 16px 16px 16px;font-family:Arial,sans-serif;text-align:center;">';
@@ -114,6 +121,17 @@ class FeedbackCard {
       if (meta) meta += ' &middot; ';
       meta += this._esc(this.entry.callerPhone);
     }
+    // Verified Dialpad facts (blank on pre-layout rows): the call's
+    // disposition and the Ai CSAT estimate — labeled as a model
+    // estimate, never presented as a member survey.
+    if (this.entry.disposition) {
+      if (meta) meta += ' &middot; ';
+      meta += this._esc(this.entry.disposition);
+    }
+    if (this.entry.aiCsat) {
+      if (meta) meta += ' &middot; ';
+      meta += this._esc(this.entry.aiCsat) + '/5 Ai CSAT <span style="color:#999;">(estimate)</span>';
+    }
 
     var body = this.entry.callSummary
       ? this._esc(this.entry.callSummary)
@@ -131,6 +149,33 @@ class FeedbackCard {
              : '')
          + '<div style="font-size:14px;color:' + CONFIG.COLORS.DARK_NAVY + ';line-height:1.5;">'
          + body + '</div>'
+         + '</td></tr></table>';
+  }
+
+  /**
+   * Renders the SOP reference footnotes — the internal SOPs the AI
+   * evaluator consulted when scoring this call. Each line arrives
+   * pre-numbered ("SOP n: Title") so the numbering matches the [SOP n]
+   * citations inside the reasoning text above.
+   * @private
+   * @return {string}
+   */
+  _renderReferences() {
+    var self = this;
+    var items = this.entry.sopReferences.map(function(ref) {
+      return '<div style="font-size:13px;color:' + CONFIG.COLORS.DARK_NAVY
+           + ';line-height:1.6;">' + self._esc(ref) + '</div>';
+    }).join('');
+
+    return '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="'
+         + 'border-left:4px solid ' + CONFIG.COLORS.TEXT_GRAY + ';background:#FAFAFA;'
+         + 'border-radius:0 4px 4px 0;">'
+         + '<tr><td style="padding:12px 16px;">'
+         + '<div style="font-size:11px;text-transform:uppercase;letter-spacing:1px;color:'
+         + CONFIG.COLORS.TEXT_GRAY + ';margin-bottom:6px;font-weight:bold;">References</div>'
+         + '<div style="font-size:11px;color:#999;margin-bottom:6px;">'
+         + 'Internal SOPs consulted by the AI evaluator when scoring this call.</div>'
+         + items
          + '</td></tr></table>';
   }
 

--- a/qa-automation/src/QAEntry.js
+++ b/qa-automation/src/QAEntry.js
@@ -61,6 +61,15 @@ class QAEntry {
     entry.callerName   = (row[L.COL_CALLER_NAME]   || '').toString().trim();
     entry.callerPhone  = (row[L.COL_CALLER_PHONE]  || '').toString().trim();
 
+    // ── Call metadata + SOP references (trailing cols; blank on rows
+    //    written before the layout widened — every read degrades to '') ──
+    entry.disposition = (row[L.COL_DISPOSITION] || '').toString().trim();
+    entry.aiCsat      = (row[L.COL_AI_CSAT]     || '').toString().trim();
+    // Newline-joined "SOP n: Title" lines from the Python projection;
+    // numbering matches the [SOP n] citations in the AI reasoning text.
+    entry.sopReferences = (row[L.COL_SOP_REFERENCES] || '').toString()
+      .split('\n').map(function(s) { return s.trim(); }).filter(String);
+
     return entry;
   }
 

--- a/qa-automation/teams/member_support/Config.js
+++ b/qa-automation/teams/member_support/Config.js
@@ -19,7 +19,7 @@ CONFIG.MAILS_SHEET_NAME   = "Mails";
 // ── Derived row layout (from HistoryLayout(N)) ───────────────
 CONFIG.HISTORY_LAYOUT = {
   N_SECTIONS:         10,
-  TOTAL_WIDTH:        43,
+  TOTAL_WIDTH:        46,
   COL_AGENT_NAME:     0,
   COL_AGENT_EMAIL:    1,
   COL_TIMESTAMP:      2,
@@ -38,6 +38,9 @@ CONFIG.HISTORY_LAYOUT = {
   COL_CALLER_NAME:    39,
   COL_CALLER_PHONE:   40,
   COL_SOURCE:         41,
+  COL_DISPOSITION:    43,
+  COL_AI_CSAT:        44,
+  COL_SOP_REFERENCES: 45,
 };
 
 // ── Section partitions ───────────────────────────────────────

--- a/qa-automation/teams/sales/Config.js
+++ b/qa-automation/teams/sales/Config.js
@@ -19,7 +19,7 @@ CONFIG.MAILS_SHEET_NAME   = "Mails";
 // ── Derived row layout (from HistoryLayout(N)) ───────────────
 CONFIG.HISTORY_LAYOUT = {
   N_SECTIONS:         15,
-  TOTAL_WIDTH:        58,
+  TOTAL_WIDTH:        61,
   COL_AGENT_NAME:     0,
   COL_AGENT_EMAIL:    1,
   COL_TIMESTAMP:      2,
@@ -38,6 +38,9 @@ CONFIG.HISTORY_LAYOUT = {
   COL_CALLER_NAME:    54,
   COL_CALLER_PHONE:   55,
   COL_SOURCE:         56,
+  COL_DISPOSITION:    58,
+  COL_AI_CSAT:        59,
+  COL_SOP_REFERENCES: 60,
 };
 
 // ── Section partitions ───────────────────────────────────────


### PR DESCRIPTION
## What

Surfaces the dispositions + Pulpo SOP provenance the pipeline already persists (migration 016 columns, `dialpad_call_metadata.pulpo_docs`) to **both audiences**, and adds the design doc for the Claude model trial.

### Evaluator site
- `EvaluationRecord` + `PostgresProvider` now serve: disposition category/sub, `ai_csat`, call duration, the Dialpad id triple, `sop_used`, and the full `pulpo_docs` provenance.
- **/datapoint**: first chiclet is now **Call Metadata** — grouped Call / Outcome / Member / Evaluation — plus a **References** card with `[SOP n]` footnotes (match score, updated date, open-flag cautions).
- **/scorecard**: verified-disposition chip in the header + a **References** section. Footnote numbering matches the `[SOP n]` citations Gemini writes into its reasoning (pulpo_docs preserves injection order).

### Agent email (GAS)
- `HistoryLayout`: 3 **append-only** trailing columns — `disposition` ("Category — Sub"), `ai_csat`, `sop_references` (newline-joined "SOP n: Title"). `TRAILING_WIDTH` 7 → 10; no existing column shifts.
- Projection renders the new cells; `build_config.py` emits the new `COL_*` constants; `Config.js` regenerated for both teams.
- `QAEntry` reads them; `FeedbackCard` shows disposition + Ai CSAT (labeled *estimate*) in the Call Summary meta line and a References footnote block above the recording button.

### Design doc
- `references/ModelProviderDesign.md` — `backend/services/llm/` provider seam mirroring `rag/`; progression service as the first Claude consumer (Claude API has no audio input, so audio scoring stays Gemini per the audio-is-SOT doctrine); env-gated rollout; §5 owner questions.

## Deploy checklist (after merge)
1. **Widen each team's Analyst_History tab by 3 columns** (MS 43 → 46, Sales +3) *before* the next finalize — the idempotent row write targets the full layout width and a too-narrow grid errors like the FR-AI incident.
2. `clasp` push/redeploy the Apps Script web app for both teams (regenerated `Config.js` + `QAEntry`/`FeedbackCard`).
3. No env changes, no migration — all data already persisted.

## Tests
`694 passed, 6 skipped, 3 xfailed` — includes new coverage for the projection cells, layout invariants, and the provider record fields (blank/absent metadata renders blank, never raises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)