### PR TITLE
feat(qa-automation): Scorecard Actions S5 — auto rescore + human_review.mode

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/team_config.py
+++ b/qa-automation/AI-Scoring/backend/config/team_config.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -97,6 +97,29 @@ class StatsConfig(BaseModel):
     spc_sigma_multiplier: float = 2.0
 
 
+class RescoreConfig(BaseModel):
+    """ScorecardActionsDesign §4.2 — the auto-rescore knob.
+
+    A finalize landing ``overall_score <= threshold`` on a ``source='ai'``
+    row triggers the machine's one retry (once EVER per evaluation —
+    the ``auto_rescored_at`` latch). Lives in team JSON beside the stats
+    knobs; absent → default 50."""
+    threshold: float = 50.0
+
+
+class HumanReviewConfig(BaseModel):
+    """ScorecardActionsDesign §0.3 — the Human-Review pipeline mode.
+
+    ``authoritative`` (default): a fired §3.14 trigger BLOCKS finalize —
+    the row holds in draft at scoring_status='flagged_human_review' until
+    an analyst resolves it. ``informative``: flagged rows finalize and
+    ship like any other; ``human_review_required_at`` stays as the queue
+    marker (required_at IS NOT NULL AND completed_at IS NULL) and the
+    blocking scoring_status is never set. Designed now so the flip lands
+    as team-JSON config, not a redesign."""
+    mode: Literal["authoritative", "informative"] = "authoritative"
+
+
 class HrExportSectionConfig(BaseModel):
     """One HR-visible section: rubric section id + the header HR sees."""
     id: str
@@ -141,6 +164,8 @@ class TeamConfig(BaseModel):
     sheets: SheetsConfig
     rubric: Rubric
     stats: StatsConfig = Field(default_factory=StatsConfig)
+    rescore: RescoreConfig = Field(default_factory=RescoreConfig)
+    human_review: HumanReviewConfig = Field(default_factory=HumanReviewConfig)
     hr_export: Optional[HrExportConfig] = None
     hr_internal_section_ids: list[str] = Field(
         default_factory=list,

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -116,6 +116,12 @@ async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
     }
 
 
+async def _await_coro(coro) -> None:
+    """BackgroundTasks.add_task takes a callable + args, not a coroutine
+    object — this adapts the S5 auto-rescore pass for scheduling."""
+    await coro
+
+
 def _dispatch_finalize_email(job, history_row, team_id, evaluation_id) -> None:
     """Apps Script email dispatch at the finalize seam — shared by the
     auto-flow and the approve path.
@@ -192,41 +198,75 @@ async def _publish_finalized_event(
         print(f"[sse] eval_approved publish failed (non-fatal): {e}")
 
 
-async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
+async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id,
+                                *, key=None, api_key_role="", semaphore=None):
     """Post-flip auto-flow (CutoverDesign §2): after the Stage-1 draft row
     lands, decide auto-finalize vs. human-review pause.
 
     CLEAN → engine computes + stamps versions, row finalizes, Analyst_History
     is projected from the DB row, the GAS email fires — zero analyst touch.
-    FLAGGED → the row stays draft with scoring_status='flagged_human_review';
-    the operator resolves it via the (red) editor + approve.
+    FLAGGED → mode-dependent (ScorecardActionsDesign §0.3, S5):
+    ``authoritative`` (default) holds the row in draft at
+    scoring_status='flagged_human_review' until an analyst resolves it;
+    ``informative`` finalizes and ships it like any other row, keeping
+    human_review_required_at as the queue marker.
+
+    S5 auto-rescore hook (§4.2): a finalize landing ≤ config.rescore
+    .threshold on a source='ai' row with the auto_rescored_at latch
+    unstamped takes the machine's one retry — this pass's projection,
+    SSE toast, and email are SUPPRESSED (the agent must not see a score
+    about to change) and the rescore pass is returned as a coroutine for
+    the CALLER to run (callers already inside a background task await it
+    after closing their own job bookkeeping; the approve route schedules
+    it via BackgroundTasks). A still-low score with the latch already
+    stamped enters the review queue instead (marker stamp; the coaching
+    → override escalation cue).
 
     Job payload gains state/scoring_status/overall_score so the lookup UI can
-    color the button (CutoverDesign §5)."""
+    color the button (CutoverDesign §5). Returns the rescore coroutine, or
+    None when the flow completed here."""
     flagged = eval_store.human_review_trigger_fired(
         eval_store._active_formula(team_id), scorecard.sections
     ) or eval_store.requires_analyst_review(config)
-    if flagged:
+    if flagged and config.human_review.mode == "authoritative":
         job["state"] = "draft"
         job["scoring_status"] = "flagged_human_review"
-        return
+        return None
 
     detail = await eval_store.stamp_and_finalize(
         evaluation_id, config, evaluator_email=scorecard.manager_email or ""
     )
+    score = float(detail.overall_score)
+    job["state"] = "finalized"
+    job["scoring_status"] = "complete"
+    job["overall_score"] = score
+
+    followup = await _maybe_auto_rescore(
+        job, evaluation_id, score, config, team_id,
+        key=key, api_key_role=api_key_role, semaphore=semaphore,
+        manager_email=scorecard.manager_email or "",
+    )
+    if followup is not None:
+        return followup
+
+    if flagged:
+        # Informative mode (§0.3): the row shipped; the queue marker is
+        # the annotation. Insurance stamp — build_draft_row set required_at
+        # for §3.14 triggers, but requires_analyst_review-only teams
+        # never got one.
+        await eval_store.mark_human_review_required(evaluation_id)
+        job["human_review_queued"] = True
+
     pool = await eval_store.get_pool()
     history_row = await project_evaluation(
         pool, evaluation_id, config, include_history=True
     )
