### PR TITLE
feat(qa-automation): Scorecard Actions S4 — manual rescore, REPLACE on the same row

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -102,6 +102,18 @@ class ApprovalRequest(BaseModel):
     evaluator_email: Optional[str] = None
 
 
+class RescoreRequest(BaseModel):
+    """POST /score/{job_id}/rescore payload (ScorecardActionsDesign §4.2).
+
+    ``evaluator_email`` identifies the requesting evaluator for the audit
+    row and becomes the fresh job's manager_email — required, because a
+    rescore is a manual trigger and must never be booked to nobody.
+    ``suppress_email`` is the §4.2.7 opt-OUT: the re-finalize dispatches
+    the disclaimer email by default."""
+    evaluator_email: str
+    suppress_email: bool = False
+
+
 class ScorecardWithMeta(Scorecard):
     """Scorecard enriched with call metadata for the pipeline."""
     call_id: Optional[str] = None

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -22,7 +22,7 @@ from backend.middleware.auth import (
     require_api_key,
     team_id_from_path,
 )
-from backend.models.scorecard import ApprovalRequest
+from backend.models.scorecard import ApprovalRequest, RescoreRequest
 from backend.services.history_service import (
     agent_email_for_name,
     agent_name_for_email,
@@ -116,6 +116,44 @@ async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
     }
 
 
+def _dispatch_finalize_email(job, history_row, team_id, evaluation_id) -> None:
+    """Apps Script email dispatch at the finalize seam — shared by the
+    auto-flow and the approve path.
+
+    S4 (ScorecardActionsDesign §4.2.7): a job carrying a ``rescore``
+    context re-sends WITH the cause-specific disclaimer by default;
+    ``suppress_email`` opts out and leaves a visible 'suppressed' receipt
+    in the job payload. The context lives on the in-memory job only — a
+    restart between rescore and re-approve loses it, and the re-finalize
+    email goes out disclaimer-less (accepted at current traffic; the
+    audit 'rescored' row still records the intervention)."""
+    if not history_row or history_row <= 0:
+        job["email_dispatch"] = {
+            "status": "skipped", "message": "no Analyst_History row projected",
+        }
+        return
+    rescore = job.get("rescore") or {}
+    if rescore.get("suppress_email"):
+        job["email_dispatch"] = {
+            "status": "suppressed",
+            "message": f"rescore ({rescore.get('cause', '?')}) requested suppress_email",
+        }
+        return
+    disclaimer = f"rescore_{rescore['cause']}" if rescore else None
+    try:
+        job["email_dispatch"] = trigger_apps_script(
+            history_row, team_id, disclaimer=disclaimer
+        )
+    except Exception as e:
+        # Visible, not swallowed-into-print-limbo: the job payload
+        # carries the failure so operators see it in the UI/logs.
+        job["email_dispatch"] = {"status": "error", "message": str(e)}
+        logging.getLogger(__name__).exception(
+            "finalize email dispatch failed for eval %s (retryable)",
+            evaluation_id,
+        )
+
+
 def _sse_eval_id_from_link(link: str) -> str:
     """Trailing path segment of dialpad_link — the /datapoint route key
     (mirrors team_stats._parse_row; see the legacy approve path)."""
@@ -195,21 +233,7 @@ async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
         key_strengths=scorecard.key_strengths,
         opportunities=scorecard.opportunities,
     )
-    if history_row is not None and history_row > 0:
-        try:
-            script_response = trigger_apps_script(history_row, team_id)
-            job["email_dispatch"] = script_response
-            print(f"[auto-flow] Apps Script response: {script_response}")
-        except Exception as e:
-            # Visible, not swallowed-into-print-limbo: the job payload
-            # carries the failure so operators see it in the UI/logs.
-            job["email_dispatch"] = {"status": "error", "message": str(e)}
-            logging.getLogger(__name__).exception(
-                "auto-flow: Apps Script dispatch failed for eval %s (retryable)",
-                evaluation_id,
-            )
-    else:
-        job["email_dispatch"] = {"status": "skipped", "message": "no Analyst_History row projected"}
+    _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
 
 
 @router.get("/calls")
