### PR TITLE
P3 — Stage-B judge; two_stage_shadow + two_stage live

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -160,3 +160,15 @@ class ScorecardWithMeta(Scorecard):
     # or annotation failed (annotation is never a scoring blocker).
     annotated_transcript: Optional[dict] = None
     annotator_model: Optional[str] = None
+    # TwoStageScoringDesign §4 — text-leg provenance. scorer_provider +
+    # `model` above identify the SCORE AUTHOR (models_used.text and
+    # ai_provider_primary); "gemini" default = single-stage today.
+    scorer_provider: str = "gemini"
+    # §5 — Plan-B record: set when a two_stage run fell back to
+    # single-stage scoring ("annotate_failed" | "text_scorer_failed");
+    # eval_store turns it into models_used.fallback.
+    pipeline_fallback_reason: Optional[str] = None
+    # §6 — shadow-week compare stamp (judge meta + per-section results,
+    # or the judge error), persisted to dialpad_call_metadata for the
+    # report; None outside two_stage_shadow.
+    two_stage_shadow: Optional[dict] = None

--- a/qa-automation/AI-Scoring/backend/prompts/judge_prompt.py
+++ b/qa-automation/AI-Scoring/backend/prompts/judge_prompt.py
@@ -1,0 +1,121 @@
+"""Stage-B judge prompt — TwoStageScoringDesign §4.
+
+The judge scores the call FROM the rendered annotated transcript — it
+never hears audio. Everything rubric-shaped is reused verbatim from
+qa_scoring_prompt (rubric, SOP block + missing-note, output schema) so
+single-stage and two-stage judges score against byte-identical
+instructions; only the evidence block and the source-of-truth doctrine
+differ.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from backend.prompts.qa_scoring_prompt import (
+    SOP_CONTEXT_BLOCK,
+    _build_sop_missing_note,
+    _sop_section_refs,
+    build_output_schema,
+    build_scoring_rubric,
+)
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+
+
+# Keep the agent-name rule in sync with qa_scoring_prompt's
+# LANDING_GENERAL_INSTRUCTIONS — a test pins the two together. Only the
+# source-of-truth bullet differs: the judge's SOT is the annotated
+# record, not audio it cannot hear.
+JUDGE_GENERAL_INSTRUCTIONS = """
+=== GENERAL LANDING RULES ===
+- Agent name in the greeting: an agent may introduce themselves with any
+  name they choose (some teams have multiple people with the same first
+  name, so reps may differentiate via a preferred or alternate name). Do
+  NOT penalize the agent for the specific name used in the greeting. Do
+  flag if the agent uses one name in the greeting and then switches to a
+  different name later in the same call — consistency within the call is
+  required. The agent's Dialpad-recorded name is internal and is NOT the
+  ground truth for what name they must use with the lead/member.
+- Source of truth: the ANNOTATED CALL RECORD is the authoritative
+  account of the call. It was produced by an audio-native annotator
+  that listened to the full recording — including for non-English
+  calls, where the annotator re-transcribed from the audio. Score from
+  the record; there is no separate transcript to consult.
+""".rstrip()
+
+
+ANNOTATION_CONTEXT_BLOCK = """
+=== ANNOTATED CALL RECORD (authoritative) ===
+You cannot hear the call. The record below is the authoritative account
+of it, produced by an audio-native annotator. How to read it:
+- Per-turn emotion / pace / [interrupts] tags are audio-derived
+  observations — use them as your evidence for tone, empathy, and
+  pacing judgments.
+- HOLD lines are labeled "observational — not system-verified": the
+  annotator HEARD them (music, dead air). Treat them as observations;
+  only the CALL CONTEXT block above (when present) contains verified
+  system data.
+- CALL-LEVEL OBSERVATIONS carry context per-turn fields can't (audio
+  quality, tone arcs, transcript divergences).
+- An "ANNOTATION TRUNCATED" observation means the record is partial:
+  score what the record shows, mark LOW confidence on any section the
+  missing tail could change, and say so in that section's reasoning.
+
+{annotation_text}
+"""
+
+
+def build_judge_system_prompt(config: "TeamConfig") -> str:
+    """Team persona template + the judge variant of the general rules."""
+    rendered = config.scoring_prompt.system_prompt_template.format(
+        company=config.company,
+    )
+    return f"{rendered}\n\n{JUDGE_GENERAL_INSTRUCTIONS}"
+
+
+def build_judge_prompt(
+    config: "TeamConfig",
+    annotation_text: str,
+    sop_title: str = "",
+    sop_content: str = "",
+    agent_name: str = "",
+    extra_notes: str = "",
+    call_context_text: str = "",
+) -> str:
+    """Assemble the Stage-B user prompt — build_prompt's shape with the
+    annotated record standing where transcript + audio stood."""
+    parts = [build_scoring_rubric(config)]
+
+    if sop_content:
+        parts.append(
+            SOP_CONTEXT_BLOCK.format(
+                sop_title=sop_title,
+                sop_section_refs=_sop_section_refs(config),
+                sop_content=sop_content,
+            )
+        )
+    else:
+        parts.append(_build_sop_missing_note(config))
+
+    # DispositionDesign §5: verified system data rides AHEAD of the
+    # call record, exactly as it rides ahead of the transcript today.
+    if call_context_text:
+        parts.append(call_context_text)
+
+    parts.append(ANNOTATION_CONTEXT_BLOCK.format(annotation_text=annotation_text))
+
+    if agent_name:
+        parts.append(f"\nAgent name: {agent_name}")
+    if extra_notes:
+        parts.append(f"Additional context: {extra_notes}")
+
+    parts.append(build_output_schema(config))
+    parts.append(
+        "\n[No audio is attached. Score exclusively from the ANNOTATED "
+        "CALL RECORD and the context blocks above. DO NOT mention a lack "
+        "of SOP in your score reasoning if no SOP context was provided.]"
+    )
+
+    return "\n".join(parts)

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -43,7 +43,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-from backend.models.formula import EvaluationSection, Formula, ModelInfo, ModelsUsed
+from backend.models.formula import EvaluationSection, FallbackInfo, Formula, ModelInfo, ModelsUsed
 
 if TYPE_CHECKING:
     from backend.config.team_config import TeamConfig
@@ -149,9 +149,20 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
             model=scorecard.annotator_model,
             version="gemini_annotate_v1",
         )
+    # §8.1 text leg = the SCORE AUTHOR: the Stage-B judge in two_stage
+    # (any provider behind the llm/ seam), single-stage Gemini otherwise.
+    # §8.1 fallback records a two_stage run rescued by single-stage
+    # (sections=[] — the whole scorecard rerouted, not a §8.3a subset).
+    fallback = None
+    if scorecard.pipeline_fallback_reason:
+        fallback = FallbackInfo(
+            provider="gemini", sections=[],
+            reason=scorecard.pipeline_fallback_reason,
+        )
     models_used = ModelsUsed(
         audio=audio_leg,
-        text=ModelInfo(provider="gemini", model=scorecard.model),
+        text=ModelInfo(provider=scorecard.scorer_provider, model=scorecard.model),
+        fallback=fallback,
     )
     duration_ms = int(scorecard.duration_ms) if scorecard.duration_ms else None
     # §3.14 gate beats long-call telemetry when both apply — the human-review
@@ -186,7 +197,7 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
         "key_strengths": scorecard.key_strengths or None,
         "opportunities": scorecard.opportunities or None,
         "models_used": json.dumps(models_used.model_dump(exclude_none=True)),
-        "ai_provider_primary": "gemini",
+        "ai_provider_primary": scorecard.scorer_provider,
         "scoring_status": scoring_status,
         "human_review_required_at": datetime.now(timezone.utc) if flagged_review else None,
         # DispositionDesign §5 step 4 — CC-match stamps (migration 016).
@@ -213,6 +224,13 @@ def build_draft_row(scorecard: "ScorecardWithMeta", config: "TeamConfig") -> dic
             # corpus evolves, so the eval records exactly which docs
             # (id + updated stamp + score) grounded its SOP context.
             "pulpo_docs": scorecard.pulpo_docs,
+            # TwoStageScoringDesign §6 — shadow-week compare stamp
+            # (judge meta + per-section results or the judge error);
+            # absent outside two_stage_shadow.
+            **(
+                {"two_stage_shadow": scorecard.two_stage_shadow}
+                if scorecard.two_stage_shadow is not None else {}
+            ),
         }),
     }
 

--- a/qa-automation/AI-Scoring/backend/services/judge_service.py
+++ b/qa-automation/AI-Scoring/backend/services/judge_service.py
@@ -1,0 +1,73 @@
+"""Stage-B judge — TwoStageScoringDesign §4.
+
+Scores a call FROM its Stage-A annotated transcript through the llm/
+provider seam: any TextModelProvider can be the judge. Resolution is
+env-keyed (SCORING_MODEL_PROVIDER = gemini | anthropic, default gemini
+— the shadow rollout judges with Gemini first to isolate the split's
+effect from the model's, then flips to Claude via
+SCORING_MODEL_PROVIDER=anthropic / SCORING_ANTHROPIC_MODEL).
+
+Output parsing matches the single-stage path byte-for-byte: fence-
+tolerant JSON extraction + Scorecard validation against the team's
+section definitions. Raises on failure — the CALLER (scoring_service)
+owns fallback semantics (two_stage falls back to single-stage
+score_audio; shadow logs and stamps the error).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from backend.models.formula import AnnotatedTranscript
+from backend.models.scorecard import Scorecard
+from backend.prompts.judge_prompt import build_judge_prompt, build_judge_system_prompt
+from backend.services.annotation_render import render_annotated_transcript
+from backend.services.audio_service import _extract_json
+from backend.services.llm.factory import resolve_stage
+from backend.services.llm.provider import LlmResult
+
+if TYPE_CHECKING:
+    from backend.config.team_config import TeamConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def score_annotation(
+    annotation: AnnotatedTranscript,
+    config: "TeamConfig",
+    *,
+    sop_title: str = "",
+    sop_content: str = "",
+    agent_name: str = "",
+    extra_notes: str = "",
+    call_context_text: str = "",
+) -> tuple[Scorecard, LlmResult]:
+    """Render the annotation, build the judge prompt, generate, validate.
+
+    Returns the validated Scorecard plus the LlmResult whose
+    provider/model feed the models_used text-leg stamp."""
+    annotation_text = render_annotated_transcript(annotation)
+    prompt = build_judge_prompt(
+        config,
+        annotation_text,
+        sop_title=sop_title,
+        sop_content=sop_content,
+        agent_name=agent_name,
+        extra_notes=extra_notes,
+        call_context_text=call_context_text,
+    )
+
+    stage = resolve_stage("scoring", config)
+    result = await stage.provider.generate(
+        prompt,
+        model=stage.model,
+        max_output_tokens=stage.max_output_tokens,
+        system=build_judge_system_prompt(config),
+    )
+
+    sections_by_id = {s.id: s for s in config.sections}
+    scorecard = Scorecard.model_validate(
+        _extract_json(result.text), context={"sections_by_id": sections_by_id}
+    )
+    return scorecard, result

