### PR TITLE
P2 — Stage-A annotator + annotate_only mode; Claude leg live-verified

### DIFF
--- a/qa-automation/AI-Scoring/.gitignore
+++ b/qa-automation/AI-Scoring/.gitignore
@@ -36,3 +36,5 @@ appsscript.json
 # trail for the backfill script. Never commit; rerun locally per team.
 .backfill-log
 .backfill-skipped.csv
+# Stage-A annotation smoke outputs — verbatim caller speech (PII), never commit
+scripts/annotations/

--- a/qa-automation/AI-Scoring/backend/models/formula.py
+++ b/qa-automation/AI-Scoring/backend/models/formula.py
@@ -708,16 +708,37 @@ class TranscriptTurn(BaseModel):
     end_ms: Optional[int] = None
 
 
-class AnnotatedTranscript(BaseModel):
-    """qa.evaluations.annotated_transcript JSONB — §8.2 shape.
+class HoldSegment(BaseModel):
+    """One OBSERVATIONAL hold heard in the audio — Stage-A output
+    (TwoStageScoringDesign §3.1). Never a verified system fact: verified
+    hold durations come from command_center.hold_times via the grounding
+    block, gated by has_hold_truth. Prompts must word these as
+    observations ("audio suggests a hold of ~63s"), never assertions."""
+    model_config = ConfigDict(extra="forbid")
+    start_ms: int
+    end_ms: int
+    kind: Literal["hold_music", "dead_air", "mute_suspected"]
+    note: Optional[str] = None
 
-    NULL for Gemini-scored evaluations (pre-LandGPT / Plan-B-only routes).
-    Always populated when models_used.audio.provider == 'landgpt'.
+
+class AnnotatedTranscript(BaseModel):
+    """qa.evaluations.annotated_transcript JSONB — §8.2 shape, extended
+    additively by TwoStageScoringDesign §3 (schema_version exists exactly
+    so variants can do this):
+
+    - ``qwen2_audio_v1``      — the original LandGPT shape (turns only)
+    - ``gemini_annotate_v1``  — the cloud Stage-A annotator; adds
+      ``holds`` (observational) + ``call_observations`` (call-level)
+
+    NULL for evaluations scored without an annotation stage (single-stage
+    Gemini / Plan-B fallback routes).
     """
     model_config = ConfigDict(extra="forbid")
     schema_version: str
     language_detected: Optional[str] = None
     turns: list[TranscriptTurn]
+    holds: list[HoldSegment] = Field(default_factory=list)
+    call_observations: list[str] = Field(default_factory=list)
 
 
 class RecordingUrls(BaseModel):

--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -142,3 +142,9 @@ class ScorecardWithMeta(Scorecard):
     # [{id, title, score, score_kind, updated_at, open_flags}, ...].
     # Stamped in shadow AND on modes; [] when retrieval was off/skipped.
     pulpo_docs: List[dict] = []
+    # TwoStageScoringDesign §3 — the Stage-A artifact (AnnotatedTranscript
+    # dump, schema gemini_annotate_v1) + the model that produced it, for
+    # the models_used audio-leg stamp. None when SCORING_PIPELINE=single
+    # or annotation failed (annotation is never a scoring blocker).
+    annotated_transcript: Optional[dict] = None
+    annotator_model: Optional[str] = None

--- a/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
@@ -67,7 +67,8 @@ exact shape (schema_version "{schema_version}"):
   up beyond removing filler stutters.
 - "holds" are what you HEAR (music, dead air, suspected mute) — you are
   an observer, not a system of record. Include an entry for any gap over
-  ~10 seconds.
+  ~10 seconds. Do NOT record gaps shorter than 10 seconds — brief pauses
+  are normal conversation, not holds.
 - Timestamps are milliseconds from the start of the recording; best
   effort, never omitted.
 - Mark "interruption": true only for genuine cut-offs, not backchannel

--- a/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
@@ -17,6 +17,58 @@ import json
 
 _SCHEMA_VERSION = "gemini_annotate_v1"
 
+# Gemini response_schema for constrained decoding — hand-authored because
+# the API speaks an OpenAPI subset that rejects pydantic's
+# additionalProperties:false (400 INVALID_ARGUMENT, observed 2026-07-27).
+# Pydantic still validates the parsed result on our side, so the
+# extra="forbid" contract holds; a test pins this dict to the model
+# fields so the two can't drift.
+ANNOTATOR_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "schema_version": {"type": "string"},
+        "language_detected": {"type": "string"},
+        "turns": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "speaker": {
+                        "type": "string",
+                        "enum": ["agent", "caller", "system", "other"],
+                    },
+                    "text": {"type": "string"},
+                    "emotion": {"type": "string"},
+                    "paraphrase_intent": {"type": "string"},
+                    "pace_marker": {"type": "string"},
+                    "interruption": {"type": "boolean"},
+                    "start_ms": {"type": "integer"},
+                    "end_ms": {"type": "integer"},
+                },
+                "required": ["speaker", "text"],
+            },
+        },
+        "holds": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "start_ms": {"type": "integer"},
+                    "end_ms": {"type": "integer"},
+                    "kind": {
+                        "type": "string",
+                        "enum": ["hold_music", "dead_air", "mute_suspected"],
+                    },
+                    "note": {"type": "string"},
+                },
+                "required": ["start_ms", "end_ms", "kind"],
+            },
+        },
+        "call_observations": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["schema_version", "turns"],
+}
+
 _ANNOTATOR_SYSTEM = """You are an audio-as-data interpreter for a QA \
 pipeline at Landing, a flexible-living company. You listen to member \
 support / sales calls and produce a structured ANNOTATED TRANSCRIPT. \

--- a/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
@@ -117,6 +117,10 @@ exact shape (schema_version "{schema_version}"):
   turns to English), and be extra thorough with emotion/pace annotations.
 - "turns.text" is verbatim speech. Do not summarize, censor, or clean it
   up beyond removing filler stutters.
+- COLLAPSE filler and stutter runs: "uh uh uh...", "eh eh eh", repeated
+  false starts — transcribe AT MOST one or two instances, never the full
+  run. Prolonged stuttering or hesitation belongs in that turn's
+  pace_marker or in call_observations, not spelled out token by token.
 - "holds" are what you HEAR (music, dead air, suspected mute) — you are
   an observer, not a system of record. Include an entry for any gap over
   ~10 seconds. Do NOT record gaps shorter than 10 seconds — brief pauses

--- a/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/annotator_prompt.py
@@ -1,0 +1,107 @@
+"""Stage-A annotator prompt — TwoStageScoringDesign §3.
+
+The annotator does NOT score. Its one job: turn the audio into the
+annotated transcript (`gemini_annotate_v1`) that Stage B judges from —
+capturing everything a text-only judge would otherwise lose (tone,
+emotion, interruptions, pacing, holds).
+
+Audio-is-SOT survives the split HERE: the annotation is the SOT-carrier
+(§3.2), so this prompt owns the v2.1 language rule — for non-English
+calls the annotator re-transcribes from audio and treats the Dialpad
+transcript as unreliable.
+"""
+
+from __future__ import annotations
+
+import json
+
+_SCHEMA_VERSION = "gemini_annotate_v1"
+
+_ANNOTATOR_SYSTEM = """You are an audio-as-data interpreter for a QA \
+pipeline at Landing, a flexible-living company. You listen to member \
+support / sales calls and produce a structured ANNOTATED TRANSCRIPT. \
+You never score, judge, or coach — a separate evaluator does that using \
+ONLY your annotation. Anything you fail to capture from the audio is \
+lost to the evaluator, so be faithful and complete."""
+
+_ANNOTATOR_INSTRUCTIONS = """\
+=== YOUR TASK ===
+Listen to the attached call audio and produce ONE JSON object with this
+exact shape (schema_version "{schema_version}"):
+
+{{
+  "schema_version": "{schema_version}",
+  "language_detected": "<primary spoken language, ISO 639-1, e.g. "en"/"es">",
+  "turns": [
+    {{
+      "speaker": "agent" | "caller" | "system" | "other",
+      "text": "<what was actually said — from the AUDIO>",
+      "emotion": "<speaker's tone, e.g. neutral_friendly, frustrated, warm, flat, anxious>",
+      "paraphrase_intent": "<one short phrase: what this turn is doing, e.g. 'greeting + identity verification'>",
+      "pace_marker": "slow" | "normal" | "rushed",
+      "interruption": <true when this turn cuts the other speaker off>,
+      "start_ms": <int>, "end_ms": <int>
+    }}, ...
+  ],
+  "holds": [
+    {{ "start_ms": <int>, "end_ms": <int>,
+       "kind": "hold_music" | "dead_air" | "mute_suspected",
+       "note": "<context, e.g. 'agent announced the hold before placing it'>" }}
+  ],
+  "call_observations": [
+    "<call-level observations a per-turn field can't carry: background noise,
+     audio quality problems, overall tone arcs, long silences not worth a
+     hold entry, notable divergences from the reference transcript>"
+  ]
+}}
+
+=== RULES ===
+- THE AUDIO IS THE SOURCE OF TRUTH. The reference transcript below is a
+  hint from an automatic transcriber; where it disagrees with what you
+  hear, trust your ears and note material divergences in
+  call_observations.
+- If the call is NOT in English: the reference transcript is unreliable.
+  Re-transcribe from the audio in the spoken language (do NOT translate
+  turns to English), and be extra thorough with emotion/pace annotations.
+- "turns.text" is verbatim speech. Do not summarize, censor, or clean it
+  up beyond removing filler stutters.
+- "holds" are what you HEAR (music, dead air, suspected mute) — you are
+  an observer, not a system of record. Include an entry for any gap over
+  ~10 seconds.
+- Timestamps are milliseconds from the start of the recording; best
+  effort, never omitted.
+- Mark "interruption": true only for genuine cut-offs, not backchannel
+  ("mm-hm", "right").
+- Output the JSON object ONLY — no markdown fences, no commentary.
+"""
+
+
+def build_annotator_system_prompt() -> str:
+    return _ANNOTATOR_SYSTEM
+
+
+def build_annotator_prompt(
+    transcript_text: str,
+    moments_display: list[dict] | None = None,
+) -> str:
+    """Render the user-side annotator prompt.
+
+    *transcript_text* is Dialpad's transcript — a HINT, explicitly
+    subordinated to the audio. *moments_display* is the full Dialpad
+    marker set (C0: filtering is a prompt decision — the annotator gets
+    everything and treats markers as hints too)."""
+    parts = [_ANNOTATOR_INSTRUCTIONS.format(schema_version=_SCHEMA_VERSION)]
+
+    if moments_display:
+        parts.append(
+            "=== DIALPAD SIGNAL MARKERS (hints, machine-detected) ===\n"
+            + json.dumps(moments_display, indent=2)
+        )
+
+    if transcript_text.strip():
+        parts.append(
+            "=== REFERENCE TRANSCRIPT (hint — the audio overrules it) ===\n"
+            + transcript_text.strip()
+        )
+
+    return "\n\n".join(parts)