@@ -687,16 +711,7 @@ async def approve_scorecard(
         history_row = await project_evaluation(
             pool, evaluation_id, config, include_history=True
         )
-        if history_row is not None and history_row > 0:
-            try:
-                script_response = trigger_apps_script(history_row, team_id)
-                job["email_dispatch"] = script_response
-            except Exception as e:
-                job["email_dispatch"] = {"status": "error", "message": str(e)}
-                logging.getLogger(__name__).exception(
-                    "approve: Apps Script dispatch failed for eval %s (retryable)",
-                    evaluation_id,
-                )
+        _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
         await _publish_finalized_event(
             team_id, job,
             agent_name=job.get("agent_name") or sc.get("agent_name"),
@@ -739,6 +754,219 @@ async def approve_scorecard(
         job["status"] = "complete"
         job["error"] = str(e)
         raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
+
+
+@router.post("/score/{job_id}/rescore")
+async def rescore_evaluation(
+    request: Request,
+    job_id: str,
+    payload: RescoreRequest,
+    background_tasks: BackgroundTasks,
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """Manual re-score — REPLACE on the same row id (ScorecardActionsDesign
+    §4.2). Team key (roster-scoped) or privileged; scorecard and datapoint
+    surfaces (job_id or bare call_id — §3 resolution).
+
+    The rescore primitive: re-download the audio by Dialpad call id, run
+    the same score_call pipeline (fresh model pass — including whatever
+    SCORING_PIPELINE stage-A mode is live), land it via the Stage-1 upsert
+    (same row id, every FK preserved), rebuild the agent's stat series so
+    the superseded score doesn't linger in the EWMA chain while the row
+    sits in draft, then let the normal auto-flow decide auto-finalize vs.
+    flagged review. The re-finalize dispatches the disclaimer email by
+    default; ``suppress_email`` opts out (§4.2.7).
+
+    Machine-owned outcome: the manual act here is the *trigger*, not the
+    score — no coaching receipt, no §4.3a acknowledgment (§0.2). The
+    audit row is action='rescored' with the superseded score AND model
+    stamp (``superseded_model=…``), so cross-model re-scores stay
+    traceable once the judge model can differ between passes
+    (TwoStageScoringDesign P3+).
+
+    Concurrency: last-writer-wins by design. qa.evaluations has no
+    updated_at column and these are low-traffic manager tools. If Landing
+    outgrows this (concurrent evaluators on one eval), add updated_at +
+    an If-Unmodified-Since-style optimistic check here — potential design
+    choice deliberately deferred, not overlooked.
+    """
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    key = _job_key(team_id, job_id)
+
+    # §4.2: refuse to race an in-flight job for the same key.
+    existing = _jobs.get(key)
+    if existing and existing.get("status") in {"pending", "scoring"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A scoring job for this call is already {existing['status']}",
+        )
+
+    ref = await eval_store.resolve_evaluation(team_id, job_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="No evaluation matches this call id")
+
+    # Auth (§7): roster-scoped for team keys, mirroring /score.
+    is_in_roster = (
+        await email_in_team_mails(ref.agent_email, team_id)
+        if ref.agent_email else False
+    )
+    try:
+        check_scoring_access(
+            identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
+        )
+    except HTTPException as exc:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=payload.evaluator_email,
+            agent_email=ref.agent_email or "",
+            agent_name=ref.agent_name_raw,
+            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes=f"http_{exc.status_code}",
+        )
+        raise
+
+    # §4.2.1: same input, fresh pass — re-download by Dialpad call id.
+    call_id = ref.dialpad_call_id or ref.dialpad_entry_point_call_id or ""
+    try:
+        audio_bytes = await download_recording(call_id)
+    except NoRecordingAvailable:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=payload.evaluator_email,
+            agent_email=ref.agent_email or "",
+            agent_name=ref.agent_name_raw,
+            call_id=call_id,
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes="no_recording",
+        )
+        raise HTTPException(
+            status_code=422,
+            detail="Call has no recording in Dialpad",
+        )
+    except DialpadRateLimited:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=payload.evaluator_email,
+            agent_email=ref.agent_email or "",
+            agent_name=ref.agent_name_raw,
+            call_id=call_id,
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes="rate_limited",
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Dialpad rate-limited; retry shortly",
+        )
+
+    # Same pre-fetch pattern as /score (sequential in the handler so
+    # fan-out background tasks don't burst Dialpad).
+    transcript_data = await get_transcript(call_id)
+    try:
+        call_details = await get_call_details(call_id)
+    except DialpadRateLimited:
+        print(f"[rescore] Dialpad rate-limited fetching call_details for {call_id}; proceeding with blanks")
+        call_details = None
+
+    # Audit BEFORE scheduling (crash-safe receipt), with the superseded
+    # score + model stamp — the cross-model traceability hook (P3+).
+    old_score = "unscored" if ref.overall_score is None else ref.overall_score
+    append_score_audit_row(
+        api_key_role=identity.role,
+        evaluator_email=payload.evaluator_email,
+        agent_email=ref.agent_email or "",
+        agent_name=ref.agent_name_raw,
+        call_id=call_id,
+        target_team=team_id,
+        action=audit_cfg.ACTION_RESCORED,
+        result_row=None,
+        notes=f"manual: {old_score}; superseded_model={ref.model}",
+    )
+
+    _jobs[key] = {
+        "status": "pending",
+        "call_id": call_id,
+        "agent_email": ref.agent_email or "",
+        "agent_name": ref.agent_name_raw,
+        "manager_email": payload.evaluator_email,
+        # Consumed by _dispatch_finalize_email on the re-finalize
+        # (in-memory only — see that helper's restart caveat).
+        "rescore": {
+            "cause": "manual",
+            "suppress_email": payload.suppress_email,
+            "superseded_score": ref.overall_score,
+            "superseded_model": ref.model,
+        },
+    }
+
+    semaphore = _semaphore_for_key(identity)
+    agent_name = ref.agent_name_raw
+    duration_ms = float(ref.duration_ms or 0)
+    expected_row_id = ref.id
+    agent_id = ref.agent_id
+
+    async def run():
+        try:
+            _jobs[key]["status"] = "scoring"
+            async with semaphore:
+                scorecard = await score_call(
+                    audio_bytes=audio_bytes,
+                    filename=f"{call_id}.mp3",
+                    call_id=call_id,
+                    agent_name=agent_name,
+                    manager_email=payload.evaluator_email,
+                    config=config,
+                    duration_ms=duration_ms,
+                    transcript_data=transcript_data,
+                    call_details=call_details,
+                )
+            # §4.2.2: the Stage-1 upsert IS the REPLACE — same row id,
+            # lifecycle columns reset, sections replaced wholesale.
+            evaluation_id = await record_draft_evaluation(
+                scorecard, config, strict=True
+            )
+            if evaluation_id != expected_row_id:
+                raise RuntimeError(
+                    f"rescore landed on row {evaluation_id}, expected "
+                    f"{expected_row_id} — REPLACE contract violated "
+                    "(dialpad_link drift?)"
+                )
+            _jobs[key]["evaluation_id"] = evaluation_id
+            _jobs[key]["scorecard"] = scorecard.model_dump()
+            # §4.2.3: row is draft now — drop its stat point and rebuild
+            # the series. Fatal by contract (§5): a failure errors the
+            # whole job loudly rather than leaving a corrupt EWMA chain.
+            if agent_id is not None:
+                pool = await eval_store.get_pool()
+                if pool is None:
+                    raise RuntimeError("rescore: no DB pool for series rebuild")
+                async with pool.acquire() as conn:
+                    async with conn.transaction():
+                        await rebuild_agent_series(conn, agent_id, config)
+            # §4.2.4: the auto-flow decides auto-finalize vs. flagged,
+            # like any first pass — the machine owns the outcome.
+            await _postgres_post_stage1(
+                _jobs[key], evaluation_id, scorecard, config, team_id
+            )
+            _jobs[key]["status"] = "complete"
+        except Exception as e:
+            _jobs[key]["status"] = "error"
+            _jobs[key]["error"] = str(e)
+
+    background_tasks.add_task(run)
+    return {
+        "job_id": job_id,
+        "status": "pending",
+        "evaluation_id": ref.id,
+        "superseded_score": ref.overall_score,
+    }
 
 
 @router.delete("/score/{job_id}")

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -769,6 +769,11 @@ class EvalRef:
     overall_score: Optional[float]
     model: str
     sections: list[dict[str, Any]]
+    # S4 additions (defaulted so S1-era constructions stay valid):
+    # agent_id feeds the §5 series rebuild; duration_ms feeds the fresh
+    # score_call pass (long-call flag parity with the original run).
+    agent_id: Optional[int] = None
+    duration_ms: Optional[float] = None
 
 
 def call_id_from_job_id(job_id: str) -> str:
@@ -808,7 +813,7 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
             "  agent_name_raw, agent_email, evaluator_email, "
             "  dialpad_call_id, dialpad_entry_point_call_id, dialpad_link, "
             "  call_summary, key_strengths, opportunities, overall_score, "
-            "  models_used "
+            "  models_used, agent_id, duration_ms "
             "FROM qa.evaluations "
             "WHERE team_id = $1 "
             "AND (dialpad_entry_point_call_id = $2 OR dialpad_call_id = $2) "
@@ -873,6 +878,10 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
         ),
         model=model,
         sections=sections,
