### PR TITLE
feat(qa-automation): Scorecard Actions S1–S3 — DB resolution seam, series rebuild, privileged delete

### DIFF
--- a/database/migrations/018_scorecard_actions.sql
+++ b/database/migrations/018_scorecard_actions.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- Migration 018: scorecard lifecycle actions
+-- Spec: qa-automation/AI-Scoring/references/ScorecardActionsDesign.md §6
+--
+-- (a) Audit action vocabulary — the rescore and override doorways get
+--     explicit actions (explicit beats notes-parsing for audit search).
+--     Applied to both the hot table and the archive twin so the 180-day
+--     mover never trips the archive CHECK.
+--
+-- (b) qa.evaluations.auto_rescored_at — the once-EVER latch for the
+--     ≤threshold auto-rescore (§4.2). Timestamp, not boolean: "when did
+--     the machine take its one retry" is audit signal. Stamped BEFORE
+--     the re-run is scheduled so a crash mid-rescore can't loop.
+--
+-- No other schema change: override rides source='ai_reviewed', rescore
+-- reuses the Stage-1 upsert, and the coaching receipt (§4.3) uses
+-- qa.coachings / qa.coaching_evaluations as-is.
+-- ============================================================================
+
+ALTER TABLE qa.score_audit
+    DROP CONSTRAINT score_audit_action_check,
+    ADD CONSTRAINT score_audit_action_check
+        CHECK (action IN ('scored', 'denied', 'approved',
+                          'evaluation_orphaned', 'rescored', 'overridden'));
+
+ALTER TABLE qa.score_audit_archive
+    DROP CONSTRAINT score_audit_archive_action_check,
+    ADD CONSTRAINT score_audit_archive_action_check
+        CHECK (action IN ('scored', 'denied', 'approved',
+                          'evaluation_orphaned', 'rescored', 'overridden'));
+
+ALTER TABLE qa.evaluations
+    ADD COLUMN auto_rescored_at TIMESTAMPTZ;

--- a/database/migrations/018_scorecard_actions_down.sql
+++ b/database/migrations/018_scorecard_actions_down.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- Migration 018 — DOWN
+--
+-- ⚠ The CHECK restores fail (CheckViolation) if any 'rescored' /
+-- 'overridden' rows exist in either audit table — delete or re-tag them
+-- first; the restored CHECKs must hold. Dropping auto_rescored_at
+-- discards the once-ever latch history.
+-- ============================================================================
+
+ALTER TABLE qa.score_audit
+    DROP CONSTRAINT score_audit_action_check,
+    ADD CONSTRAINT score_audit_action_check
+        CHECK (action IN ('scored', 'denied', 'approved',
+                          'evaluation_orphaned'));
+
+ALTER TABLE qa.score_audit_archive
+    DROP CONSTRAINT score_audit_archive_action_check,
+    ADD CONSTRAINT score_audit_archive_action_check
+        CHECK (action IN ('scored', 'denied', 'approved',
+                          'evaluation_orphaned'));
+
+ALTER TABLE qa.evaluations
+    DROP COLUMN auto_rescored_at;

