### PR TITLE
feat(qa-automation): Scorecard Actions S6 — override + acknowledgment protocol + review-queue accounting

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
-from pydantic import BaseModel, ValidationInfo, model_validator
+from typing import List, Literal, Optional
+from pydantic import BaseModel, Field, ValidationInfo, model_validator
 
 
 class ScorecardSection(BaseModel):
@@ -100,6 +100,11 @@ class ApprovalRequest(BaseModel):
     # falls back to job/row identity and 422s only when every source
     # comes up empty.
     evaluator_email: Optional[str] = None
+    # ScorecardActionsDesign §4.3a (S6): required (literally true) when
+    # the approval resolves a flagged human review — the acknowledgment
+    # binds the evaluator to notify the agent that a human manually
+    # modified their progression. Plain approvals ignore it.
+    acknowledged: bool = False
 
 
 class RescoreRequest(BaseModel):
@@ -112,6 +117,32 @@ class RescoreRequest(BaseModel):
     the disclaimer email by default."""
     evaluator_email: str
     suppress_email: bool = False
+
+
+class SopGap(BaseModel):
+    """The SOP-escalation record riding an override (ScorecardActionsDesign
+    §4.3): evidence of an outdated or missing SOP. ``document_id`` points
+    into embeddings.sop_documents when the evaluator can name the doc."""
+    note: str = Field(min_length=1)
+    document_id: Optional[int] = None
+
+
+class OverrideRequest(BaseModel):
+    """POST /score/{job_id}/override payload (ScorecardActionsDesign §4.3).
+
+    SUPERSEDE riding source='ai_reviewed': sections and formula_version
+    stay untouched, so the engine score remains reproducible forever.
+    ``acknowledged`` is the §4.3a gate — the route 422s unless it is
+    literally true; the acknowledgment binds the evaluator to notify the
+    agent their progression was manually modified. The override CREATES
+    the coaching receipt (v1.2 — receipts are written, not required)."""
+    overall_score: float = Field(ge=0, le=100)
+    reasoning: str = Field(min_length=1)
+    conducted_by_role: Literal["team_lead", "manager", "hr", "external"]
+    sop_gap: Optional[SopGap] = None
+    acknowledged: bool
+    suppress_email: bool = False
+    evaluator_email: str = Field(min_length=1)
 
 
 class ScorecardWithMeta(Scorecard):

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -22,7 +22,7 @@ from backend.middleware.auth import (
     require_api_key,
     team_id_from_path,
 )
-from backend.models.scorecard import ApprovalRequest, RescoreRequest
+from backend.models.scorecard import ApprovalRequest, OverrideRequest, RescoreRequest
 from backend.services.history_service import (
     agent_email_for_name,
     agent_name_for_email,
@@ -122,7 +122,8 @@ async def _await_coro(coro) -> None:
     await coro
 
 
-def _dispatch_finalize_email(job, history_row, team_id, evaluation_id) -> None:
+def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
+                             default_disclaimer=None) -> None:
     """Apps Script email dispatch at the finalize seam — shared by the
     auto-flow and the approve path.
 
@@ -132,7 +133,11 @@ def _dispatch_finalize_email(job, history_row, team_id, evaluation_id) -> None:
     in the job payload. The context lives on the in-memory job only — a
     restart between rescore and re-approve loses it, and the re-finalize
     email goes out disclaimer-less (accepted at current traffic; the
-    audit 'rescored' row still records the intervention)."""
+    audit 'rescored' row still records the intervention).
+
+    ``default_disclaimer`` (S6): the caller's cause tag when no rescore
+    context rides the job — e.g. 'review_resolution' on a flagged-review
+    approve. A rescore context wins over it."""
     if not history_row or history_row <= 0:
         job["email_dispatch"] = {
             "status": "skipped", "message": "no Analyst_History row projected",
@@ -145,7 +150,7 @@ def _dispatch_finalize_email(job, history_row, team_id, evaluation_id) -> None:
             "message": f"rescore ({rescore.get('cause', '?')}) requested suppress_email",
         }
         return