+        agent_id=row["agent_id"],
+        duration_ms=(
+            float(row["duration_ms"]) if row["duration_ms"] is not None else None
+        ),
     )
 
 

--- a/qa-automation/AI-Scoring/backend/services/sheets_service.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_service.py
@@ -281,12 +281,21 @@ def append_score_audit_row(
 # Apps Script trigger
 # ---------------------------------------------------------------------------
 
-def trigger_apps_script(history_row_num: int, team_id: str) -> dict:
+def trigger_apps_script(
+    history_row_num: int, team_id: str, disclaimer: Optional[str] = None
+) -> dict:
     """POST to the team's Apps Script web app to dispatch the QA email.
 
     The Apps Script reads ``Analyst_History`` row ``history_row_num``
     (already written by the post-approve projection) and sends the
     evaluation email.
+
+    ``disclaimer`` (ScorecardActionsDesign §4.2.7): cause tag for the
+    re-send of a re-scored/overridden evaluation — ``rescore_manual`` /
+    ``rescore_auto`` (S5) / ``override`` (S6). Sent as an extra payload
+    key; today's GAS Main.js ignores unknown keys, and the S7 template
+    slice renders the matching disclaimer block. Omitted entirely from
+    the payload when None so first-pass dispatches are byte-identical.
     """
     import httpx
 
@@ -298,9 +307,12 @@ def trigger_apps_script(history_row_num: int, team_id: str) -> dict:
             f"{'' if team_id == 'member_support' else '_' + team_id.upper()}"
         )
 