-    job["state"] = "finalized"
-    job["scoring_status"] = "complete"
-    job["overall_score"] = float(detail.overall_score)
     job["history_row"] = history_row
     await _publish_finalized_event(
         team_id, job,
         agent_name=scorecard.agent_name,
         evaluator_email=scorecard.manager_email or "",
-        overall_score=float(detail.overall_score),
+        overall_score=score,
         history_row=history_row,
         dialpad_link=scorecard.dialpad_link,
         call_summary=scorecard.call_summary,
@@ -234,6 +274,102 @@ async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id):
         opportunities=scorecard.opportunities,
     )
     _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
+    return None
+
+
+async def _maybe_auto_rescore(job, evaluation_id, score, config, team_id,
+                              *, key, api_key_role, semaphore, manager_email):
+    """The §4.2 finalize-seam decision. Returns the auto-rescore pass as
+    an un-started coroutine when it fires (latch won), else None — and
+    handles the still-low-after-retry queue entry as a side effect.
+
+    Eligibility: score ≤ threshold AND source='ai' (a human-approved low
+    score is a human's judgment — never discard edits; escalation for
+    those is the S6 override) AND the once-EVER latch is unstamped. The
+    latch stamp is atomic and happens BEFORE the pass is scheduled, so a
+    crash mid-rescore can't loop (§4.2 "once means once")."""
+    threshold = config.rescore.threshold
+    if score > threshold:
+        return None
+    state = await eval_store.fetch_auto_rescore_state(evaluation_id)
+    if state is None:
+        return None
+
+    if state["auto_rescored_at"] is not None:
+        # The machine already took its one retry; a still-low score is
+        # evidence about the call (or the SOP context), not a retry cue.
+        await eval_store.mark_human_review_required(evaluation_id)
+        job["human_review_queued"] = True
+        return None
+    if state["source"] != "ai":
+        return None
+    if key is None or semaphore is None:
+        # Defensive: a caller that can't host the follow-up pass (none
+        # today) must not strand a stamped latch.
+        logging.getLogger(__name__).error(
+            "auto-rescore for eval %s skipped: no job key/semaphore", evaluation_id)
+        return None
+    if not await eval_store.stamp_auto_rescored(evaluation_id):
+        return None  # lost the race — exactly one retry, someone else's
+
+    call_id = (
+        state["dialpad_call_id"] or state["dialpad_entry_point_call_id"]
+        or job.get("call_id") or ""
+    )
+    # Machine-initiated: NOT tampering (§0.2) — audit row with the
+    # triggering key's role, no evaluator, no coaching receipt. Same
+    # superseded_model stamp as the S4 manual path (P3+ traceability).
+    append_score_audit_row(
+        api_key_role=api_key_role,
+        evaluator_email="",
+        agent_email=state["agent_email"] or "",
+        agent_name=state["agent_name_raw"],
+        call_id=call_id,
+        target_team=team_id,
+        action=audit_cfg.ACTION_RESCORED,
+        result_row=None,
+        notes=f"auto: {score} ≤ {threshold}; superseded_model={state['model']}",
+    )
+    job["auto_rescore"] = "scheduled"
+
+    async def followup():
+        _jobs[key] = {
+            "status": "pending",
+            "call_id": call_id,
+            "agent_email": state["agent_email"] or "",
+            "agent_name": state["agent_name_raw"],
+            "manager_email": manager_email,
+            "rescore": {
+                "cause": "auto",
+                "suppress_email": False,
+                "superseded_score": score,
+                "superseded_model": state["model"],
+            },
+        }
+        try:
+            audio_bytes = await download_recording(call_id)
+            transcript_data = await get_transcript(call_id)
+            try:
+                call_details = await get_call_details(call_id)
+            except DialpadRateLimited:
+                call_details = None
+            await _rescore_core(
+                key=key, team_id=team_id, config=config, call_id=call_id,
+                agent_name=state["agent_name_raw"], manager_email=manager_email,
+                duration_ms=float(state["duration_ms"] or 0),
+                expected_row_id=evaluation_id, agent_id=state["agent_id"],
+                semaphore=semaphore, api_key_role=api_key_role,
+                audio_bytes=audio_bytes, transcript_data=transcript_data,
+                call_details=call_details,
+            )
+        except Exception as e:
+            # Latch already stamped — a dead pass can't loop; the audit
+            # 'rescored' row + this error are the operator's cue to use
+            # the S4 manual rescore.
+            _jobs[key]["status"] = "error"
+            _jobs[key]["error"] = str(e)
+
+    return followup()
 
 
 @router.get("/calls")
@@ -469,11 +605,17 @@ async def score_single_call(
             )
             _jobs[key]["evaluation_id"] = evaluation_id
             _jobs[key]["scorecard"] = scorecard.model_dump()
+            followup = None
             if evaluation_id is not None:
-                await _postgres_post_stage1(
-                    _jobs[key], evaluation_id, scorecard, config, team_id
+                followup = await _postgres_post_stage1(
+                    _jobs[key], evaluation_id, scorecard, config, team_id,
+                    key=key, api_key_role=identity.role, semaphore=semaphore,
                 )
             _jobs[key]["status"] = "complete"
+            if followup is not None:
+                # S5 auto-rescore fired: this job's books are closed; the
+                # pass replaces _jobs[key] and runs its own lifecycle.
+                await followup
         except Exception as e:
             _jobs[key]["status"] = "error"
             _jobs[key]["error"] = str(e)
@@ -588,11 +730,15 @@ async def score_batch(
                 )
                 _jobs[k]["evaluation_id"] = evaluation_id
                 _jobs[k]["scorecard"] = scorecard.model_dump()
+                followup = None
                 if evaluation_id is not None:
-                    await _postgres_post_stage1(
-                        _jobs[k], evaluation_id, scorecard, config, team_id
+                    followup = await _postgres_post_stage1(
+                        _jobs[k], evaluation_id, scorecard, config, team_id,
+                        key=k, api_key_role=identity.role, semaphore=semaphore,
                     )
                 _jobs[k]["status"] = "complete"
+                if followup is not None:
+                    await followup
             except Exception as e:
                 _jobs[k]["status"] = "error"
                 _jobs[k]["error"] = str(e)
@@ -607,6 +753,7 @@ async def approve_scorecard(
     request: Request,
     job_id: str,
     approval: ApprovalRequest,
+    background_tasks: BackgroundTasks,
     identity: KeyIdentity = Depends(require_api_key),
 ):
     """
@@ -621,6 +768,13 @@ async def approve_scorecard(
     Writes a Score_Audit row with action="approved" once the evaluation
     finalizes — captured before the Apps Script email dispatch so an
     Apps Script failure still leaves the audit trail intact.
+
+    S5 (ScorecardActionsDesign §4.2): the approve path is a finalize
+    seam, so the auto-rescore hook runs here too — an unedited approval
+    (source still 'ai') landing ≤ threshold with the latch unstamped
+    suppresses projection/email and schedules the machine's one retry
+    via BackgroundTasks; the response says so (`auto_rescore`). An
+    edited approval flips source to 'ai_reviewed' and never fires.
     """
     team_id = team_id_from_path(request)
     key = _job_key(team_id, job_id)
@@ -707,22 +861,33 @@ async def approve_scorecard(
         detail = await eval_store.stamp_and_finalize(
             evaluation_id, config, evaluator_email=evaluator_email
         )
-        pool = await eval_store.get_pool()
-        history_row = await project_evaluation(
-            pool, evaluation_id, config, include_history=True
+        # S5 (§4.2): the approve path is a finalize seam too. On a fire,
+        # suppress projection/SSE/email for this pass and schedule the
+        # machine's retry after the response is sent.
+        followup = await _maybe_auto_rescore(
+            job, evaluation_id, float(detail.overall_score), config, team_id,
+            key=key, api_key_role=identity.role,
+            semaphore=_semaphore_for_key(identity),
+            manager_email=evaluator_email,
         )
-        _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
-        await _publish_finalized_event(
-            team_id, job,
-            agent_name=job.get("agent_name") or sc.get("agent_name"),
-            evaluator_email=evaluator_email,
-            overall_score=float(detail.overall_score),
-            history_row=history_row,
-            dialpad_link=sc.get("dialpad_link"),
-            call_summary=sc.get("call_summary", ""),
-            key_strengths=approval.key_strengths,
-            opportunities=approval.opportunities,
-        )
+        history_row = None
+        if followup is None:
+            pool = await eval_store.get_pool()
+            history_row = await project_evaluation(
+                pool, evaluation_id, config, include_history=True
+            )
+            _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
+            await _publish_finalized_event(
+                team_id, job,
+                agent_name=job.get("agent_name") or sc.get("agent_name"),
+                evaluator_email=evaluator_email,
+                overall_score=float(detail.overall_score),
+                history_row=history_row,
+                dialpad_link=sc.get("dialpad_link"),
+                call_summary=sc.get("call_summary", ""),
+                key_strengths=approval.key_strengths,
+                opportunities=approval.opportunities,
+            )
         append_score_audit_row(
             api_key_role=identity.role,
             evaluator_email=evaluator_email,
@@ -739,11 +904,14 @@ async def approve_scorecard(
         job["scoring_status"] = "complete"
         job["overall_score"] = float(detail.overall_score)
         job["evaluation_id"] = evaluation_id
+        if followup is not None:
+            background_tasks.add_task(_await_coro, followup)
         return {
             "status": "approved",
             "state": "finalized",
             "overall_score": float(detail.overall_score),
             "history_row": history_row,
+            **({"auto_rescore": "scheduled"} if followup is not None else {}),
         }
     except HTTPException:
         job["status"] = "complete"
@@ -754,6 +922,69 @@ async def approve_scorecard(
         job["status"] = "complete"
         job["error"] = str(e)
         raise HTTPException(status_code=500, detail=f"Engine approval failed: {e}")
+
+
+async def _rescore_core(*, key, team_id, config, call_id, agent_name,
+                        manager_email, duration_ms, expected_row_id, agent_id,
+                        semaphore, api_key_role, audio_bytes, transcript_data,
+                        call_details):
+    """The §4.2 rescore primitive body, shared by the manual route and
+    the S5 auto trigger: fresh score_call pass → Stage-1 upsert (REPLACE,
+    same row id, loud guard) → series rebuild while the row is draft →
+    normal auto-flow. Owns the job's status transitions, including the
+    error state — callers just await it."""
+    try:
+        _jobs[key]["status"] = "scoring"
+        async with semaphore:
+            scorecard = await score_call(
+                audio_bytes=audio_bytes,
+                filename=f"{call_id}.mp3",
+                call_id=call_id,
+                agent_name=agent_name,
+                manager_email=manager_email,
+                config=config,
+                duration_ms=duration_ms,
+                transcript_data=transcript_data,
+                call_details=call_details,
+            )
+        # §4.2.2: the Stage-1 upsert IS the REPLACE — same row id,
+        # lifecycle columns reset, sections replaced wholesale.
+        evaluation_id = await record_draft_evaluation(
+            scorecard, config, strict=True
+        )
+        if evaluation_id != expected_row_id:
+            raise RuntimeError(
+                f"rescore landed on row {evaluation_id}, expected "
+                f"{expected_row_id} — REPLACE contract violated "
+                "(dialpad_link drift?)"
+            )
+        _jobs[key]["evaluation_id"] = evaluation_id
+        _jobs[key]["scorecard"] = scorecard.model_dump()
+        # §4.2.3: row is draft now — drop its stat point and rebuild
+        # the series. Fatal by contract (§5): a failure errors the
+        # whole job loudly rather than leaving a corrupt EWMA chain.
+        if agent_id is not None:
+            pool = await eval_store.get_pool()
+            if pool is None:
+                raise RuntimeError("rescore: no DB pool for series rebuild")
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    await rebuild_agent_series(conn, agent_id, config)
+        # §4.2.4: the auto-flow decides auto-finalize vs. flagged,
+        # like any first pass — the machine owns the outcome. A manual
+        # rescore landing ≤ threshold with the latch unstamped hands
+        # over to the machine's one auto retry (finalize seam is
+        # universal); the latch bounds the recursion at depth one.
+        followup = await _postgres_post_stage1(
+            _jobs[key], evaluation_id, scorecard, config, team_id,
+            key=key, api_key_role=api_key_role, semaphore=semaphore,
+        )
+        _jobs[key]["status"] = "complete"
+        if followup is not None:
+            await followup
+    except Exception as e:
+        _jobs[key]["status"] = "error"
+        _jobs[key]["error"] = str(e)
 
 
 @router.post("/score/{job_id}/rescore")
@@ -913,52 +1144,14 @@ async def rescore_evaluation(
     agent_id = ref.agent_id
 
     async def run():
-        try:
-            _jobs[key]["status"] = "scoring"
-            async with semaphore:
-                scorecard = await score_call(
-                    audio_bytes=audio_bytes,
-                    filename=f"{call_id}.mp3",
-                    call_id=call_id,
-                    agent_name=agent_name,
-                    manager_email=payload.evaluator_email,
-                    config=config,
-                    duration_ms=duration_ms,
-                    transcript_data=transcript_data,
-                    call_details=call_details,
-                )
-            # §4.2.2: the Stage-1 upsert IS the REPLACE — same row id,
-            # lifecycle columns reset, sections replaced wholesale.
-            evaluation_id = await record_draft_evaluation(
-                scorecard, config, strict=True
-            )
-            if evaluation_id != expected_row_id:
-                raise RuntimeError(
-                    f"rescore landed on row {evaluation_id}, expected "
-                    f"{expected_row_id} — REPLACE contract violated "
-                    "(dialpad_link drift?)"
-                )
-            _jobs[key]["evaluation_id"] = evaluation_id
-            _jobs[key]["scorecard"] = scorecard.model_dump()
-            # §4.2.3: row is draft now — drop its stat point and rebuild
-            # the series. Fatal by contract (§5): a failure errors the
-            # whole job loudly rather than leaving a corrupt EWMA chain.
-            if agent_id is not None:
-                pool = await eval_store.get_pool()
-                if pool is None:
-                    raise RuntimeError("rescore: no DB pool for series rebuild")
-                async with pool.acquire() as conn:
-                    async with conn.transaction():
-                        await rebuild_agent_series(conn, agent_id, config)
-            # §4.2.4: the auto-flow decides auto-finalize vs. flagged,
-            # like any first pass — the machine owns the outcome.
-            await _postgres_post_stage1(
-                _jobs[key], evaluation_id, scorecard, config, team_id
-            )
-            _jobs[key]["status"] = "complete"
-        except Exception as e:
-            _jobs[key]["status"] = "error"
-            _jobs[key]["error"] = str(e)
+        await _rescore_core(
+            key=key, team_id=team_id, config=config, call_id=call_id,
+            agent_name=agent_name, manager_email=payload.evaluator_email,
+            duration_ms=duration_ms, expected_row_id=expected_row_id,
+            agent_id=agent_id, semaphore=semaphore,
+            api_key_role=identity.role, audio_bytes=audio_bytes,
+            transcript_data=transcript_data, call_details=call_details,
+        )
 
     background_tasks.add_task(run)
     return {

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -765,6 +765,17 @@ async def stamp_and_finalize(
 _CONFIDENCE_UNMAP = {"HIGH": "high", "MED": "medium", "LOW": "low"}
 
 
+def _model_from_models_used(value: Any) -> str:
+    """Text-leg model out of a qa.evaluations.models_used value — str
+    (no JSONB codec) or dict (codec) both accepted."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value or "{}")
+        except ValueError:
+            value = {}
+    return ((value or {}).get("text") or {}).get("model") or "gemini-2.5-flash"
+
+
 @dataclass
 class EvalRef:
     """A qa.evaluations row resolved by Dialpad call id, plus its AI
@@ -848,13 +859,7 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
             row["id"],
         )
 
-    models_used = row["models_used"]
-    if isinstance(models_used, str):
-        try:
-            models_used = json.loads(models_used or "{}")
-        except ValueError:
-            models_used = {}
-    model = ((models_used or {}).get("text") or {}).get("model") or "gemini-2.5-flash"
+    model = _model_from_models_used(row["models_used"])
 
     # AI rows only, reshaped to the Stage-1 dump (job['scorecard']
     # ['sections']) that build_approval_sections diffs against. Manual /
@@ -904,6 +909,78 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
 
 
 # ---------------------------------------------------------------------------
+# Auto-rescore support (ScorecardActionsDesign §4.2, slice S5)
+# ---------------------------------------------------------------------------
+
+async def fetch_auto_rescore_state(evaluation_id: int) -> Optional[dict[str, Any]]:
+    """The row facts the finalize-seam auto-rescore hook needs: fire
+    eligibility (source, latch) plus enough context to schedule the
+    fresh pass without a second probe. None when dual-write is off or
+    the row is gone."""
+    pool = await _get_pool()
+    if pool is None:
+        return None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT source, auto_rescored_at, agent_id, duration_ms, "
+            "  dialpad_call_id, dialpad_entry_point_call_id, "
+            "  agent_name_raw, agent_email, models_used "
+            "FROM qa.evaluations WHERE id = $1",
+            evaluation_id,
+        )
+    if row is None:
+        return None
+    return {
+        "source": row["source"],
+        "auto_rescored_at": row["auto_rescored_at"],
+        "agent_id": row["agent_id"],
+        "duration_ms": (
+            float(row["duration_ms"]) if row["duration_ms"] is not None else None
+        ),
+        "dialpad_call_id": row["dialpad_call_id"],
+        "dialpad_entry_point_call_id": row["dialpad_entry_point_call_id"],
+        "agent_name_raw": row["agent_name_raw"],
+        "agent_email": row["agent_email"],
+        "model": _model_from_models_used(row["models_used"]),
+    }
+
+
+async def stamp_auto_rescored(evaluation_id: int) -> bool:
+    """The once-EVER latch (§4.2): atomically stamp auto_rescored_at,
+    returning True only for the request that won the stamp. Stamped
+    BEFORE the re-run is scheduled, so a crash mid-rescore can't loop —
+    and the WHERE ... IS NULL guard makes a concurrent double-finalize
+    race resolve to exactly one retry."""
+    pool = await _get_pool()
+    if pool is None:
+        return False
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "UPDATE qa.evaluations SET auto_rescored_at = NOW() "
+            "WHERE id = $1 AND auto_rescored_at IS NULL RETURNING id",
+            evaluation_id,
+        )
+    return row is not None
+
+
+async def mark_human_review_required(evaluation_id: int) -> None:
+    """Enter the §0.3 review queue (required_at IS NOT NULL AND
+    completed_at IS NULL) without disturbing an existing marker —
+    COALESCE keeps the original timestamp. Used by the still-low
+    second pass (§4.2) and as informative-mode insurance for flagged
+    rows whose draft write predates the marker."""
+    pool = await _get_pool()
+    if pool is None:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE qa.evaluations SET human_review_required_at = "
+            "  COALESCE(human_review_required_at, NOW()) WHERE id = $1",
+            evaluation_id,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Pool lifecycle
 # ---------------------------------------------------------------------------
 
@@ -943,6 +1020,9 @@ __all__ = [
     "resolve_evaluation",
     "call_id_from_job_id",
     "EvalRef",
+    "fetch_auto_rescore_state",
+    "stamp_auto_rescored",
+    "mark_human_review_required",
     "get_pool",
     "build_draft_row",
     "build_draft_sections",

--- a/qa-automation/AI-Scoring/tests/test_config_load.py
+++ b/qa-automation/AI-Scoring/tests/test_config_load.py
@@ -159,3 +159,11 @@ def test_get_all_team_ids_returns_configured_teams():
     assert "member_support" in ids
     assert "sales" in ids
     assert ids == sorted(ids)
+
+
+def test_scorecard_actions_knobs_default(config: TeamConfig):
+    """ScorecardActionsDesign §4.2/§0.3 (S5): every team gets the
+    auto-rescore threshold and the human-review mode without JSON edits —
+    absent keys mean threshold 50, authoritative (blocking) review."""
+    assert config.rescore.threshold == 50.0
+    assert config.human_review.mode == "authoritative"

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -192,3 +192,92 @@ class TestResolveEvaluation:
             return None
         monkeypatch.setattr(eval_store, "_get_pool", no_pool)
         assert await resolve_evaluation("member_support", "5035229460504576") is None
+
+
+# ---------------------------------------------------------------------------
+# S5 helpers — fetch_auto_rescore_state / stamp_auto_rescored /
+# mark_human_review_required (ScorecardActionsDesign §4.2)
+# ---------------------------------------------------------------------------
+
+from backend.services.eval_store import (  # noqa: E402
+    fetch_auto_rescore_state,
+    mark_human_review_required,
+    stamp_auto_rescored,
+)
+
+
+class _S5Conn:
+    def __init__(self, row=None):
+        self.row = row
+        self.fetchrow_calls: list[tuple] = []
+        self.execute_calls: list[tuple] = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((query, args))
+        return self.row
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return "UPDATE 1"
+
+
+@pytest.mark.asyncio
+class TestAutoRescoreHelpers:
+
+    def _wire(self, monkeypatch, conn):
+        async def fake_get_pool():
+            return FakePool(conn)
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_fetch_state_maps_row(self, monkeypatch):
+        conn = _S5Conn(row={
+            "source": "ai", "auto_rescored_at": None, "agent_id": 7,
+            "duration_ms": 180000, "dialpad_call_id": "503",
+            "dialpad_entry_point_call_id": "610",
+            "agent_name_raw": "Juan Celso", "agent_email": "j@landing.com",
+            "models_used": json.dumps({"text": {"model": "claude-sonnet-5"}}),
+        })
+        self._wire(monkeypatch, conn)
+        state = await fetch_auto_rescore_state(2377)
+        assert state["source"] == "ai"
+        assert state["auto_rescored_at"] is None
+        assert state["duration_ms"] == 180000.0
+        # The model stamp survives a provider flip — P3+ traceability.
+        assert state["model"] == "claude-sonnet-5"
+        assert conn.fetchrow_calls[0][1] == (2377,)
+
+    async def test_fetch_state_missing_row_is_none(self, monkeypatch):
+        conn = _S5Conn(row=None)
+        self._wire(monkeypatch, conn)
+        assert await fetch_auto_rescore_state(999) is None
+
+    async def test_stamp_latch_wins(self, monkeypatch):
+        conn = _S5Conn(row={"id": 2377})
+        self._wire(monkeypatch, conn)
+        assert await stamp_auto_rescored(2377) is True
+        query, args = conn.fetchrow_calls[0]
+        # The once-EVER guarantee is IN the SQL, not app logic.
+        assert "auto_rescored_at IS NULL" in query
+        assert "RETURNING id" in query
+        assert args == (2377,)
+
+    async def test_stamp_latch_already_stamped_returns_false(self, monkeypatch):
+        conn = _S5Conn(row=None)
+        self._wire(monkeypatch, conn)
+        assert await stamp_auto_rescored(2377) is False
+
+    async def test_mark_queue_preserves_existing_marker(self, monkeypatch):
+        conn = _S5Conn()
+        self._wire(monkeypatch, conn)
+        await mark_human_review_required(2377)
+        query, args = conn.execute_calls[0]
+        assert "COALESCE(human_review_required_at, NOW())" in query
+        assert args == (2377,)
+
+    async def test_no_pool_degrades_quietly(self, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        assert await fetch_auto_rescore_state(1) is None
+        assert await stamp_auto_rescored(1) is False
+        await mark_human_review_required(1)  # no raise

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -1014,15 +1014,24 @@ class _FakeScorecard:
 
 
 def _stub_rescore_pipeline(monkeypatch, *, flagged=False, draft_row_id=2377,
-                           engine_score=88.0):
+                           engine_score=88.0, engine_scores=None,
+                           auto_state=None, latch_wins=True, hr_mode=None):
     """Stub the whole rescore background pipeline, recording operation
     order in caps['ops'] — the §4.2 order proof (draft → rebuild → stamp)
-    rides on it."""
+    rides on it.
+
+    S5 knobs: ``engine_scores`` = successive stamp_and_finalize results
+    (falls back to the constant ``engine_score``); ``auto_state`` overrides
+    the fetch_auto_rescore_state row (stateful — the fake latch stamp
+    mutates it, so a second fetch sees auto_rescored_at set, mirroring the
+    DB); ``latch_wins=False`` simulates losing the stamp race;
+    ``hr_mode`` overrides config.human_review.mode via get_team_config."""
     caps = {"score_calls": [], "ops": [], "rebuilds": [], "dispatches": [],
-            "approvals": []}
+            "approvals": [], "downloads": [], "finalized_scores": []}
 
     async def fake_download(call_id):
         caps["download"] = call_id
+        caps["downloads"].append(call_id)
         return b"AUDIO"
     monkeypatch.setattr(scoring_module, "download_recording", fake_download)
 
@@ -1052,14 +1061,58 @@ def _stub_rescore_pipeline(monkeypatch, *, flagged=False, draft_row_id=2377,
         scoring_module.eval_store, "requires_analyst_review",
         lambda config: False)
 
-    class _Detail:
-        overall_score = engine_score
+    scores = list(engine_scores) if engine_scores is not None else None
 
     async def fake_stamp(evaluation_id, config, evaluator_email):
         caps["ops"].append("stamp")
+        s = scores.pop(0) if scores else engine_score
+        caps["finalized_scores"].append(s)
+
+        class _Detail:
+            overall_score = s
         return _Detail()
     monkeypatch.setattr(
         scoring_module.eval_store, "stamp_and_finalize", fake_stamp)
+
+    # S5 — auto-rescore state trio, stateful like the DB.
+    state = dict(auto_state) if auto_state else {
+        "source": "ai", "auto_rescored_at": None, "agent_id": 7,
+        "duration_ms": 180000.0, "dialpad_call_id": "5035229460504576",
+        "dialpad_entry_point_call_id": "6105002063634432",
+        "agent_name_raw": "Luis Rubio", "agent_email": "luis@landing.com",
+        "model": "gemini-2.5-flash",
+    }
+    caps["auto_state"] = state
+
+    async def fake_fetch_state(evaluation_id):
+        caps["ops"].append("fetch_state")
+        return dict(state)
+    monkeypatch.setattr(
+        scoring_module.eval_store, "fetch_auto_rescore_state", fake_fetch_state)
+
+    async def fake_stamp_latch(evaluation_id):
+        caps["ops"].append("stamp_latch")
+        if not latch_wins:
+            return False
+        state["auto_rescored_at"] = "2026-07-26T12:00:00+00:00"
+        return True
+    monkeypatch.setattr(
+        scoring_module.eval_store, "stamp_auto_rescored", fake_stamp_latch)
+
+    async def fake_mark_queue(evaluation_id):
+        caps["ops"].append("mark_queue")
+    monkeypatch.setattr(
+        scoring_module.eval_store, "mark_human_review_required", fake_mark_queue)
+
+    if hr_mode is not None:
+        from backend.config.team_config import (
+            HumanReviewConfig, get_team_config as _real_get_config,
+        )
+        base = _real_get_config("member_support")
+        patched = base.model_copy(
+            update={"human_review": HumanReviewConfig(mode=hr_mode)})
+        monkeypatch.setattr(
+            scoring_module, "get_team_config", lambda team_id: patched)
 
     pool = _NullPool()
 
@@ -1330,3 +1383,228 @@ def test_rescore_privileged_key_unrostered_allowed(client, monkeypatch):
     rescored = [r for r in client.audit_rows if r["action"] == "rescored"]
     assert len(rescored) == 1
     assert rescored[0]["api_key_role"] == "privileged"
+
+
+# ---------------------------------------------------------------------------
+# S5 — auto rescore at the finalize seam + human_review.mode
+# (ScorecardActionsDesign §4.2 auto / §0.3)
+# ---------------------------------------------------------------------------
+
+_SCORE_URL = "/api/member_support/score"
+_SCORE_FORM = {
+    "call_id": "call-abc",
+    "agent_email": "luis@landing.com",
+    "manager_email": "ana@landing.com",
+}
+_SCORE_KEY = ("member_support", "call-abc_Luis_Rubio")
+
+
+def test_low_first_pass_fires_auto_rescore_once(client, monkeypatch):
+    """§4.2 auto: finalize lands ≤ threshold on source='ai' → latch stamps
+    BEFORE the re-run, this pass's projection + email are suppressed, the
+    machine's one retry runs to a normal finalize with the rescore_auto
+    disclaimer."""
+    caps = _stub_rescore_pipeline(monkeypatch, engine_scores=[42.0, 88.0])
+
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Order proof: latch stamped before the fresh pass starts (§4.2
+    # "once means once"), and exactly ONE projection — the low first
+    # pass never reached the sheet or the agent.
+    assert caps["ops"] == [
+        "draft", "stamp", "fetch_state", "stamp_latch",   # pass 1: fired
+        "draft", "rebuild", "stamp", "project",           # pass 2: normal
+    ]
+    assert caps["downloads"] == ["call-abc", "5035229460504576"]
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "rescore_auto"}]
+
+    # Machine receipt: 'rescored' audit row, no evaluator, model stamp.
+    actions = [r["action"] for r in client.audit_rows]
+    assert actions == ["scored", "rescored"]
+    rescored = client.audit_rows[1]
+    assert rescored["notes"] == "auto: 42.0 ≤ 50.0; superseded_model=gemini-2.5-flash"
+    assert rescored["evaluator_email"] == ""
+    assert rescored["api_key_role"] == "team"
+
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["status"] == "complete"
+    assert job["state"] == "finalized"
+    assert job["overall_score"] == 88.0
+    assert job["rescore"]["cause"] == "auto"
+    assert job["rescore"]["superseded_score"] == 42.0
+
+
+def test_exact_threshold_fires(client, monkeypatch):
+    """The trigger is ≤, not < (design: 'lands overall_score ≤ 50')."""
+    caps = _stub_rescore_pipeline(monkeypatch, engine_scores=[50.0, 88.0])
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert "stamp_latch" in caps["ops"]
+    assert caps["finalized_scores"] == [50.0, 88.0]
+
+
+def test_low_ai_reviewed_does_not_fire(client, monkeypatch):
+    """§4.2: a human-approved low score is a human's judgment — never
+    discarded by the machine. Normal projection + email proceed."""
+    caps = _stub_rescore_pipeline(
+        monkeypatch, engine_scores=[42.0],
+        auto_state={
+            "source": "ai_reviewed", "auto_rescored_at": None, "agent_id": 7,
+            "duration_ms": 180000.0, "dialpad_call_id": "5035229460504576",
+            "dialpad_entry_point_call_id": None,
+            "agent_name_raw": "Luis Rubio", "agent_email": "luis@landing.com",
+            "model": "gemini-2.5-flash",
+        },
+    )
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == ["draft", "stamp", "fetch_state", "project"]
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": None}]
+    assert [r["action"] for r in client.audit_rows] == ["scored"]
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["state"] == "finalized"
+    assert "human_review_queued" not in job
+
+
+def test_latch_already_stamped_no_loop_enters_queue(client, monkeypatch):
+    """Crash-sim (§4.2 'once means once'): the latch survived a dead
+    rescore attempt — the next low finalize does NOT re-fire; the eval
+    enters the review queue and ships normally."""
+    caps = _stub_rescore_pipeline(monkeypatch, engine_scores=[42.0])
+    caps["auto_state"]["auto_rescored_at"] = "2026-07-25T09:00:00+00:00"
+
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == ["draft", "stamp", "fetch_state", "mark_queue", "project"]
+    assert "stamp_latch" not in caps["ops"]
+    assert len(caps["dispatches"]) == 1
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["human_review_queued"] is True
+    assert job["state"] == "finalized"
+
+
+def test_still_low_second_pass_enters_review_queue(client, monkeypatch):
+    """The full ladder rung: fire → retry lands still-low → review queue
+    (the coaching → override escalation cue), projected + emailed with
+    the disclaimer."""
+    caps = _stub_rescore_pipeline(monkeypatch, engine_scores=[42.0, 45.0])
+
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == [
+        "draft", "stamp", "fetch_state", "stamp_latch",
+        "draft", "rebuild", "stamp", "fetch_state", "mark_queue", "project",
+    ]
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "rescore_auto"}]
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["overall_score"] == 45.0
+    assert job["human_review_queued"] is True
+    # Exactly one 'rescored' receipt — the second low did NOT re-fire.
+    assert [r["action"] for r in client.audit_rows] == ["scored", "rescored"]
+
+
+def test_lost_latch_race_proceeds_normally(client, monkeypatch):
+    """stamp_auto_rescored returning False means another finalize won the
+    one retry — this pass ships as normal, no second run."""
+    caps = _stub_rescore_pipeline(
+        monkeypatch, engine_scores=[42.0], latch_wins=False)
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == ["draft", "stamp", "fetch_state", "stamp_latch", "project"]
+    assert len(caps["dispatches"]) == 1
+    assert [r["action"] for r in client.audit_rows] == ["scored"]
+
+
+def test_informative_mode_finalizes_flagged_with_queue_marker(client, monkeypatch):
+    """§0.3: informative mode ships flagged rows — finalized, projected,
+    emailed — keeping the review-queue marker instead of blocking."""
+    caps = _stub_rescore_pipeline(
+        monkeypatch, flagged=True, engine_score=88.0, hr_mode="informative")
+
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == ["draft", "stamp", "mark_queue", "project"]
+    assert len(caps["dispatches"]) == 1
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["state"] == "finalized"
+    assert job["scoring_status"] == "complete"
+    assert job["human_review_queued"] is True
+
+
+def test_authoritative_mode_still_blocks_flagged(client, monkeypatch):
+    """Default mode unchanged: flagged rows hold in draft for resolution."""
+    caps = _stub_rescore_pipeline(monkeypatch, flagged=True, engine_score=88.0)
+    resp = client.post(
+        _SCORE_URL, headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        data=_SCORE_FORM,
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["ops"] == ["draft"]
+    assert caps["dispatches"] == []
+    job = scoring_module._jobs[scoring_module._job_key(*_SCORE_KEY)]
+    assert job["state"] == "draft"
+    assert job["scoring_status"] == "flagged_human_review"
+
+
+def test_approve_low_unedited_fires_auto_rescore(client, monkeypatch):
+    """§4.2: the approve path is a finalize seam too. An approval whose
+    row is still source='ai' landing ≤ threshold suppresses projection/
+    email, responds with auto_rescore=scheduled, and the retry runs after
+    the response."""
+    caps = _stub_rescore_pipeline(monkeypatch, engine_scores=[42.0, 88.0])
+    _resolve_stub(monkeypatch, _eval_ref())
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={
+            "sections": [], "key_strengths": "x", "opportunities": "y",
+            "evaluator_email": "ana@landing.com",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["auto_rescore"] == "scheduled"
+    assert body["history_row"] is None
+    assert body["overall_score"] == 42.0
+
+    # The retry ran via BackgroundTasks after the response: one projection
+    # + one disclaimer dispatch total, both from the second pass.
+    assert caps["ops"] == [
+        "stamp", "fetch_state", "stamp_latch",            # approve: fired
+        "draft", "rebuild", "stamp", "project",           # retry pass
+    ]
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "rescore_auto"}]
+    actions = [r["action"] for r in client.audit_rows]
+    assert actions == ["rescored", "approved"]
+    assert client.audit_rows[1]["result_row"] is None
+
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    job = scoring_module._jobs[key]
+    assert job["status"] == "complete"
+    assert job["state"] == "finalized"
+    assert job["overall_score"] == 88.0
+    assert job["rescore"]["cause"] == "auto"


### PR DESCRIPTION
Lands slice S5 of **ScorecardActionsDesign v1.2**: the §4.2 automatic rescore and the §0.3 `human_review.mode` config flag. Completes the escalation ladder's machine rungs — S6 (override + acknowledgment protocol) is the human rung that follows.

## Auto rescore (§4.2)
- **Trigger:** any finalize landing `overall_score ≤ config.rescore.threshold` (team JSON, default 50) on a `source='ai'` row. Hooked at **both** finalize seams: `_postgres_post_stage1` (score / batch / manual-rescore flows) and the approve path (an *unedited* approval leaves `source='ai'`; an edited one flips to `ai_reviewed` and never fires — a human's low score is a human's judgment).
- **Once means once:** `auto_rescored_at` stamps atomically (`UPDATE … WHERE auto_rescored_at IS NULL RETURNING`) **before** the pass is scheduled — the once-EVER guarantee lives in the SQL, so a crash mid-rescore can't loop and a concurrent double-finalize resolves to exactly one retry.
- **Suppression:** the fired pass's Sheets projection, SSE toast, and email are all suppressed — the agent must not see a score about to change. (The stat point the finalize wrote is cleaned by the retry's own series rebuild, per the existing S4 flow.)
- **The retry** is the shared S4 primitive (`_rescore_core`, extracted for reuse): fresh pass under whatever `SCORING_PIPELINE`/provider is live, REPLACE on the same row, series rebuild, normal auto-flow, `rescore_auto` disclaimer on the final email. Machine receipt: `action='rescored'`, notes `auto: <old> ≤ <threshold>; superseded_model=<model>` — same P3+ cross-model stamp as S4, no evaluator, no coaching (§0.2: machine-initiated ≠ tampering).
- **Still low after the retry:** the eval ships normally **and** enters the review queue via a COALESCE-preserving `human_review_required_at` stamp — the cue for the coaching → override escalation.

## human_review.mode (§0.3)
Team-JSON flag, default `authoritative` — flagged rows hold in draft exactly as today (zero behavior change until a team's JSON opts in). `informative` finalizes and ships flagged rows, keeping `human_review_required_at` as the queue marker (`required_at IS NOT NULL AND completed_at IS NULL`) and never setting the blocking `scoring_status`. The flip is a config edit, not a deploy.

## Two interpretation calls (owner-checkable)
1. **"Still ≤ 50 → project + email AND enter the review queue (mode decides blocking vs annotation)":** implemented as *proceed normally + queue marker*. True pre-finalize blocking would need an engine-score preview before `stamp_and_finalize`; §3.14-triggered flags on the retry still block per mode via the normal flow. If the owner wants score-based blocking on the retry, that's a small follow-up.
2. **Audit row identity for the machine's fire:** `api_key_role` = the triggering request's key role (the finalize was caused by some keyed request), `evaluator_email` = `""`. Avoids inventing a `system` role that the role-mirror test and future DB CHECK would have to carry.

## Known bound
An approve-path fire that 500s *after* the latch stamp but before scheduling leaves the latch stamped with no retry run — the next low finalize routes to the review queue instead of looping, and the S4 manual rescore is the recovery tool. Same self-limiting shape as the crash-sim case.

## Tests
`1072 passed, 6 skipped, 3 xfailed` — 16 new: fire-once round-trip with latch-before-rerun order proof and exactly-one projection/dispatch; `≤` boundary; `ai_reviewed` no-fire; crash-sim no-loop → queue; still-low second pass → queue; lost latch race; informative ships flagged with marker; authoritative still blocks; approve-path fire with `auto_rescore=scheduled` response; helper SQL contracts (latch guard in SQL, COALESCE marker); per-team config defaults.

Next: S6 (override + §4.3a acknowledgment protocol + coaching receipt) → S7 (datapoint edit surface + frontend action bars + GAS disclaimer template — `rescore_auto` becomes agent-visible copy there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)