--- a/qa-automation/AI-Scoring/backend/services/annotation_render.py
+++ b/qa-automation/AI-Scoring/backend/services/annotation_render.py
@@ -1,0 +1,64 @@
+"""AnnotatedTranscript → readable text — TwoStageScoringDesign §4.
+
+Pure function: renders the Stage-A artifact into the lines the Stage-B
+judge (and the smoke script's human reviewers) read. Holds are
+interleaved into the turn stream by start time and ALWAYS carry the
+"observational" label — the §3.1 wording rule is enforced here, at the
+render boundary, so no prompt can accidentally present a heard hold as
+a verified system fact.
+"""
+
+from __future__ import annotations
+
+from backend.models.formula import AnnotatedTranscript, HoldSegment, TranscriptTurn
+
+
+def _mmss(ms: int | None) -> str:
+    if ms is None:
+        return "--:--"
+    total = max(0, int(ms)) // 1000
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _render_turn(turn: TranscriptTurn) -> str:
+    traits = ", ".join(
+        t for t in (turn.emotion, turn.pace_marker) if t
+    )
+    marks = " [interrupts]" if turn.interruption else ""
+    intent = f" ({turn.paraphrase_intent})" if turn.paraphrase_intent else ""
+    head = f"[{_mmss(turn.start_ms)} {turn.speaker}"
+    if traits:
+        head += f" | {traits}"
+    return f"{head}]{marks}{intent} \"{turn.text}\""
+
+
+def _render_hold(hold: HoldSegment) -> str:
+    seconds = max(0, hold.end_ms - hold.start_ms) // 1000
+    note = f" — {hold.note}" if hold.note else ""
+    return (
+        f"[{_mmss(hold.start_ms)}→{_mmss(hold.end_ms)} HOLD ~{seconds}s "
+        f"({hold.kind}, observational — not system-verified)]{note}"
+    )
+
+
+def render_annotated_transcript(annotation: AnnotatedTranscript) -> str:
+    """Turns + holds interleaved by start time, call observations last."""
+    events: list[tuple[int, int, str]] = []
+    # Sort key: (start_ms, tiebreak) — holds sort ahead of a turn starting
+    # at the same instant, mirroring how the listener experiences them.
+    for turn in annotation.turns:
+        events.append((turn.start_ms or 0, 1, _render_turn(turn)))
+    for hold in annotation.holds:
+        events.append((hold.start_ms, 0, _render_hold(hold)))
+    events.sort(key=lambda e: (e[0], e[1]))
+
+    lines = [
+        f"Language detected: {annotation.language_detected or 'unknown'} "
+        f"(annotation schema {annotation.schema_version})",
+        "",
+        *[text for _, _, text in events],
+    ]
+    if annotation.call_observations:
+        lines += ["", "CALL-LEVEL OBSERVATIONS:"]
+        lines += [f"- {obs}" for obs in annotation.call_observations]
+    return "\n".join(lines)

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -1,4 +1,10 @@
-"""Gemini audio upload and scoring."""
+"""Gemini audio upload, scoring, and Stage-A annotation.
+
+This module is the Gemini-native AUDIO leg: single-stage scoring
+(`score_audio`, today's pipeline and the two-stage Plan-B fallback) and
+the Stage-A annotator (`annotate_audio`, TwoStageScoringDesign §3) both
+live here — the only google-genai importers besides llm/gemini.py.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +13,17 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from google import genai
 from google.genai import types
 
+from backend.prompts.annotator_prompt import (
+    build_annotator_prompt,
+    build_annotator_system_prompt,
+)
 from backend.prompts.qa_scoring_prompt import build_prompt, build_system_prompt
+from backend.models.formula import AnnotatedTranscript
 from backend.models.scorecard import Scorecard
 
 if TYPE_CHECKING:
@@ -127,3 +138,71 @@ async def score_audio(
             client.files.delete(name=uploaded.name)
         except Exception:
             pass
+
+
+DEFAULT_ANNOTATOR_MODEL = "gemini-2.5-flash"
+
+
+def annotator_model() -> str:
+    """Stage-A model — env-tunable for the flash-vs-pro trial
+    (TwoStageScoringDesign §10.4); team-JSON knob lands with P4."""
+    return os.environ.get("ANNOTATOR_MODEL", "").strip() or DEFAULT_ANNOTATOR_MODEL
+
+
+async def annotate_audio(
+    audio_bytes: bytes,
+    filename: str,
+    transcript_text: str = "",
+    moments_display: Optional[list[dict]] = None,
+    model: Optional[str] = None,
+) -> AnnotatedTranscript:
+    """Stage A: upload audio to Gemini and produce the annotated
+    transcript (`gemini_annotate_v1`) — the artifact Stage B judges from.
+
+    No rubric, no SOP, no grounding: the annotator observes, it never
+    scores. Raises on failure — the CALLER decides fallback semantics
+    (scoring_service treats annotation as an enhancement, never a
+    scoring blocker)."""
+    client = _get_client()
+    mime_type = _get_mime_type(filename)
+
+    with tempfile.NamedTemporaryFile(suffix=Path(filename).suffix, delete=False) as tmp:
+        tmp.write(audio_bytes)
+        tmp_path = tmp.name
+
+    uploaded = None
+    try:
+        uploaded = client.files.upload(
+            file=tmp_path,
+            config=types.UploadFileConfig(mime_type=mime_type, display_name=filename),
+        )
+        prompt = build_annotator_prompt(
+            transcript_text=transcript_text,
+            moments_display=moments_display,
+        )
+        response = await client.aio.models.generate_content(
+            model=model or annotator_model(),
+            contents=[
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part.from_uri(file_uri=uploaded.uri, mime_type=mime_type),
+                        types.Part.from_text(text=prompt),
+                    ],
+                )
+            ],
+            config=types.GenerateContentConfig(
+                system_instruction=build_annotator_system_prompt(),
+                # Annotation wants fidelity, not creativity.
+                temperature=0.0,
+                max_output_tokens=65_536,
+            ),
+        )
+        return AnnotatedTranscript.model_validate(_extract_json(response.text))
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+        if uploaded is not None:
+            try:
+                client.files.delete(name=uploaded.name)
+            except Exception:
+                pass

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -183,6 +183,33 @@ def annotator_model() -> str:
     return os.environ.get("ANNOTATOR_MODEL", "").strip() or DEFAULT_ANNOTATOR_MODEL
 
 
+# Thinking spends from max_output_tokens on gemini-2.5 models, and the
+# annotator's budget belongs to the TRANSCRIPT: a Spanish call was
+# observed burning 62,911 thought tokens of the 65,536 cap, leaving
+# ~2.6k for JSON → MAX_TOKENS truncation on every attempt. Annotation
+# is perception-shaped work — a small budget suffices. Nonzero so
+# pro-tier models (which reject 0) stay usable in the trial.
+DEFAULT_ANNOTATOR_THINKING_BUDGET = 4096
+
+# Anti-loop doctrine: a 6.4-min call was observed emitting 24 clean
+# turns and then 184KB of "uh uh uh…" inside one text field —
+# constrained decoding guarantees syntax, not termination, and low-temp
+# verbatim transcription of a stuttering stretch can loop. Gemini
+# rejects frequency_penalty on 2.5-flash ("Penalty is not enabled"), so
+# the guards are: the prompt's stutter-collapse rule, the bumped-temp
+# retry, and — last resort — _salvage_truncated_annotation, which cuts
+# a MAX_TOKENS response back to its last complete turn (the loop always
+# lives in the incomplete tail, so salvage structurally discards it).
+
+
+def annotator_thinking_budget() -> int:
+    raw = os.environ.get("ANNOTATOR_THINKING_BUDGET", "").strip()
+    try:
+        return int(raw) if raw else DEFAULT_ANNOTATOR_THINKING_BUDGET
+    except ValueError:
+        return DEFAULT_ANNOTATOR_THINKING_BUDGET
+
+
 # Attempt temperatures: 0.0 for fidelity, then a small bump. Gemini's
 # near-deterministic decoding at temp 0 can re-serve the SAME degenerate
 # sample on retry (observed 2026-07-27 on a bilingual call: two runs,
@@ -190,8 +217,67 @@ def annotator_model() -> str:
 _ANNOTATE_ATTEMPT_TEMPS = (0.0, 0.2)
 
 
+def _salvage_truncated_annotation(text: str) -> Optional[AnnotatedTranscript]:
+    """Repair a MAX_TOKENS-truncated annotation to its last complete turn.
+
+    Walks the JSON tracking string/escape state and the container stack;
+    the last position where the stack returns to depth ≤ 2 (i.e. a
+    complete element inside a top-level array, or a complete top-level
+    field) is the cut point, and the remaining stack is closed in
+    reverse. Returns None when nothing usable survives — the caller
+    raises and the pipeline falls back to single-stage scoring.
+
+    A repetition loop always lives in the INCOMPLETE tail (that's what
+    consumed the budget), so a successful salvage structurally discards
+    it. The truncation is stamped into call_observations so Stage B and
+    human reviewers know the artifact is partial.
+    """
+    in_str = False
+    esc = False
+    stack: list[str] = []
+    last_safe: Optional[tuple[int, tuple[str, ...]]] = None
+    for i, ch in enumerate(text):
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if not stack:
+                return None    # malformed beyond salvage
+            stack.pop()
+            if len(stack) <= 2:
+                last_safe = (i + 1, tuple(stack))
+    if last_safe is None:
+        return None
+    cut, snapshot = last_safe
+    closers = "".join("}" if c == "{" else "]" for c in reversed(snapshot))
+    try:
+        annotation = AnnotatedTranscript.model_validate(
+            json.loads(text[:cut] + closers)
+        )
+    except Exception:  # noqa: BLE001 — salvage is best-effort by definition
+        return None
+    if not annotation.turns:
+        return None
+    annotation.call_observations.append(
+        f"ANNOTATION TRUNCATED: the output budget was exhausted "
+        f"mid-generation; the first {len(annotation.turns)} turns were "
+        f"salvaged — later turns and holds may be missing."
+    )
+    return annotation
+
+
 async def _annotate_once(
-    client, uploaded, mime_type: str, prompt: str, model: str, temperature: float
+    client, uploaded, mime_type: str, prompt: str, model: str,
+    temperature: float, allow_salvage: bool = False,
 ) -> AnnotatedTranscript:
     response = await client.aio.models.generate_content(
         model=model,
@@ -208,6 +294,10 @@ async def _annotate_once(
             system_instruction=build_annotator_system_prompt(),
             temperature=temperature,
             max_output_tokens=65_536,
+            # Bounded thinking — see DEFAULT_ANNOTATOR_THINKING_BUDGET.
+            thinking_config=types.ThinkingConfig(
+                thinking_budget=annotator_thinking_budget()
+            ),
             # Constrained decoding: the response is grammar-forced into
             # the annotation schema, so syntactically-malformed JSON
             # (the observed bilingual failure class) can't happen. The
@@ -217,6 +307,27 @@ async def _annotate_once(
             response_schema=ANNOTATOR_RESPONSE_SCHEMA,
         ),
     )
+    # Truncated output can never parse — name the real problem instead
+    # of surfacing a misleading JSON syntax error. (Very long calls can
+    # exhaust the 65k output cap legitimately; that's the §3 long-call
+    # caveat, and the pipeline falls back to single-stage scoring.)
+    try:
+        finish = str(response.candidates[0].finish_reason)
+    except Exception:  # noqa: BLE001 — no candidates handled below
+        finish = ""
+    if "MAX_TOKENS" in finish:
+        if allow_salvage:
+            salvaged = _salvage_truncated_annotation(response.text or "")
+            if salvaged is not None:
+                logger.warning(
+                    "annotation truncated [%s] — salvaged %d turns",
+                    _finish_diagnostics(response), len(salvaged.turns),
+                )
+                return salvaged
+        raise ValueError(
+            f"annotation truncated — output budget exhausted "
+            f"[{_finish_diagnostics(response)}]"
+        )
     try:
         # genai parses schema'd responses itself; fall back to the
         # fence-tolerant path if .parsed is absent (older SDKs, stubs).
@@ -267,7 +378,12 @@ async def annotate_audio(
         for temperature in _ANNOTATE_ATTEMPT_TEMPS:
             try:
                 return await _annotate_once(
-                    client, uploaded, mime_type, prompt, resolved_model, temperature
+                    client, uploaded, mime_type, prompt, resolved_model,
+                    temperature,
+                    # Salvage only on the FINAL attempt — a retry might
+                    # still yield a complete artifact; a partial one is
+                    # the last resort before falling back entirely.
+                    allow_salvage=(temperature == _ANNOTATE_ATTEMPT_TEMPS[-1]),
                 )
             except Exception as exc:  # noqa: BLE001 — one retry, then surface
                 last_exc = exc

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -9,6 +9,7 @@ live here — the only google-genai importers besides llm/gemini.py.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import tempfile
@@ -19,6 +20,7 @@ from google import genai
 from google.genai import types
 
 from backend.prompts.annotator_prompt import (
+    ANNOTATOR_RESPONSE_SCHEMA,
     build_annotator_prompt,
     build_annotator_system_prompt,
 )
@@ -28,6 +30,8 @@ from backend.models.scorecard import Scorecard
 
 if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_MIME_TYPES = {
     ".mp3": "audio/mp3",
@@ -143,10 +147,87 @@ async def score_audio(
 DEFAULT_ANNOTATOR_MODEL = "gemini-2.5-flash"
 
 
+def _finish_diagnostics(response) -> str:
+    """Why did generation stop? Gemini can end a candidate early
+    (MAX_TOKENS, SAFETY, RECITATION — hold-music lyrics trigger the
+    latter) and `response.text` alone hides it; a truncated candidate
+    then surfaces as a misleading JSON parse error. Best-effort string
+    for exception messages and logs."""
+    bits = []
+    try:
+        candidates = response.candidates or []
+        if candidates:
+            bits.append(f"finish_reason={candidates[0].finish_reason}")
+        else:
+            bits.append("no candidates")
+        usage = getattr(response, "usage_metadata", None)
+        if usage is not None:
+            bits.append(
+                "tokens(prompt={}, out={}, thoughts={})".format(
+                    getattr(usage, "prompt_token_count", None),
+                    getattr(usage, "candidates_token_count", None),
+                    getattr(usage, "thoughts_token_count", None),
+                )
+            )
+        feedback = getattr(response, "prompt_feedback", None)
+        if feedback:
+            bits.append(f"prompt_feedback={feedback}")
+    except Exception:  # noqa: BLE001 — diagnostics must never mask the real error
+        bits.append("diagnostics unavailable")
+    return "; ".join(bits)
+
+
 def annotator_model() -> str:
     """Stage-A model — env-tunable for the flash-vs-pro trial
     (TwoStageScoringDesign §10.4); team-JSON knob lands with P4."""
     return os.environ.get("ANNOTATOR_MODEL", "").strip() or DEFAULT_ANNOTATOR_MODEL
+
+
+# Attempt temperatures: 0.0 for fidelity, then a small bump. Gemini's
+# near-deterministic decoding at temp 0 can re-serve the SAME degenerate
+# sample on retry (observed 2026-07-27 on a bilingual call: two runs,
+# byte-identical truncated JSON) — the bump exists to break that loop.
+_ANNOTATE_ATTEMPT_TEMPS = (0.0, 0.2)
+
+
+async def _annotate_once(
+    client, uploaded, mime_type: str, prompt: str, model: str, temperature: float
+) -> AnnotatedTranscript:
+    response = await client.aio.models.generate_content(
+        model=model,
+        contents=[
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_uri(file_uri=uploaded.uri, mime_type=mime_type),
+                    types.Part.from_text(text=prompt),
+                ],
+            )
+        ],
+        config=types.GenerateContentConfig(
+            system_instruction=build_annotator_system_prompt(),
+            temperature=temperature,
+            max_output_tokens=65_536,
+            # Constrained decoding: the response is grammar-forced into
+            # the annotation schema, so syntactically-malformed JSON
+            # (the observed bilingual failure class) can't happen. The
+            # hand-authored dict, not the pydantic class — Gemini's
+            # OpenAPI subset rejects additionalProperties (400).
+            response_mime_type="application/json",
+            response_schema=ANNOTATOR_RESPONSE_SCHEMA,
+        ),
+    )
+    try:
+        # genai parses schema'd responses itself; fall back to the
+        # fence-tolerant path if .parsed is absent (older SDKs, stubs).
+        parsed = getattr(response, "parsed", None)
+        if isinstance(parsed, AnnotatedTranscript):
+            return parsed
+        return AnnotatedTranscript.model_validate(_extract_json(response.text))
+    except Exception as exc:
+        raise ValueError(
+            f"annotation unusable [{_finish_diagnostics(response)}]: {exc}"
+        ) from exc
 
 
 async def annotate_audio(
@@ -160,9 +241,10 @@ async def annotate_audio(
     transcript (`gemini_annotate_v1`) — the artifact Stage B judges from.
 
     No rubric, no SOP, no grounding: the annotator observes, it never
-    scores. Raises on failure — the CALLER decides fallback semantics
-    (scoring_service treats annotation as an enhancement, never a
-    scoring blocker)."""
+    scores. One internal retry (bumped temperature) on an unusable
+    generation; raises after that — the CALLER decides fallback
+    semantics (scoring_service treats annotation as an enhancement,
+    never a scoring blocker)."""
     client = _get_client()
     mime_type = _get_mime_type(filename)
 
@@ -180,25 +262,22 @@ async def annotate_audio(
             transcript_text=transcript_text,
             moments_display=moments_display,
         )
-        response = await client.aio.models.generate_content(
-            model=model or annotator_model(),
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part.from_uri(file_uri=uploaded.uri, mime_type=mime_type),
-                        types.Part.from_text(text=prompt),
-                    ],
+        resolved_model = model or annotator_model()
+        last_exc: Exception | None = None
+        for temperature in _ANNOTATE_ATTEMPT_TEMPS:
+            try:
+                return await _annotate_once(
+                    client, uploaded, mime_type, prompt, resolved_model, temperature
                 )
-            ],
-            config=types.GenerateContentConfig(
-                system_instruction=build_annotator_system_prompt(),
-                # Annotation wants fidelity, not creativity.
-                temperature=0.0,
-                max_output_tokens=65_536,
-            ),
-        )
-        return AnnotatedTranscript.model_validate(_extract_json(response.text))
+            except Exception as exc:  # noqa: BLE001 — one retry, then surface
+                last_exc = exc
+                logger.warning(
+                    "annotate attempt at temp=%s failed (%s) — %s",
+                    temperature, exc,
+                    "retrying with bumped temperature"
+                    if temperature != _ANNOTATE_ATTEMPT_TEMPS[-1] else "giving up",
+                )
+        raise last_exc  # type: ignore[misc]  # loop always ran at least once
     finally:
         Path(tmp_path).unlink(missing_ok=True)
         if uploaded is not None:

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -139,8 +139,19 @@ def human_review_trigger_fired(formula: Optional[Formula], sections: list[Any]) 
 
 def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dict[str, Any]:
     """qa.evaluations column dict for a Stage-1 draft (§3.2 row shape)."""
+    # §8.1 audio leg: populated when Stage A annotated this call
+    # (TwoStageScoringDesign §2) — the version stamp names the annotation
+    # schema so old rows stay reproducible as the annotator evolves.
+    audio_leg = None
+    if scorecard.annotated_transcript and scorecard.annotator_model:
+        audio_leg = ModelInfo(
+            provider="gemini",
+            model=scorecard.annotator_model,
+            version="gemini_annotate_v1",
+        )
     models_used = ModelsUsed(
-        text=ModelInfo(provider="gemini", model=scorecard.model)
+        audio=audio_leg,
+        text=ModelInfo(provider="gemini", model=scorecard.model),
     )
     duration_ms = int(scorecard.duration_ms) if scorecard.duration_ms else None
     # §3.14 gate beats long-call telemetry when both apply — the human-review
@@ -184,6 +195,14 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
         "dialpad_disposition_category": scorecard.dialpad_disposition_category,
         "dialpad_disposition": scorecard.dialpad_disposition,
         "ai_csat": scorecard.ai_csat,
+        # TwoStageScoringDesign §3 — the Stage-A artifact fills the
+        # migration-006 column that has waited for it (§8.2). NULL on
+        # single-pipeline rows and annotate failures; the rescore-REPLACE
+        # path overwrites it with the rest of the row.
+        "annotated_transcript": (
+            json.dumps(scorecard.annotated_transcript)
+            if scorecard.annotated_transcript else None
+        ),
         "dialpad_call_metadata": json.dumps({
             "sop_used": scorecard.sop_used,
             "stage1_flags": sorted({f for s in scorecard.sections for f in s.flags}),

--- a/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
@@ -37,10 +37,29 @@ class AnthropicTextProvider(TextModelProvider):
     def _get_client(self):
         if self._client is not None:
             return self._client
-        if not os.getenv("ANTHROPIC_API_KEY"):
-            raise LlmProviderError("ANTHROPIC_API_KEY not set in environment")
+        # Key resolution: engineering-provisioned key wins, then the
+        # Landing key, then the owner's personal key (funded interim,
+        # 2026-07-26). Sub-20-char values are placeholders (the .env
+        # carries a stub _LANDING entry until engineering delivers) —
+        # skipped so the first REAL key wins without editing .env.
+        api_key = next(
+            (
+                key for key in (
+                    os.getenv("ANTHROPIC_API_KEY"),
+                    os.getenv("ANTHROPIC_API_KEY_LANDING"),
+                    os.getenv("ANTHROPIC_API_KEY_PERSONAL"),
+                )
+                if key and len(key) >= 20
+            ),
+            None,
+        )
+        if not api_key:
+            raise LlmProviderError(
+                "no Anthropic key in environment (ANTHROPIC_API_KEY / "
+                "_LANDING / _PERSONAL)"
+            )
         from anthropic import AsyncAnthropic
-        self._client = AsyncAnthropic()
+        self._client = AsyncAnthropic(api_key=api_key)
         return self._client
 
     async def generate(

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -53,6 +53,12 @@ step 2 and honor the constraints listed at the bottom.
                page path was decommissioned 2026-07-23; when
                retrieval is off/skipped/sub-τ the prompt takes the
                sop_context_missing conservative path.
+     Step 2.5  Stage-A annotation (TwoStageScoringDesign §3), gated by
+               SCORING_PIPELINE (single | annotate_only | two_stage*):
+               annotate_audio produces the gemini_annotate_v1 artifact,
+               persisted to qa.evaluations.annotated_transcript. In
+               annotate_only the scoring prompt is untouched; Stage-B
+               judging (two_stage*) lands with P3. Never a blocker.
      Step 3    `score_audio`: upload audio to Gemini, build the prompt
                (rubric + SOP + grounding + transcript, from TeamConfig
                JSON), parse/validate the Scorecard.
@@ -94,10 +100,11 @@ Constraints the automated trigger MUST keep in mind:
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Optional
 
 from backend.models.scorecard import ScorecardWithMeta
-from backend.services.audio_service import score_audio
+from backend.services.audio_service import annotate_audio, annotator_model, score_audio
 from backend.services.cc_context import (
     build_call_context_block,
     fetch_call_context,
@@ -116,6 +123,25 @@ if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
 
 logger = logging.getLogger(__name__)
+
+_PIPELINE_MODES = ("single", "annotate_only", "two_stage_shadow", "two_stage")
+
+
+def scoring_pipeline() -> str:
+    """SCORING_PIPELINE — TwoStageScoringDesign §6 (house pattern:
+    unknown values collapse to the off-state).
+
+      single           today's one-call Gemini scoring (default)
+      annotate_only    P2: Stage A runs alongside single-stage scoring;
+                       the annotation persists, the prompt is untouched —
+                       inspectable audio evidence accumulates before any
+                       judge change
+      two_stage_shadow / two_stage — land with P3; until then they run
+                       as annotate_only (with a warning) rather than
+                       silently doing nothing
+    """
+    mode = os.environ.get("SCORING_PIPELINE", "single").strip().lower()
+    return mode if mode in _PIPELINE_MODES else "single"
 
 
 async def score_call(
@@ -200,6 +226,42 @@ async def score_call(
     else:
         sop_data = {"sop_title": "", "sop_content": ""}
 
+    # Step 2.5: Stage-A annotation (TwoStageScoringDesign §3). In
+    # annotate_only the artifact persists while the scoring prompt stays
+    # untouched — same log-only instinct as the CC/Pulpo shadow modes.
+    # Non-fatal throughout: annotation is an enhancement, never a
+    # scoring blocker (the cc_context doctrine).
+    pipeline = scoring_pipeline()
+    annotation = None
+    annotation_model = None
+    if pipeline != "single":
+        if pipeline in ("two_stage_shadow", "two_stage"):
+            logger.warning(
+                "SCORING_PIPELINE=%s: Stage-B judging lands with P3 — "
+                "running annotation only for call=%s", pipeline, call_id,
+            )
+        try:
+            annotation_model = annotator_model()
+            annotation = await annotate_audio(
+                audio_bytes,
+                filename,
+                transcript_text=transcript_text,
+                moments_display=transcript_data.get("moments_display", []),
+                model=annotation_model,
+            )
+            logger.info(
+                "stage_a[%s] call=%s model=%s: %d turns, %d holds, lang=%s",
+                pipeline, call_id, annotation_model,
+                len(annotation.turns), len(annotation.holds),
+                annotation.language_detected,
+            )
+        except Exception:
+            logger.exception(
+                "stage_a annotate failed for call=%s — scoring proceeds "
+                "without an annotation", call_id,
+            )
+            annotation = None
+
     # Step 3: Score
     extra_notes = ""
     flagged_long = duration_ms > CALL_DURATION_FLAG_MS
@@ -267,4 +329,8 @@ async def score_call(
         # PulpoConnection §4.2 step 6 — retrieval provenance for the eval
         # row (stamped in shadow AND on: the shadow window's compare data).
         pulpo_docs=sop_ctx.provenance if sop_ctx else [],
+        # TwoStageScoringDesign §3 — the Stage-A artifact + audio-leg
+        # model stamp (eval_store fills models_used.audio from these).
+        annotated_transcript=annotation.model_dump() if annotation else None,
+        annotator_model=annotation_model if annotation else None,
     )

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -1,7 +1,24 @@
 # TwoStageScoringDesign — Gemini annotates, any LLM scores
 
-**Status:** v1.1 — §10 RESOLVED (owner, 2026-07-25); P1 building.
-**Date:** 2026-07-24 (v1), 2026-07-25 (v1.1)
+**Status:** v1.2 — P1 shipped (PR #140, Claude leg live-verified incl.
+structured output); P2 shipped (Stage-A annotator + `annotate_only`).
+**Date:** 2026-07-24 (v1), 2026-07-25 (v1.1), 2026-07-26 (v1.2)
+
+**v1.2 amendments:**
+- `SCORING_PIPELINE` gains **`annotate_only`** between `single` and the
+  `two_stage*` modes: Stage A runs on every scored call and the
+  annotation persists, while the scoring prompt stays untouched —
+  inspectable audio evidence accumulates before any judge change. The
+  `two_stage*` values are accepted early but run as annotate_only (with
+  a warning) until P3 lands — never silently nothing.
+- Anthropic key resolution: `ANTHROPIC_API_KEY` →
+  `ANTHROPIC_API_KEY_LANDING` → `ANTHROPIC_API_KEY_PERSONAL` (the
+  owner's funded interim key), skipping placeholder-length values so
+  the first REAL key wins without .env edits when engineering delivers.
+- Annotator model knob for the §10.4 flash-vs-pro trial: env
+  `ANNOTATOR_MODEL` (default `gemini-2.5-flash`);
+  `scripts/annotate_smoke.py --model both` produces the side-by-side
+  files for the Spanish-manager spot-check.
 **Owner mandate:** "To incorporate Claude models (until Anthropic releases
 a model that can natively listen to audio) we now have to split the
 scoring work into the two-stage process we have outlined in this repo …

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -19,6 +19,35 @@ structured output); P2 shipped (Stage-A annotator + `annotate_only`).
   `ANNOTATOR_MODEL` (default `gemini-2.5-flash`);
   `scripts/annotate_smoke.py --model both` produces the side-by-side
   files for the Spanish-manager spot-check.
+- **Annotator output-budget doctrine** (hardening, 2026-07-27): the
+  annotation is decoded under a grammar (`response_mime_type` +
+  hand-authored `ANNOTATOR_RESPONSE_SCHEMA` — Gemini's OpenAPI subset
+  rejects pydantic's `additionalProperties`), with ONE retry at a
+  bumped temperature (temp-0 decoding was observed re-serving the same
+  degenerate sample), and **bounded thinking**
+  (`ANNOTATOR_THINKING_BUDGET`, default 4096): thoughts spend from
+  `max_output_tokens`, and a Spanish call burned 62,911 of the 65,536
+  cap thinking, leaving ~2.6k for JSON → MAX_TOKENS truncation on
+  every attempt. The output budget belongs to the transcript.
+  **Repetition loops** are the other budget-killer: a 6.4-min call
+  emitted 24 clean turns then 184KB of "uh uh uh…" in one text field —
+  constrained decoding guarantees syntax, not termination, and Gemini
+  rejects frequency_penalty on 2.5-flash. Guards, in order: the
+  prompt's stutter-collapse rule, the bumped-temp retry, and the
+  **salvage path** — a final-attempt MAX_TOKENS response is repaired
+  to its last complete turn (the loop always lives in the incomplete
+  tail, so salvage structurally discards it) and stamped with an
+  ANNOTATION TRUNCATED call_observation so Stage B and reviewers know
+  the artifact is partial. Live-verified: the looping call salvages
+  22 turns.
+  **Long-call caveat:** the 65,536 cap is Gemini's ceiling; ~61k
+  post-thinking tokens fit roughly 45–60 min of dense annotation.
+  Calls beyond that hit the same salvage path (partial artifact,
+  labeled) or, when nothing salvages, an explicit "output budget
+  exhausted" error and single-stage fallback. Segmented annotation
+  (chunked audio, stitched artifact) is the designated follow-up if
+  long calls matter before the LandGPT era — track truncation rate
+  during the annotate_only window to decide.
 **Owner mandate:** "To incorporate Claude models (until Anthropic releases
 a model that can natively listen to audio) we now have to split the
 scoring work into the two-stage process we have outlined in this repo …

--- a/qa-automation/AI-Scoring/scripts/annotate_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/annotate_smoke.py
@@ -1,0 +1,101 @@
+"""Stage-A annotator smoke — TwoStageScoringDesign P2 (§10.4 trial).
+
+Annotates real Dialpad calls WITHOUT touching the scoring pipeline or
+the database, printing the rendered annotation for human review — the
+Spanish-manager spot-check reads this output. `--model both` runs
+flash AND pro on the same audio for the side-by-side comparison.
+
+Usage (from qa-automation/AI-Scoring, .env loaded):
+
+    .venv/bin/python scripts/annotate_smoke.py --call-id 4501234...
+    .venv/bin/python scripts/annotate_smoke.py --call-id ... --model both
+    .venv/bin/python scripts/annotate_smoke.py --call-id ... --raw-json
+
+Output goes to stdout and (per model) to
+scripts/annotations/<call_id>.<model>.txt for sharing with reviewers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from backend.services.annotation_render import render_annotated_transcript  # noqa: E402
+from backend.services.audio_service import annotate_audio  # noqa: E402
+from backend.services.dialpad_client import (  # noqa: E402
+    download_recording,
+    get_transcript,
+)
+
+_OUT_DIR = Path(__file__).resolve().parent / "annotations"
+_MODELS = {
+    "flash": "gemini-2.5-flash",
+    "pro": "gemini-2.5-pro",
+}
+
+
+async def _run_one(call_id: str, model: str, audio_bytes: bytes,
+                   transcript_data, raw_json: bool):
+    started = time.monotonic()
+    annotation = await annotate_audio(
+        audio_bytes,
+        f"{call_id}.mp3",
+        transcript_text=transcript_data.get("transcript_text", ""),
+        moments_display=transcript_data.get("moments_display", []),
+        model=model,
+    )
+    elapsed = time.monotonic() - started
+
+    rendered = render_annotated_transcript(annotation)
+    header = (
+        f"===== {call_id} | {model} | {elapsed:.1f}s | "
+        f"{len(annotation.turns)} turns, {len(annotation.holds)} holds, "
+        f"lang={annotation.language_detected} ====="
+    )
+    print(f"\n{header}\n{rendered}\n")
+
+    _OUT_DIR.mkdir(exist_ok=True)
+    out = _OUT_DIR / f"{call_id}.{model}.txt"
+    out.write_text(f"{header}\n\n{rendered}\n", encoding="utf-8")
+    if raw_json:
+        raw = _OUT_DIR / f"{call_id}.{model}.json"
+        raw.write_text(
+            json.dumps(annotation.model_dump(), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    print(f"(saved → {out})")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--call-id", required=True,
+                        help="Dialpad call id (the /lookup per-leg id)")
+    parser.add_argument("--model", choices=("flash", "pro", "both"),
+                        default="flash")
+    parser.add_argument("--raw-json", action="store_true",
+                        help="also save the raw gemini_annotate_v1 JSON")
+    args = parser.parse_args()
+
+    print(f"→ downloading recording + transcript for {args.call_id} …")
+    audio_bytes = await download_recording(args.call_id)
+    transcript_data = await get_transcript(args.call_id)
+
+    models = ("flash", "pro") if args.model == "both" else (args.model,)
+    for key in models:
+        await _run_one(args.call_id, _MODELS[key], audio_bytes,
+                       transcript_data, args.raw_json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/qa-automation/AI-Scoring/scripts/annotate_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/annotate_smoke.py
@@ -38,9 +38,13 @@ from backend.services.dialpad_client import (  # noqa: E402
 )
 
 _OUT_DIR = Path(__file__).resolve().parent / "annotations"
+# "pro" is Google's rolling alias — gemini-2.5-pro 404s for new API users
+# (observed 2026-07-26: "no longer available to new users"). Any raw
+# model id also works as --model (e.g. gemini-3-pro-preview,
+# gemini-3.5-flash) for one-off trials.
 _MODELS = {
     "flash": "gemini-2.5-flash",
-    "pro": "gemini-2.5-pro",
+    "pro": "gemini-pro-latest",
 }
 
 
@@ -80,8 +84,8 @@ async def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--call-id", required=True,
                         help="Dialpad call id (the /lookup per-leg id)")
-    parser.add_argument("--model", choices=("flash", "pro", "both"),
-                        default="flash")
+    parser.add_argument("--model", default="flash",
+                        help="flash | pro | both | any raw Gemini model id")
     parser.add_argument("--raw-json", action="store_true",
                         help="also save the raw gemini_annotate_v1 JSON")
     args = parser.parse_args()
@@ -90,11 +94,17 @@ async def main() -> int:
     audio_bytes = await download_recording(args.call_id)
     transcript_data = await get_transcript(args.call_id)
 
-    models = ("flash", "pro") if args.model == "both" else (args.model,)
-    for key in models:
-        await _run_one(args.call_id, _MODELS[key], audio_bytes,
-                       transcript_data, args.raw_json)
-    return 0
+    keys = ("flash", "pro") if args.model == "both" else (args.model,)
+    failures = 0
+    for key in keys:
+        model = _MODELS.get(key, key)   # alias, or a raw model id
+        try:
+            await _run_one(args.call_id, model, audio_bytes,
+                           transcript_data, args.raw_json)
+        except Exception as exc:  # noqa: BLE001 — one model must not kill the comparison
+            failures += 1
+            print(f"\n!! {model} FAILED: {type(exc).__name__}: {exc}\n")
+    return 1 if failures == len(keys) else 0
 
 
 if __name__ == "__main__":

--- a/qa-automation/AI-Scoring/tests/test_annotator.py
+++ b/qa-automation/AI-Scoring/tests/test_annotator.py
@@ -1,0 +1,227 @@
+"""Stage-A annotator — TwoStageScoringDesign P2.
+
+Pins: the additive gemini_annotate_v1 schema extension, the annotator
+prompt's doctrine lines (audio-SOT, non-English re-transcription,
+observational holds), the renderer's interleave + observational
+labeling, the SCORING_PIPELINE gate, annotate_audio's parse/cleanup
+path, and the eval_store persistence + models_used audio-leg stamp.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.models.formula import AnnotatedTranscript, HoldSegment, TranscriptTurn
+from backend.prompts.annotator_prompt import (
+    build_annotator_prompt,
+    build_annotator_system_prompt,
+)
+from backend.services.annotation_render import render_annotated_transcript
+from backend.services.scoring_service import scoring_pipeline
+
+
+# ---------------------------------------------------------------------------
+# Schema extension (§3 — additive on §8.2)
+# ---------------------------------------------------------------------------
+
+def _turn(**overrides):
+    base = dict(speaker="agent", text="Buenos días", emotion="neutral_friendly",
+                paraphrase_intent="greeting", pace_marker="normal",
+                interruption=False, start_ms=1200, end_ms=4800)
+    base.update(overrides)
+    return TranscriptTurn(**base)
+
+
+def test_gemini_annotate_v1_shape_roundtrips():
+    annotation = AnnotatedTranscript(
+        schema_version="gemini_annotate_v1",
+        language_detected="es",
+        turns=[_turn()],
+        holds=[HoldSegment(start_ms=182_000, end_ms=245_000, kind="hold_music",
+                           note="announced")],
+        call_observations=["background noise on caller side"],
+    )
+    dumped = annotation.model_dump()
+    assert AnnotatedTranscript.model_validate(dumped) == annotation
+
+
+def test_legacy_qwen_shape_still_validates():
+    """The original §8.2 shape (no holds/call_observations) must keep
+    validating — schema_version exists so variants coexist."""
+    legacy = {
+        "schema_version": "qwen2_audio_v1",
+        "language_detected": "en",
+        "turns": [_turn().model_dump()],
+    }
+    annotation = AnnotatedTranscript.model_validate(legacy)
+    assert annotation.holds == [] and annotation.call_observations == []
+
+
+def test_hold_kind_is_closed_vocabulary():
+    with pytest.raises(Exception):
+        HoldSegment(start_ms=0, end_ms=1, kind="coffee_break")
+
+
+# ---------------------------------------------------------------------------
+# Annotator prompt doctrine (§3.1 / §3.2)
+# ---------------------------------------------------------------------------
+
+def test_prompt_carries_audio_sot_and_language_rule():
+    prompt = build_annotator_prompt(transcript_text="hello", moments_display=[])
+    assert "gemini_annotate_v1" in prompt
+    assert "AUDIO IS THE SOURCE OF TRUTH" in prompt
+    assert "NOT in English" in prompt          # re-transcribe rule
+    assert "do NOT translate" in prompt
+    system = build_annotator_system_prompt()
+    assert "never score" in system
+
+
+def test_prompt_subordinates_transcript_and_markers_as_hints():
+    prompt = build_annotator_prompt(
+        transcript_text="the words",
+        moments_display=[{"timestamp": "01:00", "type": "hold"}],
+    )
+    assert "hint — the audio overrules it" in prompt
+    assert "hints, machine-detected" in prompt
+    # Both omitted cleanly when absent
+    bare = build_annotator_prompt(transcript_text="", moments_display=None)
+    assert "REFERENCE TRANSCRIPT" not in bare
+    assert "SIGNAL MARKERS" not in bare
+
+
+# ---------------------------------------------------------------------------
+# Renderer (§4) — the Stage-B input format
+# ---------------------------------------------------------------------------
+
+def test_render_interleaves_holds_and_labels_them_observational():
+    annotation = AnnotatedTranscript(
+        schema_version="gemini_annotate_v1",
+        language_detected="en",
+        turns=[
+            _turn(text="one", start_ms=0, end_ms=1000),
+            _turn(text="two", speaker="caller", emotion="frustrated",
+                  interruption=True, start_ms=70_000, end_ms=75_000),
+        ],
+        holds=[HoldSegment(start_ms=10_000, end_ms=63_000, kind="dead_air")],
+        call_observations=["poor audio quality"],
+    )
+    rendered = render_annotated_transcript(annotation)
+    lines = rendered.splitlines()
+    # Hold sits between the turns (10s is after turn one, before turn two)
+    hold_idx = next(i for i, l in enumerate(lines) if "HOLD" in l)
+    one_idx = next(i for i, l in enumerate(lines) if '"one"' in l)
+    two_idx = next(i for i, l in enumerate(lines) if '"two"' in l)
+    assert one_idx < hold_idx < two_idx
+    # §3.1 wording rule enforced at the render boundary
+    assert "observational — not system-verified" in lines[hold_idx]
+    assert "~53s" in lines[hold_idx]
+    assert "[interrupts]" in lines[two_idx] and "frustrated" in lines[two_idx]
+    assert rendered.endswith("- poor audio quality")
+
+
+def test_render_without_holds_or_observations_is_clean():
+    annotation = AnnotatedTranscript(
+        schema_version="gemini_annotate_v1", turns=[_turn()],
+    )
+    rendered = render_annotated_transcript(annotation)
+    assert "HOLD" not in rendered and "CALL-LEVEL" not in rendered
+    assert "Language detected: unknown" in rendered
+
+
+# ---------------------------------------------------------------------------
+# SCORING_PIPELINE gate (§6)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("", "single"),
+    ("single", "single"),
+    ("annotate_only", "annotate_only"),
+    ("two_stage_shadow", "two_stage_shadow"),
+    ("two_stage", "two_stage"),
+    ("TWO_STAGE", "two_stage"),
+    ("bogus", "single"),
+])
+def test_scoring_pipeline_env_collapse(monkeypatch, raw, expected):
+    if raw:
+        monkeypatch.setenv("SCORING_PIPELINE", raw)
+    else:
+        monkeypatch.delenv("SCORING_PIPELINE", raising=False)
+    assert scoring_pipeline() == expected
+
+
+# ---------------------------------------------------------------------------
+# annotate_audio — parse + cleanup with a fake Gemini client
+# ---------------------------------------------------------------------------
+
+def _fake_genai_client(payload_text):
+    class _Uploaded:
+        uri = "files/fake"
+        name = "files/fake"
+
+    class _Files:
+        def __init__(self):
+            self.deleted = []
+
+        def upload(self, *, file, config):
+            return _Uploaded()
+
+        def delete(self, *, name):
+            self.deleted.append(name)
+
+    class _AioModels:
+        async def generate_content(self, *, model, contents, config):
+            class _Resp:
+                text = payload_text
+            return _Resp()
+
+    class _Aio:
+        models = _AioModels()
+
+    class _Client:
+        def __init__(self):
+            self.files = _Files()
+            self.aio = _Aio()
+
+    return _Client()
+
+
+def _annotation_json():
+    return json.dumps({
+        "schema_version": "gemini_annotate_v1",
+        "language_detected": "en",
+        "turns": [_turn().model_dump()],
+        "holds": [],
+        "call_observations": [],
+    })
+
+
+def test_annotate_audio_parses_and_cleans_up(monkeypatch):
+    import backend.services.audio_service as audio_service
+
+    client = _fake_genai_client(f"```json\n{_annotation_json()}\n```")
+    monkeypatch.setattr(audio_service, "_get_client", lambda: client)
+    annotation = asyncio.run(audio_service.annotate_audio(
+        b"bytes", "call.mp3", transcript_text="hi", moments_display=[],
+    ))
+    assert annotation.schema_version == "gemini_annotate_v1"
+    assert client.files.deleted == ["files/fake"]   # upload cleaned up
+
+
+def test_annotate_audio_invalid_json_raises(monkeypatch):
+    import backend.services.audio_service as audio_service
+
+    client = _fake_genai_client("I am not JSON")
+    monkeypatch.setattr(audio_service, "_get_client", lambda: client)
+    with pytest.raises(ValueError):
+        asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+
+
+def test_annotator_model_env_override(monkeypatch):
+    from backend.services.audio_service import annotator_model
+    monkeypatch.delenv("ANNOTATOR_MODEL", raising=False)
+    assert annotator_model() == "gemini-2.5-flash"
+    monkeypatch.setenv("ANNOTATOR_MODEL", "gemini-2.5-pro")
+    assert annotator_model() == "gemini-2.5-pro"

--- a/qa-automation/AI-Scoring/tests/test_annotator.py
+++ b/qa-automation/AI-Scoring/tests/test_annotator.py
@@ -65,6 +65,24 @@ def test_hold_kind_is_closed_vocabulary():
         HoldSegment(start_ms=0, end_ms=1, kind="coffee_break")
 
 
+def test_response_schema_pinned_to_pydantic_contract():
+    """The hand-authored Gemini response_schema (OpenAPI subset — no
+    additionalProperties) must track the pydantic models field-for-field
+    so constrained decoding and post-hoc validation can't drift."""
+    from backend.prompts.annotator_prompt import ANNOTATOR_RESPONSE_SCHEMA as s
+
+    assert set(s["properties"]) == set(AnnotatedTranscript.model_fields)
+    turn = s["properties"]["turns"]["items"]
+    assert set(turn["properties"]) == set(TranscriptTurn.model_fields)
+    hold = s["properties"]["holds"]["items"]
+    assert set(hold["properties"]) == set(HoldSegment.model_fields)
+    assert hold["properties"]["kind"]["enum"] == [
+        "hold_music", "dead_air", "mute_suspected",
+    ]
+    # The field Gemini's schema dialect rejects must never reappear.
+    assert "additionalProperties" not in json.dumps(s)
+
+
 # ---------------------------------------------------------------------------
 # Annotator prompt doctrine (§3.1 / §3.2)
 # ---------------------------------------------------------------------------
@@ -156,7 +174,12 @@ def test_scoring_pipeline_env_collapse(monkeypatch, raw, expected):
 # annotate_audio — parse + cleanup with a fake Gemini client
 # ---------------------------------------------------------------------------
 
-def _fake_genai_client(payload_text):
+def _fake_genai_client(*payload_texts):
+    """One payload per generate attempt (retry consumes the next);
+    the last repeats if attempts exceed payloads. Records the
+    temperature + response config of each attempt."""
+    payloads = list(payload_texts)
+
     class _Uploaded:
         uri = "files/fake"
         name = "files/fake"
@@ -172,13 +195,20 @@ def _fake_genai_client(payload_text):
             self.deleted.append(name)
 
     class _AioModels:
+        def __init__(self):
+            self.attempts = []
+
         async def generate_content(self, *, model, contents, config):
+            self.attempts.append(config)
+            text = payloads[min(len(self.attempts) - 1, len(payloads) - 1)]
             class _Resp:
-                text = payload_text
+                pass
+            _Resp.text = text
             return _Resp()
 
     class _Aio:
-        models = _AioModels()
+        def __init__(self):
+            self.models = _AioModels()
 
     class _Client:
         def __init__(self):
@@ -208,15 +238,35 @@ def test_annotate_audio_parses_and_cleans_up(monkeypatch):
     ))
     assert annotation.schema_version == "gemini_annotate_v1"
     assert client.files.deleted == ["files/fake"]   # upload cleaned up
