### PR TITLE
fix(qa-automation): clamp Pulpo search queries to the 500-char server cap

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
@@ -42,6 +42,12 @@ _CLIENT_INFO = {"name": "landing-qa-scoring", "version": "1.0"}
 CONNECT_TIMEOUT_S = 3.0
 READ_TIMEOUT_S = 8.0
 
+# Pulpo's search_knowledge_base rejects query strings over 500 chars
+# (server-side zod cap, observed 2026-07-24). Longer queries — e.g. the
+# transcript-head disposition fallback — are clamped here so the limit
+# never escapes this boundary.
+QUERY_MAX_CHARS = 500
+
 
 def _parse_rpc_response(resp: httpx.Response) -> Optional[dict]:
     """JSON-RPC response body → dict. Handles both plain JSON and SSE
@@ -206,12 +212,13 @@ class PulpoProvider(RagProvider):
     ) -> list[list[RagHit]]:
         if not queries:
             return []
+        sent = [q[:QUERY_MAX_CHARS] for q in queries]
         # rerank stays False by design (§4.2): Gemini reads full bodies,
         # so Pulpo's precision pass is declined — their own guidance for
         # agents that read the candidates themselves.
         payload = await self._tool_call(
             "search_knowledge_base",
-            {"queries": queries, "limit": limit, "rerank": False},
+            {"queries": sent, "limit": limit, "rerank": False},
         )
         if not isinstance(payload, dict):
             raise RagProviderError(f"pulpo: unexpected search payload: {payload!r:.200}")
@@ -220,8 +227,9 @@ class PulpoProvider(RagProvider):
             b.get("query"): [self._map_hit(r) for r in (b.get("results") or [])]
             for b in batches
         }
-        # Order-align with the request; a query Pulpo dropped yields [].
-        return [by_query.get(q, []) for q in queries]
+        # Order-align with the request (Pulpo echoes the clamped query,
+        # so align against `sent`); a query Pulpo dropped yields [].
+        return [by_query.get(q, []) for q in sent]
 
     async def get_document(self, doc_id: str) -> Optional[RagDoc]:
         try:

--- a/qa-automation/AI-Scoring/tests/test_rag_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_rag_provider.py
@@ -69,6 +69,16 @@ def _mcp_handler(request: httpx.Request) -> httpx.Response:
         args = body["params"]["arguments"]
         if tool == "search_knowledge_base":
             assert args["rerank"] is False  # §4.2 stance, enforced at transport
+            # Mirror the live server's zod cap: >500-char queries are a
+            # -32602 tool error, not a served search.
+            if any(len(q) > 500 for q in args["queries"]):
+                return httpx.Response(
+                    200,
+                    json={"jsonrpc": "2.0", "id": body["id"],
+                          "result": {"isError": True,
+                                     "content": [{"type": "text",
+                                                  "text": "MCP error -32602: too_big"}]}},
+                )
             payload = _SEARCH_PAYLOAD
         elif tool == "get_document":
             payload = _DOC_PAYLOAD if args["id"] == "doc-1" else {"error": "not found"}
@@ -104,6 +114,19 @@ async def test_search_maps_neutral_hits(provider: PulpoProvider):
     assert top.flag_count == 1
     # Nothing Pulpo-shaped escapes: neutral dataclass, no score_type attr.
     assert not hasattr(top, "score_type")
+
+
+@pytest.mark.asyncio
+async def test_search_clamps_overlong_queries(provider: PulpoProvider):
+    """A >500-char query (the transcript-head disposition fallback is cut
+    at 600) is clamped to Pulpo's cap before the tool call, and the batch
+    echo of the clamped string still order-aligns."""
+    long_query = "Access & Entry — Smart-lock failure" + " padding" * 100
+    assert len(long_query) > 500
+    batches = await provider.search([long_query, "no-batch-for-this"])
+    # No RagProviderError raised, and positions hold: the clamped query
+    # got no batch back from the fixture, so both slots are [].
+    assert batches == [[], []]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Intermittent `RagProviderError: MCP error -32602 ... too_big: expected string to have <=500 characters` from `search_knowledge_base`, with scoring proceeding without SOP context.

Root cause: Pulpo enforces a server-side 500-char cap per query string. Calls with a verified disposition send a short `"{category} — {disposition}"` query and always pass; calls **without** a disposition fall back to the first **600** chars of transcript head (`sop_retrieval.py` §3.3 fallback), so any disposition-less call with a longish transcript failed validation deterministically. (The disposition gap itself goes away with next week's webhook integration replacing the 30-min backfill — this fix keeps the fallback path safe regardless.)

## Fix

- `backend/services/rag/pulpo.py`: added `QUERY_MAX_CHARS = 500` and clamp every outgoing query in `search()` before the tool call. The limit is Pulpo's, so it lives at the Pulpo boundary — the provider-agnostic layer (and its 600-char design value) is untouched.
- Batch order-alignment now keys off the clamped strings, since Pulpo echoes back the query it received; without this, a clamped query's hits would silently drop to `[]`.

## Tests

- Mock MCP handler in `tests/test_rag_provider.py` now mirrors the live cap: any >500-char query returns the `-32602 too_big` tool error, so future leaks fail the suite.
- New `test_search_clamps_overlong_queries` covers the 600-char fallback-style query end to end.
- Full suite: 695 passed, 6 skipped, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)