--- a/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
@@ -69,6 +69,7 @@ class AnthropicTextProvider(TextModelProvider):
         model: str,
         max_output_tokens: int,
         json_schema: Optional[dict] = None,
+        system: Optional[str] = None,
     ) -> LlmResult:
         client = self._get_client()
         kwargs: dict = {
@@ -77,6 +78,8 @@ class AnthropicTextProvider(TextModelProvider):
             "thinking": {"type": "adaptive"},
             "messages": [{"role": "user", "content": prompt}],
         }
+        if system:
+            kwargs["system"] = system
         if json_schema is not None:
             # Provider-enforced structured output — replaces markdown-fence
             # stripping entirely on this path (guaranteed-valid JSON).

--- a/qa-automation/AI-Scoring/backend/services/llm/factory.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/factory.py
@@ -1,16 +1,18 @@
 """Stage → provider resolution (mirrors rag/factory's env-keyed seam).
 
 A *stage* is one text-generation job in the pipeline: ``progression``
-today; ``scoring`` (the Stage-B judge) lands with TwoStageScoringDesign
-P3. Resolution order per stage:
+(the dashboard card + EOM one-pager) and ``scoring`` (the Stage-B judge
+— TwoStageScoringDesign §4). Resolution order per stage:
 
-  1. env override  — ``PROGRESSION_MODEL_PROVIDER`` = gemini | anthropic
+  1. env override  — ``{STAGE}_MODEL_PROVIDER`` = gemini | anthropic
      (unknown values collapse to the default, house pattern)
   2. default       — gemini with the team JSON's existing ``gemini.*``
-     knobs, so day one is a pure refactor: no team JSON changes, no
-     behavior changes until someone flips the env var.
+     knobs: no team JSON changes, no behavior changes until someone
+     flips the env var. For scoring this also matches the shadow
+     rollout order — Gemini-judge first isolates the split's effect on
+     scores before the Claude flip isolates the model's (§6).
 
-Anthropic model per stage comes from ``PROGRESSION_ANTHROPIC_MODEL``
+Anthropic model per stage comes from ``{STAGE}_ANTHROPIC_MODEL``
 (default ``claude-sonnet-5`` — the §10 starting tier; the newest Opus
 tier is the intended progression upgrade later, never Fable).
 """
