### PR TITLE
P1 — llm/ provider seam; progression on it; Claude provider ready

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/assessment_store.py
+++ b/qa-automation/AI-Scoring/backend/services/assessment_store.py
@@ -191,7 +191,7 @@ async def get_or_generate_month_assessment(
     if not records:
         return None
     try:
-        result = generate_from_records(records, agent_name, days, config)
+        result = await generate_from_records(records, agent_name, days, config)
     except AssessmentParseError:
         logger.warning(
             "assessment_store: month generation unparseable for %r (%s %s) — "

--- a/qa-automation/AI-Scoring/backend/services/llm/__init__.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/__init__.py
@@ -1,0 +1,7 @@
+"""Text-model provider seam — ModelProviderDesign §3 / TwoStageScoringDesign §4.
+
+Neutral contract in ``provider.py``; ``gemini.py`` and ``anthropic.py``
+are the ONLY vendor-shaped modules (grep-gated); ``factory.py`` resolves
+a stage (progression today, the Stage-B scorer next) to a configured
+provider + model.
+"""

--- a/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
@@ -1,0 +1,81 @@
+"""Anthropic (Claude) text provider — the ONLY anthropic-SDK-shaped
+module in the backend (grep-gated, same rule as pulpo.py for the RAG
+seam).
+
+Model doctrine (TwoStageScoringDesign §10, owner 2026-07-25):
+``claude-sonnet-5`` is the starting judge; the newest Opus tier is
+reserved for progression analysis later; **never Fable**. Current
+Claude models reject sampling params (temperature/top_p) — none are
+sent. Adaptive thinking is set explicitly so behavior is identical
+across Sonnet 5 and Opus-tier models.
+
+Requires ``ANTHROPIC_API_KEY`` in the environment (Railway + .env —
+owner adds it; until then any call raises LlmProviderError cleanly).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from backend.services.llm.provider import (
+    LlmProviderError,
+    LlmResult,
+    TextModelProvider,
+)
+
+
+class AnthropicTextProvider(TextModelProvider):
+    name = "anthropic"
+
+    def __init__(self, client=None):
+        """*client* is a test seam; production constructs lazily from env
+        (lazy so the `anthropic` package is only required when this
+        provider is actually selected)."""
+        self._client = client
+
+    def _get_client(self):
+        if self._client is not None:
+            return self._client
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            raise LlmProviderError("ANTHROPIC_API_KEY not set in environment")
+        from anthropic import AsyncAnthropic
+        self._client = AsyncAnthropic()
+        return self._client
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_output_tokens: int,
+        json_schema: Optional[dict] = None,
+    ) -> LlmResult:
+        client = self._get_client()
+        kwargs: dict = {
+            "model": model,
+            "max_tokens": max_output_tokens,
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if json_schema is not None:
+            # Provider-enforced structured output — replaces markdown-fence
+            # stripping entirely on this path (guaranteed-valid JSON).
+            kwargs["output_config"] = {
+                "format": {"type": "json_schema", "schema": json_schema}
+            }
+        response = await client.messages.create(**kwargs)
+
+        if response.stop_reason == "refusal":
+            raise LlmProviderError(f"model {model} refused the request")
+        text = "".join(
+            block.text for block in response.content if block.type == "text"
+        )
+        if not text:
+            raise LlmProviderError(
+                f"model {model} returned no text (stop_reason="
+                f"{response.stop_reason!r})"
+            )
+        return LlmResult(
+            text=text, provider=self.name, model=getattr(response, "model", model)
+        )

--- a/qa-automation/AI-Scoring/backend/services/llm/factory.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/factory.py
@@ -1,0 +1,73 @@
+"""Stage → provider resolution (mirrors rag/factory's env-keyed seam).
+
+A *stage* is one text-generation job in the pipeline: ``progression``
+today; ``scoring`` (the Stage-B judge) lands with TwoStageScoringDesign
+P3. Resolution order per stage:
+
+  1. env override  — ``PROGRESSION_MODEL_PROVIDER`` = gemini | anthropic
+     (unknown values collapse to the default, house pattern)
+  2. default       — gemini with the team JSON's existing ``gemini.*``
+     knobs, so day one is a pure refactor: no team JSON changes, no
+     behavior changes until someone flips the env var.
+
+Anthropic model per stage comes from ``PROGRESSION_ANTHROPIC_MODEL``
+(default ``claude-sonnet-5`` — the §10 starting tier; the newest Opus
+tier is the intended progression upgrade later, never Fable).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from backend.services.llm.anthropic import AnthropicTextProvider
+from backend.services.llm.gemini import GeminiTextProvider
+from backend.services.llm.provider import TextModelProvider
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+
+_DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-5"
+
+
+@dataclass
+class StageModel:
+    """Everything a call site needs to run one stage's generation."""
+    provider: TextModelProvider
+    model: str
+    max_output_tokens: int
+
+
+def _env_provider(stage: str) -> str:
+    raw = os.environ.get(f"{stage.upper()}_MODEL_PROVIDER", "").strip().lower()
+    return raw if raw in ("gemini", "anthropic") else "gemini"
+
+
+def resolve_stage(stage: str, config: "TeamConfig") -> StageModel:
+    """Resolve *stage* ("progression") to a constructed provider + model.
+
+    Providers are lightweight per-call constructs (the Gemini client is
+    built per request exactly as the pre-seam code did; the Anthropic
+    client is lazy inside its provider) — no singleton needed yet.
+    """
+    if stage != "progression":
+        raise ValueError(f"unknown llm stage: {stage!r}")
+
+    provider_name = _env_provider(stage)
+    if provider_name == "anthropic":
+        model = os.environ.get(
+            "PROGRESSION_ANTHROPIC_MODEL", _DEFAULT_ANTHROPIC_MODEL
+        ).strip() or _DEFAULT_ANTHROPIC_MODEL
+        return StageModel(
+            provider=AnthropicTextProvider(),
+            model=model,
+            max_output_tokens=config.gemini.progression_max_output_tokens,
+        )
+    return StageModel(
+        provider=GeminiTextProvider(
+            temperature=config.gemini.progression_temperature
+        ),
+        model=config.gemini.progression_model,
+        max_output_tokens=config.gemini.progression_max_output_tokens,
+    )

--- a/qa-automation/AI-Scoring/backend/services/llm/gemini.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/gemini.py
@@ -1,0 +1,65 @@
+"""Gemini text provider — the google-genai client code extracted from
+progression_service (P1 pure refactor: same client, same knobs, same
+missing-key error message; only the module moved).
+
+The ONLY other google-genai importer is audio_service (the Stage-A
+audio leg, which is Gemini-native by design and outside this seam).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from google import genai
+from google.genai import types
+
+from backend.services.llm.provider import (
+    LlmProviderError,
+    LlmResult,
+    TextModelProvider,
+)
+
+
+class GeminiTextProvider(TextModelProvider):
+    name = "gemini"
+
+    def __init__(self, temperature: Optional[float] = None, client=None):
+        """*temperature* is a Gemini-specific knob mapped at construction
+        (the neutral contract carries none — ModelProviderDesign §3).
+        *client* is a test seam; production constructs from env."""
+        self._temperature = temperature
+        self._client = client
+
+    def _get_client(self):
+        if self._client is not None:
+            return self._client
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            raise RuntimeError("GEMINI_API_KEY not set in environment")
+        return genai.Client(api_key=api_key)
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_output_tokens: int,
+        json_schema: Optional[dict] = None,
+    ) -> LlmResult:
+        if json_schema is not None:
+            # Provider-enforced structured output lands with the Stage-B
+            # scorer (TwoStageScoringDesign P3) — mapped against the live
+            # SDK then, never silently ignored now (provider.py contract).
+            raise LlmProviderError(
+                "structured output not implemented for the gemini provider yet"
+            )
+        client = self._get_client()
+        config = types.GenerateContentConfig(
+            temperature=self._temperature,
+            max_output_tokens=max_output_tokens,
+        )
+        response = await client.aio.models.generate_content(
+            model=model, contents=prompt, config=config,
+        )
+        return LlmResult(text=response.text or "", provider=self.name, model=model)

--- a/qa-automation/AI-Scoring/backend/services/llm/provider.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/provider.py
@@ -1,0 +1,56 @@
+"""Neutral text-model contract — no vendor imports live here.
+
+Deliberately text-only (``generate(prompt) -> LlmResult``): that covers
+progression + the EOM one-pager today and the Stage-B scorer next,
+without inventing an audio interface nobody can implement twice
+(TwoStageScoringDesign §2 — audio stays on the Stage-A annotator).
+
+Sampling knobs (temperature etc.) stay OUT of the contract — current
+Claude models reject them; each provider module maps its own knobs at
+construction time (ModelProviderDesign §3).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+class LlmProviderError(Exception):
+    """The provider could not produce usable text (API error, refusal,
+    missing credentials, unsupported feature). Callers decide whether
+    that means fallback, placeholder, or raise — the seam never does."""
+
+
+@dataclass
+class LlmResult:
+    """One completed generation, with provenance for models_used stamps."""
+    text: str
+    provider: str      # "gemini" | "anthropic"
+    model: str         # the model that actually served the request
+
+
+class TextModelProvider(ABC):
+    """One vendor's text-generation surface behind the neutral contract."""
+
+    name: str = "unknown"
+
+    @abstractmethod
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_output_tokens: int,
+        json_schema: Optional[dict] = None,
+    ) -> LlmResult:
+        """Generate text for *prompt* on *model*.
+
+        ``json_schema`` requests provider-enforced structured output
+        (the Stage-B scorer path). Providers that cannot enforce it MUST
+        raise LlmProviderError rather than silently returning free text
+        — a scorecard parsed from unconstrained output is a different
+        reliability class and the caller needs to know.
+        """
+        ...

--- a/qa-automation/AI-Scoring/backend/services/progression_service.py
+++ b/qa-automation/AI-Scoring/backend/services/progression_service.py
@@ -1,16 +1,19 @@
-"""Gemini-powered agent progression assessment service."""
+"""Agent progression assessment service.
+
+Generation goes through the llm/ provider seam (ModelProviderDesign):
+Gemini by default with the team JSON's existing knobs; flip to Claude
+via PROGRESSION_MODEL_PROVIDER=anthropic — no code change.
+"""
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import time
 from typing import Optional, TYPE_CHECKING
 
-from google import genai
-from google.genai import types
+from backend.services.llm.factory import resolve_stage
 
 from backend.models.dashboard import (
     EvaluationRecord,
@@ -128,8 +131,8 @@ async def get_progression(
         return result
 
     try:
-        result = generate_from_records(records, agent_name, days, config,
-                                       data_source=provider.name)
+        result = await generate_from_records(records, agent_name, days, config,
+                                             data_source=provider.name)
     except AssessmentParseError:
         # parse-failure placeholder — cached (avoids hammering Gemini) but
         # never persisted (§Q4.a: only genuine AI output lands).
@@ -164,38 +167,31 @@ async def get_progression(
 
 
 class AssessmentParseError(Exception):
-    """Gemini's response wasn't valid JSON — no genuine assessment exists."""
+    """The model's response wasn't valid JSON — no genuine assessment exists."""
 
 
-def generate_from_records(
+async def generate_from_records(
     records: list[EvaluationRecord],
     agent_name: str,
     days: int,
     config: TeamConfig,
     data_source: str = "PostgreSQL",
 ) -> ProgressionAssessment:
-    """The generation core: serialize → prompt → Gemini → parse. Shared by
+    """The generation core: serialize → prompt → model → parse. Shared by
     the dashboard path (get_progression, rolling window) and the EOM
     one-pager (calendar-month records). No caching, no persistence —
     callers own both. Raises AssessmentParseError on unparseable output."""
     evaluations_json = _serialize_records(records)
     prompt = build_progression_prompt(config, agent_name, evaluations_json, days)
 
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise RuntimeError("GEMINI_API_KEY not set in environment")
-
-    client = genai.Client(api_key=api_key)
-    response = client.models.generate_content(
-        model=config.gemini.progression_model,
-        contents=prompt,
-        config=types.GenerateContentConfig(
-            temperature=config.gemini.progression_temperature,
-            max_output_tokens=config.gemini.progression_max_output_tokens,
-        ),
+    stage = resolve_stage("progression", config)
+    result = await stage.provider.generate(
+        prompt,
+        model=stage.model,
+        max_output_tokens=stage.max_output_tokens,
     )
 
-    raw_text = _strip_markdown_fences(response.text)
+    raw_text = _strip_markdown_fences(result.text)
     try:
         parsed = json.loads(raw_text)
     except json.JSONDecodeError as exc:

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -1,7 +1,7 @@
 # TwoStageScoringDesign — Gemini annotates, any LLM scores
 
-**Status:** v1 draft — design only (design-doc-first).
-**Date:** 2026-07-24
+**Status:** v1.1 — §10 RESOLVED (owner, 2026-07-25); P1 building.
+**Date:** 2026-07-24 (v1), 2026-07-25 (v1.1)
 **Owner mandate:** "To incorporate Claude models (until Anthropic releases
 a model that can natively listen to audio) we now have to split the
 scoring work into the two-stage process we have outlined in this repo …
@@ -155,8 +155,9 @@ consumer (progression the first — same seam, no divergence).
   `output_config.format` json_schema — kills fence-stripping; Gemini:
   `response_schema` equivalent) → same `Scorecard.model_validate`
   boundary as today.
-- Default scorer: `claude-opus-4-8` (owner: not Fable); `claude-sonnet-5`
-  is the cost lever. Adaptive thinking on; no sampling params.
+- Default scorer: **`claude-sonnet-5`** (§10.2 — the starting tier; the
+  newest Opus tier is reserved for progression analysis later; never
+  Fable). Adaptive thinking on; no sampling params.
 - Because Stage B is provider-agnostic, **Gemini can also be the judge**
   — useful for isolating "did the split change scores?" from "did
   Claude change scores?" (see §6 shadow design).
@@ -187,7 +188,7 @@ Team JSON grows (back-compat: absent → synthesized from `gemini.*`):
   "scoring": {
     "pipeline": "single",                    // single | two_stage
     "annotator": { "provider": "gemini", "model": "gemini-2.5-flash" },
-    "scorer":    { "provider": "anthropic", "model": "claude-opus-4-8" }
+    "scorer":    { "provider": "anthropic", "model": "claude-sonnet-5" }
   },
   "progression": { "provider": "gemini", "model": "gemini-2.5-flash" }
 }
@@ -255,20 +256,28 @@ it lands**; `score_call`'s signature stays frozen so rescore composes
 with the pipeline switch for free; migration numbers — 018 is taken,
 this design needs **no migration** (column 006, JSONB stamps only).
 
-## 10. Open questions (owner)
+## 10. Open questions — RESOLVED (owner, 2026-07-25)
 
-1. **Key/billing** (carried from ModelProviderDesign §5): Anthropic org +
-   `ANTHROPIC_API_KEY` — new Landing account or existing?
-2. **Judge tier:** confirm `claude-opus-4-8` default vs `claude-sonnet-5`
-   for the trial (cost table §6).
-3. **Shadow scope:** all MS calls for a week, or a sampled subset?
-   (Volume says "all" is affordable.)
-4. **Annotator model:** keep `gemini-2.5-flash`, or trial `-pro` for
-   annotation fidelity on Spanish/accented audio? (Flash first is the
-   cheap default; the Spanish spot-check decides.)
-5. **PII surface:** `annotated_transcript` carries verbatim caller
-   speech; SQLMigration §8.4 gates raw reads behind
-   `KEY_ROLE_PRIVILEGED`. v1 renders it **nowhere** in the frontend —
-   surfacing it on /datapoint (privileged-only) is a follow-up decision.
-6. **Sequencing:** OK to start P1 (the `llm/` seam — zero overlap with
-   ScorecardActions) now, before the other session lands?
+1. **Key/billing:** Landing has (or the owner can mint) an Anthropic API
+   key; lands in `.env` + Railway ~Monday. Until then the anthropic
+   provider raises a clean `LlmProviderError` and nothing selects it by
+   default.
+2. **Judge tier:** **`claude-sonnet-5` is the starting point.** The
+   newest Opus tier (Opus 4.8 today; its successor when released) is
+   reserved for **progression analysis** specifically, later. **Never
+   Fable.**
+3. **Shadow scope:** **all MS calls for a week** — volume makes it
+   manageable and easy to extrapolate.
+4. **Annotator model:** trial **both** `gemini-2.5-flash` AND
+   `gemini-2.5-pro` — the P2 smoke runs the same calls through each and
+   the Spanish spot-check compares annotations side by side.
+5. **PII surface:** carried as **debt**, deliberately. The forcing
+   function is the future **Agent view** — agents monitoring their own
+   progress/performance — where raw transcriptions must NOT appear.
+   That surface gets its own spec: **`AgentView.md`** (future branch +
+   PR group); redaction/visibility rules for `annotated_transcript` are
+   designed there, not here. Until then: rendered nowhere in the
+   frontend, `KEY_ROLE_PRIVILEGED` gates raw reads (SQLMigration §8.4).
+6. **Sequencing:** **go.** ScorecardActions doesn't touch model
+   providers beyond what's already spec'd, so P1 starts immediately;
+   the §9 rebase rule holds for P2+.

--- a/qa-automation/AI-Scoring/requirements.txt
+++ b/qa-automation/AI-Scoring/requirements.txt
@@ -10,3 +10,4 @@ pandas>=2.0.0
 numpy>=1.24.0
 asyncpg>=0.30.0
 pyjwt>=2.8.0
+anthropic>=0.120.0

--- a/qa-automation/AI-Scoring/scripts/llm_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/llm_smoke.py
@@ -1,0 +1,72 @@
+"""Live smoke for the llm/ provider seam (ModelProviderDesign P1).
+
+Usage (from qa-automation/AI-Scoring, .env loaded):
+
+    .venv/bin/python scripts/llm_smoke.py                    # gemini
+    .venv/bin/python scripts/llm_smoke.py --provider anthropic
+    .venv/bin/python scripts/llm_smoke.py --provider anthropic --json
+
+Gemini works today; anthropic needs ANTHROPIC_API_KEY (owner adds it —
+TwoStageScoringDesign §10.1). --json exercises the structured-output
+path (anthropic only until the Gemini mapping lands with P3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from backend.services.llm.anthropic import AnthropicTextProvider  # noqa: E402
+from backend.services.llm.gemini import GeminiTextProvider  # noqa: E402
+
+_PROMPT = (
+    "In exactly one sentence, describe what a QA analyst does at a "
+    "residential-living company's member support team."
+)
+_JSON_PROMPT = "Give a one-sentence QA analyst job description."
+_SCHEMA = {
+    "type": "object",
+    "properties": {"description": {"type": "string"}},
+    "required": ["description"],
+    "additionalProperties": False,
+}
+_MODELS = {"gemini": "gemini-2.5-flash", "anthropic": "claude-sonnet-5"}
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider", choices=("gemini", "anthropic"),
+                        default="gemini")
+    parser.add_argument("--model", default=None,
+                        help=f"override the default ({_MODELS})")
+    parser.add_argument("--json", action="store_true",
+                        help="exercise the structured-output path")
+    args = parser.parse_args()
+
+    provider = (GeminiTextProvider() if args.provider == "gemini"
+                else AnthropicTextProvider())
+    model = args.model or _MODELS[args.provider]
+
+    kwargs: dict = {"model": model, "max_output_tokens": 1024}
+    prompt = _PROMPT
+    if args.json:
+        kwargs["json_schema"] = _SCHEMA
+        prompt = _JSON_PROMPT
+
+    print(f"→ {args.provider} / {model} (json={args.json})")
+    result = await provider.generate(prompt, **kwargs)
+    print(f"← provider={result.provider} model={result.model}")
+    print(result.text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/qa-automation/AI-Scoring/tests/test_assessment_store.py
+++ b/qa-automation/AI-Scoring/tests/test_assessment_store.py
@@ -186,18 +186,24 @@ def _wire(monkeypatch, gemini_text):
     monkeypatch.setattr(ast, "persist_assessment", fake_persist)
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")
 
+    # The Gemini client moved behind the llm/ seam (ModelProviderDesign
+    # P1) — stub the async surface the GeminiTextProvider actually calls.
     class _Resp:
         text = gemini_text
 
-    class _Models:
-        def generate_content(self, **kw):
+    class _AioModels:
+        async def generate_content(self, **kw):
             return _Resp()
+
+    class _Aio:
+        models = _AioModels()
 
     class _Client:
         def __init__(self, api_key=None):
-            self.models = _Models()
+            self.aio = _Aio()
 
-    monkeypatch.setattr(ps.genai, "Client", _Client)
+    import backend.services.llm.gemini as llm_gemini
+    monkeypatch.setattr(llm_gemini.genai, "Client", _Client)
     return ps, calls
 
 

--- a/qa-automation/AI-Scoring/tests/test_llm_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_llm_provider.py
@@ -1,0 +1,236 @@
+"""llm/ provider seam — ModelProviderDesign P1 / TwoStageScoringDesign §4.
+
+Pins: factory resolution (env-keyed, house pattern), the Gemini
+provider's knob mapping (pure-refactor parity with the pre-seam
+progression client code), the Anthropic provider's request shape
+(no sampling params, adaptive thinking, structured-output opt-in),
+and the vendor-import grep gates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.services.llm.anthropic import AnthropicTextProvider
+from backend.services.llm.factory import resolve_stage
+from backend.services.llm.gemini import GeminiTextProvider
+from backend.services.llm.provider import LlmProviderError, LlmResult
+from tests.conftest import load_test_config
+
+_BACKEND = Path(__file__).resolve().parent.parent / "backend"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeGenaiClient:
+    """Mimics google-genai's async surface; records the call."""
+
+    def __init__(self):
+        self.calls = []
+        outer = self
+
+        class _AioModels:
+            async def generate_content(self, *, model, contents, config):
+                outer.calls.append(
+                    {"model": model, "contents": contents, "config": config}
+                )
+                class _Resp:
+                    text = '{"ok": true}'
+                return _Resp()
+
+        class _Aio:
+            models = _AioModels()
+
+        self.aio = _Aio()
+
+
+class FakeAnthropicClient:
+    """Mimics the anthropic SDK's messages.create; records the call."""
+
+    def __init__(self, stop_reason="end_turn", text="hello"):
+        self.calls = []
+        outer = self
+
+        class _Block:
+            type = "text"
+        _Block.text = text
+
+        class _Resp:
+            model = "claude-sonnet-5"
+            content = [_Block()] if text else []
+        _Resp.stop_reason = stop_reason
+
+        class _Messages:
+            async def create(self, **kwargs):
+                outer.calls.append(kwargs)
+                return _Resp()
+
+        self.messages = _Messages()
+
+
+# ---------------------------------------------------------------------------
+# Factory resolution
+# ---------------------------------------------------------------------------
+
+def test_factory_defaults_to_gemini_with_team_knobs(monkeypatch):
+    monkeypatch.delenv("PROGRESSION_MODEL_PROVIDER", raising=False)
+    config = load_test_config("sales_lite")
+    stage = resolve_stage("progression", config)
+    assert isinstance(stage.provider, GeminiTextProvider)
+    assert stage.model == config.gemini.progression_model
+    assert stage.max_output_tokens == config.gemini.progression_max_output_tokens
+
+
+def test_factory_env_flips_to_anthropic(monkeypatch):
+    monkeypatch.setenv("PROGRESSION_MODEL_PROVIDER", "anthropic")
+    monkeypatch.delenv("PROGRESSION_ANTHROPIC_MODEL", raising=False)
+    stage = resolve_stage("progression", load_test_config("sales_lite"))
+    assert isinstance(stage.provider, AnthropicTextProvider)
+    assert stage.model == "claude-sonnet-5"     # §10 starting tier
+
+
+def test_factory_unknown_provider_collapses_to_gemini(monkeypatch):
+    monkeypatch.setenv("PROGRESSION_MODEL_PROVIDER", "openai")
+    stage = resolve_stage("progression", load_test_config("sales_lite"))
+    assert isinstance(stage.provider, GeminiTextProvider)
+
+
+def test_factory_rejects_unknown_stage():
+    with pytest.raises(ValueError):
+        resolve_stage("scoring", load_test_config("sales_lite"))
+
+
+# ---------------------------------------------------------------------------
+# Gemini provider — pure-refactor parity with the pre-seam client code
+# ---------------------------------------------------------------------------
+
+def test_gemini_maps_model_temperature_and_tokens():
+    fake = FakeGenaiClient()
+    provider = GeminiTextProvider(temperature=0.3, client=fake)
+    result = asyncio.run(provider.generate(
+        "the prompt", model="gemini-2.5-flash", max_output_tokens=4096,
+    ))
+    assert result == LlmResult(
+        text='{"ok": true}', provider="gemini", model="gemini-2.5-flash"
+    )
+    (call,) = fake.calls
+    assert call["contents"] == "the prompt"
+    assert call["config"].temperature == 0.3
+    assert call["config"].max_output_tokens == 4096
+
+
+def test_gemini_missing_key_keeps_legacy_error(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    provider = GeminiTextProvider()
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY not set"):
+        asyncio.run(provider.generate(
+            "x", model="m", max_output_tokens=1,
+        ))
+
+
+def test_gemini_structured_output_raises_not_silently_ignores():
+    provider = GeminiTextProvider(client=FakeGenaiClient())
+    with pytest.raises(LlmProviderError):
+        asyncio.run(provider.generate(
+            "x", model="m", max_output_tokens=1, json_schema={"type": "object"},
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider — request-shape doctrine
+# ---------------------------------------------------------------------------
+
+def test_anthropic_request_shape_no_sampling_adaptive_thinking():
+    fake = FakeAnthropicClient()
+    provider = AnthropicTextProvider(client=fake)
+    result = asyncio.run(provider.generate(
+        "judge this", model="claude-sonnet-5", max_output_tokens=8192,
+    ))
+    assert result.provider == "anthropic"
+    assert result.text == "hello"
+    (call,) = fake.calls
+    assert call["model"] == "claude-sonnet-5"
+    assert call["max_tokens"] == 8192
+    assert call["thinking"] == {"type": "adaptive"}
+    assert call["messages"] == [{"role": "user", "content": "judge this"}]
+    # Current Claude models reject sampling params — none may be sent.
+    assert "temperature" not in call and "top_p" not in call
+    assert "output_config" not in call    # only with json_schema
+
+
+def test_anthropic_json_schema_sets_structured_output():
+    fake = FakeAnthropicClient(text='{"score": 5}')
+    provider = AnthropicTextProvider(client=fake)
+    asyncio.run(provider.generate(
+        "x", model="claude-sonnet-5", max_output_tokens=100,
+        json_schema={"type": "object"},
+    ))
+    (call,) = fake.calls
+    assert call["output_config"] == {
+        "format": {"type": "json_schema", "schema": {"type": "object"}}
+    }
+
+
+def test_anthropic_refusal_raises():
+    provider = AnthropicTextProvider(
+        client=FakeAnthropicClient(stop_reason="refusal")
+    )
+    with pytest.raises(LlmProviderError, match="refused"):
+        asyncio.run(provider.generate(
+            "x", model="claude-sonnet-5", max_output_tokens=1,
+        ))
+
+
+def test_anthropic_missing_key_raises_cleanly(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    provider = AnthropicTextProvider()
+    with pytest.raises(LlmProviderError, match="ANTHROPIC_API_KEY"):
+        asyncio.run(provider.generate(
+            "x", model="claude-sonnet-5", max_output_tokens=1,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Vendor-import grep gates (same guard pattern as the Notion gate)
+# ---------------------------------------------------------------------------
+
+def _py_files():
+    for path in _BACKEND.rglob("*.py"):
+        if "__pycache__" not in path.parts:
+            yield path
+
+
+def test_anthropic_sdk_imports_only_inside_llm_seam():
+    allowed = {_BACKEND / "services" / "llm" / "anthropic.py"}
+    offenders = [
+        str(p.relative_to(_BACKEND))
+        for p in _py_files()
+        if p not in allowed
+        and ("from anthropic" in p.read_text() or "import anthropic" in p.read_text())
+    ]
+    assert not offenders, (
+        f"anthropic SDK usage outside the llm/ seam: {offenders} "
+        "(ModelProviderDesign: anthropic.py is the only Claude-shaped module)"
+    )
+
+
+def test_genai_text_imports_only_in_seam_and_audio_leg():
+    """google-genai belongs to llm/gemini.py (text seam) and
+    audio_service.py (the Gemini-native Stage-A audio leg)."""
+    allowed = {
+        _BACKEND / "services" / "llm" / "gemini.py",
+        _BACKEND / "services" / "audio_service.py",
+    }
+    offenders = [
+        str(p.relative_to(_BACKEND))
+        for p in _py_files()
+        if p not in allowed and "from google import genai" in p.read_text()
+    ]
+    assert not offenders, (
+        f"google-genai usage outside llm/gemini.py + audio_service.py: {offenders}"
+    )


### PR DESCRIPTION
## What

TwoStageScoringDesign **P1** — the zero-overlap slice, green-lit with §10 resolved (answers folded into the doc, now v1.1).

- **`backend/services/llm/`** — the seam: neutral `TextModelProvider` contract (`provider.py`), `GeminiTextProvider` (progression's client code extracted verbatim — same temperature/token knobs, same `GEMINI_API_KEY` error), `AnthropicTextProvider` (the only anthropic-SDK-shaped module: `claude-sonnet-5` doctrine, adaptive thinking, **no sampling params**, structured-output via `output_config.format`, refusal → clean error), and a stage factory (`PROGRESSION_MODEL_PROVIDER=gemini|anthropic`, unknown collapses to gemini — nothing changes until someone flips the env var).
- **Progression + EOM one-pager** now generate through the seam (`generate_from_records` is async; both call sites await). Prompt and parsing are byte-identical — pure refactor.
- **Grep gates** (Notion-gate pattern): `anthropic` imports only inside `llm/anthropic.py`; `google-genai` only in `llm/gemini.py` + `audio_service.py` (the Gemini-native Stage-A audio leg).
- **`scripts/llm_smoke.py`** — Gemini path **live-verified** through the seam; `--provider anthropic` ready to run the moment `ANTHROPIC_API_KEY` lands (also add it to Railway).

## Flip instructions (once the key exists)
```
PROGRESSION_MODEL_PROVIDER=anthropic     # progression on claude-sonnet-5
PROGRESSION_ANTHROPIC_MODEL=<override>   # optional
```

## Coordination
Touches only `llm/` (new), `progression_service`, `assessment_store` — none of ScorecardActions' files. P2 (Stage-A annotator) rebases onto that branch once it lands, per §9.

## Tests
`725 passed, 6 skipped, 3 xfailed` — 12 new seam tests (factory resolution, Gemini knob parity, Anthropic request-shape doctrine, both grep gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)