-    disclaimer = f"rescore_{rescore['cause']}" if rescore else None
+    disclaimer = f"rescore_{rescore['cause']}" if rescore else default_disclaimer
     try:
         job["email_dispatch"] = trigger_apps_script(
             history_row, team_id, disclaimer=disclaimer
@@ -840,6 +845,17 @@ async def approve_scorecard(
             status_code=422,
             detail=f"Manual sections require scores before approval: {unscored}",
         )
+    # §4.3a (S6): resolving a flagged review is a manual mutation of an
+    # agent-visible score — the acknowledgment gate applies.
+    resolving = job.get("scoring_status") == "flagged_human_review"
+    if resolving and approval.acknowledged is not True:
+        job["status"] = "complete"
+        raise HTTPException(
+            status_code=422,
+            detail="acknowledged required: resolving a human-review flag "
+                   "binds the evaluator to notify the agent that their "
+                   "progression was manually modified (§4.3a)",
+        )
     try:
         evaluation_id = await record_approval(
             config,
@@ -854,7 +870,7 @@ async def approve_scorecard(
             agent_email=job.get("agent_email") or None,
             model=sc.get("model", "gemini-2.5-flash"),
             strict=True,
-            resolving_review=job.get("scoring_status") == "flagged_human_review",
+            resolving_review=resolving,
         )
         if evaluation_id is None:
             raise HTTPException(status_code=500, detail="No draft evaluation row to approve")
@@ -870,13 +886,27 @@ async def approve_scorecard(
             semaphore=_semaphore_for_key(identity),
             manager_email=evaluator_email,
         )
+        # §4.3a.3 (S6): the resolution creates the coaching receipt —
+        # a human looked, and the agent is owed notice. Created even
+        # when the auto-rescore fired (the human DID resolve; the
+        # suppressed email leaves the receipt pending, correctly).
+        coaching_id = None
+        if resolving:
+            coaching_id = await eval_store.create_resolution_receipt(
+                evaluation_id=evaluation_id, team_id=team_id,
+                evaluator_email=evaluator_email,
+                agent_name=job.get("agent_name") or sc.get("agent_name") or "the agent",
+            )
         history_row = None
         if followup is None:
             pool = await eval_store.get_pool()
             history_row = await project_evaluation(
                 pool, evaluation_id, config, include_history=True
             )
-            _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
+            _dispatch_finalize_email(
+                job, history_row, team_id, evaluation_id,
+                default_disclaimer="review_resolution" if resolving else None,
+            )
             await _publish_finalized_event(
                 team_id, job,
                 agent_name=job.get("agent_name") or sc.get("agent_name"),
@@ -888,6 +918,20 @@ async def approve_scorecard(
                 key_strengths=approval.key_strengths,
                 opportunities=approval.opportunities,
             )
+            # The disclaimer email discharges the §4.3a notification duty.
+            dispatched_ok = (job.get("email_dispatch") or {}).get("status") \
+                not in ("error", "suppressed", "skipped")
+            if coaching_id is not None and dispatched_ok:
+                await eval_store.complete_coaching_notified(
+                    coaching_id, completed_by=evaluator_email,
+                    summary="Agent notified via review-resolution email",
+                )
+        approve_notes = "engine-scored"
+        if resolving:
+            approve_notes += (
+                f"; resolved_review ack:{evaluator_email}"
+                f"; coaching={coaching_id if coaching_id is not None else 'none'}"
+            )
         append_score_audit_row(
             api_key_role=identity.role,
             evaluator_email=evaluator_email,
@@ -897,7 +941,7 @@ async def approve_scorecard(
             target_team=team_id,
             action=audit_cfg.ACTION_APPROVED,
             result_row=history_row,
-            notes="engine-scored",
+            notes=approve_notes,
         )
         job["status"] = "approved"
         job["state"] = "finalized"
@@ -1160,6 +1204,193 @@ async def rescore_evaluation(
         "evaluation_id": ref.id,
         "superseded_score": ref.overall_score,
     }
+
+
+@router.post("/score/{job_id}/override")
+async def override_scorecard(
+    request: Request,
+    job_id: str,
+    payload: OverrideRequest,
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """Override the auto score — SUPERSEDE riding source='ai_reviewed'
+    (ScorecardActionsDesign §4.3). Team key (roster-scoped) or
+    privileged. Scorecard surface only by design — an approval-flow
+    action, not an archaeology action; the datapoint page never renders
+    the control (S7 checkpoint).
+
+    Target must be finalized. No precondition beyond that — the coaching
+    record is not a gate you pass, it's a receipt the action writes
+    (v1.2): one transaction sets the score a human stands behind, creates
+    the pending qa.coachings receipt (+ 3-day notification deadline) and
+    the coaching_evaluations link, resolves any standing review-queue
+    entry, and rebuilds the stat series. Sections and formula_version
+    stay — the superseded engine score is reproducible forever, so the
+    UI can render "engine would say X" without storing X.
+
+    §4.3a: `acknowledged` must be literally true (422 otherwise). The
+    disclaimer email dispatches by default and mechanically discharges
+    the notification duty (coaching completes); `suppress_email` leaves
+    it pending — idx_coachings_pending is the accountability queue.
+
+    Concurrency: last-writer-wins by design. qa.evaluations has no
+    updated_at column and these are low-traffic manager tools. If Landing
+    outgrows this (concurrent evaluators on one eval), add updated_at +
+    an If-Unmodified-Since-style optimistic check here — potential design
+    choice deliberately deferred, not overlooked.
+    """
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    key = _job_key(team_id, job_id)
+
+    if payload.acknowledged is not True:
+        raise HTTPException(
+            status_code=422,
+            detail="acknowledged required: overriding binds the evaluator "
+                   "to notify the agent that their progression was manually "
+                   "modified (§4.3a)",
+        )
+
+    existing = _jobs.get(key)
+    if existing and existing.get("status") in {"pending", "scoring"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A scoring job for this call is already {existing['status']}",
+        )
+
+    ref = await eval_store.resolve_evaluation(team_id, job_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="No evaluation matches this call id")
+
+    is_in_roster = (
+        await email_in_team_mails(ref.agent_email, team_id)
+        if ref.agent_email else False
+    )
+    try:
+        check_scoring_access(
+            identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
+        )
+    except HTTPException as exc:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=payload.evaluator_email,
+            agent_email=ref.agent_email or "",
+            agent_name=ref.agent_name_raw,
+            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes=f"http_{exc.status_code}",
+        )
+        raise
+
+    if ref.state != "finalized":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Evaluation is '{ref.state}' — only finalized "
+                   "evaluations can be overridden (draft evals go through "
+                   "the normal edit + approve flow)",
+        )
+    if ref.agent_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Evaluation has no linked agent (qa.agents) — the "
+                   "coaching receipt cannot be created. Import the agent "
+                   "first (scripts/import_agents.py).",
+        )
+
+    old_score = ref.overall_score
+    coaching_id = await eval_store.apply_override(
+        evaluation_id=ref.id, team_id=team_id, agent_id=ref.agent_id,
+        agent_name=ref.agent_name_raw, old_score=old_score,
+        new_score=payload.overall_score, reasoning=payload.reasoning,
+        conducted_by_role=payload.conducted_by_role,
+        evaluator_email=payload.evaluator_email, config=config,
+    )
+
+    # Post-transaction, visible-not-blocking: projection, audit, email.
+    pool = await eval_store.get_pool()
+    history_row = await project_evaluation(
+        pool, ref.id, config, include_history=True
+    )
+    notes = f"{old_score} → {payload.overall_score}: {payload.reasoning}"
+    if payload.sop_gap is not None:
+        doc = (
+            f" (doc {payload.sop_gap.document_id})"
+            if payload.sop_gap.document_id is not None else ""
+        )
+        notes += f" | SOP gap: {payload.sop_gap.note}{doc}"
+    notes += f" | ack:{payload.evaluator_email}"
+    append_score_audit_row(
+        api_key_role=identity.role,
+        evaluator_email=payload.evaluator_email,
+        agent_email=ref.agent_email or "",
+        agent_name=ref.agent_name_raw,
+        call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        target_team=team_id,
+        action=audit_cfg.ACTION_OVERRIDDEN,
+        result_row=history_row,
+        notes=notes,
+    )
+
+    coaching_status = "pending"
+    email_dispatch: dict = {"status": "suppressed", "message": "suppress_email requested"}
+    if not payload.suppress_email:
+        try:
+            email_dispatch = trigger_apps_script(
+                history_row, team_id, disclaimer="override"
+            ) if history_row and history_row > 0 else {
+                "status": "skipped", "message": "no Analyst_History row projected",
+            }
+        except Exception as e:
+            email_dispatch = {"status": "error", "message": str(e)}
+            logging.getLogger(__name__).exception(
+                "override: disclaimer dispatch failed for eval %s (retryable; "
+                "coaching stays pending)", ref.id,
+            )
+        if email_dispatch.get("status") not in ("error", "suppressed", "skipped"):
+            # §4.3.5: the disclaimer email discharges the notification
+            # duty mechanically — the receipt completes.
+            await eval_store.complete_coaching_notified(
+                coaching_id, completed_by=payload.evaluator_email,
+                summary="Agent notified via override disclaimer email",
+            )
+            coaching_status = "completed"
+
+    # Refresh the cached job so the scorecard page shows the new score.
+    cached = _jobs.get(key)
+    if cached:
+        cached["overall_score"] = payload.overall_score
+        cached["source"] = "ai_reviewed"
+
+    return {
+        "status": "overridden",
+        "evaluation_id": ref.id,
+        "old_score": old_score,
+        "new_score": payload.overall_score,
+        "superseded_engine_score": old_score,
+        "coaching_id": coaching_id,
+        "coaching_status": coaching_status,
+        "history_row": history_row,
+        "email_dispatch": email_dispatch,
+    }
+
+
+@router.get("/review-queue")
+async def review_queue(
+    request: Request,
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """The §0.3 review queue — every evaluation that WOULD require a
+    human look and hasn't had one (human_review_required_at set,
+    human_review_completed_at not). This is the accounting surface for
+    the no-hard-blockers doctrine: blocked drafts (authoritative mode),
+    shipped-but-queued rows (informative mode), and still-low
+    auto-rescore survivors all appear here until a human resolution
+    (approve) or an override stamps them completed."""
+    team_id = team_id_from_path(request)
+    rows = await eval_store.list_review_queue(team_id)
+    return {"team_id": team_id, "count": len(rows), "evaluations": rows}
 
 
 @router.delete("/score/{job_id}")

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -963,6 +963,168 @@ async def stamp_auto_rescored(evaluation_id: int) -> bool:
     return row is not None
 
 
+async def create_notification_coaching(
+    conn: Any, *, agent_id: int, team_id: str, conducted_by_role: str,
+    conducted_by_email: str, action_plan: str, per_eval_note: str,
+    evaluation_id: int,
+) -> int:
+    """The §4.3a coaching receipt: a pending qa.coachings row with the
+    3-day notification deadline + the coaching_evaluations link carrying
+    the reasoning and the row's opportunities snapshot. Two inserts, one
+    (sub)transaction. Returns the coaching id."""
+    async with conn.transaction():
+        coaching_id = (await conn.fetchrow(
+            "INSERT INTO qa.coachings "
+            "  (agent_id, team_id, conducted_by_role, conducted_by_email, "
+            "   status, action_plan, action_plan_deadline) "
+            "VALUES ($1, $2, $3, $4, 'pending', $5, NOW() + interval '3 days') "
+            "RETURNING id",
+            agent_id, team_id, conducted_by_role, conducted_by_email,
+            action_plan,
+        ))["id"]
+        await conn.execute(
+            "INSERT INTO qa.coaching_evaluations "
+            "  (coaching_id, evaluation_id, per_eval_note, opportunities_snapshot) "
+            "SELECT $1, $2, $3, opportunities FROM qa.evaluations WHERE id = $2",
+            coaching_id, evaluation_id, per_eval_note,
+        )
+    return coaching_id
+
+
+async def complete_coaching_notified(
+    coaching_id: int, *, completed_by: str, summary: str,
+) -> None:
+    """Mechanical discharge of the §4.3a notification duty — the
+    disclaimer email went out, so the pending receipt completes. Own
+    connection: runs after the mutating transaction committed AND the
+    email actually dispatched."""
+    pool = await _get_pool()
+    if pool is None:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE qa.coachings SET status = 'completed', "
+            "  coaching_summary = $2, completed_by = $3, completed_at = NOW() "
+            "WHERE id = $1 AND status = 'pending'",
+            coaching_id, summary, completed_by,
+        )
+
+
+async def apply_override(
+    *, evaluation_id: int, team_id: str, agent_id: int, agent_name: str,
+    old_score: Optional[float], new_score: float, reasoning: str,
+    conducted_by_role: str, evaluator_email: str, config: Any,
+) -> int:
+    """The §4.3 override transaction — SUPERSEDE riding source='ai_reviewed'.
+
+    One transaction: (1) overall_score := new, source := 'ai_reviewed' —
+    sections and formula_version STAY, so the superseded engine score is
+    reproducible forever; a standing review-queue entry is resolved
+    (human_review_completed_at) since the override IS the human look.
+    (2) The coaching receipt (§4.3a) — pending + 3-day deadline.
+    (3) Stat point rebuilt (§5) — fatal by contract, rolls everything
+    back on failure. Returns the coaching id."""
+    from backend.services.stat_points import rebuild_agent_series
+
+    pool = await _get_pool()
+    if pool is None:
+        raise RuntimeError(f"override for {team_id} requires a DATABASE_URL")
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "UPDATE qa.evaluations SET "
+                "  overall_score = $2, "
+                "  source = 'ai_reviewed', "
+                "  human_review_completed_at = CASE "
+                "    WHEN human_review_required_at IS NOT NULL "
+                "    THEN COALESCE(human_review_completed_at, NOW()) "
+                "    ELSE human_review_completed_at END "
+                "WHERE id = $1",
+                evaluation_id, new_score,
+            )
+            coaching_id = await create_notification_coaching(
+                conn, agent_id=agent_id, team_id=team_id,
+                conducted_by_role=conducted_by_role,
+                conducted_by_email=evaluator_email,
+                action_plan=(
+                    f"Notify {agent_name}: score manually overridden "
+                    f"{old_score} → {new_score}"
+                ),
+                per_eval_note=reasoning,
+                evaluation_id=evaluation_id,
+            )
+            await rebuild_agent_series(conn, agent_id, config)
+    return coaching_id
+
+
+async def create_resolution_receipt(
+    *, evaluation_id: int, team_id: str, evaluator_email: str,
+    agent_name: str,
+) -> Optional[int]:
+    """§4.3a.3 — a human-review resolution creates the same receipt: the
+    flag said 'a human must look'; this records that a human looked AND
+    owes the agent notice. Returns None (logged) when the row has no
+    linked agent — the resolution itself must not be blocked on roster
+    hygiene, and the audit note records the gap."""
+    pool = await _get_pool()
+    if pool is None:
+        return None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT agent_id FROM qa.evaluations WHERE id = $1", evaluation_id)
+        if row is None or row["agent_id"] is None:
+            logger.warning(
+                "resolution receipt skipped for eval %s: no linked agent",
+                evaluation_id)
+            return None
+        return await create_notification_coaching(
+            conn, agent_id=row["agent_id"], team_id=team_id,
+            conducted_by_role="manager",
+            conducted_by_email=evaluator_email,
+            action_plan=(
+                f"Notify {agent_name}: flagged evaluation resolved by "
+                "human review"
+            ),
+            per_eval_note=f"Human-review resolution (ack:{evaluator_email})",
+            evaluation_id=evaluation_id,
+        )
+
+
+async def list_review_queue(team_id: str) -> list[dict[str, Any]]:
+    """The §0.3 review queue — every eval that WOULD require a human look
+    and hasn't had one: human_review_required_at IS NOT NULL AND
+    human_review_completed_at IS NULL. Covers blocked drafts
+    (authoritative mode), shipped-but-queued rows (informative mode),
+    and still-low auto-rescore survivors. Exits: analyst resolution
+    (record_approval stamps completed_at) or override (apply_override
+    does). Empty when dual-write is off."""
+    pool = await _get_pool()
+    if pool is None:
+        return []
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id, dialpad_call_id, dialpad_entry_point_call_id, "
+            "  agent_name_raw, agent_email, overall_score, state, "
+            "  scoring_status, source, human_review_required_at, "
+            "  auto_rescored_at, finalized_at "
+            "FROM qa.evaluations "
+            "WHERE team_id = $1 AND human_review_required_at IS NOT NULL "
+            "  AND human_review_completed_at IS NULL "
+            "ORDER BY human_review_required_at",
+            team_id,
+        )
+    return [
+        {
+            **dict(r),
+            "overall_score": (
+                float(r["overall_score"])
+                if r["overall_score"] is not None else None
+            ),
+        }
+        for r in rows
+    ]
+
+
 async def mark_human_review_required(evaluation_id: int) -> None:
     """Enter the §0.3 review queue (required_at IS NOT NULL AND
     completed_at IS NULL) without disturbing an existing marker —
@@ -1023,6 +1185,11 @@ __all__ = [
     "fetch_auto_rescore_state",
     "stamp_auto_rescored",
     "mark_human_review_required",
+    "apply_override",
+    "create_notification_coaching",
+    "complete_coaching_notified",
+    "create_resolution_receipt",
+    "list_review_queue",
     "get_pool",
     "build_draft_row",
     "build_draft_sections",

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -365,7 +365,17 @@ function showLoadError(msg) {
   }
 }
 
+// Job-level meta the action flows consult (ScorecardActions S6):
+// scoring_status drives the §4.3a resolution acknowledgment; state
+// gates the override control.
+let _jobMeta = {};
+
 function renderPanel(data) {
+  _jobMeta = {
+    scoring_status: data.scoring_status || null,
+    state: data.state || null,
+    overall_score: data.overall_score != null ? data.overall_score : null,
+  };
   const loadingRow = document.getElementById('loadingRow');
   if (loadingRow) loadingRow.remove();
   document.getElementById('scHeaderMeta').textContent =
@@ -387,7 +397,10 @@ function renderPanel(data) {
   }
 
   // Post-cutover (CutoverDesign §5): an engine-finalized evaluation is
-  // immutable — render everything, then lock it down completely.
+  // immutable — render everything, then lock it down completely. The
+  // S6 override doorway is the ONE designed hole in this wall
+  // (ScorecardActionsDesign §4.3) — injected after the lockdown so its
+  // controls stay live.
   if (data.state === 'finalized') {
     panel.querySelectorAll('select, textarea, input, button').forEach(el => el.disabled = true);
     const btn = document.getElementById(`approve-btn-${JOB_ID}`);
@@ -399,6 +412,128 @@ function renderPanel(data) {
     }
     document.getElementById('scHeaderMeta').textContent =
       `Job ${JOB_ID} — ${TEAM_ID} — finalized (read-only)`;
+    injectOverrideBar(panel, data);
+  }
+}
+
+// --------------------------------------------------------------------
+// S6 — Override doorway (ScorecardActionsDesign §4.3 / §4.3a).
+// Scorecard surface ONLY by design — the datapoint page must never
+// render this control (an approval-flow action, not archaeology).
+// --------------------------------------------------------------------
+
+const ACK_TEXT =
+  'You are manually modifying an AI-scored evaluation. By continuing ' +
+  'you commit to at least notifying the agent that their progression ' +
+  'was manually modified by a human.';
+
+function injectOverrideBar(panel, data) {
+  const bar = document.createElement('div');
+  bar.className = 'approve-bar';
+  bar.id = `override-bar-${JOB_ID}`;
+  bar.innerHTML = `
+    <span class="approve-status">Wrong score? A human can stand behind a different one.</span>
+    <button class="btn-approve" style="background:#7c2d12;" id="override-toggle-${JOB_ID}"
+            onclick="toggleOverrideForm()">Override Score…</button>
+    <div id="override-form-${JOB_ID}" style="display:none; width:100%; margin-top:0.75rem;
+         padding:0.75rem; border:1px solid var(--border); border-radius:8px;">
+      <div style="display:flex; gap:0.75rem; flex-wrap:wrap; margin-bottom:0.5rem;">
+        <label style="font-size:0.8rem;">New score (0–100)
+          <input type="number" id="ov-score-${JOB_ID}" min="0" max="100" step="0.1"
+                 style="width:6rem; display:block;">
+        </label>
+        <label style="font-size:0.8rem;">Your role
+          <select id="ov-role-${JOB_ID}" style="display:block;">
+            <option value="team_lead">Team lead</option>
+            <option value="manager" selected>Manager</option>
+            <option value="hr">HR</option>
+            <option value="external">External</option>
+          </select>
+        </label>
+        <label style="font-size:0.8rem;">Your email
+          <input type="email" id="ov-email-${JOB_ID}" placeholder="you@landing.com"
+                 style="display:block; width:14rem;">
+        </label>
+      </div>
+      <label style="font-size:0.8rem; display:block; margin-bottom:0.5rem;">Reasoning (required — this is the audit record)
+        <textarea id="ov-reasoning-${JOB_ID}" rows="2" style="width:100%;"></textarea>
+      </label>
+      <label style="font-size:0.8rem; display:block; margin-bottom:0.5rem;">SOP gap (optional — outdated/missing SOP evidence)
+        <textarea id="ov-sopgap-${JOB_ID}" rows="1" style="width:100%;"></textarea>
+      </label>
+      <label style="font-size:0.8rem; display:block; margin-bottom:0.35rem;">
+        <input type="checkbox" id="ov-suppress-${JOB_ID}"> Do NOT re-send the evaluation email
+        (leaves your notification duty pending)
+      </label>
+      <label style="font-size:0.8rem; display:block; margin-bottom:0.6rem;">
+        <input type="checkbox" id="ov-ack-${JOB_ID}"> ${ACK_TEXT}
+      </label>
+      <button class="btn-approve" style="background:#7c2d12;" id="ov-submit-${JOB_ID}"
+              onclick="submitOverride()">Override & Record</button>
+      <span class="approve-status" id="ov-status-${JOB_ID}"></span>
+    </div>`;
+  panel.appendChild(bar);
+  const saved = localStorage.getItem('qa_evaluator_email');
+  if (saved) document.getElementById(`ov-email-${JOB_ID}`).value = saved;
+}
+
+function toggleOverrideForm() {
+  const form = document.getElementById(`override-form-${JOB_ID}`);
+  if (form) form.style.display = form.style.display === 'none' ? 'block' : 'none';
+}
+
+async function submitOverride() {
+  const g = id => document.getElementById(`${id}-${JOB_ID}`);
+  const statusEl = g('ov-status');
+  const score = parseFloat(g('ov-score').value);
+  const reasoning = g('ov-reasoning').value.trim();
+  const email = g('ov-email').value.trim();
+  const sopNote = g('ov-sopgap').value.trim();
+
+  if (Number.isNaN(score) || score < 0 || score > 100) {
+    statusEl.textContent = 'Enter a score between 0 and 100.'; return;
+  }
+  if (!reasoning) { statusEl.textContent = 'Reasoning is required.'; return; }
+  if (!email) { statusEl.textContent = 'Your email is required.'; return; }
+  if (!g('ov-ack').checked) {
+    statusEl.textContent = 'You must acknowledge the notification duty (§4.3a).'; return;
+  }
+  localStorage.setItem('qa_evaluator_email', email);
+
+  const btn = g('ov-submit');
+  btn.disabled = true; btn.textContent = 'Recording…';
+  statusEl.textContent = 'Applying override, rebuilding stats, dispatching…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}/override`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({
+        overall_score: score,
+        reasoning,
+        conducted_by_role: g('ov-role').value,
+        sop_gap: sopNote ? { note: sopNote } : null,
+        acknowledged: true,
+        suppress_email: g('ov-suppress').checked,
+        evaluator_email: email,
+      }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(typeof err.detail === 'string' ? err.detail : JSON.stringify(err.detail));
+    }
+    const data = await res.json();
+    btn.textContent = 'Overridden';
+    btn.style.background = '#065f46';
+    const duty = data.coaching_status === 'completed'
+      ? 'Agent notified via the disclaimer email.'
+      : `Notification duty PENDING (coaching #${data.coaching_id}, 3-day deadline) — you owe the agent a conversation.`;
+    statusEl.textContent =
+      `Score ${data.old_score} → ${data.new_score}. ${duty}`;
+    document.getElementById('scHeaderMeta').textContent =
+      `Job ${JOB_ID} — ${TEAM_ID} — overridden (${data.new_score})`;
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}`;
+    btn.disabled = false; btn.textContent = 'Override & Record';
   }
 }
 
@@ -673,6 +808,13 @@ async function approveScorecard(jobId) {
   const statusEl = document.getElementById(`approve-status-${jobId}`);
   const panel = document.getElementById(`scorecard-${jobId}`);
 
+  // §4.3a (S6): resolving a flagged human review is a manual mutation
+  // of an agent-visible score — explicit acknowledgment or nothing.
+  const resolvingReview = _jobMeta.scoring_status === 'flagged_human_review';
+  if (resolvingReview && !window.confirm(ACK_TEXT + '\n\nProceed with the resolution?')) {
+    return;
+  }
+
   btn.disabled = true;
   btn.textContent = 'Sending...';
   statusEl.textContent = 'Updating sheets and sending email...';
@@ -750,6 +892,7 @@ async function approveScorecard(jobId) {
     sections,
     key_strengths: document.getElementById(`strengths-${jobId}`).value,
     opportunities: document.getElementById(`opportunities-${jobId}`).value,
+    acknowledged: resolvingReview,  // §4.3a — the route 422s a resolution without it
   };
 
   try {

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -281,3 +281,212 @@ class TestAutoRescoreHelpers:
         assert await fetch_auto_rescore_state(1) is None
         assert await stamp_auto_rescored(1) is False
         await mark_human_review_required(1)  # no raise
+
+
+# ---------------------------------------------------------------------------
+# S6 — apply_override / coaching receipts / review queue
+# (ScorecardActionsDesign §4.3, §4.3a, §0.3)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from backend.services.eval_store import (  # noqa: E402
+    apply_override,
+    complete_coaching_notified,
+    create_notification_coaching,
+    create_resolution_receipt,
+    list_review_queue,
+)
+
+
+class _S6Conn:
+    """Records queries in order; answers the coaching INSERT with an id."""
+
+    def __init__(self, agent_row=None, queue_rows=()):
+        self.agent_row = agent_row
+        self.queue_rows = list(queue_rows)
+        self.queries: list[tuple[str, tuple]] = []
+        self.fail_on_rebuild = False
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.queries.append(("BEGIN", ()))
+        yield
+        self.queries.append(("COMMIT", ()))
+
+    async def fetchrow(self, query, *args):
+        self.queries.append((query, args))
+        if "INSERT INTO qa.coachings" in query:
+            return {"id": 55}
+        if "SELECT agent_id" in query:
+            return self.agent_row
+        raise AssertionError(f"unexpected fetchrow: {query}")
+
+    async def fetch(self, query, *args):
+        self.queries.append((query, args))
+        return self.queue_rows
+
+    async def execute(self, query, *args):
+        self.queries.append((query, args))
+        return "UPDATE 1"
+
+
+def _sql_ops(conn):
+    return [q for q, _ in conn.queries if q not in ("BEGIN", "COMMIT")]
+
+
+@pytest.mark.asyncio
+class TestApplyOverride:
+
+    def _wire(self, monkeypatch, conn, rebuild_calls=None):
+        async def fake_get_pool():
+            return FakePool(conn)
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+        calls = rebuild_calls if rebuild_calls is not None else []
+
+        async def fake_rebuild(c, agent_id, config):
+            if conn.fail_on_rebuild:
+                raise RuntimeError("rebuild boom")
+            calls.append(agent_id)
+            conn.queries.append(("REBUILD", (agent_id,)))
+            return 3
+        import backend.services.stat_points as sp
+        monkeypatch.setattr(sp, "rebuild_agent_series", fake_rebuild)
+        return calls
+
+    async def _run(self):
+        return await apply_override(
+            evaluation_id=2377, team_id="member_support", agent_id=7,
+            agent_name="Luis Rubio", old_score=62.5, new_score=85.0,
+            reasoning="hold SOP v3", conducted_by_role="manager",
+            evaluator_email="ana@landing.com",
+            config=SimpleNamespace(),
+        )
+
+    async def test_supersede_touches_only_score_source_and_queue(self, monkeypatch):
+        """Engine-score reproducibility: the UPDATE must leave sections
+        and formula_version alone — old score reproducible forever."""
+        conn = _S6Conn()
+        self._wire(monkeypatch, conn)
+        coaching_id = await self._run()
+        assert coaching_id == 55
+
+        update = next(q for q, _ in conn.queries if q.startswith("UPDATE qa.evaluations"))
+        assert "overall_score = $2" in update
+        assert "source = 'ai_reviewed'" in update
+        assert "human_review_completed_at" in update  # queue exit (§0.3)
+        assert "formula_version" not in update
+        assert "evaluation_sections" not in update
+
+    async def test_order_update_receipt_rebuild_one_transaction(self, monkeypatch):
+        rebuilds = []
+        conn = _S6Conn()
+        self._wire(monkeypatch, conn, rebuilds)
+        await self._run()
+        ops = _sql_ops(conn)
+        assert ops[0].startswith("UPDATE qa.evaluations")
+        assert "INSERT INTO qa.coachings" in ops[1]
+        assert "INSERT INTO qa.coaching_evaluations" in ops[2]
+        assert ops[3] == "REBUILD"
+        assert rebuilds == [7]
+        # Everything between the outermost BEGIN/COMMIT pair.
+        assert conn.queries[0][0] == "BEGIN"
+        assert conn.queries[-1][0] == "COMMIT"
+
+    async def test_receipt_carries_deadline_and_action_plan(self, monkeypatch):
+        conn = _S6Conn()
+        self._wire(monkeypatch, conn)
+        await self._run()
+        insert_q, insert_args = next(
+            (q, a) for q, a in conn.queries if "INSERT INTO qa.coachings" in q)
+        assert "'pending'" in insert_q
+        assert "interval '3 days'" in insert_q
+        assert insert_args[2] == "manager"
+        assert insert_args[3] == "ana@landing.com"
+        assert insert_args[4] == "Notify Luis Rubio: score manually overridden 62.5 → 85.0"
+        link_q, link_args = next(
+            (q, a) for q, a in conn.queries
+            if "INSERT INTO qa.coaching_evaluations" in q)
+        assert "opportunities FROM qa.evaluations" in link_q  # snapshot
+        assert link_args == (55, 2377, "hold SOP v3")
+
+    async def test_rebuild_failure_rolls_back(self, monkeypatch):
+        """Fatal by contract (§5) — apply_override must propagate."""
+        conn = _S6Conn()
+        conn.fail_on_rebuild = True
+        self._wire(monkeypatch, conn)
+        with pytest.raises(RuntimeError, match="rebuild boom"):
+            await self._run()
+
+
+@pytest.mark.asyncio
+class TestReceiptHelpers:
+
+    def _wire(self, monkeypatch, conn):
+        async def fake_get_pool():
+            return FakePool(conn)
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_complete_guarded_by_pending_status(self, monkeypatch):
+        conn = _S6Conn()
+        self._wire(monkeypatch, conn)
+        await complete_coaching_notified(
+            55, completed_by="ana@landing.com", summary="notified")
+        q, args = conn.queries[0]
+        assert "status = 'completed'" in q
+        assert "WHERE id = $1 AND status = 'pending'" in q
+        assert args == (55, "notified", "ana@landing.com")
+
+    async def test_resolution_receipt_skips_agentless(self, monkeypatch):
+        conn = _S6Conn(agent_row={"agent_id": None})
+        self._wire(monkeypatch, conn)
+        assert await create_resolution_receipt(
+            evaluation_id=5, team_id="member_support",
+            evaluator_email="ana@landing.com", agent_name="Ghost") is None
+
+    async def test_resolution_receipt_creates(self, monkeypatch):
+        conn = _S6Conn(agent_row={"agent_id": 7})
+        self._wire(monkeypatch, conn)
+        cid = await create_resolution_receipt(
+            evaluation_id=5, team_id="member_support",
+            evaluator_email="ana@landing.com", agent_name="Luis Rubio")
+        assert cid == 55
+        insert_q, insert_args = next(
+            (q, a) for q, a in conn.queries if "INSERT INTO qa.coachings" in q)
+        assert insert_args[2] == "manager"
+        assert "resolved by" in insert_args[4]
+
+
+@pytest.mark.asyncio
+class TestListReviewQueue:
+
+    async def test_queue_filter_and_mapping(self, monkeypatch):
+        conn = _S6Conn(queue_rows=[{
+            "id": 2377, "dialpad_call_id": "503",
+            "dialpad_entry_point_call_id": None,
+            "agent_name_raw": "Luis Rubio", "agent_email": "l@landing.com",
+            "overall_score": 45, "state": "finalized",
+            "scoring_status": "complete", "source": "ai",
+            "human_review_required_at": "t1", "auto_rescored_at": "t0",
+            "finalized_at": "t1",
+        }])
+
+        async def fake_get_pool():
+            return FakePool(conn)
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+        rows = await list_review_queue("member_support")
+        q, args = conn.queries[0]
+        assert "human_review_required_at IS NOT NULL" in q
+        assert "human_review_completed_at IS NULL" in q
+        assert "ORDER BY human_review_required_at" in q
+        assert args == ("member_support",)
+        assert rows[0]["overall_score"] == 45.0
+        assert isinstance(rows[0]["overall_score"], float)
+
+    async def test_no_pool_returns_empty(self, monkeypatch):
+        async def no_pool():
+            return None
+        monkeypatch.setattr(eval_store, "_get_pool", no_pool)
+        assert await list_review_queue("member_support") == []

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -626,11 +626,26 @@ def _eval_ref(**overrides):
 
 def _stub_engine_path(monkeypatch, captured_approvals):
     """Same engine stubs as test_approve_writes_audit_row, capturing the