--- a/qa-automation/AI-Scoring/backend/config/score_audit.py
+++ b/qa-automation/AI-Scoring/backend/config/score_audit.py
@@ -36,8 +36,16 @@ COLUMNS: list[str] = [
 ACTION_SCORED = "scored"
 ACTION_DENIED = "denied"
 ACTION_APPROVED = "approved"
+# ScorecardActionsDesign §6 — manual-doorway receipts (migration 018
+# carries the matching qa.score_audit CHECK for the future DB audit path).
+ACTION_ORPHANED = "evaluation_orphaned"
+ACTION_RESCORED = "rescored"
+ACTION_OVERRIDDEN = "overridden"
 
-ACTIONS: frozenset[str] = frozenset({ACTION_SCORED, ACTION_DENIED, ACTION_APPROVED})
+ACTIONS: frozenset[str] = frozenset({
+    ACTION_SCORED, ACTION_DENIED, ACTION_APPROVED,
+    ACTION_ORPHANED, ACTION_RESCORED, ACTION_OVERRIDDEN,
+})
 
 # Allowed roles — mirrors KeyIdentity.role in middleware/auth.py.
 ROLE_TEAM = "team"

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -93,6 +93,13 @@ class ApprovalRequest(BaseModel):
     sections: List[ScorecardSection]
     key_strengths: str
     opportunities: str
+    # ScorecardActionsDesign §3 (S1): the in-memory job carries the
+    # original manager_email, but an approval context reconstructed from
+    # the DB after a restart doesn't — the frontend sends the signed-in
+    # evaluator here. Optional for backward compatibility; the route
+    # falls back to job/row identity and 422s only when every source
+    # comes up empty.
+    evaluator_email: Optional[str] = None
 
 
 class ScorecardWithMeta(Scorecard):

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -30,7 +30,8 @@ from backend.services.history_service import (
 )
 from backend.services import eval_store
 from backend.services.eval_store import record_approval, record_draft_evaluation
-from backend.services.sheets_projection import project_evaluation
+from backend.services.sheets_projection import project_evaluation, tombstone_evaluation
+from backend.services.stat_points import rebuild_agent_series
 from backend.services.event_bus import get_event_bus
 from backend.services.scoring_service import score_call
 from backend.services.sheets_service import (
@@ -76,6 +77,43 @@ def _job_key(team_id: str, job_id: str) -> str:
 
 def _make_job_id(call_id: str, agent_name: str) -> str:
     return f"{call_id}_{agent_name}".replace(" ", "_")
+
+
+async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
+    """Reconstruct an approval context from qa.evaluations when the
+    in-memory job is gone — server restart, old scorecard URL, or the
+    /datapoints surface (ScorecardActionsDesign §3, slice S1).
+
+    Concurrency: last-writer-wins by design. qa.evaluations has no
+    updated_at column and these are low-traffic manager tools. If Landing
+    outgrows this (concurrent evaluators on one eval), add updated_at +
+    an If-Unmodified-Since-style optimistic check here — potential design
+    choice deliberately deferred, not overlooked.
+    """
+    ref = await eval_store.resolve_evaluation(team_id, job_id)
+    if ref is None:
+        return None
+    return {
+        "status": "complete",
+        "state": ref.state,
+        "scoring_status": ref.scoring_status,
+        "evaluation_id": ref.id,
+        "call_id": ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        "agent_name": ref.agent_name_raw,
+        "agent_email": ref.agent_email or "",
+        "overall_score": ref.overall_score,
+        "restored_from_db": True,
+        "scorecard": {
+            "sections": ref.sections,
+            "manager_email": ref.evaluator_email or "",
+            "dialpad_link": ref.dialpad_link,
+            "call_summary": ref.call_summary or "",
+            "key_strengths": ref.key_strengths or "",
+            "opportunities": ref.opportunities or "",
+            "agent_name": ref.agent_name_raw,
+            "model": ref.model,
+        },
+    }
 
 
 def _sse_eval_id_from_link(link: str) -> str:
@@ -564,7 +602,13 @@ async def approve_scorecard(
     key = _job_key(team_id, job_id)
     job = _jobs.get(key)
     if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
+        # S1 fallback (ScorecardActionsDesign §3): the in-memory job died
+        # with the process, but the evaluation didn't — reconstruct the
+        # approval context from the DB row and cache it like a live job.
+        job = await _job_from_db(team_id, job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        _jobs[key] = job
     if job["status"] == "approved":
         raise HTTPException(status_code=409, detail="Already approved")
     if job["status"] != "complete":
@@ -597,7 +641,17 @@ async def approve_scorecard(
     # + projections. No destination tab, no readback — DB errors are hard
     # errors (§7.3 Phase C).
     sc = job["scorecard"]
-    evaluator_email = sc.get("manager_email", "")
+    # Payload evaluator wins (S1: restored jobs have no original manager);
+    # then the job's manager; then the row's evaluator already inside
+    # manager_email for restored jobs. All empty → 422, because "" would
+    # satisfy the NOT-NULL approval CHECK while recording nobody.
+    evaluator_email = approval.evaluator_email or sc.get("manager_email", "")
+    if not evaluator_email:
+        job["status"] = "complete"
+        raise HTTPException(
+            status_code=422,
+            detail="evaluator_email required: approval context has no evaluator identity",
+        )
     # Backend guard behind the frontend's "Score Required" gate: manual
     # sections without a formula na_default must carry real scores —
     # NA would ride into full credit (the 2026-07-06 Sales find).
@@ -685,3 +739,125 @@ async def approve_scorecard(
         job["status"] = "complete"
         job["error"] = str(e)
         raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
+
+
+@router.delete("/score/{job_id}")
+async def delete_evaluation(
+    request: Request,
+    job_id: str,
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """Delete an evaluation — the privileged-only tampering doorway
+    (ScorecardActionsDesign §4.4; formalizes the 2026-07-24 manual
+    procedure).
+
+    Order inside one transaction: stat point out (its FK is NO ACTION and
+    would block the row delete), evaluation out (sections/tags/sweeps
+    cascade), agent series rebuilt (§5 — the manual procedure got lucky
+    with a latest-point delete; this route must not depend on luck).
+    Coaching links refuse the delete with a 409 — they are the human-side
+    tampering ledger and cascading them would erase the receipts that
+    justify score changes.
+
+    The response carries a full JSON snapshot of what was deleted (row +
+    sections + stat point) — the caller's client-side backup, replacing
+    the ad-hoc eval_2377_backup.json.
+
+    Concurrency: last-writer-wins by design. qa.evaluations has no
+    updated_at column and these are low-traffic manager tools. If Landing
+    outgrows this (concurrent evaluators on one eval), add updated_at +
+    an If-Unmodified-Since-style optimistic check here — potential design
+    choice deliberately deferred, not overlooked.
+    """
+    team_id = team_id_from_path(request)
+    if identity.role != "privileged":
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email="",
+            agent_email="",
+            agent_name="",
+            call_id=eval_store.call_id_from_job_id(job_id),
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes="delete_requires_privileged_key",
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Deleting evaluations requires the privileged API key",
+        )
+
+    ref = await eval_store.resolve_evaluation(team_id, job_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="No evaluation matches this call id")
+    config = get_team_config(team_id)
+
+    pool = await eval_store.get_pool()
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    async with pool.acquire() as conn:
+        coaching_rows = await conn.fetch(
+            "SELECT coaching_id, linked_at FROM qa.coaching_evaluations "
+            "WHERE evaluation_id = $1", ref.id,
+        )
+        if coaching_rows:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "Evaluation has coaching/1:1 records and cannot be "
+                               "deleted — they are the audit trail for score "
+                               "changes. Unlink the coachings first if this "
+                               "delete is truly intended.",
+                    "coaching_ids": [r["coaching_id"] for r in coaching_rows],
+                },
+            )
+
+        # Snapshot BEFORE deleting — the response is the caller's backup,
+        # and dialpad_link must outlive the row for the tombstone.
+        eval_row = await conn.fetchrow(
+            "SELECT * FROM qa.evaluations WHERE id = $1", ref.id)
+        section_rows = await conn.fetch(
+            "SELECT * FROM qa.evaluation_sections WHERE evaluation_id = $1 "
+            "ORDER BY section_number", ref.id)
+        point_row = await conn.fetchrow(
+            "SELECT * FROM qa.agent_stat_points WHERE evaluation_id = $1", ref.id)
+        snapshot = {
+            "evaluation": dict(eval_row) if eval_row else None,
+            "sections": [dict(r) for r in section_rows],
+            "stat_point": dict(point_row) if point_row else None,
+        }
+        agent_id = eval_row["agent_id"] if eval_row else None
+
+        async with conn.transaction():
+            await conn.execute(
+                "DELETE FROM qa.agent_stat_points WHERE evaluation_id = $1", ref.id)
+            await conn.execute(
+                "DELETE FROM qa.evaluations WHERE id = $1", ref.id)
+            if agent_id is not None:
+                # Fatal by contract — a failed rebuild rolls the delete back.
+                await rebuild_agent_series(conn, agent_id, config)
+
+    # Post-commit, both retryable/visible rather than delete-blocking:
+    tombstone_row = await tombstone_evaluation(ref.dialpad_link or "", config)
+    append_score_audit_row(
+        api_key_role=identity.role,
+        evaluator_email="",
+        agent_email=ref.agent_email or "",
+        agent_name=ref.agent_name_raw,
+        call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        target_team=team_id,
+        action=audit_cfg.ACTION_ORPHANED,
+        result_row=tombstone_row,
+        notes=f"role={identity.role} old_score={ref.overall_score}; "
+              "backup returned in delete response",
+    )
+    # Evict any cached job so the scorecard page stops serving the ghost.
+    _jobs.pop(_job_key(team_id, job_id), None)
+
+    return {
+        "status": "deleted",
+        "evaluation_id": ref.id,
+        "tombstoned_history_row": tombstone_row,
+        "snapshot": snapshot,
+    }

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -37,6 +37,7 @@ import asyncio
 import json
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -720,6 +721,143 @@ async def stamp_and_finalize(
 
 
 # ---------------------------------------------------------------------------
+# DB-backed action resolution (ScorecardActionsDesign §3, slice S1)
+# ---------------------------------------------------------------------------
+
+# Reverse of _CONFIDENCE_MAP — DB rows back into the draft-dump vocabulary.
+_CONFIDENCE_UNMAP = {"HIGH": "high", "MED": "medium", "LOW": "low"}
+
+
+@dataclass
+class EvalRef:
+    """A qa.evaluations row resolved by Dialpad call id, plus its AI
+    sections reshaped into the Stage-1 draft-dump form — enough context
+    to reconstruct an approval flow without the in-memory job."""
+    id: int
+    team_id: str
+    state: str
+    source: str
+    scoring_status: str
+    agent_name_raw: str
+    agent_email: Optional[str]
+    evaluator_email: Optional[str]
+    dialpad_call_id: Optional[str]
+    dialpad_entry_point_call_id: Optional[str]
+    dialpad_link: Optional[str]
+    call_summary: Optional[str]
+    key_strengths: Optional[str]
+    opportunities: Optional[str]
+    overall_score: Optional[float]
+    model: str
+    sections: list[dict[str, Any]]
+
+
+def call_id_from_job_id(job_id: str) -> str:
+    """The Dialpad call id inside a scorecard job_id.
+
+    ``_make_job_id`` builds ``<call_id>_<agent_name>`` with spaces
+    flattened to underscores, so the call id is the digits before the
+    first ``_``; a bare call id (the /datapoints surface) passes through
+    unchanged. Returns "" for ids with no numeric prefix — the caller
+    skips the DB probe entirely rather than querying junk."""
+    head = job_id.split("_", 1)[0]
+    return head if head.isdigit() else ""
+
+
+async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
+    """Resolve an action target from Postgres, not the in-memory job store.
+
+    Probes BOTH dialpad_entry_point_call_id and dialpad_call_id — the
+    2026-07-24 incident eval was addressed by its dialpad_call_id while
+    everyone believed it was the entry-point id. Do not "simplify" this
+    to one column. Ordering mirrors db_provider.get_by_eval_id so a
+    (rare) duplicate call id resolves to the same row every surface
+    picks. Unlike that read-path helper, drafts resolve too — actions
+    target any lifecycle state.
+
+    Returns None when dual-write is off (no pool), the job_id has no
+    numeric call id, or nothing matches."""
+    call_id = call_id_from_job_id(job_id)
+    if not call_id:
+        return None
+    pool = await _get_pool()
+    if pool is None:
+        return None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id, team_id, state, source, scoring_status, "
+            "  agent_name_raw, agent_email, evaluator_email, "
+            "  dialpad_call_id, dialpad_entry_point_call_id, dialpad_link, "
+            "  call_summary, key_strengths, opportunities, overall_score, "
+            "  models_used "
+            "FROM qa.evaluations "
+            "WHERE team_id = $1 "
+            "AND (dialpad_entry_point_call_id = $2 OR dialpad_call_id = $2) "
+            "ORDER BY COALESCE(call_connected_at, created_at) LIMIT 1",
+            team_id, call_id,
+        )
+        if row is None:
+            return None
+        section_rows = await conn.fetch(
+            "SELECT section_id, score_type, numeric_score, binary_value, "
+            "  score_source, confidence, reasoning "
+            "FROM qa.evaluation_sections WHERE evaluation_id = $1 "
+            "ORDER BY section_number",
+            row["id"],
+        )
+
+    models_used = row["models_used"]
+    if isinstance(models_used, str):
+        try:
+            models_used = json.loads(models_used or "{}")
+        except ValueError:
+            models_used = {}
+    model = ((models_used or {}).get("text") or {}).get("model") or "gemini-2.5-flash"
+
+    # AI rows only, reshaped to the Stage-1 dump (job['scorecard']
+    # ['sections']) that build_approval_sections diffs against. Manual /
+    # auto_value rows are regenerated from team config at approval time.
+    sections: list[dict[str, Any]] = []
+    for s in section_rows:
+        if s["score_source"] != "ai":
+            continue
+        is_binary = s["score_type"] == "binary"
+        sections.append({
+            "id": s["section_id"],
+            "name": s["section_id"],
+            "score": None if is_binary else s["numeric_score"],
+            "score_type": "yn" if is_binary else "numeric",
+            "yn_value": s["binary_value"],
+            "confidence": _CONFIDENCE_UNMAP.get(s["confidence"] or "", "medium"),
+            "reasoning": s["reasoning"] or "",
+            "audio_dependent": False,
+            "flags": [],
+        })
+
+    return EvalRef(
+        id=row["id"],
+        team_id=row["team_id"],
+        state=row["state"],
+        source=row["source"],
+        scoring_status=row["scoring_status"],
+        agent_name_raw=row["agent_name_raw"],
+        agent_email=row["agent_email"],
+        evaluator_email=row["evaluator_email"],
+        dialpad_call_id=row["dialpad_call_id"],
+        dialpad_entry_point_call_id=row["dialpad_entry_point_call_id"],
+        dialpad_link=row["dialpad_link"],
+        call_summary=row["call_summary"],
+        key_strengths=row["key_strengths"],
+        opportunities=row["opportunities"],
+        overall_score=(
+            float(row["overall_score"]) if row["overall_score"] is not None else None
+        ),
+        model=model,
+        sections=sections,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Pool lifecycle
 # ---------------------------------------------------------------------------
 
@@ -756,6 +894,9 @@ __all__ = [
     "record_draft_evaluation",
     "record_approval",
     "stamp_and_finalize",
+    "resolve_evaluation",
+    "call_id_from_job_id",
+    "EvalRef",
     "get_pool",
     "build_draft_row",
     "build_draft_sections",

--- a/qa-automation/AI-Scoring/backend/services/sheets_projection.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_projection.py
@@ -214,4 +214,40 @@ async def project_evaluation(
     return history_row_num
 
 
-__all__ = ["project_evaluation", "build_projection_row"]
+async def tombstone_evaluation(dialpad_link: str, config: "TeamConfig") -> Optional[int]:
+    """Blank the Analyst_History row of a DELETED evaluation
+    (ScorecardActionsDesign §4.4.6).
+
+    Sheets is a projection — a deleted DB row with a surviving sheet row
+    is drift, not history. Callers must capture ``dialpad_link`` BEFORE
+    deleting the qa.evaluations row; there is nothing left to resolve it
+    from afterwards.
+
+    Same failure semantics as project_evaluation: Sheets errors log and
+    return None (the nightly reproject sweep can't repair a tombstone,
+    but the audit row records the delete — a stale sheet row is visible,
+    not silent). Returns the blanked 1-indexed row number, or None when
+    the link is empty, Sheets is unconfigured, or no row matches."""
+    if not dialpad_link:
+        return None
+    if not _sheets_configured(config.team_id):
+        logger.warning("tombstone: Sheets not configured for %s — nothing to blank",
+                       config.team_id)
+        return None
+    try:
+        sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
+        existing = _find_row_by_dialpad_link(sheet, dialpad_link)
+        if existing is None:
+            return None
+        width = config.history_layout.total_width
+        end_letter = col_index_to_letter(width - 1)
+        sheet.update(f"A{existing}:{end_letter}{existing}", [[""] * width],
+                     value_input_option="USER_ENTERED")
+        return existing
+    except Exception:
+        logger.exception("tombstone: Analyst_History blank failed for link %s — "
+                         "sheet row is stale until manually cleared", dialpad_link)
+        return None
+
+
+__all__ = ["project_evaluation", "build_projection_row", "tombstone_evaluation"]

--- a/qa-automation/AI-Scoring/backend/services/stat_points.py
+++ b/qa-automation/AI-Scoring/backend/services/stat_points.py
@@ -131,6 +131,59 @@ async def insert_point(conn, *, team_id: str, agent_id: int, evaluation_id: int,
     return result.endswith("1")
 
 
+def build_series(evals: list[dict], *, span: int,
+                 sigma_multiplier: float) -> list[dict]:
+    """Deterministic per-agent series from approved_at-ordered evals.
+
+    Moved here from scripts/backfill_stat_points.py (ScorecardActionsDesign
+    §5) so the F1 replay CLI and the action-time rebuild share one math
+    core — parity by construction, not by test."""
+    prior = PriorState()
+    rows = []
+    for ev in evals:
+        score = float(ev["overall_score"])
+        point = compute_point(score, prior, span=span,
+                              sigma_multiplier=sigma_multiplier)
+        rows.append({"evaluation_id": ev["id"], "score": score, "point": point})
+        prior = PriorState(n=prior.n + 1, ewma=point.ewma,
+                           mean=point.spc_mean, sigma=point.spc_sigma)
+    return rows
+
+
+async def rebuild_agent_series(conn, agent_id: int, config) -> int:
+    """Rebuild one agent's whole stat series from finalized history.
+
+    Called by the scorecard actions (rescore / override / delete —
+    ScorecardActionsDesign §5) after they change or remove a finalized
+    score: the EWMA/SPC chain is recursive, so any mid-chain change
+    invalidates every later point. The series is deterministic; DELETE +
+    re-INSERT inside the caller's transaction is correct and idempotent.
+
+    FATAL by contract — the finalize-time `write_point_for_finalize` is
+    non-fatal because a missed point is a gap replay repairs, but a
+    rebuild runs INSIDE a mutating transaction and a half-applied action
+    with a silently corrupt EWMA chain is worse than a loud rollback.
+    Callers must NOT wrap this in try/except.
+
+    Returns the number of points written (0 for an agent with no
+    finalized history — their stale points still get deleted)."""
+    evals = await conn.fetch(
+        "SELECT id, team_id, overall_score FROM qa.evaluations "
+        "WHERE agent_id = $1 AND state = 'finalized' "
+        "ORDER BY approved_at, id", agent_id)
+    await conn.execute(
+        "DELETE FROM qa.agent_stat_points WHERE agent_id = $1", agent_id)
+    series = build_series(
+        evals, span=config.stats.ewma_span,
+        sigma_multiplier=config.stats.spc_sigma_multiplier)
+    for ev, row in zip(evals, series):
+        await insert_point(
+            conn, team_id=ev["team_id"], agent_id=agent_id,
+            evaluation_id=row["evaluation_id"], score=row["score"],
+            point=row["point"])
+    return len(series)
+
+
 async def write_point_for_finalize(conn, evaluation_id: int, config) -> None:
     """Finalize-seam entry: read the (just-finalized) evaluation, compute
     the incremental point, insert. NON-FATAL — logs and returns on any

--- a/qa-automation/AI-Scoring/references/ScorecardActionsDesign.md
+++ b/qa-automation/AI-Scoring/references/ScorecardActionsDesign.md
@@ -1,0 +1,421 @@
+# ScorecardActionsDesign — formal lifecycle actions on the scorecard/datapoint pair
+
+**Status:** v1.2 — doctrine settled, S1 build started (design-doc-first).
+**Date:** 2026-07-24 (v1/v1.1) → 2026-07-25 (v1.2)
+**Prompted by:** "Getting some formal methods directly into the
+`/scorecard/<team>/<call_id>_<agent>` route — re-score, delete, edit — plus a
+way of overriding the auto score only from this scorecard page." v1.1 added
+the escalation ladder and the ≤50 auto-rescore; v1.2 inverts the coaching
+gate (override *creates* the coaching), adds the acknowledgment protocol,
+and writes down the tampering doctrine that frames all of it.
+
+---
+
+## 0. Doctrine — zero-touch is the goal; manual touch is designed tampering
+
+The owner's framing (2026-07-25), which every section below serves:
+
+> Ceteris paribus and all things working good, there should be **NO manual
+> interaction at all** — manual interaction is tampering, and if tampering
+> occurs, it needs to be a **designed, auditable hole** in the
+> auto-pipeline.
+
+Consequences:
+
+1. **The auto-pipeline is the authority.** Score → finalize → project →
+   email, zero analyst touch (this is already the clean-call reality via
+   `_postgres_post_stage1`). Every manual doorway in this doc exists as a
+   *safeguard* against three failure classes: AI hallucination, missing or
+   outdated SOPs, and pipeline errors — not as a routine workflow.
+2. **Every manual doorway leaves a double receipt**: a `score_audit` row
+   (the machine-side ledger: `approved` / `rescored` / `overridden` /
+   `evaluation_orphaned`) AND — for score-changing interventions — a
+   `qa.coachings` record (the human-side ledger: who told the agent, when;
+   §4.3a). Tampering without a receipt is a bug, not a feature.
+3. **The Human-Review pipeline is authoritative today, informative
+   tomorrow.** Today a fired §3.14 trigger *blocks* finalize
+   (`flagged_human_review` holds the row in draft). At some point it flips
+   to non-blocking: flagged evals finalize and ship like any other, the
+   flag becomes an annotation feeding a review queue, and post-hoc
+   corrections go through the override doorway. The flip is designed now
+   as team config (`human_review: {mode: authoritative | informative}`,
+   default `authoritative`) so it lands as a config change, not a
+   redesign: in informative mode `_postgres_post_stage1` finalizes flagged
+   rows too, keeps `human_review_required_at` as the queue marker
+   (`required_at IS NOT NULL AND completed_at IS NULL`), and never sets
+   the blocking `scoring_status`.
+4. **Steady-state metric:** the audit ledger should show ~100%
+   `scored`-only traffic. Manual-action rows are signal — each one is
+   evidence of one of the three failure classes and should be traceable to
+   a fix (a re-score, an SOP escalation, a pipeline bug).
+
+## 1. Where we actually stand
+
+The scorecard page (`main.py` → `frontend/scorecard.html`) drives three
+routes in `backend/routes/scoring.py`, all keyed off the **in-memory
+`_jobs` dict** (`_job_key(team_id, job_id)`, `job_id =
+<dialpad_call_id>_<agent_name>`, spaces → underscores):
+
+| Action | Route | State today |
+|---|---|---|
+| Edit + approve | `POST /score/{job_id}/approve` | **Exists — the default behavior.** Analyst edits ride the approval payload; `record_approval` rewrites sections (DELETE + re-INSERT), flips `source` to `ai_reviewed` when anything changed, then `stamp_and_finalize` computes the engine score. |
+| Human-review hold | (same route, `resolving_review`) | A fired §3.14 trigger holds the row at `scoring_status='flagged_human_review'`; the manager's approval IS the resolution. Authoritative mode — see §0.3. |
+| Re-score | — | No route. But `record_draft_evaluation` already upserts on the dedupe key and resets lifecycle columns (tests: `test_rescore_updates_row_and_replaces_sections`) — Stage 1 was built rescore-shaped; §4.2 adds the trigger paths, not the write. |
+| Delete | — | Doesn't exist anywhere in code. The 2026-07-24 manual delete of eval 2377 (0.0-score outlier) was raw SQL; the schema reserved `score_audit.action='evaluation_orphaned'` for exactly this path but no route writes it. |
+| Override auto score | — | Doesn't exist. `overall_score` is engine-owned (`stamp_and_finalize`); `record_approval` is always called with `overall_score_raw=None` post-cutover. |
+
+Two structural facts shape the design:
+
+1. **`_jobs` is process-lifetime.** A server restart 404s every old
+   scorecard URL, while the same evaluation stays reachable forever at
+   `/datapoint/{team}/{call_id}` via the indexed DB probe
+   (`db_provider.get_by_eval_id`, migration 014). The scorecard and
+   datapoint pages already render the same record — two views of one
+   evaluation, one ephemeral, one durable.
+2. **Finalized = read-only is enforced twice** (frontend
+   `scorecard.html` and the 409 in `approve_scorecard`). Every action
+   below punches a *specific, audited* hole in that wall (§0.2) rather
+   than removing it.
+
+## 2. Owner decisions (2026-07-24 → 25)
+
+| Question | Decision |
+|---|---|
+| Doctrine | §0: zero-touch authority; manual = designed, auditable tampering. (v1.2) |
+| Re-score semantics | **REPLACE.** Same eval row, downstream computations rebuilt — no supersede chain, no second row. |
+| Auto re-score | Fires when a finalize lands `overall_score ≤ 50` — **exactly once per evaluation**; then the score stays. |
+| Override semantics | **SUPERSEDE, riding `source='ai_reviewed'`.** Auto score stays reproducible from `evaluation_sections` + `formula_version`. |
+| Override ↔ coaching | **Overriding CREATES the coaching**: a `qa.coachings` row + `coaching_evaluations` link, plus an acknowledgment pop-up binding the evaluator to notify the agent their progression was manually modified. Same protocol for human-review resolutions. (v1.2 — inverts v1.1's "coaching must pre-exist" gate) |
+| HR pipeline trajectory | Authoritative today; **informative (non-blocking) later** via team-config mode — designed now, flipped by config (§0.3). (v1.2) |
+| Delete auth | **Privileged key only.** |
+| Edit auth | Team keys keep edit on the scorecard AND gain it on `/datapoints/*` — mirrored surfaces; the datapoint one survives restarts. |
+| Override surface | Scorecard page only (not datapoint) — an approval-flow action, not an archaeology action. |
+| Email on rescore/override | Default: re-send WITH a cause-specific disclaimer; checkbox opts *out*. |
+| Sheets row of a deleted eval | Blank the projected row (tombstone mode) — Sheets is a projection; drift is a bug. |
+| Concurrent-edit protection | Not worth it at current traffic; docstring records the optimistic-`updated_at` upgrade path (§3). |
+
+## 3. The enabling seam — DB-backed action resolution (S1)
+
+Every new action resolves its target **from Postgres, not `_jobs`**:
+
+```
+eval_store.resolve_evaluation(team_id, job_id) -> EvalRef | None
+    # job_id = "<call_id>_<agent_name>" (spaces → "_"), or a bare
+    # call_id on the datapoint surface. The call-id prefix is the
+    # digits before the first "_"; probe qa.evaluations the way
+    # get_by_eval_id does:
+    #   WHERE team_id=$1 AND (dialpad_entry_point_call_id=$2
+    #                         OR dialpad_call_id=$2)
+    # NOTE: both id columns are probed on purpose — the 2026-07-24
+    # incident eval was addressed by its dialpad_call_id while everyone
+    # believed it was the entry-point id. Do not "simplify" to one column.
+```
+
+`_jobs` remains the live-scoring progress channel (SSE polling, status
+transitions). Actions consult it only to refuse racing an in-flight job
+(§4.2). This makes every action work on a years-old evaluation from the
+datapoint page after any number of restarts.
+
+The approve path adopts the seam immediately (S1): on a `_jobs` miss it
+reconstructs the approval context from the DB row + sections instead of
+404ing. One payload consequence: the in-memory job carried the original
+`manager_email`; a reconstructed context doesn't have it, so
+`ApprovalRequest` gains an optional `evaluator_email` (frontend sends the
+signed-in evaluator; absent → fall back to the row's `evaluator_email`;
+neither → 422).
+
+Every mutating action route carries the traffic-scale docstring (§2):
+
+```
+Concurrency: last-writer-wins by design. qa.evaluations has no
+updated_at column and these are low-traffic manager tools. If Landing
+outgrows this (concurrent evaluators on one eval), add updated_at +
+an If-Unmodified-Since-style optimistic check here — potential design
+choice deliberately deferred, not overlooked.
+```
+
+## 4. The actions
+
+### 4.0 The escalation ladder — how the pieces compose
+
+The mutations are not peers; they form a quality-control loop whose end
+state escalates *process* problems (outdated or missing SOPs), not just
+call scores:
+
+```
+finalize lands score ≤ 50
+        │
+        ▼
+auto re-score (once, ever) ─────── score now > 50 → done, email w/ disclaimer
+        │ still ≤ 50
+        ▼
+review queue (blocking today, informative later — §0.3)
+        │
+        ▼
+override (scorecard only) — the evaluator sets the score a human stands
+behind; the act CREATES the coaching/1:1 record + notification duty
+(§4.3a), and its SOP-gap note is the escalation record for missing or
+outdated SOPs
+```
+
+An eval that scores badly twice under the same rubric+SOP context is
+evidence about the *context*, not just the call — the override's
+reasoning and SOP-gap field are where that evidence lands.
+
+### 4.1 Edit — extend, don't rebuild
+
+Approve-with-edits stays the default scorecard behavior, human-review
+gate included. Changes:
+
+- **`POST /datapoints/{call_id}/edit`** (team key or privileged): same
+  `ApprovalRequest` payload and validation
+  (`missing_manual_scores`, section-vs-config defense), routed through
+  `record_approval` + `stamp_and_finalize` via §3 resolution. Editing a
+  **finalized** eval from this surface is a re-approval — it re-runs the
+  engine, re-projects, clears any standing override (the engine
+  recomputes `overall_score`), and, being manual tampering with a shipped
+  score, triggers the §4.3a acknowledgment protocol exactly like an
+  override does.
+- The scorecard approve path adopts §3 resolution as fallback when
+  `_jobs` misses (S1), instead of 404ing.
+
+### 4.2 Re-score — REPLACE, manual and automatic
+
+**Manual:** `POST /score/{job_id}/rescore`, team key (roster-scoped) or
+privileged. Refuse (409) when a `pending`/`scoring` job for the same key
+is in flight.
+
+**Automatic:** hooked at the finalize seam (both `_postgres_post_stage1`
+and the approve path), after `stamp_and_finalize`:
+
+```
+if overall_score <= config.rescore.threshold      # default 50, team JSON
+   and eval.auto_rescored_at IS NULL              # once, EVER
+   and source == 'ai':                            # never discard human edits
+    stamp auto_rescored_at = NOW()
+    SUPPRESS this pass's projection + email       # agent must not see a
+                                                  # score about to change
+    schedule the rescore primitive (same background-task pattern as /score)
+```
+
+- **Once means once.** `auto_rescored_at` (migration 018, §6) is stamped
+  *before* the re-run is scheduled, so a crash mid-rescore can't loop.
+  The second finalize proceeds normally whatever the number: > 50 →
+  project + email with the re-score disclaimer; still ≤ 50 → project +
+  email AND enter the review queue (§0.3 mode decides blocking vs
+  annotation) — the cue for the coaching → override escalation.
+- **`source='ai'` only.** A human-approved (`ai_reviewed`) low score is a
+  human's judgment of a genuinely bad call — auto-rescoring it would
+  discard the analyst's edits. Escalation for those is override directly.
+- The auto-rescore is machine-initiated and therefore NOT tampering
+  (§0): it books `action='rescored'` with notes `"auto: <old> ≤
+  <threshold>"` and creates no coaching record.
+- Threshold lives in team JSON (`rescore: {threshold: 50}`) beside the
+  stats knobs.
+
+**The rescore primitive** (shared by both triggers):
+
+1. Resolve the eval (§3). Re-download audio by `dialpad_call_id`
+   (`download_recording`) — same input, fresh model pass through the
+   existing `score_call` pipeline.
+2. Reuse the Stage-1 upsert (`record_draft_evaluation` already resets
+   lifecycle columns and replaces sections on the same row id — §1).
+   Keeping the row id preserves every FK.
+3. Delete the row's `agent_stat_points` point and rebuild the agent's
+   series (§5) — the old finalized score must not linger in the EWMA
+   chain while the row sits in draft.
+4. Manual path: fresh job entry, normal review/approve flow. Auto path:
+   the auto-flow decides auto-finalize vs. flagged, like any first pass.
+5. Audit: `action='rescored'`, notes `"manual: <old>"` / `"auto: <old> ≤
+   <threshold>"`.
+6. Sheets projection: re-projected on the re-finalize, overwriting the
+   history row — REPLACE all the way down.
+7. Email: on the re-finalize, dispatch WITH the re-score disclaimer by
+   default; manual-rescore UI shows the opt-out checkbox
+   (`suppress_email=true`). The GAS template gains the disclaimer block
+   (teams overlay + `push.sh` redeploy — Railway watch paths don't cover
+   GAS).
+
+### 4.3 Override — `POST /score/{job_id}/override` (SUPERSEDE)
+
+Team key (roster-scoped) or privileged; **scorecard surface only**.
+Target must be `finalized`. No precondition beyond that — the coaching
+record is not a gate you pass, it's a receipt the action writes (v1.2).
+
+```
+{
+  overall_score: float,
+  reasoning: str,                     # required
+  conducted_by_role: 'team_lead' | 'manager' | 'hr' | 'external',
+  sop_gap: {note: str,                # optional — the SOP escalation:
+            document_id: int?} | null #  outdated/missing SOP evidence;
+                                      #  document_id → embeddings.sop_documents
+  acknowledged: true,                 # §4.3a — literal true or 422
+  suppress_email: bool = false,
+  evaluator_email: str
+}
+```
+
+One transaction:
+
+1. `overall_score = $new`, `source='ai_reviewed'`. `formula_version` and
+   sections stay — that pair reproduces the superseded auto score
+   forever, so the UI can render "engine would say X" without storing X.
+2. **Create the coaching receipt**: a `qa.coachings` row
+   (`agent_id`, `team_id`, `conducted_by_role`, `conducted_by_email =
+   evaluator_email`, `status='pending'`,
+   `action_plan = 'Notify <agent>: score manually overridden <old> →
+   <new>'`, `action_plan_deadline = NOW() + interval '3 days'`) + a
+   `coaching_evaluations` link (`per_eval_note = reasoning`,
+   `opportunities_snapshot` from the row). No schema change — the
+   existing tables model this exactly.
+3. Stat point deleted + series rebuilt (§5); re-projection to Sheets.
+4. Audit: `action='overridden'`, notes
+   `"<old> → <new>: <reasoning>" [+ " | SOP gap: <note>"]`.
+5. Email: disclaimer dispatch by default. **If the disclaimer email goes
+   out, the notification duty is discharged mechanically** — the coaching
+   completes in the same transaction (`status='completed'`,
+   `coaching_summary='Agent notified via override disclaimer email'`,
+   `completed_by = evaluator_email`). If `suppress_email`, the coaching
+   stays `pending` with its deadline — and `idx_coachings_pending`
+   becomes the accountability queue for evaluators who owe an agent a
+   conversation.
+
+**SOP escalation:** `sop_gap` notes land in the audit row now;
+aggregating them into an SOP-owner queue (Pulpo-side review of
+`document_id`-clustered gaps) is deliberately deferred — filtering
+`action='overridden'` in audit search is enough to start.
+
+### 4.3a The acknowledgment protocol (v1.2) — every manual doorway
+
+Any manual mutation of an agent-visible score — **override, human-review
+resolution, edit-of-finalized** — exposes the same UI behavior:
+
+1. A pop-up states what is about to happen ("You are manually modifying
+   an AI-scored evaluation…") and requires explicit acknowledgment. The
+   acknowledgment text binds the evaluator to **at least notify the
+   agent that their progression has been manually modified by a human**.
+2. `acknowledged: true` rides the request; the route 422s without it.
+   The acknowledgment is recorded in the audit notes (`ack:<evaluator>`)
+   and embodied in the coaching receipt (§4.3.2) — pending until the
+   agent is notified, auto-completed when the disclaimer email
+   discharges the duty.
+3. Human-review resolutions (approve with `resolving_review`) create the
+   same coaching receipt: the §3.14 flag said "a human must look"; the
+   receipt records that a human looked AND that the agent knows.
+
+Machine-initiated actions (auto-rescore, auto-finalize) never see this
+protocol — it exists precisely at the human/pipeline boundary (§0.2).
+
+### 4.4 Delete — `DELETE /score/{job_id}` (privileged only)
+
+`identity.role == "privileged"` or 403 (+ `denied` audit row, matching
+`check_scoring_access`'s pattern). Formalizes the 2026-07-24 manual
+procedure, in order, one transaction:
+
+1. Resolve (§3); capture a JSON snapshot of the row + sections + stat
+   point into the response (client-side backup — `eval_2377_backup.json`,
+   formalized).
+2. `DELETE FROM qa.agent_stat_points WHERE evaluation_id=$1` (its FK is
+   NO ACTION and blocks the row delete otherwise), remember `agent_id`.
+3. `DELETE FROM qa.evaluations WHERE id=$1` — sections, tags, sweeps
+   cascade. `coaching_evaluations` is NO ACTION **and stays that way**:
+   refuse with 409 listing the coaching rows. Doubly load-bearing in
+   v1.2 — coachings are the human-side tampering ledger (§0.2), so
+   cascading them would erase the receipts that justify score changes.
+4. Rebuild the agent's stat series (§5) — the manual procedure got lucky
+   (the deleted point was the latest); the route must not depend on luck.
+5. Audit: `action='evaluation_orphaned'` — the reserved action, finally
+   written by code. `notes` records the requesting key role + old score.
+6. Sheets projection: blank the projected history row via a
+   `project_evaluation` tombstone mode.
+
+Both pages get the button; datapoint is the primary home (it outlives
+restarts), scorecard mirrors it. UI: type-the-agent-name confirm.
+
+## 5. Stat-series rebuild — one primitive, three callers
+
+`backfill_stat_points.py` already proves the series is deterministic
+(DELETE + re-INSERT per agent, approved_at order, id tiebreak). Extract
+its core into the service layer:
+
+```
+backend/services/stat_points.py
+  async def rebuild_agent_series(conn, agent_id, config) -> int
+      # DELETE the agent's points; replay finalized evals in
+      # approved_at order via compute_point(); INSERT the fresh series.
+      # Same transaction as the caller's mutation. Returns row count.
+```
+
+Callers: rescore (§4.2.3), override (§4.3.3), delete (§4.4.4). The
+script becomes a thin CLI over the same function. Unlike the
+finalize-time write, rebuild runs INSIDE the mutating transaction — if
+the rebuild fails the whole action rolls back (an action that silently
+corrupts the EWMA chain is worse than one that fails loudly; the
+non-fatal contract stays finalize-only).
+
+## 6. Migration 018 — audit vocabulary + auto-rescore stamp
+
+```sql
+-- 018_scorecard_actions.sql (+ _down.sql)
+
+-- (a) audit action vocabulary — explicit actions beat notes-parsing
+ALTER TABLE qa.score_audit DROP CONSTRAINT score_audit_action_check;
+ALTER TABLE qa.score_audit ADD CONSTRAINT score_audit_action_check
+    CHECK (action IN ('scored','denied','approved',
+                      'evaluation_orphaned','rescored','overridden'));
+-- same for qa.score_audit_archive
+
+-- (b) the once-ever auto-rescore latch (§4.2). Timestamp, not boolean:
+--     "when did the machine take its one retry" is audit signal.
+ALTER TABLE qa.evaluations ADD COLUMN auto_rescored_at TIMESTAMPTZ;
+```
+
+No other DB change: override rides `ai_reviewed`, rescore reuses the
+Stage-1 upsert, the coaching receipt uses `qa.coachings` /
+`qa.coaching_evaluations` as-is, and the HR mode flip (§0.3) is team
+JSON, not schema.
+
+## 7. Auth matrix
+
+| Action | Team key | Privileged key | Surfaces | Preconditions |
+|---|---|---|---|---|
+| View | ✓ | ✓ | scorecard, datapoint | — |
+| Edit / approve (draft) | ✓ (roster-scoped) | ✓ | scorecard, datapoint | — |
+| Edit of finalized | ✓ (roster-scoped) | ✓ | datapoint (primary) | §4.3a acknowledgment |
+| Re-score (manual) | ✓ (roster-scoped) | ✓ | scorecard, datapoint | no in-flight job |
+| Re-score (auto) | system | system | finalize seam | score ≤ threshold, `auto_rescored_at IS NULL`, `source='ai'` |
+| HR resolution | ✓ (roster-scoped) | ✓ | scorecard | flagged eval + §4.3a acknowledgment |
+| Override score | ✓ (roster-scoped) | ✓ | **scorecard only** | finalized + §4.3a acknowledgment |
+| Delete | ✗ → 403 + audit | ✓ | scorecard, datapoint | no coaching rows (409 otherwise) |
+
+"Roster-scoped" = the existing `check_scoring_access` gate: the target
+agent must be in the team's Mails roster for team keys.
+
+## 8. Resolved-question log (v1 → v1.2)
+
+1. **Email on re-finalize:** re-send by default WITH a disclaimer naming
+   the cause; checkbox opts out. The disclaimer email doubles as the
+   mechanical discharge of the §4.3a notification duty.
+2. **Sheets projection of a deleted eval:** blank the row (tombstone).
+3. **Concurrent edit protection:** skipped at current traffic; docstring
+   on every action route records the upgrade path (§3).
+4. **Coaching gate direction (v1.1 → v1.2):** overrides *create* the
+   coaching receipt rather than requiring one to pre-exist.
+5. **HR pipeline:** authoritative → informative later, via team config;
+   designed now, default `authoritative` (§0.3).
+
+## 9. Build order & pytest checkpoints
+
+Slices land in this order; each has its checkpoint before the next
+starts (workflow rule):
+
+| Slice | Contents | Checkpoint tests |
+|---|---|---|
+| S1 | §3 `resolve_evaluation` + approve-path fallback + `ApprovalRequest.evaluator_email` + concurrency docstrings | probe by call_id / entry_point id / miss → None; job-id parsing (agent underscores, bare call_id); restart simulation (empty `_jobs`) approves via fallback; finalized fallback → 409; evaluator_email fallback chain |
+| S2 | §5 `rebuild_agent_series` + CLI rewire | golden-series parity vs `backfill_stat_points.py` on fixture history; mid-chain delete rebuild correctness (EWMA/σ recomputed, flags re-judged) |
+| S3 | Migration 018 + §4.4 delete route + tombstone projection | 403 + denied-audit for team key; coaching-row 409; cascade verification; `evaluation_orphaned` row written; snapshot in response; Sheets row blanked |
+| S4 | §4.2 manual rescore | in-flight 409; same-row-id preservation via Stage-1 upsert; stat point removed while draft; full re-approve round-trip; disclaimer email + opt-out |
+| S5 | §4.2 auto rescore + `human_review.mode` config flag (default authoritative) | fires at ≤ threshold on `source='ai'` only; latch stamps before re-run (crash sim → no loop); first-pass email suppressed; second-low-score enters review queue per mode; `ai_reviewed` low score does NOT fire; informative mode finalizes flagged rows with queue marker |
+| S6 | §4.3 override + §4.3a acknowledgment protocol (override + HR resolution + edit-of-finalized) + scorecard UI | `acknowledged` 422 gate; coaching receipt created (pending + deadline); disclaimer email auto-completes the coaching; suppress_email leaves it pending; HR resolution creates receipt; `overridden` audit with SOP-gap note; series rebuilt; engine-score reproducibility (recompute from sections == old score) |
+| S7 | §4.1 datapoint edit surface + frontend action bars + GAS disclaimer template | datapoint edit round-trip; override control absent on datapoint page; role-gated button rendering; GAS overlay builds via `push.sh` |

--- a/qa-automation/AI-Scoring/scripts/backfill_stat_points.py
+++ b/qa-automation/AI-Scoring/scripts/backfill_stat_points.py
@@ -44,8 +44,7 @@ if str(_AI_SCORING) not in sys.path:
 from backend.config.team_config import get_team_config  # noqa: E402
 from backend.services.stat_points import (  # noqa: E402
     COVERAGE_REGIME,
-    PriorState,
-    compute_point,
+    build_series,
 )
 
 _b1_spec = importlib.util.spec_from_file_location(
@@ -54,18 +53,9 @@ b1 = importlib.util.module_from_spec(_b1_spec)
 _b1_spec.loader.exec_module(b1)
 
 
-def build_series(evals: list[dict], *, span: int, sigma_multiplier: float) -> list[dict]:
-    """Deterministic per-agent series from approved_at-ordered evals."""
-    prior = PriorState()
-    rows = []
-    for ev in evals:
-        score = float(ev["overall_score"])
-        point = compute_point(score, prior, span=span,
-                              sigma_multiplier=sigma_multiplier)
-        rows.append({"evaluation_id": ev["id"], "score": score, "point": point})
-        prior = PriorState(n=prior.n + 1, ewma=point.ewma,
-                           mean=point.spc_mean, sigma=point.spc_sigma)
-    return rows
+# build_series moved to backend.services.stat_points (ScorecardActionsDesign
+# §5) — the action-time rebuild (rescore/override/delete) and this replay
+# CLI share one math core.
 
 
 async def run(args) -> int:

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -1,0 +1,188 @@
+"""ScorecardActionsDesign §3 (S1) — DB-backed action resolution.
+
+`resolve_evaluation` is the seam every scorecard action stands on after
+the in-memory `_jobs` dict dies with the process. These tests pin the
+job-id parsing, the two-column Dialpad-id probe, and the DB-row →
+Stage-1-draft-dump section reshaping against a stub pool (same FakeConn
+pattern as test_eval_store — no real DB, per Wave2Plan Phase 1).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+
+from backend.services import eval_store
+from backend.services.eval_store import call_id_from_job_id, resolve_evaluation
+
+
+# ---------------------------------------------------------------------------
+# call_id_from_job_id
+# ---------------------------------------------------------------------------
+
+class TestCallIdFromJobId:
+
+    def test_job_id_with_agent_suffix(self):
+        assert call_id_from_job_id("5035229460504576_Juan_Celso") == "5035229460504576"
+
+    def test_bare_call_id_passes_through(self):
+        assert call_id_from_job_id("5035229460504576") == "5035229460504576"
+
+    def test_agent_name_with_many_underscores(self):
+        # _make_job_id flattens spaces, so multi-word names produce
+        # multiple underscores — only the first split matters.
+        assert call_id_from_job_id("42_Maria_de_la_Cruz") == "42"
+
+    def test_non_numeric_prefix_returns_empty(self):
+        # Junk ids skip the DB probe entirely.
+        assert call_id_from_job_id("Juan_Celso") == ""
+
+    def test_empty_returns_empty(self):
+        assert call_id_from_job_id("") == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_evaluation
+# ---------------------------------------------------------------------------
+
+def _eval_row(**overrides):
+    row = {
+        "id": 2377,
+        "team_id": "member_support",
+        "state": "draft",
+        "source": "ai",
+        "scoring_status": "flagged_human_review",
+        "agent_name_raw": "Juan Celso",
+        "agent_email": "juan.celso@hellolanding.com",
+        "evaluator_email": None,
+        "dialpad_call_id": "5035229460504576",
+        "dialpad_entry_point_call_id": "6105002063634432",
+        "dialpad_link": "https://dialpad.com/callhistory/callreview/6105002063634432",
+        "call_summary": "Member called about billing",
+        "key_strengths": "Good tone",
+        "opportunities": "Faster holds",
+        "overall_score": None,
+        "models_used": json.dumps(
+            {"text": {"provider": "gemini", "model": "gemini-2.5-flash"}}
+        ),
+    }
+    row.update(overrides)
+    return row
+
+
+def _section_rows():
+    return [
+        {"section_id": "greeting", "score_type": "numeric", "numeric_score": 5,
+         "binary_value": None, "score_source": "ai", "confidence": "HIGH",
+         "reasoning": "warm open"},
+        {"section_id": "caller_id", "score_type": "binary", "numeric_score": None,
+         "binary_value": "Y", "score_source": "ai", "confidence": "MED",
+         "reasoning": "verified"},
+        # migration-012 numeric-NA shape: numeric section, binary_value='NA'
+        {"section_id": "efficiency", "score_type": "numeric", "numeric_score": None,
+         "binary_value": "NA", "score_source": "ai", "confidence": "LOW",
+         "reasoning": "no holds to judge"},
+        # non-AI rows are regenerated from config at approval — filtered out
+        {"section_id": "human_review_required", "score_type": "manual_binary",
+         "numeric_score": None, "binary_value": "NA",
+         "score_source": "manual_default", "confidence": None, "reasoning": None},
+        {"section_id": "documentation", "score_type": "auto_value",
+         "numeric_score": None, "binary_value": "Y",
+         "score_source": "auto_value", "confidence": None, "reasoning": None},
+    ]
+
+
+class FakeConn:
+    def __init__(self, row, sections):
+        self.row = row
+        self.sections = sections
+        self.fetchrow_args = None
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_args = (query, args)
+        return self.row
+
+    async def fetch(self, query, *args):
+        return self.sections
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+@pytest.mark.asyncio
+class TestResolveEvaluation:
+
+    @pytest.fixture(autouse=True)
+    def _stub_pool(self, monkeypatch):
+        self.conn = FakeConn(_eval_row(), _section_rows())
+
+        async def fake_get_pool():
+            return FakePool(self.conn)
+
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_resolves_by_job_id_and_probes_both_id_columns(self):
+        ref = await resolve_evaluation("member_support", "5035229460504576_Juan_Celso")
+        assert ref is not None
+        assert ref.id == 2377
+        assert ref.state == "draft"
+        assert ref.scoring_status == "flagged_human_review"
+        assert ref.model == "gemini-2.5-flash"
+        # The 2026-07-24 incident guarantee: one probe, both columns.
+        query, args = self.conn.fetchrow_args
+        assert "dialpad_entry_point_call_id = $2" in query
+        assert "dialpad_call_id = $2" in query
+        assert args == ("member_support", "5035229460504576")
+
+    async def test_sections_reshaped_to_draft_dump(self):
+        ref = await resolve_evaluation("member_support", "5035229460504576")
+        by_id = {s["id"]: s for s in ref.sections}
+        # AI rows only — manual_default and auto_value rows are excluded.
+        assert set(by_id) == {"greeting", "caller_id", "efficiency"}
+        assert by_id["greeting"] == {
+            "id": "greeting", "name": "greeting", "score": 5,
+            "score_type": "numeric", "yn_value": None, "confidence": "high",
+            "reasoning": "warm open", "audio_dependent": False, "flags": [],
+        }
+        assert by_id["caller_id"]["score_type"] == "yn"
+        assert by_id["caller_id"]["score"] is None
+        assert by_id["caller_id"]["yn_value"] == "Y"
+        assert by_id["caller_id"]["confidence"] == "medium"
+        # numeric NA keeps the (score=None, yn_value='NA') draft shape.
+        assert by_id["efficiency"]["score"] is None
+        assert by_id["efficiency"]["yn_value"] == "NA"
+        assert by_id["efficiency"]["score_type"] == "numeric"
+
+    async def test_models_used_accepts_dict_codec(self):
+        # asyncpg with a JSONB codec hands back a dict, not a str.
+        self.conn.row = _eval_row(models_used={"text": {"model": "gemma-4-27b-q4"}})
+        ref = await resolve_evaluation("member_support", "5035229460504576")
+        assert ref.model == "gemma-4-27b-q4"
+
+    async def test_overall_score_numeric_to_float(self):
+        self.conn.row = _eval_row(state="finalized", overall_score=85)
+        ref = await resolve_evaluation("member_support", "5035229460504576")
+        assert ref.overall_score == 85.0
+        assert isinstance(ref.overall_score, float)
+
+    async def test_miss_returns_none(self):
+        self.conn.row = None
+        assert await resolve_evaluation("member_support", "999") is None
+
+    async def test_non_numeric_job_id_skips_probe(self):
+        assert await resolve_evaluation("member_support", "Juan_Celso") is None
+        assert self.conn.fetchrow_args is None
+
+    async def test_no_pool_returns_none(self, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        assert await resolve_evaluation("member_support", "5035229460504576") is None

--- a/qa-automation/AI-Scoring/tests/test_score_audit.py
+++ b/qa-automation/AI-Scoring/tests/test_score_audit.py
@@ -31,7 +31,13 @@ def test_columns_are_ten_in_canonical_order():
 
 
 def test_actions_set_matches_design():
-    assert audit_cfg.ACTIONS == frozenset({"scored", "denied", "approved"})
+    # Extended by migration 018 (ScorecardActionsDesign §6): the manual
+    # doorways get explicit receipts. Must stay in sync with the
+    # score_audit_action_check CHECK in both audit tables.
+    assert audit_cfg.ACTIONS == frozenset({
+        "scored", "denied", "approved",
+        "evaluation_orphaned", "rescored", "overridden",
+    })
 
 
 def test_roles_set_matches_key_identity():

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -588,3 +588,373 @@ def test_batch_privileged_role_recorded_in_audit(client):
     assert row["api_key_role"] == "privileged"
     assert row["target_team"] == "sales"
     assert row["notes"] == "batch_upload"
+
+
+# ---------------------------------------------------------------------------
+# S1 — approve falls back to DB resolution (ScorecardActionsDesign §3)
+# ---------------------------------------------------------------------------
+
+def _eval_ref(**overrides):
+    from backend.services.eval_store import EvalRef
+    defaults = dict(
+        id=2377,
+        team_id="member_support",
+        state="draft",
+        source="ai",
+        scoring_status="flagged_human_review",
+        agent_name_raw="Luis Rubio",
+        agent_email="luis@landing.com",
+        evaluator_email=None,
+        dialpad_call_id="5035229460504576",
+        dialpad_entry_point_call_id="6105002063634432",
+        dialpad_link="https://dialpad.com/callhistory/callreview/6105002063634432",
+        call_summary="Billing question",
+        key_strengths="Good tone",
+        opportunities="Faster holds",
+        overall_score=None,
+        model="gemini-2.5-flash",
+        sections=[],
+    )
+    defaults.update(overrides)
+    return EvalRef(**defaults)
+
+
+def _stub_engine_path(monkeypatch, captured_approvals):
+    """Same engine stubs as test_approve_writes_audit_row, capturing the
+    record_approval kwargs so the fallback context can be asserted."""
+    monkeypatch.setattr(
+        scoring_module.eval_store, "missing_manual_scores",
+        lambda config, sections: [],
+    )
+
+    async def fake_record_approval(config, **kw):
+        captured_approvals.append(kw)
+        return kw.get("evaluation_id")
+    monkeypatch.setattr(scoring_module, "record_approval", fake_record_approval)
+
+    class _Detail:
+        overall_score = 72.0
+
+    async def fake_stamp(evaluation_id, config, evaluator_email):
+        return _Detail()
+    monkeypatch.setattr(scoring_module.eval_store, "stamp_and_finalize", fake_stamp)
+
+    async def fake_pool():
+        return object()
+    monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
+
+    async def fake_project(pool, evaluation_id, config, include_history=True):
+        return 321
+    monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
+    monkeypatch.setattr(
+        scoring_module, "trigger_apps_script", lambda row, team_id: {"status": "ok"}
+    )
+
+
+def _resolve_stub(monkeypatch, ref):
+    calls = []
+
+    async def fake_resolve(team_id, job_id):
+        calls.append((team_id, job_id))
+        return ref
+    monkeypatch.setattr(scoring_module.eval_store, "resolve_evaluation", fake_resolve)
+    return calls
+
+
+def test_approve_restart_simulation_falls_back_to_db(client, monkeypatch):
+    """Empty _jobs (process restarted) — approve reconstructs the context
+    from qa.evaluations, finalizes, and caches the restored job."""
+    approvals: list[dict] = []
+    _stub_engine_path(monkeypatch, approvals)
+    resolve_calls = _resolve_stub(monkeypatch, _eval_ref())
+
+    job_id = "5035229460504576_Luis_Rubio"
+    resp = client.post(
+        f"/api/member_support/score/{job_id}/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={
+            "sections": [],
+            "key_strengths": "x",
+            "opportunities": "y",
+            "evaluator_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "finalized"
+    assert resolve_calls == [("member_support", job_id)]
+
+    # The approval ran against the resolved row, flagged-review resolution
+    # included (scoring_status came back flagged_human_review).
+    assert len(approvals) == 1
+    assert approvals[0]["evaluation_id"] == 2377
+    assert approvals[0]["evaluator_email"] == "ana@landing.com"
+    assert approvals[0]["resolving_review"] is True
+
+    # Restored job is cached like a live one and now shows approved.
+    key = scoring_module._job_key("member_support", job_id)
+    assert scoring_module._jobs[key]["status"] == "approved"
+    assert scoring_module._jobs[key]["restored_from_db"] is True
+
+    approved = [r for r in client.audit_rows if r["action"] == "approved"]
+    assert len(approved) == 1
+    assert approved[0]["evaluator_email"] == "ana@landing.com"
+    assert approved[0]["agent_name"] == "Luis Rubio"
+
+
+def test_approve_fallback_finalized_row_is_read_only(client, monkeypatch):
+    """A finalized eval resolved from the DB keeps the 409 wall — the
+    edit-of-finalized doorway (ack protocol) is slice S6, not S1."""
+    approvals: list[dict] = []
+    _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete", overall_score=88.0),
+    )
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={
+            "sections": [], "key_strengths": "x", "opportunities": "y",
+            "evaluator_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 409
+    assert "read-only" in resp.json()["detail"]
+    assert approvals == []
+
+
+def test_approve_fallback_no_row_is_404(client, monkeypatch):
+    _resolve_stub(monkeypatch, None)
+    resp = client.post(
+        "/api/member_support/score/999_Nobody/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+    )
+    assert resp.status_code == 404
+
+
+def test_approve_fallback_without_any_evaluator_is_422(client, monkeypatch):
+    """Restored draft has no evaluator identity and the payload sends none:
+    422 rather than approving as nobody ('' would pass the NOT-NULL CHECK)."""
+    approvals: list[dict] = []
+    _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(monkeypatch, _eval_ref(evaluator_email=None))
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+    )
+    assert resp.status_code == 422
+    assert "evaluator_email" in resp.json()["detail"]
+    assert approvals == []
+    # Job stays approvable after the rejection.
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio"
+    )
+    assert scoring_module._jobs[key]["status"] == "complete"
+
+
+def test_approve_fallback_row_evaluator_backfills_payload(client, monkeypatch):
+    """No payload evaluator, but the row carries one (e.g. re-approving a
+    draft that had an evaluator stamped) — the row identity is used."""
+    approvals: list[dict] = []
+    _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(evaluator_email="lead@landing.com", scoring_status="complete"),
+    )
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert approvals[0]["evaluator_email"] == "lead@landing.com"
+    assert approvals[0]["resolving_review"] is False
+
+
+# ---------------------------------------------------------------------------
+# S3 — DELETE /score/{job_id} (ScorecardActionsDesign §4.4)
+# ---------------------------------------------------------------------------
+
+from contextlib import asynccontextmanager  # noqa: E402
+
+
+class _FakeDeleteConn:
+    def __init__(self, coachings=(), eval_row=None, sections=(), point=None):
+        self.coachings = list(coachings)
+        self.eval_row = eval_row
+        self.sections = list(sections)
+        self.point = point
+        self.deletes: list[tuple[str, tuple]] = []
+        self.in_transaction_deletes: list[str] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+    async def fetch(self, query, *args):
+        if "coaching_evaluations" in query:
+            return self.coachings
+        if "evaluation_sections" in query:
+            return self.sections
+        raise AssertionError(f"unexpected fetch: {query}")
+
+    async def fetchrow(self, query, *args):
+        if "FROM qa.evaluations" in query:
+            return self.eval_row
+        if "agent_stat_points" in query:
+            return self.point
+        raise AssertionError(f"unexpected fetchrow: {query}")
+
+    async def execute(self, query, *args):
+        assert query.startswith("DELETE")
+        self.deletes.append((query, args))
+        return "DELETE 1"
+
+
+class _FakeDeletePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+def _wire_delete(monkeypatch, ref, conn):
+    async def fake_resolve(team_id, job_id):
+        return ref
+    monkeypatch.setattr(scoring_module.eval_store, "resolve_evaluation", fake_resolve)
+
+    async def fake_pool():
+        return _FakeDeletePool(conn)
+    monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
+
+    rebuilds: list[int] = []
+
+    async def fake_rebuild(c, agent_id, config):
+        rebuilds.append(agent_id)
+        return 3
+    monkeypatch.setattr(scoring_module, "rebuild_agent_series", fake_rebuild)
+
+    tombstones: list[str] = []
+
+    async def fake_tombstone(link, config):
+        tombstones.append(link)
+        return 42
+    monkeypatch.setattr(scoring_module, "tombstone_evaluation", fake_tombstone)
+    return rebuilds, tombstones
+
+
+def test_delete_requires_privileged_key(client, monkeypatch):
+    resolve_calls = []
+
+    async def fake_resolve(team_id, job_id):
+        resolve_calls.append(job_id)
+        return None
+    monkeypatch.setattr(scoring_module.eval_store, "resolve_evaluation", fake_resolve)
+
+    resp = client.delete(
+        "/api/member_support/score/5035229460504576_Luis_Rubio",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+    )
+    assert resp.status_code == 403
+    assert resolve_calls == []  # denied before touching the DB
+    denied = [r for r in client.audit_rows if r["action"] == "denied"]
+    assert len(denied) == 1
+    assert denied[0]["notes"] == "delete_requires_privileged_key"
+    assert denied[0]["call_id"] == "5035229460504576"
+    assert denied[0]["api_key_role"] == "team"
+
+
+def test_delete_unknown_eval_404(client, monkeypatch):
+    async def fake_resolve(team_id, job_id):
+        return None
+    monkeypatch.setattr(scoring_module.eval_store, "resolve_evaluation", fake_resolve)
+    resp = client.delete(
+        "/api/member_support/score/999_Nobody",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_refuses_when_coaching_rows_exist(client, monkeypatch):
+    conn = _FakeDeleteConn(coachings=[{"coaching_id": 9, "linked_at": None}])
+    _wire_delete(monkeypatch, _eval_ref(state="finalized"), conn)
+
+    resp = client.delete(
+        "/api/member_support/score/5035229460504576_Luis_Rubio",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["coaching_ids"] == [9]
+    assert conn.deletes == []  # nothing touched
+
+
+def test_delete_happy_path(client, monkeypatch):
+    eval_row = {
+        "id": 2377, "agent_id": 7, "team_id": "member_support",
+        "overall_score": 0.0, "dialpad_link": "https://dialpad.test/call/X",
+    }
+    point = {"id": 1404, "evaluation_id": 2377, "ewma": 43.6}
+    conn = _FakeDeleteConn(
+        eval_row=eval_row,
+        sections=[{"section_id": "greeting", "numeric_score": 5}],
+        point=point,
+    )
+    ref = _eval_ref(state="finalized", overall_score=0.0)
+    rebuilds, tombstones = _wire_delete(monkeypatch, ref, conn)
+
+    # Pre-seed a cached job to verify eviction.
+    key = scoring_module._job_key("member_support", "5035229460504576_Luis_Rubio")
+    scoring_module._jobs[key] = {"status": "complete"}
+
+    resp = client.delete(
+        "/api/member_support/score/5035229460504576_Luis_Rubio",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "deleted"
+    assert body["evaluation_id"] == 2377
+    assert body["tombstoned_history_row"] == 42
+    # Snapshot is the caller's backup.
+    assert body["snapshot"]["evaluation"]["id"] == 2377
+    assert body["snapshot"]["sections"][0]["section_id"] == "greeting"
+    assert body["snapshot"]["stat_point"]["id"] == 1404
+
+    # Delete order: stat point first (NO ACTION FK), then the eval row.
+    assert "agent_stat_points" in conn.deletes[0][0]
+    assert "FROM qa.evaluations" in conn.deletes[1][0]
+    assert rebuilds == [7]
+    assert tombstones == [ref.dialpad_link]
+
+    orphaned = [r for r in client.audit_rows if r["action"] == "evaluation_orphaned"]
+    assert len(orphaned) == 1
+    assert orphaned[0]["result_row"] == 42
+    assert "old_score=0.0" in orphaned[0]["notes"]
+    assert orphaned[0]["agent_name"] == "Luis Rubio"
+
+    assert key not in scoring_module._jobs  # ghost evicted
+
+
+def test_delete_skips_rebuild_for_agentless_eval(client, monkeypatch):
+    """agent_id NULL (departed agent, no stat point) — delete proceeds,
+    no series rebuild."""
+    conn = _FakeDeleteConn(
+        eval_row={"id": 5, "agent_id": None, "dialpad_link": ""},
+        sections=[], point=None,
+    )
+    rebuilds, _ = _wire_delete(monkeypatch, _eval_ref(id=5), conn)
+
+    resp = client.delete(
+        "/api/member_support/score/5035229460504576_Luis_Rubio",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert rebuilds == []
+    assert resp.json()["snapshot"]["stat_point"] is None

--- a/qa-automation/AI-Scoring/tests/test_sheets_projection.py
+++ b/qa-automation/AI-Scoring/tests/test_sheets_projection.py
@@ -157,3 +157,63 @@ class TestOverallRendering:
     ])
     def test_render_overall(self, value, expected):
         assert _render_overall(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# tombstone_evaluation — ScorecardActionsDesign §4.4.6 (slice S3)
+# ---------------------------------------------------------------------------
+
+from backend.services import sheets_projection as sp_module  # noqa: E402
+from backend.services.sheets_projection import tombstone_evaluation  # noqa: E402
+
+
+class _FakeSheet:
+    def __init__(self):
+        self.updates: list[tuple] = []
+
+    def update(self, rng, values, value_input_option=None):
+        self.updates.append((rng, values, value_input_option))
+
+
+@pytest.mark.asyncio
+class TestTombstoneEvaluation:
+
+    @pytest.fixture(autouse=True)
+    def _stub_sheets(self, monkeypatch):
+        self.sheet = _FakeSheet()
+        self.found_row = 42
+        monkeypatch.setattr(sp_module, "_sheets_configured", lambda team_id: True)
+        monkeypatch.setattr(sp_module, "_get_sheet", lambda config, tab: self.sheet)
+        monkeypatch.setattr(
+            sp_module, "_find_row_by_dialpad_link",
+            lambda sheet, link: self.found_row,
+        )
+
+    async def test_blanks_full_layout_width(self, ms_config):
+        row = await tombstone_evaluation("https://dialpad.test/call/DP123", ms_config)
+        assert row == 42
+        assert len(self.sheet.updates) == 1
+        rng, values, _ = self.sheet.updates[0]
+        width = ms_config.history_layout.total_width
+        end = history_layout.col_index_to_letter(width - 1)
+        assert rng == f"A42:{end}42"
+        assert values == [[""] * width]
+
+    async def test_empty_link_is_noop(self, ms_config):
+        assert await tombstone_evaluation("", ms_config) is None
+        assert self.sheet.updates == []
+
+    async def test_missing_row_is_noop(self, ms_config):
+        self.found_row = None
+        assert await tombstone_evaluation("https://x/1", ms_config) is None
+        assert self.sheet.updates == []
+
+    async def test_unconfigured_sheets_is_noop(self, ms_config, monkeypatch):
+        monkeypatch.setattr(sp_module, "_sheets_configured", lambda team_id: False)
+        assert await tombstone_evaluation("https://x/1", ms_config) is None
+
+    async def test_sheet_error_swallowed_returns_none(self, ms_config, monkeypatch):
+        def boom(sheet, link):
+            raise RuntimeError("gspread down")
+        monkeypatch.setattr(sp_module, "_find_row_by_dialpad_link", boom)
+        assert await tombstone_evaluation("https://x/1", ms_config) is None

--- a/qa-automation/AI-Scoring/tests/test_stat_points_rebuild.py
+++ b/qa-automation/AI-Scoring/tests/test_stat_points_rebuild.py
@@ -1,0 +1,132 @@
+"""rebuild_agent_series — ScorecardActionsDesign §5 (slice S2).
+
+The action-time rebuild (rescore / override / delete) and the F1 replay
+CLI share `build_series`, so parity with scripts/backfill_stat_points.py
+is structural. What these tests pin is the rebuild's DB contract: fetch
+order, delete-before-insert, write fidelity, the mid-chain invalidation
+the manual 2026-07-24 delete couldn't handle, and the fatal-by-contract
+error path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.services.stat_points import (
+    COVERAGE_REGIME,
+    build_series,
+    rebuild_agent_series,
+)
+
+
+def _config(span=5, k=2.0):
+    return SimpleNamespace(
+        stats=SimpleNamespace(ewma_span=span, spc_sigma_multiplier=k)
+    )
+
+
+def _evals(scores):
+    return [
+        {"id": i, "team_id": "member_support", "overall_score": s}
+        for i, s in enumerate(scores, start=1)
+    ]
+
+
+class FakeConn:
+    """Captures the rebuild's operation order and INSERT payloads."""
+
+    def __init__(self, evals, fail_on_insert=False):
+        self.evals = evals
+        self.fail_on_insert = fail_on_insert
+        self.ops: list[str] = []
+        self.inserts: list[tuple] = []
+
+    async def fetch(self, query, *args):
+        self.ops.append("fetch")
+        assert "state = 'finalized'" in query
+        assert "ORDER BY approved_at, id" in query
+        return self.evals
+
+    async def execute(self, query, *args):
+        if query.startswith("DELETE"):
+            self.ops.append("delete")
+            return "DELETE 3"
+        assert query.startswith("INSERT INTO qa.agent_stat_points")
+        if self.fail_on_insert:
+            raise RuntimeError("boom")
+        self.ops.append("insert")
+        self.inserts.append(args)
+        return "INSERT 0 1"
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_rebuild_writes_full_series_delete_first():
+    scores = [80.0, 92.0, 75.0, 88.0]
+    conn = FakeConn(_evals(scores))
+    written = await rebuild_agent_series(conn, agent_id=7, config=_config())
+
+    assert written == 4
+    assert conn.ops == ["fetch", "delete", "insert", "insert", "insert", "insert"]
+
+    expected = build_series(_evals(scores), span=5, sigma_multiplier=2.0)
+    for args, exp in zip(conn.inserts, expected):
+        team_id, agent_id, evaluation_id, score, ewma, lam, mean, sigma, flags, regime = args
+        assert (team_id, agent_id) == ("member_support", 7)
+        assert evaluation_id == exp["evaluation_id"]
+        assert score == exp["score"]
+        assert ewma == exp["point"].ewma
+        assert lam == exp["point"].ewma_lambda
+        assert mean == exp["point"].spc_mean
+        assert sigma == exp["point"].spc_sigma
+        assert flags == exp["point"].spc_flags
+        assert regime == COVERAGE_REGIME
+
+
+async def test_mid_chain_removal_recomputes_downstream():
+    """The 2026-07-24 manual delete got lucky (latest point). The rebuild
+    must handle the unlucky case: removing a mid-chain eval changes every
+    downstream EWMA/σ and re-judges flags against the new control limits."""
+    full_scores = [85.0, 86.0, 84.0, 85.0, 40.0]
+    full = build_series(_evals(full_scores), span=5, sigma_multiplier=2.0)
+    # The 40.0 crash is flagged in the intact series (pinned in
+    # test_stat_points); removing eval 2 (86.0) must not change that
+    # verdict but must shift the whole chain's values.
+    assert full[4]["point"].spc_flags == ["below_lcl"]
+
+    remaining = [
+        {"id": i, "team_id": "member_support", "overall_score": s}
+        for i, s in [(1, 85.0), (3, 84.0), (4, 85.0), (5, 40.0)]
+    ]
+    conn = FakeConn(remaining)
+    written = await rebuild_agent_series(conn, agent_id=7, config=_config())
+
+    assert written == 4
+    rebuilt = build_series(remaining, span=5, sigma_multiplier=2.0)
+    # Downstream of the removal, the chain genuinely differs from the
+    # original series' corresponding points...
+    assert rebuilt[1]["point"].ewma != full[2]["point"].ewma
+    assert rebuilt[3]["point"].spc_mean != full[4]["point"].spc_mean
+    # ...and what lands in the DB is exactly the recomputed chain.
+    assert [a[4] for a in conn.inserts] == [r["point"].ewma for r in rebuilt]
+    assert conn.inserts[3][8] == rebuilt[3]["point"].spc_flags
+
+
+async def test_empty_history_still_clears_stale_points():
+    """An agent whose last finalized eval was deleted keeps zero points —
+    the DELETE must run even when there is nothing to re-insert."""
+    conn = FakeConn([])
+    written = await rebuild_agent_series(conn, agent_id=7, config=_config())
+    assert written == 0
+    assert conn.ops == ["fetch", "delete"]
+
+
+async def test_rebuild_is_fatal_by_contract():
+    """Unlike write_point_for_finalize (non-fatal), a rebuild failure must
+    propagate so the caller's surrounding transaction rolls back."""
+    conn = FakeConn(_evals([80.0, 90.0]), fail_on_insert=True)
+    with pytest.raises(RuntimeError, match="boom"):
+        await rebuild_agent_series(conn, agent_id=7, config=_config())


### PR DESCRIPTION
Lands the first three slices of **ScorecardActionsDesign v1.2** (design doc included in this PR at `qa-automation/AI-Scoring/references/ScorecardActionsDesign.md`) — the doctrine: zero-touch auto-pipeline is the authority; every manual doorway is designed, auditable tampering with a double receipt.

## S1 — DB-backed action resolution (§3)
- `eval_store.resolve_evaluation(team_id, job_id)` resolves action targets from Postgres instead of the process-lifetime `_jobs` dict. Probes **both** `dialpad_entry_point_call_id` and `dialpad_call_id` (the 2026-07-24 incident guarantee — do not simplify to one column), and reshapes DB sections back into the Stage-1 draft-dump form the approval diff expects.
- The approve path adopts the seam as fallback: a `_jobs` miss (server restart, old scorecard URL) reconstructs the approval context from the DB row instead of 404ing. Finalized rows keep the 409 read-only wall — edit-of-finalized is S6.
- `ApprovalRequest.evaluator_email` (optional): payload evaluator → job's manager → row's evaluator; all empty → 422, because `""` would satisfy the NOT-NULL approval CHECK while recording nobody.
- Every mutating route carries the §2 concurrency docstring (last-writer-wins deliberately, upgrade path recorded).

## S2 — stat-series rebuild primitive (§5)
- `build_series` moves from `scripts/backfill_stat_points.py` into `backend/services/stat_points.py`; the CLI becomes a thin wrapper — **parity by construction, not by test**.
- `rebuild_agent_series(conn, agent_id, config)` replays finalized history in `approved_at, id` order inside the caller's transaction. **Fatal by contract**: a failed rebuild rolls the whole action back (unlike the non-fatal finalize-time write) — a silently corrupt EWMA chain is worse than a loud failure.

## S3 — migration 018 + delete route (§4.4)
- Migration 018 (+ down): audit action vocabulary gains `rescored` / `overridden` on both audit tables, and `qa.evaluations.auto_rescored_at` — the once-EVER auto-rescore latch for S5.
- `DELETE /score/{job_id}`: privileged key only (403 **+ denied audit row** for team keys); 409 listing coaching ids when `coaching_evaluations` links exist (coachings are the human-side tampering ledger — never cascaded); stat point deleted before the row (NO ACTION FK), sections/tags/sweeps cascade; agent series rebuilt in the same transaction; full JSON snapshot (row + sections + stat point) returned as the caller's backup — `eval_2377_backup.json`, formalized.
- `tombstone_evaluation` blanks the projected Analyst_History row (Sheets is a projection; a surviving row for a deleted eval is drift). Sheets failures log-and-return like `project_evaluation`; the audit row records the delete either way.
- `action='evaluation_orphaned'` — reserved since the schema landed, finally written by code instead of raw SQL.

## Tests
`1002 passed, 6 skipped, 3 xfailed` — new coverage: `test_eval_resolve.py` (job-id parsing, dual-column probe, section reshaping, NA/codec edge cases), `test_stat_points_rebuild.py` (delete-first order, mid-chain removal recompute, empty-history clear, fatal contract), S1 restart-simulation + evaluator fallback chain and S3 auth/409/happy-path/agentless suites in `test_scoring_route.py`, tombstone suite in `test_sheets_projection.py`.

## Deploy notes
- **Migration 018 is already applied to the live DB** (2026-07-25). Nothing in S1–S3 strictly requires it at runtime (audit rows still go through the sheet-side ledger; `auto_rescored_at` is read only from S5 on), so code and schema are free to deploy in either order.
- `database/` is outside the Railway watch paths; the `qa-automation/AI-Scoring/` changes will trigger the deploy normally.

Next: S4 (manual rescore) → S5 (auto rescore + HR mode flag) → S6 (override + acknowledgment protocol) → S7 (datapoint edit surface + UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