@@ -45,29 +47,39 @@ def _env_provider(stage: str) -> str:
 
 
 def resolve_stage(stage: str, config: "TeamConfig") -> StageModel:
-    """Resolve *stage* ("progression") to a constructed provider + model.
+    """Resolve *stage* ("progression" | "scoring") to a constructed
+    provider + model.
 
     Providers are lightweight per-call constructs (the Gemini client is
     built per request exactly as the pre-seam code did; the Anthropic
     client is lazy inside its provider) — no singleton needed yet.
     """
-    if stage != "progression":
+    if stage == "progression":
+        gemini_knobs = (
+            config.gemini.progression_model,
+            config.gemini.progression_temperature,
+            config.gemini.progression_max_output_tokens,
+        )
+    elif stage == "scoring":
+        gemini_knobs = (
+            config.gemini.scoring_model,
+            config.gemini.scoring_temperature,
+            config.gemini.scoring_max_output_tokens,
+        )
+    else:
         raise ValueError(f"unknown llm stage: {stage!r}")
 
+    gemini_model, gemini_temperature, max_output_tokens = gemini_knobs
     provider_name = _env_provider(stage)
     if provider_name == "anthropic":
-        model = os.environ.get(
-            "PROGRESSION_ANTHROPIC_MODEL", _DEFAULT_ANTHROPIC_MODEL
-        ).strip() or _DEFAULT_ANTHROPIC_MODEL
+        env_model = os.environ.get(f"{stage.upper()}_ANTHROPIC_MODEL", "").strip()
         return StageModel(
             provider=AnthropicTextProvider(),
-            model=model,
-            max_output_tokens=config.gemini.progression_max_output_tokens,
+            model=env_model or _DEFAULT_ANTHROPIC_MODEL,
+            max_output_tokens=max_output_tokens,
         )
     return StageModel(
-        provider=GeminiTextProvider(
-            temperature=config.gemini.progression_temperature
-        ),
-        model=config.gemini.progression_model,
-        max_output_tokens=config.gemini.progression_max_output_tokens,
+        provider=GeminiTextProvider(temperature=gemini_temperature),
+        model=gemini_model,
+        max_output_tokens=max_output_tokens,
     )

--- a/qa-automation/AI-Scoring/backend/services/llm/gemini.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/gemini.py
@@ -46,16 +46,19 @@ class GeminiTextProvider(TextModelProvider):
         model: str,
         max_output_tokens: int,
         json_schema: Optional[dict] = None,
+        system: Optional[str] = None,
     ) -> LlmResult:
         if json_schema is not None:
-            # Provider-enforced structured output lands with the Stage-B
-            # scorer (TwoStageScoringDesign P3) — mapped against the live
-            # SDK then, never silently ignored now (provider.py contract).
+            # Gemini's response_schema dialect rejects standard-JSON-schema
+            # fields (additionalProperties → 400, learned the hard way in
+            # the annotator) — callers on this seam parse fence-tolerant
+            # JSON instead. Raise rather than silently ignore (contract).
             raise LlmProviderError(
                 "structured output not implemented for the gemini provider yet"
             )
         client = self._get_client()
         config = types.GenerateContentConfig(
+            system_instruction=system,
             temperature=self._temperature,
             max_output_tokens=max_output_tokens,
         )

--- a/qa-automation/AI-Scoring/backend/services/llm/provider.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/provider.py
@@ -44,13 +44,19 @@ class TextModelProvider(ABC):
         model: str,
         max_output_tokens: int,
         json_schema: Optional[dict] = None,
+        system: Optional[str] = None,
     ) -> LlmResult:
         """Generate text for *prompt* on *model*.
 