+    payload: dict = {"historyRowNumber": history_row_num}
+    if disclaimer:
+        payload["disclaimer"] = disclaimer
     response = httpx.post(
         url,
-        json={"historyRowNumber": history_row_num},
+        json=payload,
         timeout=60.0,
         follow_redirects=True,
     )

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -67,6 +67,8 @@ def _eval_row(**overrides):
         "models_used": json.dumps(
             {"text": {"provider": "gemini", "model": "gemini-2.5-flash"}}
         ),
+        "agent_id": 7,
+        "duration_ms": 180000,
     }
     row.update(overrides)
     return row
@@ -136,6 +138,10 @@ class TestResolveEvaluation:
         assert ref.state == "draft"
         assert ref.scoring_status == "flagged_human_review"
         assert ref.model == "gemini-2.5-flash"
+        # S4 fields — series-rebuild target and long-call-flag parity.
+        assert ref.agent_id == 7
+        assert ref.duration_ms == 180000.0
+        assert isinstance(ref.duration_ms, float)
         # The 2026-07-24 incident guarantee: one probe, both columns.
         query, args = self.conn.fetchrow_args
         assert "dialpad_entry_point_call_id = $2" in query

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -387,7 +387,10 @@ def test_approve_writes_audit_row(client, monkeypatch):
     async def fake_project(pool, evaluation_id, config, include_history=True):
         return 555
     monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