+    # Constrained decoding requested (the bilingual-call fix)
+    (config,) = client.aio.models.attempts
+    assert config.response_mime_type == "application/json"
+    assert config.temperature == 0.0
 
 
-def test_annotate_audio_invalid_json_raises(monkeypatch):
+def test_annotate_audio_retries_once_with_bumped_temperature(monkeypatch):
+    """The observed failure class: temp-0 decoding re-serving the same
+    degenerate sample. First attempt bad → one retry at bumped temp."""
+    import backend.services.audio_service as audio_service
+
+    client = _fake_genai_client("NOT JSON", _annotation_json())
+    monkeypatch.setattr(audio_service, "_get_client", lambda: client)
+    annotation = asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+    assert annotation.schema_version == "gemini_annotate_v1"
+    first, second = client.aio.models.attempts
+    assert first.temperature == 0.0
+    assert second.temperature == 0.2
+    assert client.files.deleted == ["files/fake"]   # cleanup after retries too
+
+
+def test_annotate_audio_invalid_json_raises_after_both_attempts(monkeypatch):
     import backend.services.audio_service as audio_service
 
     client = _fake_genai_client("I am not JSON")
     monkeypatch.setattr(audio_service, "_get_client", lambda: client)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="annotation unusable"):
         asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+    assert len(client.aio.models.attempts) == 2    # retried, then surfaced
 
 
 def test_annotator_model_env_override(monkeypatch):