-        ``json_schema`` requests provider-enforced structured output
-        (the Stage-B scorer path). Providers that cannot enforce it MUST
-        raise LlmProviderError rather than silently returning free text
-        — a scorecard parsed from unconstrained output is a different
-        reliability class and the caller needs to know.
+        ``json_schema`` requests provider-enforced structured output.
+        Providers that cannot enforce it MUST raise LlmProviderError
+        rather than silently returning free text — a scorecard parsed
+        from unconstrained output is a different reliability class and
+        the caller needs to know.
+
+        ``system`` is the system-level instruction (the Stage-B judge
+        carries the team's scoring persona here); providers map it to
+        their native channel (Gemini system_instruction / Anthropic
+        system param).
         """
         ...

--- a/qa-automation/AI-Scoring/backend/services/scoring_service.py
+++ b/qa-automation/AI-Scoring/backend/services/scoring_service.py
@@ -101,6 +101,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Optional
 
 from backend.models.scorecard import ScorecardWithMeta
@@ -117,6 +118,7 @@ from backend.services.dialpad_client import (
     get_call_details,
     get_transcript,
 )
+from backend.services.judge_service import score_annotation
 from backend.services.rag.sop_retrieval import fetch_sop_context, pulpo_sop_mode
 
 if TYPE_CHECKING:
@@ -132,16 +134,81 @@ def scoring_pipeline() -> str:
     unknown values collapse to the off-state).
 
       single           today's one-call Gemini scoring (default)
-      annotate_only    P2: Stage A runs alongside single-stage scoring;
-                       the annotation persists, the prompt is untouched —
+      annotate_only    Stage A runs alongside single-stage scoring; the
+                       annotation persists, the prompt is untouched —
                        inspectable audio evidence accumulates before any
                        judge change
-      two_stage_shadow / two_stage — land with P3; until then they run
-                       as annotate_only (with a warning) rather than
-                       silently doing nothing
+      two_stage_shadow single-stage result is SERVED; the Stage-B judge
+                       also runs on the annotation and the compare stamp
+                       rides dialpad_call_metadata.two_stage_shadow
+      two_stage        the Stage-B judge is the score author; Stage
+                       failures fall back to single-stage
+                       (models_used.fallback records why)
     """
     mode = os.environ.get("SCORING_PIPELINE", "single").strip().lower()
     return mode if mode in _PIPELINE_MODES else "single"
+
+
+def _shadow_sections(scorecard) -> dict:
+    """Compact per-section view for the shadow stamp — enough for the
+    report to compute agreement without re-parsing full scorecards."""
+    return {
+        s.id: {"score": s.score, "yn_value": s.yn_value, "confidence": s.confidence}
+        for s in scorecard.sections
+    }
+
+
+async def _run_shadow_judge(
+    annotation, config, primary_scorecard, *,
+    sop_data, agent_name, extra_notes, call_context_text, call_id,
+) -> dict:
+    """Run the Stage-B judge in shadow (§6): compare against the served
+    single-stage scorecard, log the disagreement summary, and return the
+    stamp for dialpad_call_metadata. Never raises."""
+    started = time.monotonic()
+    try:
+        shadow_sc, judge_result = await score_annotation(
+            annotation,
+            config,
+            sop_title=sop_data["sop_title"],
+            sop_content=sop_data["sop_content"],
+            agent_name=agent_name,
+            extra_notes=extra_notes,
+            call_context_text=call_context_text,
+        )
+    except Exception as exc:  # noqa: BLE001 — shadow never blocks scoring
+        logger.exception(
+            "two_stage_shadow judge failed for call=%s — stamped as error",
+            call_id,
+        )
+        return {
+            "error": f"{type(exc).__name__}: {exc}"[:300],
+            "elapsed_s": round(time.monotonic() - started, 1),
+        }
+
+    primary = _shadow_sections(primary_scorecard)
+    shadow = _shadow_sections(shadow_sc)
+    mismatches = [
+        sid for sid, vals in shadow.items()
+        if sid in primary
+        and (vals["score"], vals["yn_value"])
+        != (primary[sid]["score"], primary[sid]["yn_value"])
+    ]
+    logger.info(
+        "two_stage_shadow call=%s judge=%s/%s: %d/%d sections disagree%s",
+        call_id, judge_result.provider, judge_result.model,
+        len(mismatches), len(shadow),
+        f" ({', '.join(mismatches)})" if mismatches else "",
+    )
+    return {
+        "scorer_provider": judge_result.provider,
+        "scorer_model": judge_result.model,
+        "sections": shadow,
+        "mismatched_section_ids": mismatches,
+        "key_strengths": shadow_sc.key_strengths,
+        "opportunities": shadow_sc.opportunities,
+        "elapsed_s": round(time.monotonic() - started, 1),
+    }
 
 
 async def score_call(
@@ -228,18 +295,14 @@ async def score_call(
 
     # Step 2.5: Stage-A annotation (TwoStageScoringDesign §3). In
     # annotate_only the artifact persists while the scoring prompt stays
-    # untouched — same log-only instinct as the CC/Pulpo shadow modes.
-    # Non-fatal throughout: annotation is an enhancement, never a
-    # scoring blocker (the cc_context doctrine).
+    # untouched; the two_stage modes judge from it (Step 3). Non-fatal
+    # throughout: annotation is an enhancement, never a scoring blocker
+    # (the cc_context doctrine) — a two_stage run without an annotation
+    # falls back to single-stage scoring.
     pipeline = scoring_pipeline()
     annotation = None
     annotation_model = None
     if pipeline != "single":
-        if pipeline in ("two_stage_shadow", "two_stage"):
-            logger.warning(
-                "SCORING_PIPELINE=%s: Stage-B judging lands with P3 — "
-                "running annotation only for call=%s", pipeline, call_id,
-            )
         try:
             annotation_model = annotator_model()
             annotation = await annotate_audio(
@@ -288,17 +351,71 @@ async def score_call(
                 "delays, or pacing issues, including timestamps. "
             )
 
-    scorecard = await score_audio(
-        audio_bytes=audio_bytes,
-        filename=filename,
-        config=config,
-        transcript_text=transcript_text,
-        sop_title=sop_data["sop_title"],
-        sop_content=sop_data["sop_content"],
-        agent_name=agent_name,
-        extra_notes=extra_notes,
-        call_context_text=call_context_text,
-    )
+    # Step 3a — two_stage: the Stage-B judge IS the score author
+    # (TwoStageScoringDesign §4); single-stage score_audio survives as
+    # Plan B (§5) so a Stage failure never loses a scoring day.
+    scorecard = None
+    scorer_provider = "gemini"
+    scorer_model = None
+    pipeline_fallback_reason = None
+    if pipeline == "two_stage":
+        if annotation is None:
+            pipeline_fallback_reason = "annotate_failed"
+        else:
+            try:
+                scorecard, judge_result = await score_annotation(
+                    annotation,
+                    config,
+                    sop_title=sop_data["sop_title"],
+                    sop_content=sop_data["sop_content"],
+                    agent_name=agent_name,
+                    extra_notes=extra_notes,
+                    call_context_text=call_context_text,
+                )
+                scorer_provider = judge_result.provider
+                scorer_model = judge_result.model
+                logger.info(
+                    "two_stage call=%s judged by %s/%s",
+                    call_id, scorer_provider, scorer_model,
+                )
+            except Exception:
+                logger.exception(
+                    "two_stage judge failed for call=%s — falling back to "
+                    "single-stage scoring", call_id,
+                )
+                pipeline_fallback_reason = "text_scorer_failed"
+        if pipeline_fallback_reason:
+            logger.warning(
+                "two_stage fallback (%s) for call=%s — models_used.fallback "
+                "will record it", pipeline_fallback_reason, call_id,
+            )
+
+    # Step 3b — single-stage Gemini scoring: the primary in single /
+    # annotate_only / two_stage_shadow, and two_stage's Plan B.
+    if scorecard is None:
+        scorecard = await score_audio(
+            audio_bytes=audio_bytes,
+            filename=filename,
+            config=config,
+            transcript_text=transcript_text,
+            sop_title=sop_data["sop_title"],
+            sop_content=sop_data["sop_content"],
+            agent_name=agent_name,
+            extra_notes=extra_notes,
+            call_context_text=call_context_text,
+        )
+
+    # Step 3c — shadow judging (§6): the served result stays single-stage;
+    # the judge runs on the same inputs and the compare stamp rides
+    # dialpad_call_metadata.two_stage_shadow for the report. Never blocks.
+    two_stage_shadow = None
+    if pipeline == "two_stage_shadow" and annotation is not None:
+        two_stage_shadow = await _run_shadow_judge(
+            annotation, config, scorecard,
+            sop_data=sop_data, agent_name=agent_name,
+            extra_notes=extra_notes, call_context_text=call_context_text,
+            call_id=call_id,
+        )
 
     return ScorecardWithMeta(
         **scorecard.model_dump(),
@@ -333,4 +450,11 @@ async def score_call(
         # model stamp (eval_store fills models_used.audio from these).
         annotated_transcript=annotation.model_dump() if annotation else None,
         annotator_model=annotation_model if annotation else None,
+        # §4 text-leg provenance + §5 fallback + §6 shadow stamp.
+        # `model` identifies the score author; single-stage keeps its
+        # (pre-existing) default when scorer_model is None.
+        scorer_provider=scorer_provider,
+        pipeline_fallback_reason=pipeline_fallback_reason,
+        two_stage_shadow=two_stage_shadow,
+        **({"model": scorer_model} if scorer_model else {}),
     )

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -1,8 +1,33 @@
 # TwoStageScoringDesign — Gemini annotates, any LLM scores
 
-**Status:** v1.2 — P1 shipped (PR #140, Claude leg live-verified incl.
-structured output); P2 shipped (Stage-A annotator + `annotate_only`).
-**Date:** 2026-07-24 (v1), 2026-07-25 (v1.1), 2026-07-26 (v1.2)
+**Status:** v1.3 — P1 (#140), P2 (#142 + hardening #143), **P3 built**:
+Stage-B judge + `two_stage_shadow` / `two_stage` are live code.
+**Date:** 2026-07-24 (v1) … 2026-07-26 (v1.2), 2026-07-29 (v1.3)
+
+**v1.3 amendments (P3):**
+- Judge resolution: `SCORING_MODEL_PROVIDER` = gemini (default) |
+  anthropic; `SCORING_ANTHROPIC_MODEL` (default `claude-sonnet-5`).
+  The gemini default IS the rollout order — shadow week 1 judges with
+  Gemini (isolates the split's effect), then
+  `SCORING_MODEL_PROVIDER=anthropic` isolates the model's.
+- Judge prompt reuses the single-stage rubric / SOP blocks / output
+  schema **verbatim** (`judge_prompt.py` imports them); only the
+  evidence block differs — the rendered annotated record replaces
+  transcript+audio, with doctrine: record is authoritative,
+  "observational" holds are heard-not-verified, ANNOTATION TRUNCATED →
+  low confidence on affected sections. Agent-name rule duplicated with
+  a sync-gate test; judge output parsed with the same fence-tolerant
+  path as single-stage (provider-enforced schema is a later
+  tightening; Gemini's dialect can't express ours).
+- Shadow stamp (`dialpad_call_metadata.two_stage_shadow`): judge
+  provider/model, per-section {score, yn_value, confidence},
+  mismatched_section_ids vs the served scorecard, judge
+  strengths/opportunities, elapsed_s — or {error} when the judge
+  failed. `scripts/two_stage_shadow_report.py` aggregates the week
+  (per-section disagreement table, §6.1-style).
+- two_stage provenance: `models_used.text` + `ai_provider_primary` =
+  the judge; `models_used.fallback` records single-stage rescues
+  (`annotate_failed` | `text_scorer_failed`, sections=[]).
 
 **v1.2 amendments:**
 - `SCORING_PIPELINE` gains **`annotate_only`** between `single` and the

--- a/qa-automation/AI-Scoring/scripts/two_stage_shadow_report.py
+++ b/qa-automation/AI-Scoring/scripts/two_stage_shadow_report.py
@@ -1,0 +1,115 @@
+"""Shadow-week report — TwoStageScoringDesign §6 (PulpoConnection §6.1 pattern).
+
+Aggregates the two_stage_shadow stamps that score_call persists to
+dialpad_call_metadata during SCORING_PIPELINE=two_stage_shadow: per-
+section agreement between the served single-stage scorecard and the
+Stage-B judge, judge errors, and latency. Markdown to stdout — paste
+into the PR / owner review that decides the two_stage flip.
+
+Usage (from qa-automation/AI-Scoring, .env loaded, DATABASE_URL set):
+
+    .venv/bin/python scripts/two_stage_shadow_report.py
+    .venv/bin/python scripts/two_stage_shadow_report.py --team member_support --days 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+import asyncpg  # noqa: E402
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--team", default="member_support")
+    parser.add_argument("--days", type=int, default=7)
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 1
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT id, dialpad_call_id, created_at,
+                   dialpad_call_metadata->'two_stage_shadow' AS stamp
+            FROM qa.evaluations
+            WHERE team_id = $1
+              AND dialpad_call_metadata ? 'two_stage_shadow'
+              AND created_at >= NOW() - make_interval(days => $2)
+            ORDER BY created_at
+            """,
+            args.team, args.days,
+        )
+    finally:
+        await conn.close()
+
+    stamps = []
+    for r in rows:
+        stamp = r["stamp"]
+        stamps.append((r, json.loads(stamp) if isinstance(stamp, str) else stamp))
+
+    ok = [(r, s) for r, s in stamps if "error" not in s]
+    errored = [(r, s) for r, s in stamps if "error" in s]
+
+    print(f"# Two-stage shadow report — {args.team}, last {args.days}d")
+    print(f"\nShadowed evals: **{len(stamps)}** "
+          f"(judged: {len(ok)}, judge errors: {len(errored)})")
+    if not ok:
+        for r, s in errored[:10]:
+            print(f"- eval {r['id']} call {r['dialpad_call_id']}: {s['error']}")
+        return 0
+
+    judges = Counter(f"{s.get('scorer_provider')}/{s.get('scorer_model')}"
+                     for _, s in ok)
+    print("Judges: " + ", ".join(f"{j} ×{n}" for j, n in judges.most_common()))
+    latencies = sorted(s.get("elapsed_s", 0) for _, s in ok)
+    print(f"Judge latency: median {latencies[len(latencies) // 2]}s, "
+          f"max {latencies[-1]}s")
+
+    # Per-section disagreement rate (mismatched_section_ids vs sections seen)
+    seen: Counter = Counter()
+    mismatched: Counter = Counter()
+    examples: dict[str, list] = defaultdict(list)
+    for r, s in ok:
+        for sid in s.get("sections", {}):
+            seen[sid] += 1
+        for sid in s.get("mismatched_section_ids", []):
+            mismatched[sid] += 1
+            if len(examples[sid]) < 3:
+                examples[sid].append(str(r["dialpad_call_id"]))
+
+    fully_agreeing = sum(1 for _, s in ok if not s.get("mismatched_section_ids"))
+    print(f"Scorecards in full agreement: {fully_agreeing}/{len(ok)} "
+          f"({100 * fully_agreeing / len(ok):.0f}%)\n")
+    print("| section | disagree | of | rate | example calls |")
+    print("|---|---|---|---|---|")
+    for sid, total in sorted(seen.items(), key=lambda kv: -mismatched[kv[0]] / kv[1]):
+        bad = mismatched[sid]
+        print(f"| {sid} | {bad} | {total} | {100 * bad / total:.0f}% | "
+              f"{', '.join(examples[sid]) or '—'} |")
+
+    if errored:
+        print(f"\n## Judge errors ({len(errored)})")
+        for r, s in errored[:10]:
+            print(f"- eval {r['id']} call {r['dialpad_call_id']}: {s['error']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/qa-automation/AI-Scoring/tests/test_judge.py
+++ b/qa-automation/AI-Scoring/tests/test_judge.py
@@ -1,0 +1,302 @@
+"""Stage-B judge — TwoStageScoringDesign P3.
+
+Pins: factory "scoring" stage resolution, the system-prompt channel on
+the llm contract, the judge prompt's doctrine (annotation authoritative,
+observational holds, truncation handling, agent-name rule kept in sync
+with the single-stage prompt), judge_service parsing, the shadow-judge
+stamp, and eval_store's text-leg/fallback/shadow provenance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.models.formula import AnnotatedTranscript, TranscriptTurn
+from backend.prompts.judge_prompt import (
+    JUDGE_GENERAL_INSTRUCTIONS,
+    build_judge_prompt,
+    build_judge_system_prompt,
+)
+from backend.prompts.qa_scoring_prompt import LANDING_GENERAL_INSTRUCTIONS
+from backend.services.llm.anthropic import AnthropicTextProvider
+from backend.services.llm.factory import resolve_stage
+from backend.services.llm.gemini import GeminiTextProvider
+from backend.services.llm.provider import LlmResult, TextModelProvider
+from tests.conftest import load_test_config, make_gemini_scoring_json
+
+
+@pytest.fixture(scope="module")
+def config():
+    return load_test_config("sales_lite")
+
+
+def _annotation():
+    return AnnotatedTranscript(
+        schema_version="gemini_annotate_v1",
+        language_detected="en",
+        turns=[TranscriptTurn(speaker="agent", text="Hello, this is Sam.",
+                              emotion="warm", start_ms=0, end_ms=2000)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Factory — scoring stage
+# ---------------------------------------------------------------------------
+
+def test_factory_scoring_defaults_to_gemini_scoring_knobs(monkeypatch, config):
+    monkeypatch.delenv("SCORING_MODEL_PROVIDER", raising=False)
+    stage = resolve_stage("scoring", config)
+    assert isinstance(stage.provider, GeminiTextProvider)
+    assert stage.model == config.gemini.scoring_model
+    assert stage.max_output_tokens == config.gemini.scoring_max_output_tokens
+
+
+def test_factory_scoring_env_flips_to_anthropic(monkeypatch, config):
+    monkeypatch.setenv("SCORING_MODEL_PROVIDER", "anthropic")
+    monkeypatch.delenv("SCORING_ANTHROPIC_MODEL", raising=False)
+    stage = resolve_stage("scoring", config)
+    assert isinstance(stage.provider, AnthropicTextProvider)
+    assert stage.model == "claude-sonnet-5"    # §10.2 starting tier
+    monkeypatch.setenv("SCORING_ANTHROPIC_MODEL", "claude-haiku-4-5")
+    assert resolve_stage("scoring", config).model == "claude-haiku-4-5"
+
+
+def test_factory_stages_resolve_independently(monkeypatch, config):
+    """Flipping the judge must not flip progression, and vice versa."""
+    monkeypatch.setenv("SCORING_MODEL_PROVIDER", "anthropic")
+    monkeypatch.delenv("PROGRESSION_MODEL_PROVIDER", raising=False)
+    assert isinstance(resolve_stage("scoring", config).provider,
+                      AnthropicTextProvider)
+    assert isinstance(resolve_stage("progression", config).provider,
+                      GeminiTextProvider)
+
+
+# ---------------------------------------------------------------------------
+# Provider system-channel
+# ---------------------------------------------------------------------------
+
+def test_gemini_provider_maps_system_instruction():
+    from tests.test_llm_provider import FakeGenaiClient
+
+    fake = FakeGenaiClient()
+    provider = GeminiTextProvider(client=fake)
+    asyncio.run(provider.generate(
+        "p", model="m", max_output_tokens=10, system="be a judge",
+    ))
+    (call,) = fake.calls
+    assert call["config"].system_instruction == "be a judge"
+
+
+def test_anthropic_provider_maps_system_param():
+    from tests.test_llm_provider import FakeAnthropicClient
+
+    fake = FakeAnthropicClient()
+    provider = AnthropicTextProvider(client=fake)
+    asyncio.run(provider.generate(
+        "p", model="claude-sonnet-5", max_output_tokens=10, system="be a judge",
+    ))
+    (call,) = fake.calls
+    assert call["system"] == "be a judge"
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt doctrine
+# ---------------------------------------------------------------------------
+
+def test_judge_prompt_carries_annotation_doctrine(config):
+    prompt = build_judge_prompt(config, "RENDERED-RECORD",
+                                call_context_text="=== CALL CONTEXT ===")
+    assert "ANNOTATED CALL RECORD (authoritative)" in prompt
+    assert "RENDERED-RECORD" in prompt
+    assert "observational — not system-verified" in prompt
+    assert "ANNOTATION TRUNCATED" in prompt
+    assert "No audio is attached" in prompt
+    # Rubric + output schema reused from the single-stage prompt
+    assert "=== SCORING RUBRIC ===" in prompt
+    # Grounding block rides ahead of the record, same as single-stage
+    assert prompt.index("CALL CONTEXT") < prompt.index("ANNOTATED CALL RECORD")
+
+
+def test_judge_prompt_sop_missing_path(config):
+    prompt = build_judge_prompt(config, "X")
+    assert "SOP" in prompt          # missing-note present
+    assert "DO NOT mention a lack of SOP" in prompt
+
+
+def test_judge_system_prompt_agent_name_rule_in_sync(config):
+    """The agent-name rule is duplicated (judge swaps only the SOT
+    bullet) — this gate keeps the shared sentences identical."""
+    shared = (
+        "NOT penalize the agent for the specific name used in the greeting."
+    )
+    assert shared in LANDING_GENERAL_INSTRUCTIONS
+    assert shared in JUDGE_GENERAL_INSTRUCTIONS
+    system = build_judge_system_prompt(config)
+    assert shared in system
+    # The judge must NOT claim audio is its source of truth.
+    assert "the audio is authoritative" not in system
+    assert "ANNOTATED CALL RECORD" in system
+
+
+# ---------------------------------------------------------------------------
+# judge_service — generation + parse
+# ---------------------------------------------------------------------------
+
+class FakeJudgeProvider(TextModelProvider):
+    name = "fake"
+
+    def __init__(self, text):
+        self._text = text
+        self.calls = []
+
+    async def generate(self, prompt, *, model, max_output_tokens,
+                       json_schema=None, system=None):
+        self.calls.append({"prompt": prompt, "model": model, "system": system})
+        return LlmResult(text=self._text, provider="anthropic", model=model)
+
+
+def test_score_annotation_parses_and_returns_provenance(monkeypatch, config):
+    from backend.services import judge_service
+    from backend.services.llm.factory import StageModel
+
+    raw = json.dumps(make_gemini_scoring_json(config))
+    fake = FakeJudgeProvider(f"```json\n{raw}\n```")
+    monkeypatch.setattr(
+        judge_service, "resolve_stage",
+        lambda stage, cfg: StageModel(provider=fake, model="claude-sonnet-5",
+                                      max_output_tokens=8192),
+    )
+    scorecard, result = asyncio.run(judge_service.score_annotation(
+        _annotation(), config, sop_title="T", sop_content="C",
+        agent_name="Sam", call_context_text="=== CALL CONTEXT ===",
+    ))
+    assert scorecard.sections                     # validated Scorecard
+    assert result.provider == "anthropic"
+    (call,) = fake.calls
+    assert "ANNOTATED CALL RECORD" in call["prompt"]
+    assert '"Hello, this is Sam."' in call["prompt"]   # rendered record
+    assert call["system"] and "ANNOTATED CALL RECORD" in call["system"]
+
+
+def test_score_annotation_surfaces_parse_failure(monkeypatch, config):
+    from backend.services import judge_service
+    from backend.services.llm.factory import StageModel
+
+    fake = FakeJudgeProvider("not json")
+    monkeypatch.setattr(
+        judge_service, "resolve_stage",
+        lambda stage, cfg: StageModel(provider=fake, model="m",
+                                      max_output_tokens=10),
+    )
+    with pytest.raises(ValueError):
+        asyncio.run(judge_service.score_annotation(_annotation(), config))
+
+
+# ---------------------------------------------------------------------------
+# Shadow judge stamp
+# ---------------------------------------------------------------------------
+
+def test_run_shadow_judge_stamps_compare(monkeypatch, config):
+    from backend.models.scorecard import Scorecard
+    from backend.services import scoring_service
+
+    primary = Scorecard(**make_gemini_scoring_json(config, score_seed=4))
+    shadow = Scorecard(**make_gemini_scoring_json(config, score_seed=5))
+
+    async def fake_judge(annotation, cfg, **kw):
+        return shadow, LlmResult(text="", provider="anthropic",
+                                 model="claude-sonnet-5")
+
+    monkeypatch.setattr(scoring_service, "score_annotation", fake_judge)
+    stamp = asyncio.run(scoring_service._run_shadow_judge(
+        _annotation(), config, primary,
+        sop_data={"sop_title": "", "sop_content": ""},
+        agent_name="Sam", extra_notes="", call_context_text="",
+        call_id="C1",
+    ))
+    assert stamp["scorer_provider"] == "anthropic"
+    assert stamp["scorer_model"] == "claude-sonnet-5"
+    # seed 4 vs 5 → every numeric section disagrees; yn sections agree
+    numeric_ids = {s["id"] for s in make_gemini_scoring_json(config)["sections"]
+                   if s["score_type"] == "numeric"}
+    assert set(stamp["mismatched_section_ids"]) == numeric_ids
+    assert set(stamp["sections"]) == {
+        s["id"] for s in make_gemini_scoring_json(config)["sections"]
+    }
+
+
+def test_run_shadow_judge_never_raises(monkeypatch, config):
+    from backend.models.scorecard import Scorecard
+    from backend.services import scoring_service
+
+    async def boom(annotation, cfg, **kw):
+        raise RuntimeError("judge exploded")
+
+    monkeypatch.setattr(scoring_service, "score_annotation", boom)
+    stamp = asyncio.run(scoring_service._run_shadow_judge(
+        _annotation(), config,
+        Scorecard(**make_gemini_scoring_json(config)),
+        sop_data={"sop_title": "", "sop_content": ""},
+        agent_name="", extra_notes="", call_context_text="", call_id="C1",
+    ))
+    assert "judge exploded" in stamp["error"]
+    assert "elapsed_s" in stamp
+
+
+# ---------------------------------------------------------------------------
+# eval_store provenance
+# ---------------------------------------------------------------------------
+
+def test_eval_store_stamps_judge_provenance():
+    from tests.test_eval_store import _scorecard
+    from backend.services.eval_store import build_draft_row
+
+    ms_config = load_test_config("member_support")
+    sc = _scorecard(
+        ms_config,
+        scorer_provider="anthropic",
+        model="claude-sonnet-5",
+        annotated_transcript={"schema_version": "gemini_annotate_v1",
+                              "turns": []},
+        annotator_model="gemini-2.5-flash",
+    )
+    row = build_draft_row(sc, ms_config)
+    models_used = json.loads(row["models_used"])
+    assert models_used["text"] == {"provider": "anthropic",
+                                   "model": "claude-sonnet-5"}
+    assert row["ai_provider_primary"] == "anthropic"
+    assert "fallback" not in models_used
+
+
+def test_eval_store_stamps_fallback_and_shadow():
+    from tests.test_eval_store import _scorecard
+    from backend.services.eval_store import build_draft_row
+
+    ms_config = load_test_config("member_support")
+    shadow_stamp = {"scorer_provider": "gemini", "sections": {}}
+    sc = _scorecard(
+        ms_config,
+        pipeline_fallback_reason="text_scorer_failed",
+        two_stage_shadow=shadow_stamp,
+    )
+    row = build_draft_row(sc, ms_config)
+    models_used = json.loads(row["models_used"])
+    assert models_used["fallback"] == {
+        "provider": "gemini", "sections": [], "reason": "text_scorer_failed",
+    }
+    # Fallback rows are authored by single-stage gemini
+    assert row["ai_provider_primary"] == "gemini"
+    metadata = json.loads(row["dialpad_call_metadata"])
+    assert metadata["two_stage_shadow"] == shadow_stamp
+
+
+def test_eval_store_single_stage_rows_have_no_shadow_key():
+    from tests.test_eval_store import _scorecard
+    from backend.services.eval_store import build_draft_row
+
+    ms_config = load_test_config("member_support")
+    row = build_draft_row(_scorecard(ms_config), ms_config)
+    assert "two_stage_shadow" not in json.loads(row["dialpad_call_metadata"])

--- a/qa-automation/AI-Scoring/tests/test_llm_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_llm_provider.py
@@ -102,7 +102,7 @@ def test_factory_unknown_provider_collapses_to_gemini(monkeypatch):
 
 def test_factory_rejects_unknown_stage():
     with pytest.raises(ValueError):
-        resolve_stage("scoring", load_test_config("sales_lite"))
+        resolve_stage("annotation", load_test_config("sales_lite"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

TwoStageScoringDesign **P3** — the judge half of the split. Both `two_stage_shadow` and `two_stage` are now real pipeline modes (P2's placeholder warning is gone).

- **Judge resolution** — `SCORING_MODEL_PROVIDER=gemini|anthropic` (default **gemini** — deliberately: shadow week 1 judges with Gemini to isolate the *split's* effect on scores; flipping to `anthropic` then isolates the *model's*). `SCORING_ANTHROPIC_MODEL` defaults to `claude-sonnet-5`. Stages resolve independently — flipping the judge never flips progression.
- **Judge prompt** (`judge_prompt.py`) — reuses the single-stage rubric, SOP block/missing-note, and output schema **verbatim** (imports, not copies), so both pipelines score against byte-identical instructions. Only the evidence differs: the rendered annotated record replaces transcript+audio, with the doctrine spelled out — the record is authoritative, "observational" holds are heard-not-verified (only the CALL CONTEXT block carries verified facts), and an ANNOTATION TRUNCATED observation demands low confidence on affected sections. The duplicated agent-name rule is pinned to the single-stage prompt by a sync-gate test.
- **`two_stage`** — the judge is the score author: `models_used.text` + `ai_provider_primary` record it; Stage-A or judge failure falls back to single-stage `score_audio` with `models_used.fallback` (`annotate_failed` | `text_scorer_failed`). No scoring day is ever lost.
- **`two_stage_shadow`** — the served result stays single-stage; the judge runs on the same SOP/grounding/notes inputs and `dialpad_call_metadata.two_stage_shadow` stamps judge provider/model, per-section results, `mismatched_section_ids` vs the served scorecard, strengths/opportunities, and latency (or the judge error). Never blocks.
- **`scripts/two_stage_shadow_report.py`** — aggregates the shadow week into the §6.1-style report: full-agreement rate, per-section disagreement table with example calls, judge errors, latency.
- llm/ contract grows a `system` channel (Gemini `system_instruction` / Anthropic `system`), so the judge carries the team persona through the seam.

## Rollout (after merge)
1. Railway: `SCORING_PIPELINE=two_stage_shadow` (judge defaults to Gemini) — week 1.
2. `.venv/bin/python scripts/two_stage_shadow_report.py --team member_support --days 7` → review split effect.
3. `SCORING_MODEL_PROVIDER=anthropic` (+ `ANTHROPIC_API_KEY*` on Railway) — week 2 → same report isolates the Claude effect.
4. Owner sign-off → `SCORING_PIPELINE=two_stage` for MS; Sales stays `single`.

## Tests
`791 passed, 6 skipped, 3 xfailed` — 25 new: factory scoring-stage + independence, system-channel pass-through on both providers, judge-prompt doctrine + sync gate, judge parse/provenance, shadow stamp compare + never-raises, eval_store text-leg/fallback/shadow persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)