-    monkeypatch.setattr(scoring_module, "trigger_apps_script", lambda row, team_id: {"status": "ok"})
+    monkeypatch.setattr(
+        scoring_module, "trigger_apps_script",
+        lambda row, team_id, disclaimer=None: {"status": "ok"},
+    )
 
     resp = client.post(
         f"/api/member_support/score/{job_id}/approve",
@@ -614,6 +617,8 @@ def _eval_ref(**overrides):
         overall_score=None,
         model="gemini-2.5-flash",
         sections=[],
+        agent_id=7,
+        duration_ms=180000.0,
     )
     defaults.update(overrides)
     return EvalRef(**defaults)
@@ -647,7 +652,8 @@ def _stub_engine_path(monkeypatch, captured_approvals):
         return 321
     monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
     monkeypatch.setattr(
-        scoring_module, "trigger_apps_script", lambda row, team_id: {"status": "ok"}
+        scoring_module, "trigger_apps_script",
+        lambda row, team_id, disclaimer=None: {"status": "ok"},
     )
 
 
@@ -958,3 +964,369 @@ def test_delete_skips_rebuild_for_agentless_eval(client, monkeypatch):
     assert resp.status_code == 200, resp.text
     assert rebuilds == []
     assert resp.json()["snapshot"]["stat_point"] is None