--- a/qa-automation/AI-Scoring/tests/test_annotator.py
+++ b/qa-automation/AI-Scoring/tests/test_annotator.py
@@ -104,6 +104,8 @@ def test_prompt_subordinates_transcript_and_markers_as_hints():
     )
     assert "hint — the audio overrules it" in prompt
     assert "hints, machine-detected" in prompt
+    # Anti-loop rule: stutter runs collapse instead of being spelled out
+    assert "COLLAPSE filler and stutter runs" in prompt
     # Both omitted cleanly when absent
     bare = build_annotator_prompt(transcript_text="", moments_display=None)
     assert "REFERENCE TRANSCRIPT" not in bare
@@ -174,10 +176,11 @@ def test_scoring_pipeline_env_collapse(monkeypatch, raw, expected):
 # annotate_audio — parse + cleanup with a fake Gemini client
 # ---------------------------------------------------------------------------
 
-def _fake_genai_client(*payload_texts):
+def _fake_genai_client(*payload_texts, finish_reason=None):
     """One payload per generate attempt (retry consumes the next);
     the last repeats if attempts exceed payloads. Records the
-    temperature + response config of each attempt."""
+    temperature + response config of each attempt. *finish_reason*
+    stamps every response's candidate (e.g. "FinishReason.MAX_TOKENS")."""
     payloads = list(payload_texts)
 
     class _Uploaded:
@@ -201,9 +204,13 @@ def _fake_genai_client(*payload_texts):
         async def generate_content(self, *, model, contents, config):
             self.attempts.append(config)
             text = payloads[min(len(self.attempts) - 1, len(payloads) - 1)]
+            class _Cand:
+                pass
+            _Cand.finish_reason = finish_reason or "FinishReason.STOP"
             class _Resp:
                 pass
             _Resp.text = text
+            _Resp.candidates = [_Cand()]
             return _Resp()
 
     class _Aio:
@@ -242,6 +249,9 @@ def test_annotate_audio_parses_and_cleans_up(monkeypatch):
     (config,) = client.aio.models.attempts
     assert config.response_mime_type == "application/json"
     assert config.temperature == 0.0
+    # Bounded thinking (the MAX_TOKENS fix: thoughts spend from the
+    # output budget, and the budget belongs to the transcript)
+    assert config.thinking_config.thinking_budget == 4096
 
 
 def test_annotate_audio_retries_once_with_bumped_temperature(monkeypatch):
@@ -269,9 +279,85 @@ def test_annotate_audio_invalid_json_raises_after_both_attempts(monkeypatch):
     assert len(client.aio.models.attempts) == 2    # retried, then surfaced
 
 
+def test_annotate_audio_max_tokens_names_truncation(monkeypatch):
+    """A MAX_TOKENS candidate with NOTHING salvageable must raise an
+    error naming the real problem (budget exhaustion), not a JSON
+    syntax artifact."""
+    import backend.services.audio_service as audio_service
+
+    client = _fake_genai_client(
+        '{"schema_version": "gemini_annotate_v1", "turns": [',   # no complete turn
+        finish_reason="FinishReason.MAX_TOKENS",
+    )
+    monkeypatch.setattr(audio_service, "_get_client", lambda: client)
+    with pytest.raises(ValueError, match="output budget exhausted"):
+        asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+    assert len(client.aio.models.attempts) == 2    # still retried once
+
+
+_TRUNCATED_MID_LOOP = (
+    '{"schema_version": "gemini_annotate_v1", "language_detected": "es", '
+    '"turns": ['
+    '{"speaker": "agent", "text": "Hola, buenas tardes.", "start_ms": 200, '
+    '"end_ms": 3660}, '
+    '{"speaker": "caller", "text": "uh uh uh uh uh uh uh uh uh uh uh uh'
+)
+
+
+def test_salvage_cuts_to_last_complete_turn():
+    """The observed failure: clean turns, then a repetition loop inside
+    one text field until the budget dies. Salvage keeps the clean turns,
+    structurally discards the looping tail, and stamps the truncation."""
+    from backend.services.audio_service import _salvage_truncated_annotation
+
+    salvaged = _salvage_truncated_annotation(_TRUNCATED_MID_LOOP)
+    assert salvaged is not None
+    assert len(salvaged.turns) == 1
+    assert salvaged.turns[0].text == "Hola, buenas tardes."
+    assert "uh uh" not in json.dumps(salvaged.model_dump())
+    assert any("ANNOTATION TRUNCATED" in o for o in salvaged.call_observations)
+
+
+def test_salvage_returns_none_when_nothing_usable():
+    from backend.services.audio_service import _salvage_truncated_annotation
+
+    assert _salvage_truncated_annotation("") is None
+    assert _salvage_truncated_annotation("not json at all") is None
+    # No complete turn ever closed
+    assert _salvage_truncated_annotation(
+        '{"schema_version": "gemini_annotate_v1", "turns": [{"speaker": "ag'
+    ) is None
+
+
+def test_annotate_audio_salvages_on_final_attempt_only(monkeypatch):
+    """Attempt 1 truncates → retry (no salvage: a fresh sample might be
+    complete). Attempt 2 truncates → salvage the partial artifact."""
+    import backend.services.audio_service as audio_service
+
+    client = _fake_genai_client(
+        _TRUNCATED_MID_LOOP,
+        finish_reason="FinishReason.MAX_TOKENS",
+    )
+    monkeypatch.setattr(audio_service, "_get_client", lambda: client)
+    annotation = asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+    assert len(client.aio.models.attempts) == 2    # salvage came second
+    assert len(annotation.turns) == 1
+    assert any("ANNOTATION TRUNCATED" in o for o in annotation.call_observations)
+
+
 def test_annotator_model_env_override(monkeypatch):
     from backend.services.audio_service import annotator_model
     monkeypatch.delenv("ANNOTATOR_MODEL", raising=False)
     assert annotator_model() == "gemini-2.5-flash"
     monkeypatch.setenv("ANNOTATOR_MODEL", "gemini-2.5-pro")
     assert annotator_model() == "gemini-2.5-pro"