-    record_approval kwargs so the fallback context can be asserted."""
+    record_approval kwargs so the fallback context can be asserted.
+    Returns {'receipts': [...], 'completions': [...]} capturing the S6
+    §4.3a coaching-receipt calls."""
     monkeypatch.setattr(
         scoring_module.eval_store, "missing_manual_scores",
         lambda config, sections: [],
     )
+
+    s6 = {"receipts": [], "completions": []}
+
+    async def fake_receipt(**kw):
+        s6["receipts"].append(kw)
+        return 91
+    monkeypatch.setattr(
+        scoring_module.eval_store, "create_resolution_receipt", fake_receipt)
+
+    async def fake_complete(coaching_id, **kw):
+        s6["completions"].append({"coaching_id": coaching_id, **kw})
+    monkeypatch.setattr(
+        scoring_module.eval_store, "complete_coaching_notified", fake_complete)
 
     async def fake_record_approval(config, **kw):
         captured_approvals.append(kw)
@@ -655,6 +670,7 @@ def _stub_engine_path(monkeypatch, captured_approvals):
         scoring_module, "trigger_apps_script",
         lambda row, team_id, disclaimer=None: {"status": "ok"},
     )
+    return s6
 
 
 def _resolve_stub(monkeypatch, ref):
@@ -682,6 +698,7 @@ def test_approve_restart_simulation_falls_back_to_db(client, monkeypatch):
             "sections": [],
             "key_strengths": "x",
             "opportunities": "y",