+
+
+# ---------------------------------------------------------------------------
+# S4 — POST /score/{job_id}/rescore (ScorecardActionsDesign §4.2, manual)
+# ---------------------------------------------------------------------------
+
+class _NullConn:
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+
+class _NullPool:
+    def __init__(self):
+        self.conn = _NullConn()
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+class _FakeScorecard:
+    """Just enough of ScorecardWithMeta for the post-Stage-1 flow."""
+
+    def __init__(self, manager_email):
+        self.sections = []
+        self.manager_email = manager_email
+        self.agent_name = "Luis Rubio"
+        self.dialpad_link = (
+            "https://dialpad.com/callhistory/callreview/6105002063634432"
+        )
+        self.call_summary = "Billing question"
+        self.key_strengths = "Good tone"
+        self.opportunities = "Faster holds"
+        self.model = "gemini-2.5-flash"
+
+    def model_dump(self):
+        return {
+            "sections": self.sections,
+            "manager_email": self.manager_email,
+            "dialpad_link": self.dialpad_link,
+            "call_summary": self.call_summary,
+            "key_strengths": self.key_strengths,
+            "opportunities": self.opportunities,
+            "agent_name": self.agent_name,
+            "model": self.model,
+        }
+
+
+def _stub_rescore_pipeline(monkeypatch, *, flagged=False, draft_row_id=2377,
+                           engine_score=88.0):
+    """Stub the whole rescore background pipeline, recording operation
+    order in caps['ops'] — the §4.2 order proof (draft → rebuild → stamp)
+    rides on it."""
+    caps = {"score_calls": [], "ops": [], "rebuilds": [], "dispatches": [],
+            "approvals": []}
+
+    async def fake_download(call_id):
+        caps["download"] = call_id
+        return b"AUDIO"
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    async def fake_score_call(**kw):
+        caps["score_calls"].append(kw)
+        return _FakeScorecard(kw["manager_email"])
+    monkeypatch.setattr(scoring_module, "score_call", fake_score_call)
+
+    async def fake_record_draft(scorecard, config, strict=False):
+        caps["ops"].append("draft")
+        return draft_row_id
+    monkeypatch.setattr(
+        scoring_module, "record_draft_evaluation", fake_record_draft)
+
+    async def fake_rebuild(conn, agent_id, config):
+        caps["ops"].append("rebuild")
+        caps["rebuilds"].append(agent_id)
+        return 3
+    monkeypatch.setattr(scoring_module, "rebuild_agent_series", fake_rebuild)
+
+    monkeypatch.setattr(
+        scoring_module.eval_store, "_active_formula", lambda team_id: None)
+    monkeypatch.setattr(
+        scoring_module.eval_store, "human_review_trigger_fired",
+        lambda formula, sections: flagged)
+    monkeypatch.setattr(
+        scoring_module.eval_store, "requires_analyst_review",
+        lambda config: False)
+
+    class _Detail:
+        overall_score = engine_score
+
+    async def fake_stamp(evaluation_id, config, evaluator_email):
+        caps["ops"].append("stamp")
+        return _Detail()
+    monkeypatch.setattr(
+        scoring_module.eval_store, "stamp_and_finalize", fake_stamp)
+
+    pool = _NullPool()
+
+    async def fake_pool():
+        return pool
+    monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
+
+    async def fake_project(pool_, evaluation_id, config, include_history=True):
+        caps["ops"].append("project")
+        return 321
+    monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
+
+    def fake_trigger(row, team_id, disclaimer=None):
+        caps["dispatches"].append({"row": row, "disclaimer": disclaimer})
+        return {"status": "ok"}
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", fake_trigger)
+
+    # Approve-path stubs so the flagged → re-approve round-trip works.
+    monkeypatch.setattr(
+        scoring_module.eval_store, "missing_manual_scores",
+        lambda config, sections: [])
+
+    async def fake_record_approval(config, **kw):
+        caps["approvals"].append(kw)
+        return kw.get("evaluation_id")
+    monkeypatch.setattr(scoring_module, "record_approval", fake_record_approval)
+
+    return caps
+
+
+_RESCORE_URL = "/api/member_support/score/5035229460504576_Luis_Rubio/rescore"
+
+
+def test_rescore_in_flight_409(client, monkeypatch):
+    """§4.2: refuse to race a pending/scoring job — before any DB probe."""
+    resolve_calls = _resolve_stub(monkeypatch, _eval_ref())
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    scoring_module._jobs[key] = {"status": "scoring"}
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 409
+    assert "scoring" in resp.json()["detail"]
+    assert resolve_calls == []
+    assert client.audit_rows == []
+
+
+def test_rescore_unknown_eval_404(client, monkeypatch):
+    _resolve_stub(monkeypatch, None)
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 404
+    assert client.audit_rows == []
+
+
+def test_rescore_team_key_unrostered_403_denied_audit(client, monkeypatch):
+    """§7: team keys are roster-scoped for rescore, same as /score."""
+    _resolve_stub(monkeypatch, _eval_ref(agent_email="ghost@landing.com"))
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 403
+    denied = [r for r in client.audit_rows if r["action"] == "denied"]
+    assert len(denied) == 1
+    assert denied[0]["notes"] == "http_403"
+    assert denied[0]["evaluator_email"] == "ana@landing.com"
+    assert denied[0]["agent_name"] == "Luis Rubio"
+
+
+def test_rescore_no_recording_422(client, monkeypatch):
+    _resolve_stub(monkeypatch, _eval_ref())
+
+    async def fake_download(call_id):
+        raise scoring_module.NoRecordingAvailable("gone")
+    monkeypatch.setattr(scoring_module, "download_recording", fake_download)
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 422
+    denied = [r for r in client.audit_rows if r["action"] == "denied"]
+    assert len(denied) == 1
+    assert denied[0]["notes"] == "no_recording"
+    rescored = [r for r in client.audit_rows if r["action"] == "rescored"]
+    assert rescored == []
+
+
+def test_rescore_clean_pass_auto_finalizes_with_disclaimer(client, monkeypatch):
+    """Full REPLACE round-trip on a clean fresh pass: same row id, series
+    rebuilt while the row is draft (§4.2.3 — after the upsert, before
+    finalize), auto-finalize, disclaimer email by default."""
+    caps = _stub_rescore_pipeline(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5),
+    )
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["evaluation_id"] == 2377
+    assert body["superseded_score"] == 62.5
+
+    # Audit receipt with the superseded score AND model stamp (the
+    # P3+ cross-model traceability hook).
+    rescored = [r for r in client.audit_rows if r["action"] == "rescored"]
+    assert len(rescored) == 1
+    assert rescored[0]["notes"] == "manual: 62.5; superseded_model=gemini-2.5-flash"
+    assert rescored[0]["evaluator_email"] == "ana@landing.com"
+    assert rescored[0]["call_id"] == "5035229460504576"
+
+    # Fresh pass ran with the row's own inputs.
+    assert caps["download"] == "5035229460504576"
+    assert len(caps["score_calls"]) == 1
+    assert caps["score_calls"][0]["duration_ms"] == 180000.0
+    assert caps["score_calls"][0]["manager_email"] == "ana@landing.com"
+
+    # §4.2 order proof: upsert → rebuild (row is draft) → finalize.
+    assert caps["ops"] == ["draft", "rebuild", "stamp", "project"]
+    assert caps["rebuilds"] == [7]
+
+    # Disclaimer email dispatched by default.
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "rescore_manual"}]
+
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    job = scoring_module._jobs[key]
+    assert job["status"] == "complete"
+    assert job["state"] == "finalized"
+    assert job["overall_score"] == 88.0
+    assert job["rescore"]["superseded_score"] == 62.5
+    assert job["email_dispatch"] == {"status": "ok"}
+
+
+def test_rescore_suppress_email_opts_out(client, monkeypatch):
+    caps = _stub_rescore_pipeline(monkeypatch)
+    _resolve_stub(monkeypatch, _eval_ref(state="finalized", overall_score=62.5))
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com", "suppress_email": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["dispatches"] == []
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    job = scoring_module._jobs[key]
+    assert job["status"] == "complete"
+    assert job["email_dispatch"]["status"] == "suppressed"
+
+
+def test_rescore_row_id_mismatch_errors_job(client, monkeypatch):
+    """REPLACE contract guard: if the upsert lands anywhere but the
+    resolved row, the job errors loudly before touching the stat chain."""
+    caps = _stub_rescore_pipeline(monkeypatch, draft_row_id=9999)
+    _resolve_stub(monkeypatch, _eval_ref(state="finalized", overall_score=62.5))
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200  # scheduling succeeded; the job errored
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    job = scoring_module._jobs[key]
+    assert job["status"] == "error"
+    assert "REPLACE contract violated" in job["error"]
+    assert "rebuild" not in caps["ops"]
+    assert "stamp" not in caps["ops"]
+
+
+def test_rescore_flagged_pass_holds_draft_then_approve_dispatches_disclaimer(
+        client, monkeypatch):
+    """The fresh pass fires §3.14 → row holds in draft review; the
+    re-approve finalizes with resolving_review and the disclaimer email
+    still rides the job's rescore context."""
+    caps = _stub_rescore_pipeline(monkeypatch, flagged=True)
+    _resolve_stub(monkeypatch, _eval_ref(state="finalized", overall_score=45.0))
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    job = scoring_module._jobs[key]
+    assert job["status"] == "complete"
+    assert job["state"] == "draft"
+    assert job["scoring_status"] == "flagged_human_review"
+    # Stat point already removed while the row sits in draft (§4.2.3).
+    assert caps["ops"] == ["draft", "rebuild"]
+    assert caps["dispatches"] == []
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "finalized"
+    assert caps["approvals"][0]["resolving_review"] is True
+    assert caps["approvals"][0]["evaluator_email"] == "ana@landing.com"
+    assert caps["ops"] == ["draft", "rebuild", "stamp", "project"]
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "rescore_manual"}]
+
+    actions = [r["action"] for r in client.audit_rows]
+    assert actions == ["rescored", "approved"]
+
+
+def test_rescore_agentless_eval_skips_rebuild(client, monkeypatch):
+    """agent_id NULL (departed agent) — fresh pass proceeds, no series
+    rebuild, matching the delete route's behavior."""
+    caps = _stub_rescore_pipeline(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", overall_score=62.5, agent_id=None),
+    )
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    assert scoring_module._jobs[key]["status"] == "complete"
+    assert caps["rebuilds"] == []
+    assert caps["ops"] == ["draft", "stamp", "project"]
+
+
+def test_rescore_privileged_key_unrostered_allowed(client, monkeypatch):
+    """§7: privileged keys rescore unrostered agents (same as /score)."""
+    caps = _stub_rescore_pipeline(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", overall_score=62.5,
+                  agent_email="ghost@landing.com"),
+    )
+
+    resp = client.post(
+        _RESCORE_URL,
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    rescored = [r for r in client.audit_rows if r["action"] == "rescored"]
+    assert len(rescored) == 1
+    assert rescored[0]["api_key_role"] == "privileged"


### PR DESCRIPTION
Lands slice S4 of **ScorecardActionsDesign v1.2** (§4.2, manual trigger path — the auto ≤50 trigger is S5).

## The route
`POST /score/{job_id}/rescore` — team key (roster-scoped) or privileged; works from both the scorecard and datapoint surfaces via §3 DB resolution (job_id or bare call id). Refuses (409) to race an in-flight `pending`/`scoring` job for the same key.

## The rescore primitive
1. Re-download the audio by Dialpad call id — same input, fresh model pass through the existing `score_call` pipeline, **including whatever `SCORING_PIPELINE` Stage-A mode is live** (an `annotate_only` rescore regenerates and overwrites `annotated_transcript`, as P2's `build_draft_row` comment anticipated).
2. Land it via the Stage-1 upsert — same row id, every FK preserved, lifecycle columns reset (`_RESCORE_RESET` was built for exactly this). A runtime guard errors the job loudly if the upsert ever lands on a different row (`REPLACE contract violated`).
3. Rebuild the agent's stat series while the row sits in draft (§4.2.3) — the superseded score must not linger in the EWMA chain. Fatal by contract (§5).
4. The normal auto-flow decides auto-finalize vs. flagged review, like any first pass — **the machine owns the outcome**. The manual act is only the trigger, so no coaching receipt and no §4.3a acknowledgment (§0.2 — this is not score-tampering; the escalation rung for disagreeing with the fresh result is the S6 override).

## Audit — with the model stamp
`action='rescored'`, notes `manual: <old>; superseded_model=<model>`. The stamp is deliberate: once the judge model can differ between passes (TwoStageScoringDesign P3+), every cross-model rescore stays traceable in audit search instead of silently blending two models' scores. See the PR comment below for the note addressed to the model-provider-trial workstream.

## Email (§4.2.7)
The re-finalize dispatches the disclaimer email **by default**; `suppress_email: true` opts out and leaves a visible `"suppressed"` receipt on the job. `trigger_apps_script` gains an optional `disclaimer` payload key (`rescore_manual` now; `rescore_auto`/`override` reserved for S5/S6) — today's GAS Main.js ignores unknown keys; the S7 template slice renders the block. First-pass dispatch payloads are byte-identical to before. Both finalize-seam dispatch sites (auto-flow + approve) now share `_dispatch_finalize_email`.

Known bound (documented in the helper): the rescore context lives on the in-memory job, so a server restart between rescore and re-approve loses the disclaimer/suppress flags — accepted at current traffic; the audit `rescored` row still records the intervention.

## Plumbing
`EvalRef` gains `agent_id` (series-rebuild target) + `duration_ms` (long-call-flag parity on the fresh pass), both defaulted so S1-era constructions are unchanged.

## Tests
`1038 passed, 6 skipped, 3 xfailed` — 10 new: in-flight 409, roster 403 + denied audit, no-recording 422, clean-pass round-trip with the `draft → rebuild → stamp → project` order proof, suppress opt-out, REPLACE-guard error path, flagged → re-approve round-trip (`resolving_review` + disclaimer dispatch), agentless skip, privileged-unrostered allow, audit model-stamp assertion.

Next: S5 (auto rescore + `human_review.mode` config) → S6 (override + ack protocol) → S7 (datapoint edit surface + frontend action bars + GAS disclaimer template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)