### PR TITLE
Annotator: fail-fast on deterministic 400s; Gemini-3 audio gap recorded

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from google import genai
+from google.genai import errors as genai_errors
 from google.genai import types
 
 from backend.prompts.annotator_prompt import (
@@ -386,6 +387,12 @@ async def annotate_audio(
                     allow_salvage=(temperature == _ANNOTATE_ATTEMPT_TEMPS[-1]),
                 )
             except Exception as exc:  # noqa: BLE001 — one retry, then surface
+                if isinstance(exc, genai_errors.APIError) and exc.code == 400:
+                    # Deterministic request rejection (e.g. a model that
+                    # doesn't accept audio input — every Gemini 3.x as of
+                    # 2026-07, "Penalty is not enabled", bad schema).
+                    # Retrying the identical request cannot succeed.
+                    raise
                 last_exc = exc
                 logger.warning(
                     "annotate attempt at temp=%s failed (%s) — %s",

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -317,6 +317,17 @@ this design needs **no migration** (column 006, JSONB stamps only).
 4. **Annotator model:** trial **both** `gemini-2.5-flash` AND
    `gemini-2.5-pro` — the P2 smoke runs the same calls through each and
    the Spanish spot-check compares annotations side by side.
+   **CLOSED BY WALKOVER (2026-07-28):** `gemini-2.5-pro` is shut to new
+   API users, and a live probe matrix showed **every Gemini 3.x model
+   rejects audio input on our key** (400 on file-URI and inline alike;
+   identical requests succeed text-only). `gemini-2.5-flash` is
+   currently the ONLY audio-capable Gemini available to us — flash by
+   default and by necessity. ⚠ Strategic note: the whole audio leg
+   (Stage A + single-stage scoring) rides on one model that Google
+   could gate the way it gated 2.5-pro. This strengthens both the
+   two-stage split (the judge is already provider-portable) and the
+   LandGPT audio-leg independence case. Re-probe occasionally with
+   `scripts/annotate_smoke.py --model gemini-pro-latest`.
 5. **PII surface:** carried as **debt**, deliberately. The forcing
    function is the future **Agent view** — agents monitoring their own
    progress/performance — where raw transcriptions must NOT appear.

--- a/qa-automation/AI-Scoring/scripts/annotate_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/annotate_smoke.py
@@ -38,10 +38,15 @@ from backend.services.dialpad_client import (  # noqa: E402
 )
 
 _OUT_DIR = Path(__file__).resolve().parent / "annotations"
-# "pro" is Google's rolling alias — gemini-2.5-pro 404s for new API users
-# (observed 2026-07-26: "no longer available to new users"). Any raw
-# model id also works as --model (e.g. gemini-3-pro-preview,
-# gemini-3.5-flash) for one-off trials.
+# AUDIO-CAPABILITY STATUS (probed live 2026-07-28): gemini-2.5-flash is
+# the ONLY model on this key that accepts audio input. gemini-2.5-pro is
+# closed to new API users (404), and EVERY Gemini 3.x model (pro-latest,
+# 3.1-pro-preview, 3.5-flash, 3-flash-preview, flash-latest) returns
+# 400 INVALID_ARGUMENT on audio parts — file-URI and inline alike; the
+# same requests succeed text-only. §10.4's flash-vs-pro trial therefore
+# closed by walkover. The "pro" alias stays pointed at the rolling name
+# so it starts working the day Google re-opens audio; any raw model id
+# also works as --model for re-probing.
 _MODELS = {
     "flash": "gemini-2.5-flash",
     "pro": "gemini-pro-latest",

--- a/qa-automation/AI-Scoring/tests/test_annotator.py
+++ b/qa-automation/AI-Scoring/tests/test_annotator.py
@@ -361,3 +361,42 @@ def test_annotator_thinking_budget_env_override(monkeypatch):
     assert annotator_thinking_budget() == 8192
     monkeypatch.setenv("ANNOTATOR_THINKING_BUDGET", "not-a-number")
     assert annotator_thinking_budget() == 4096
+
+
+def test_annotate_audio_fails_fast_on_deterministic_400(monkeypatch):
+    """A 400 INVALID_ARGUMENT (model rejects audio input, unsupported
+    knob) is deterministic — retrying the identical request wastes a
+    call. One attempt, immediate surface."""
+    from google.genai import errors as genai_errors
+    import backend.services.audio_service as audio_service
+
+    attempts = []
+
+    class _AioModels:
+        async def generate_content(self, **kwargs):
+            attempts.append(kwargs)
+            raise genai_errors.ClientError(
+                400, {"error": {"message": "Request contains an invalid argument."}}
+            )
+
+    class _Aio:
+        models = _AioModels()
+
+    class _Files:
+        def upload(self, *, file, config):
+            class _Up:
+                uri = "files/fake"
+                name = "files/fake"
+            return _Up()
+
+        def delete(self, *, name):
+            pass
+
+    class _Client:
+        files = _Files()
+        aio = _Aio()
+
+    monkeypatch.setattr(audio_service, "_get_client", lambda: _Client())
+    with pytest.raises(genai_errors.ClientError):
+        asyncio.run(audio_service.annotate_audio(b"bytes", "call.mp3"))
+    assert len(attempts) == 1    # no retry on a deterministic rejection


### PR DESCRIPTION
## What

Diagnosis of the `gemini-pro-latest` bare-400 from the smoke run, plus the code hardening it implies.

**Probe matrix** (live, same key, same uploaded ACTIVE file):
- Every config combo — thinking_budget / thinking_level / response_schema / 65k cap, in all combinations — passes **text-only** on pro-latest.
- Every **audio** request fails 400 on pro-latest, `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3-flash-preview`, and `gemini-flash-latest` — file-URI and inline bytes alike. `gemini-3-pro-preview` is itself now 404.
- The same file reads fine on `gemini-2.5-flash`.

**Verdict:** no Gemini 3.x model accepts audio input on our key; `gemini-2.5-flash` is the **only audio-capable Gemini available to us** (2.5-pro closed to new users). TwoStageScoringDesign §10.4 (flash-vs-pro) closes by walkover — flash by default and by necessity — and the doc now records the strategic exposure: the whole audio leg rides on one model Google could gate tomorrow, which strengthens both the two-stage split (the judge is already portable) and LandGPT audio-leg independence.

**Code change:** `annotate_audio` no longer retries deterministic `400 INVALID_ARGUMENT` rejections (the bumped-temp retry only helps stochastic failures) — one attempt, immediate surface. The smoke script's model-alias comment documents the audio-capability status with the probe date; re-probe occasionally with `--model gemini-pro-latest`.

Production impact: none — the pipeline default is flash and `annotate_only` on Railway is unaffected (and producing real artifacts).

## Tests
`766 passed, 6 skipped, 3 xfailed` — new fail-fast test pins one-attempt behavior on 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)