+
+
+def test_annotator_thinking_budget_env_override(monkeypatch):
+    from backend.services.audio_service import annotator_thinking_budget
+    monkeypatch.delenv("ANNOTATOR_THINKING_BUDGET", raising=False)
+    assert annotator_thinking_budget() == 4096
+    monkeypatch.setenv("ANNOTATOR_THINKING_BUDGET", "8192")
+    assert annotator_thinking_budget() == 8192
+    monkeypatch.setenv("ANNOTATOR_THINKING_BUDGET", "not-a-number")
+    assert annotator_thinking_budget() == 4096

--- a/qa-automation/AI-Scoring/tests/test_eval_store.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_store.py
@@ -905,3 +905,49 @@ class TestSalesManualReviewGate:
         designed state (only reviewer-flagged calls score it)."""
         eval_store._active_formula.cache_clear()
         assert eval_store.missing_manual_scores(ms_config, []) == []
+
+
+# ---------------------------------------------------------------------------
+# Stage-A annotation persistence (TwoStageScoringDesign §3)
+# ---------------------------------------------------------------------------
+
+def _annotation_dump():
+    return {
+        "schema_version": "gemini_annotate_v1",
+        "language_detected": "es",
+        "turns": [{
+            "speaker": "agent", "text": "Buenos días", "emotion": "warm",
+            "paraphrase_intent": "greeting", "pace_marker": "normal",
+            "interruption": False, "start_ms": 0, "end_ms": 2000,
+        }],
+        "holds": [{"start_ms": 10_000, "end_ms": 40_000, "kind": "hold_music",
+                   "note": None}],
+        "call_observations": ["clean audio"],
+    }
+
+
+class TestAnnotatedTranscriptPersistence:
+
+    def test_annotation_persists_with_audio_leg_stamp(self, ms_config):
+        sc = _scorecard(
+            ms_config,
+            annotated_transcript=_annotation_dump(),
+            annotator_model="gemini-2.5-flash",
+        )
+        row = build_draft_row(sc, ms_config)
+        assert json.loads(row["annotated_transcript"]) == _annotation_dump()
+        models_used = json.loads(row["models_used"])
+        assert models_used["audio"] == {
+            "provider": "gemini",
+            "model": "gemini-2.5-flash",
+            "version": "gemini_annotate_v1",
+        }
+        # The text leg (the score author) is untouched by annotation.
+        assert models_used["text"]["model"] == "gemini-2.5-flash"
+
+    def test_single_pipeline_rows_keep_null_annotation_and_no_audio_leg(
+        self, ms_config
+    ):
+        row = build_draft_row(_scorecard(ms_config), ms_config)
+        assert row["annotated_transcript"] is None
+        assert "audio" not in json.loads(row["models_used"])

--- a/qa-automation/AI-Scoring/tests/test_llm_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_llm_provider.py
@@ -187,9 +187,11 @@ def test_anthropic_refusal_raises():
 
 
 def test_anthropic_missing_key_raises_cleanly(monkeypatch):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_LANDING",
+                "ANTHROPIC_API_KEY_PERSONAL"):
+        monkeypatch.delenv(var, raising=False)
     provider = AnthropicTextProvider()
-    with pytest.raises(LlmProviderError, match="ANTHROPIC_API_KEY"):
+    with pytest.raises(LlmProviderError, match="Anthropic key"):
         asyncio.run(provider.generate(
             "x", model="claude-sonnet-5", max_output_tokens=1,
         ))


### PR DESCRIPTION
## What

TwoStageScoringDesign **P2** — the Stage-A annotator, rebased on #141 (composes with rescore-REPLACE: the annotation is overwritten with the rest of the row).

- **Schema** — `AnnotatedTranscript` extended additively for `gemini_annotate_v1`: `holds[]` (observational; closed `hold_music|dead_air|mute_suspected` vocabulary) + `call_observations[]`. Legacy `qwen2_audio_v1` shape still validates.
- **Annotator** — `annotate_audio()` in `audio_service`: uploads audio, produces the artifact, never scores. The prompt owns the doctrine: **audio is SOT**, non-English calls are re-transcribed from audio (not translated), Dialpad transcript + markers are explicitly subordinated as hints, holds are observations.
- **Renderer** — `render_annotated_transcript()` (pure): interleaves holds into the turn stream by time and stamps every hold line "observational — not system-verified" at the render boundary, so no downstream prompt can present a heard hold as a verified fact.
- **Pipeline gate** — `SCORING_PIPELINE=single|annotate_only|two_stage_shadow|two_stage` (unknown → single). `annotate_only` runs Stage A on every scored call and persists the artifact while the scoring prompt stays untouched; `two_stage*` accepted early but run as annotate_only with a warning until P3. Annotation failures log and never block scoring.
- **Persistence** — the migration-006 `annotated_transcript` column finally fills; `models_used.audio` stamps `{gemini, <annotator model>, gemini_annotate_v1}` while the text leg stays the score author.
- **Claude leg LIVE-VERIFIED** — with the personal key: plain generation + schema-enforced JSON both clean on `claude-sonnet-5` through the seam. Key resolution is now `ANTHROPIC_API_KEY` → `_LANDING` → `_PERSONAL` with placeholder-length values skipped, so the engineering key wins automatically when it lands.
- **Smoke** — `scripts/annotate_smoke.py --call-id <id> --model both` writes flash + pro renderings side-by-side to `scripts/annotations/` for the Spanish-manager spot-check (no DB writes, no pipeline involvement).

## After merge
1. Optionally set `SCORING_PIPELINE=annotate_only` on Railway — annotations start accumulating on every scored call (adds one Gemini audio call per eval; trivial at MS volume).
2. Run the spot-check: `.venv/bin/python scripts/annotate_smoke.py --call-id <spanish-call> --model both` and hand the two files to the Spanish-speaking manager.
3. Add the Anthropic key to Railway when convenient (P3 shadow needs it server-side).

## Tests
`758 passed, 6 skipped, 3 xfailed` — 19 new (schema roundtrip/legacy-compat, prompt doctrine pins, renderer interleave + observational labeling, env-gate collapse, annotate parse/cleanup fakes, persistence + audio-leg stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)