+            "acknowledged": True,
             "evaluator_email": "ana@landing.com",
         },
     )
@@ -1104,6 +1121,22 @@ def _stub_rescore_pipeline(monkeypatch, *, flagged=False, draft_row_id=2377,
     monkeypatch.setattr(
         scoring_module.eval_store, "mark_human_review_required", fake_mark_queue)
 
+    # S6 — §4.3a receipt writers (the approve path may create/complete
+    # a resolution receipt; stubbed so no real pool is ever touched).
+    caps["receipts"] = []
+    caps["completions"] = []
+
+    async def fake_receipt(**kw):
+        caps["receipts"].append(kw)
+        return 91
+    monkeypatch.setattr(
+        scoring_module.eval_store, "create_resolution_receipt", fake_receipt)
+
+    async def fake_complete(coaching_id, **kw):
+        caps["completions"].append({"coaching_id": coaching_id, **kw})
+    monkeypatch.setattr(
+        scoring_module.eval_store, "complete_coaching_notified", fake_complete)
+
     if hr_mode is not None:
         from backend.config.team_config import (
             HumanReviewConfig, get_team_config as _real_get_config,
@@ -1330,7 +1363,8 @@ def test_rescore_flagged_pass_holds_draft_then_approve_dispatches_disclaimer(
     resp = client.post(
         "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
         headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
-        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y",
+              "acknowledged": True},
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["state"] == "finalized"
@@ -1581,6 +1615,7 @@ def test_approve_low_unedited_fires_auto_rescore(client, monkeypatch):
         headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
         json={
             "sections": [], "key_strengths": "x", "opportunities": "y",
+            "acknowledged": True,
             "evaluator_email": "ana@landing.com",
         },
     )
@@ -1608,3 +1643,309 @@ def test_approve_low_unedited_fires_auto_rescore(client, monkeypatch):
     assert job["state"] == "finalized"
     assert job["overall_score"] == 88.0
     assert job["rescore"]["cause"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# S6 — POST /score/{job_id}/override + §4.3a + /review-queue
+# (ScorecardActionsDesign §4.3, §4.3a, §0.3 accounting)
+# ---------------------------------------------------------------------------
+
+_OVERRIDE_URL = "/api/member_support/score/5035229460504576_Luis_Rubio/override"
+
+
+def _override_payload(**overrides):
+    p = {
+        "overall_score": 85.0,
+        "reasoning": "Agent followed the new hold SOP; model judged v3",
+        "conducted_by_role": "manager",
+        "sop_gap": None,
+        "acknowledged": True,
+        "suppress_email": False,
+        "evaluator_email": "ana@landing.com",
+    }
+    p.update(overrides)
+    return p
+
+
+def _stub_override(monkeypatch):
+    caps = {"applies": [], "completions": [], "dispatches": []}
+
+    async def fake_apply(**kw):
+        caps["applies"].append(kw)
+        return 55
+    monkeypatch.setattr(scoring_module.eval_store, "apply_override", fake_apply)
+
+    async def fake_complete(coaching_id, **kw):
+        caps["completions"].append({"coaching_id": coaching_id, **kw})
+    monkeypatch.setattr(
+        scoring_module.eval_store, "complete_coaching_notified", fake_complete)
+
+    async def fake_pool():
+        return object()
+    monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
+
+    async def fake_project(pool, evaluation_id, config, include_history=True):
+        return 321
+    monkeypatch.setattr(scoring_module, "project_evaluation", fake_project)
+
+    def fake_trigger(row, team_id, disclaimer=None):
+        caps["dispatches"].append({"row": row, "disclaimer": disclaimer})
+        return {"status": "ok"}
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", fake_trigger)
+    return caps
+
+
+def test_override_requires_acknowledged(client, monkeypatch):
+    """§4.3a: the literal-true gate, checked before anything else."""
+    resolve_calls = _resolve_stub(monkeypatch, _eval_ref(state="finalized"))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(acknowledged=False),
+    )
+    assert resp.status_code == 422
+    assert "acknowledged" in str(resp.json()["detail"])
+    assert resolve_calls == []
+    assert client.audit_rows == []
+
+
+def test_override_only_finalized(client, monkeypatch):
+    _stub_override(monkeypatch)
+    _resolve_stub(monkeypatch, _eval_ref(state="draft"))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(),
+    )
+    assert resp.status_code == 409
+    assert "finalized" in resp.json()["detail"]
+
+
+def test_override_team_key_unrostered_403_denied_audit(client, monkeypatch):
+    _stub_override(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", agent_email="ghost@landing.com"))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(),
+    )
+    assert resp.status_code == 403
+    denied = [r for r in client.audit_rows if r["action"] == "denied"]
+    assert len(denied) == 1
+    assert denied[0]["notes"] == "http_403"
+
+
+def test_override_agentless_422(client, monkeypatch):
+    """No qa.agents link → no coaching receipt possible → refuse: the
+    receipt is not optional (v1.2 doctrine)."""
+    caps = _stub_override(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", overall_score=62.5, agent_id=None))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(),
+    )
+    assert resp.status_code == 422
+    assert "coaching receipt" in resp.json()["detail"]
+    assert caps["applies"] == []
+
+
+def test_override_happy_path_email_completes_coaching(client, monkeypatch):
+    """§4.3 full flow: SUPERSEDE + receipt + rebuild (inside apply), then
+    projection, 'overridden' audit with SOP gap + ack, disclaimer email,
+    and the mechanical §4.3a discharge."""
+    caps = _stub_override(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5))
+
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(
+            sop_gap={"note": "Hold SOP v3 not in Pulpo", "document_id": 12}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "overridden"
+    assert body["old_score"] == 62.5
+    assert body["new_score"] == 85.0
+    assert body["superseded_engine_score"] == 62.5
+    assert body["coaching_id"] == 55
+    assert body["coaching_status"] == "completed"
+    assert body["history_row"] == 321
+
+    assert len(caps["applies"]) == 1
+    ap = caps["applies"][0]
+    assert ap["evaluation_id"] == 2377
+    assert ap["agent_id"] == 7
+    assert ap["old_score"] == 62.5
+    assert ap["new_score"] == 85.0
+    assert ap["conducted_by_role"] == "manager"
+
+    assert caps["dispatches"] == [{"row": 321, "disclaimer": "override"}]
+    assert caps["completions"] == [{
+        "coaching_id": 55, "completed_by": "ana@landing.com",
+        "summary": "Agent notified via override disclaimer email",
+    }]
+
+    overridden = [r for r in client.audit_rows if r["action"] == "overridden"]
+    assert len(overridden) == 1
+    assert overridden[0]["notes"] == (
+        "62.5 → 85.0: Agent followed the new hold SOP; model judged v3"
+        " | SOP gap: Hold SOP v3 not in Pulpo (doc 12)"
+        " | ack:ana@landing.com"
+    )
+    assert overridden[0]["result_row"] == 321
+
+
+def test_override_suppress_email_leaves_coaching_pending(client, monkeypatch):
+    """§4.3.5: suppress_email → no dispatch, receipt stays pending —
+    idx_coachings_pending is the accountability queue."""
+    caps = _stub_override(monkeypatch)
+    _resolve_stub(
+        monkeypatch, _eval_ref(state="finalized", overall_score=62.5))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(suppress_email=True),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["coaching_status"] == "pending"
+    assert body["email_dispatch"]["status"] == "suppressed"
+    assert caps["dispatches"] == []
+    assert caps["completions"] == []
+
+
+def test_override_dispatch_error_leaves_coaching_pending(client, monkeypatch):
+    """A failed disclaimer email must NOT mark the duty discharged."""
+    caps = _stub_override(monkeypatch)
+
+    def boom(row, team_id, disclaimer=None):
+        raise RuntimeError("GAS down")
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", boom)
+    _resolve_stub(
+        monkeypatch, _eval_ref(state="finalized", overall_score=62.5))
+    resp = client.post(
+        _OVERRIDE_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_override_payload(),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["coaching_status"] == "pending"
+    assert body["email_dispatch"]["status"] == "error"
+    assert caps["completions"] == []
+    # The override itself and its audit row still landed.
+    assert len(caps["applies"]) == 1
+    assert [r["action"] for r in client.audit_rows] == ["overridden"]
+
+
+def test_approve_resolution_without_ack_422(client, monkeypatch):
+    """§4.3a on the HR-resolution doorway: no acknowledgment, no
+    resolution — and the job stays approvable."""
+    approvals: list[dict] = []
+    _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(monkeypatch, _eval_ref())  # flagged_human_review
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y",
+              "evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 422
+    assert "acknowledged" in resp.json()["detail"]
+    assert approvals == []
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    assert scoring_module._jobs[key]["status"] == "complete"
+
+
+def test_approve_resolution_creates_and_completes_receipt(client, monkeypatch):
+    """§4.3a.3: the resolution books the receipt; the resolution email
+    (with the review_resolution disclaimer) discharges it."""
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    dispatches: list[dict] = []
+
+    def fake_trigger(row, team_id, disclaimer=None):
+        dispatches.append({"row": row, "disclaimer": disclaimer})
+        return {"status": "ok"}
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", fake_trigger)
+    _resolve_stub(monkeypatch, _eval_ref())  # flagged_human_review
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y",
+              "acknowledged": True, "evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(s6["receipts"]) == 1
+    assert s6["receipts"][0]["evaluation_id"] == 2377
+    assert s6["receipts"][0]["evaluator_email"] == "ana@landing.com"
+    assert dispatches == [{"row": 321, "disclaimer": "review_resolution"}]
+    assert s6["completions"] == [{
+        "coaching_id": 91, "completed_by": "ana@landing.com",
+        "summary": "Agent notified via review-resolution email",
+    }]
+    approved = [r for r in client.audit_rows if r["action"] == "approved"]
+    assert "resolved_review ack:ana@landing.com" in approved[0]["notes"]
+    assert "coaching=91" in approved[0]["notes"]
+
+
+def test_plain_approve_needs_no_ack_and_no_receipt(client, monkeypatch):
+    """A non-flagged approval is untouched by §4.3a."""
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(scoring_status="complete", evaluator_email="lead@landing.com"))
+
+    resp = client.post(
+        "/api/member_support/score/5035229460504576_Luis_Rubio/approve",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"sections": [], "key_strengths": "x", "opportunities": "y"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert s6["receipts"] == []
+    assert s6["completions"] == []
+    approved = [r for r in client.audit_rows if r["action"] == "approved"]
+    assert approved[0]["notes"] == "engine-scored"
+
+
+def test_review_queue_endpoint(client, monkeypatch):
+    """§0.3 accounting: the queue lists every would-need-review eval."""
+    rows = [
+        {"id": 2377, "agent_name_raw": "Luis Rubio", "overall_score": 45.0,
+         "state": "finalized", "scoring_status": "complete", "source": "ai",
+         "dialpad_call_id": "503", "dialpad_entry_point_call_id": None,
+         "agent_email": "luis@landing.com",
+         "human_review_required_at": "2026-07-27T10:00:00+00:00",
+         "auto_rescored_at": "2026-07-27T09:00:00+00:00",
+         "finalized_at": "2026-07-27T10:00:00+00:00"},
+    ]
+    listed = []
+
+    async def fake_list(team_id):
+        listed.append(team_id)
+        return rows
+    monkeypatch.setattr(scoring_module.eval_store, "list_review_queue", fake_list)
+
+    resp = client.get(
+        "/api/member_support/review-queue",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert listed == ["member_support"]
+    assert body["count"] == 1
+    assert body["evaluations"][0]["id"] == 2377
+    assert body["evaluations"][0]["auto_rescored_at"] is not None


### PR DESCRIPTION
Lands slice S6 of **ScorecardActionsDesign v1.2** — the human rung of the escalation ladder — plus the review-queue accounting surface from the owner's 2026-07-27 direction (*no hard blockers beyond formula-triggered review, but every eval that WOULD need a human look must be flagged and accounted for*).

## Override (§4.3) — `POST /score/{job_id}/override`
- Team key (roster-scoped) or privileged; **scorecard surface only** (the datapoint page never renders the control — S7 pins that); target must be `finalized`; `acknowledged: true` or 422, checked before anything else.
- **One transaction** (`eval_store.apply_override`): `overall_score := new`, `source := 'ai_reviewed'` — **sections and `formula_version` stay**, so the superseded engine score is reproducible forever (the SQL guard is pinned by test); any standing review-queue entry resolves (`human_review_completed_at`); the §4.3a **coaching receipt** is created (`qa.coachings` pending, 3-day notification deadline, `coaching_evaluations` link carrying the reasoning + opportunities snapshot); the stat series rebuilds — fatal by contract, everything rolls back together.
- Post-commit: re-projection, audit `action='overridden'` with `"<old> → <new>: <reasoning> | SOP gap: <note> (doc N) | ack:<evaluator>"`, and the disclaimer email (cause `override`) by default. **A successful dispatch mechanically completes the coaching** (`Agent notified via override disclaimer email`); `suppress_email` — or a dispatch failure — leaves it pending, keeping `idx_coachings_pending` as the accountability queue.
- An eval with no `qa.agents` link 422s: the receipt is not optional (v1.2 doctrine — tampering without a receipt is a bug).

## Acknowledgment protocol (§4.3a)
- `ApprovalRequest.acknowledged` (default false): resolving a `flagged_human_review` eval without it → 422. The resolution books the same coaching receipt (even when the S5 auto-rescore fires — the human did look; the suppressed email correctly leaves the receipt pending), and the resolution email now carries a `review_resolution` disclaimer whose success discharges the receipt. Plain approvals are completely untouched.
- Frontend (`scorecard.html`): the finalized read-only lockdown gains its one designed hole — an override bar (score / reasoning / role / SOP gap / suppress / acknowledgment checkbox) injected *after* the lockdown; flagged-review approvals get the §4.3a confirm dialog and send `acknowledged`; evaluator email is remembered in localStorage.

## Review-queue accounting (§0.3 + owner 2026-07-27)
`GET /{team}/review-queue` — every eval with `human_review_required_at IS NOT NULL AND human_review_completed_at IS NULL`: blocked drafts (authoritative mode), shipped-but-queued rows (informative mode), and still-low auto-rescore survivors, oldest first, with `auto_rescored_at`/`source`/`state` context for triage. Queue exits stamp `completed_at`: analyst resolution (existing `record_approval` path) or override (`apply_override`). This is the accounting half of the no-hard-blockers doctrine — nothing blocks, nothing goes unaccounted.

## Notes for review
- Resolution receipts default `conducted_by_role='manager'` (the approve UI has no role selector) — flag if the owner wants a picker there.
- The evaluator identity on the override form is a typed email (localStorage-remembered); there is no signed-in identity on these pages today.
- GAS ignores the `override`/`review_resolution` disclaimer keys until the S7 template slice renders them.

## Tests
`1092 passed, 6 skipped, 3 xfailed` — 20 new across both doorways' ack gates, receipt lifecycle under every email outcome, the SUPERSEDE reproducibility SQL guard, transaction order (update → receipt → rebuild inside one BEGIN/COMMIT), rollback on rebuild failure, resolution disclaimer + audit notes, agentless handling, and the queue filter + endpoint.

Next: **S7** — datapoint edit surface (edit-of-finalized rides this same ack + receipt protocol), frontend action bars (rescore/delete buttons, role-gated), and the GAS disclaimer template block (teams overlay + `push.sh` — Railway watch paths don't cover GAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)