### PR TITLE
feat(qa-automation): Scorecard Actions S7 — datapoint edit surface, action bars, GAS disclaimer template

### DIFF
--- a/qa-automation/AI-Scoring/backend/models/scorecard.py
+++ b/qa-automation/AI-Scoring/backend/models/scorecard.py
@@ -103,8 +103,12 @@ class ApprovalRequest(BaseModel):
     # ScorecardActionsDesign §4.3a (S6): required (literally true) when
     # the approval resolves a flagged human review — the acknowledgment
     # binds the evaluator to notify the agent that a human manually
-    # modified their progression. Plain approvals ignore it.
+    # modified their progression. Plain approvals ignore it. S7: the
+    # edit-of-finalized re-approval requires it too.
     acknowledged: bool = False
+    # §8.1 opt-out (S7): honored only on the edit-of-finalized re-send —
+    # plain approvals always dispatch, as before.
+    suppress_email: bool = False
 
 
 class RescoreRequest(BaseModel):

--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -93,6 +93,11 @@ async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
     ref = await eval_store.resolve_evaluation(team_id, job_id)
     if ref is None:
         return None
+    return _job_from_ref(ref)
+
+
+def _job_from_ref(ref) -> dict:
+    """EvalRef → restored-job dict (the S1 reconstruction shape)."""
     return {
         "status": "complete",
         "state": ref.state,
@@ -116,6 +121,20 @@ async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
     }
 
 
+def _call_in_flight(team_id: str, call_ids: set[str]) -> Optional[str]:
+    """Whether any live job for this team is actively scoring one of the
+    given Dialpad call ids. The scorecard and datapoint surfaces key jobs
+    differently (call_id_agent vs bare call id), so an in-flight check by
+    key alone misses cross-surface races — this scans job payloads."""
+    prefix = f"{team_id}:"
+    for k, j in _jobs.items():
+        if (k.startswith(prefix)
+                and j.get("call_id") in call_ids
+                and j.get("status") in {"pending", "scoring"}):
+            return j.get("status")
+    return None
+
+
 async def _await_coro(coro) -> None:
     """BackgroundTasks.add_task takes a callable + args, not a coroutine
     object — this adapts the S5 auto-rescore pass for scheduling."""
@@ -123,7 +142,7 @@ async def _await_coro(coro) -> None:
 
 
 def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
-                             default_disclaimer=None) -> None:
+                             default_disclaimer=None, suppress=False) -> None:
     """Apps Script email dispatch at the finalize seam — shared by the
     auto-flow and the approve path.
 
@@ -137,10 +156,17 @@ def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
 
     ``default_disclaimer`` (S6): the caller's cause tag when no rescore
     context rides the job — e.g. 'review_resolution' on a flagged-review
-    approve. A rescore context wins over it."""
+    approve. A rescore context wins over it. ``suppress`` (S7): the
+    caller's own opt-out — the edit-of-finalized §8.1 checkbox."""
     if not history_row or history_row <= 0:
         job["email_dispatch"] = {
             "status": "skipped", "message": "no Analyst_History row projected",
+        }
+        return
+    if suppress:
+        job["email_dispatch"] = {
+            "status": "suppressed",
+            "message": "caller requested suppress_email",
         }
         return
     rescore = job.get("rescore") or {}
@@ -631,12 +657,29 @@ async def score_single_call(
 
 @router.get("/score/{job_id}")
 async def get_score_result(request: Request, job_id: str):
-    """Poll for the result of a scoring job."""
+    """Poll for the result of a scoring job.
+
+    S7: on a `_jobs` miss, restore the context from qa.evaluations (the
+    §3 seam) and cache it — the scorecard page now renders ANY
+    evaluation forever, not just jobs the current process scored. The
+    datapoint page links here as the mirrored edit surface (§4.1)."""
     team_id = team_id_from_path(request)
-    job = _jobs.get(_job_key(team_id, job_id))
+    key = _job_key(team_id, job_id)
+    job = _jobs.get(key)
     if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
+        job = await _job_from_db(team_id, job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        _jobs[key] = job
     return job
+
+
+@router.get("/whoami")
+async def whoami(identity: KeyIdentity = Depends(require_api_key)):
+    """Resolved identity of the presented API key — lets the frontend
+    role-gate controls (S7: the Delete button renders for privileged
+    keys only). Rendering is UX; the routes still enforce."""
+    return {"role": identity.role, "team_id": identity.team_id}
 
 
 @router.post("/score/batch")
@@ -792,14 +835,33 @@ async def approve_scorecard(
         if not job:
             raise HTTPException(status_code=404, detail="Job not found")
         _jobs[key] = job
-    if job["status"] == "approved":
+    return await _approve_core(
+        team_id=team_id, key=key, job=job, approval=approval,
+        identity=identity, background_tasks=background_tasks,
+    )
+
+
+async def _approve_core(*, team_id, key, job, approval, identity,
+                        background_tasks, edit_of_finalized=False,
+                        rebuild_agent_id=None, suppress_email=False):
+    """The shared approval engine — scorecard approve and the S7
+    datapoint edit surface run the same flow (§4.1: extend, don't
+    rebuild). ``edit_of_finalized`` is the one behavioral fork: the
+    finalized read-only wall is bypassed (the caller already enforced
+    the §4.3a acknowledgment), the re-approval books the edit coaching
+    receipt, the stat series is rebuilt after the re-finalize (a
+    mid-chain score change invalidates every later EWMA point), the
+    email carries the edit_finalized disclaimer, and §8.1
+    ``suppress_email`` is honored."""
+    if job["status"] == "approved" and not edit_of_finalized:
         raise HTTPException(status_code=409, detail="Already approved")
-    if job["status"] != "complete":
+    if job["status"] not in ("complete", "approved"):
         raise HTTPException(
             status_code=409,
             detail=f"Job is '{job['status']}', must be 'complete' to approve",
         )
 
+    old_score = job.get("overall_score")
     job["status"] = "approving"
     config = get_team_config(team_id)
 
@@ -815,8 +877,10 @@ async def approve_scorecard(
     except Exception as e:
         raise HTTPException(status_code=422, detail=f"Approval payload invalid: {e}")
 
-    # Post-flip: finalized evaluations are immutable from the UI.
-    if job.get("state") == "finalized":
+    # Post-flip: finalized evaluations are immutable from the UI — except
+    # through the S7 edit-of-finalized doorway, whose caller enforced the
+    # §4.3a acknowledgment before setting the flag.
+    if job.get("state") == "finalized" and not edit_of_finalized:
         job["status"] = "complete"
         raise HTTPException(status_code=409, detail="Evaluation is finalized (engine-scored) — read-only")
 
@@ -877,6 +941,15 @@ async def approve_scorecard(
         detail = await eval_store.stamp_and_finalize(
             evaluation_id, config, evaluator_email=evaluator_email
         )
+        # S7 (§4.1): a re-approved finalized score is a mid-chain change —
+        # every later EWMA/SPC point is stale until the series rebuilds.
+        # Loud on failure (500 + retryable), never silent.
+        if edit_of_finalized and rebuild_agent_id is not None:
+            pool = await eval_store.get_pool()
+            if pool is not None:
+                async with pool.acquire() as conn:
+                    async with conn.transaction():
+                        await rebuild_agent_series(conn, rebuild_agent_id, config)
         # S5 (§4.2): the approve path is a finalize seam too. On a fire,
         # suppress projection/SSE/email for this pass and schedule the
         # machine's retry after the response is sent.
@@ -891,12 +964,22 @@ async def approve_scorecard(
         # when the auto-rescore fired (the human DID resolve; the
         # suppressed email leaves the receipt pending, correctly).
         coaching_id = None
+        receipt_summary = None
         if resolving:
             coaching_id = await eval_store.create_resolution_receipt(
                 evaluation_id=evaluation_id, team_id=team_id,
                 evaluator_email=evaluator_email,
                 agent_name=job.get("agent_name") or sc.get("agent_name") or "the agent",
             )
+            receipt_summary = "Agent notified via review-resolution email"
+        elif edit_of_finalized:
+            coaching_id = await eval_store.create_edit_receipt(
+                evaluation_id=evaluation_id, team_id=team_id,
+                evaluator_email=evaluator_email,
+                agent_name=job.get("agent_name") or sc.get("agent_name") or "the agent",
+                old_score=old_score,
+            )
+            receipt_summary = "Agent notified via edit-of-finalized disclaimer email"
         history_row = None
         if followup is None:
             pool = await eval_store.get_pool()
@@ -905,7 +988,11 @@ async def approve_scorecard(
             )
             _dispatch_finalize_email(
                 job, history_row, team_id, evaluation_id,
-                default_disclaimer="review_resolution" if resolving else None,
+                default_disclaimer=(
+                    "review_resolution" if resolving
+                    else "edit_finalized" if edit_of_finalized else None
+                ),
+                suppress=suppress_email,
             )
             await _publish_finalized_event(
                 team_id, job,
@@ -924,12 +1011,18 @@ async def approve_scorecard(
             if coaching_id is not None and dispatched_ok:
                 await eval_store.complete_coaching_notified(
                     coaching_id, completed_by=evaluator_email,
-                    summary="Agent notified via review-resolution email",
+                    summary=receipt_summary,
                 )
         approve_notes = "engine-scored"
         if resolving:
             approve_notes += (
                 f"; resolved_review ack:{evaluator_email}"
+                f"; coaching={coaching_id if coaching_id is not None else 'none'}"
+            )
+        elif edit_of_finalized:
+            approve_notes += (
+                f"; edit_of_finalized {old_score} → {float(detail.overall_score)}"
+                f" ack:{evaluator_email}"
                 f"; coaching={coaching_id if coaching_id is not None else 'none'}"
             )
         append_score_audit_row(
@@ -956,6 +1049,11 @@ async def approve_scorecard(
             "overall_score": float(detail.overall_score),
             "history_row": history_row,
             **({"auto_rescore": "scheduled"} if followup is not None else {}),
+            **({
+                "edited_finalized": True,
+                "old_score": old_score,
+                "coaching_id": coaching_id,
+            } if edit_of_finalized else {}),
         }
     except HTTPException:
         job["status"] = "complete"
@@ -1374,6 +1472,107 @@ async def override_scorecard(
         "history_row": history_row,
         "email_dispatch": email_dispatch,
     }
+
+
+@router.post("/datapoints/{call_id}/edit")
+async def edit_datapoint(
+    request: Request,
+    call_id: str,
+    approval: ApprovalRequest,
+    background_tasks: BackgroundTasks,
+    identity: KeyIdentity = Depends(require_api_key),
+):
+    """The mirrored edit surface (ScorecardActionsDesign §4.1, S7) —
+    keyed by Dialpad call id (or a full job id; §3 resolution accepts
+    both), so it survives restarts and reaches years-old evaluations.
+
+    Draft target → identical semantics to the scorecard approve (same
+    payload, same validation, flagged-review resolutions included with
+    their §4.3a gate). FINALIZED target → a re-approval: requires
+    `acknowledged` (422 otherwise), re-runs the engine (which clears any
+    standing S6 override — overall_score is recomputed from sections),
+    re-projects, rebuilds the stat series, books the §4.3a edit coaching
+    receipt, and re-sends with the edit_finalized disclaimer
+    (`suppress_email` opts out; a successful dispatch discharges the
+    receipt).
+
+    Concurrency: last-writer-wins by design. qa.evaluations has no
+    updated_at column and these are low-traffic manager tools. If Landing
+    outgrows this (concurrent evaluators on one eval), add updated_at +
+    an If-Unmodified-Since-style optimistic check here — potential design
+    choice deliberately deferred, not overlooked.
+    """
+    team_id = team_id_from_path(request)
+    key = _job_key(team_id, call_id)
+
+    ref = await eval_store.resolve_evaluation(team_id, call_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="No evaluation matches this call id")
+
+    # Roster-scoped team keys or privileged (§7), mirroring rescore/override.
+    is_in_roster = (
+        await email_in_team_mails(ref.agent_email, team_id)
+        if ref.agent_email else False
+    )
+    try:
+        check_scoring_access(
+            identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
+        )
+    except HTTPException as exc:
+        append_score_audit_row(
+            api_key_role=identity.role,
+            evaluator_email=approval.evaluator_email or "",
+            agent_email=ref.agent_email or "",
+            agent_name=ref.agent_name_raw,
+            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            target_team=team_id,
+            action=audit_cfg.ACTION_DENIED,
+            result_row=None,
+            notes=f"http_{exc.status_code}",
+        )
+        raise
+
+    # Cross-surface race guard: the scorecard keys jobs as
+    # <call_id>_<agent>, this surface as the bare call id — check by
+    # payload, not key.
+    in_flight = _call_in_flight(
+        team_id,
+        {c for c in (ref.dialpad_call_id, ref.dialpad_entry_point_call_id) if c},
+    )
+    if in_flight:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A scoring job for this call is already {in_flight}",
+        )
+
+    edit_of_finalized = ref.state == "finalized"
+    if edit_of_finalized:
+        if approval.acknowledged is not True:
+            raise HTTPException(
+                status_code=422,
+                detail="acknowledged required: editing a finalized "
+                       "evaluation binds the evaluator to notify the agent "
+                       "that their progression was manually modified (§4.3a)",
+            )
+        if ref.agent_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Evaluation has no linked agent (qa.agents) — the "
+                       "coaching receipt cannot be created. Import the "
+                       "agent first (scripts/import_agents.py).",
+            )
+
+    # Always rebuild the context from DB truth — this surface's whole
+    # point is not trusting process memory.
+    job = _job_from_ref(ref)
+    _jobs[key] = job
+    return await _approve_core(
+        team_id=team_id, key=key, job=job, approval=approval,
+        identity=identity, background_tasks=background_tasks,
+        edit_of_finalized=edit_of_finalized,
+        rebuild_agent_id=ref.agent_id if edit_of_finalized else None,
+        suppress_email=approval.suppress_email if edit_of_finalized else False,
+    )
 
 
 @router.get("/review-queue")

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -1057,15 +1057,15 @@ async def apply_override(
     return coaching_id
 
 
-async def create_resolution_receipt(
+async def _receipt_for_eval(
     *, evaluation_id: int, team_id: str, evaluator_email: str,
-    agent_name: str,
+    action_plan: str, per_eval_note: str,
 ) -> Optional[int]:
-    """§4.3a.3 — a human-review resolution creates the same receipt: the
-    flag said 'a human must look'; this records that a human looked AND
-    owes the agent notice. Returns None (logged) when the row has no
-    linked agent — the resolution itself must not be blocked on roster
-    hygiene, and the audit note records the gap."""
+    """Shared §4.3a receipt writer keyed by evaluation: fetches the
+    agent link, then books the pending coaching + link. Returns None
+    (logged) when the row has no linked agent — the triggering action
+    must not be blocked on roster hygiene, and the audit note records
+    the gap."""
     pool = await _get_pool()
     if pool is None:
         return None
@@ -1074,20 +1074,53 @@ async def create_resolution_receipt(
             "SELECT agent_id FROM qa.evaluations WHERE id = $1", evaluation_id)
         if row is None or row["agent_id"] is None:
             logger.warning(
-                "resolution receipt skipped for eval %s: no linked agent",
+                "coaching receipt skipped for eval %s: no linked agent",
                 evaluation_id)
             return None
         return await create_notification_coaching(
             conn, agent_id=row["agent_id"], team_id=team_id,
             conducted_by_role="manager",
             conducted_by_email=evaluator_email,
-            action_plan=(
-                f"Notify {agent_name}: flagged evaluation resolved by "
-                "human review"
-            ),
-            per_eval_note=f"Human-review resolution (ack:{evaluator_email})",
+            action_plan=action_plan,
+            per_eval_note=per_eval_note,
             evaluation_id=evaluation_id,
         )
+
+
+async def create_resolution_receipt(
+    *, evaluation_id: int, team_id: str, evaluator_email: str,
+    agent_name: str,
+) -> Optional[int]:
+    """§4.3a.3 — a human-review resolution creates the same receipt: the
+    flag said 'a human must look'; this records that a human looked AND
+    owes the agent notice."""
+    return await _receipt_for_eval(
+        evaluation_id=evaluation_id, team_id=team_id,
+        evaluator_email=evaluator_email,
+        action_plan=(
+            f"Notify {agent_name}: flagged evaluation resolved by "
+            "human review"
+        ),
+        per_eval_note=f"Human-review resolution (ack:{evaluator_email})",
+    )
+
+
+async def create_edit_receipt(
+    *, evaluation_id: int, team_id: str, evaluator_email: str,
+    agent_name: str, old_score: Optional[float],
+) -> Optional[int]:
+    """§4.1 / §4.3a (S7) — editing a FINALIZED evaluation is manual
+    tampering with a shipped score: same receipt, same notification
+    duty as an override."""
+    return await _receipt_for_eval(
+        evaluation_id=evaluation_id, team_id=team_id,
+        evaluator_email=evaluator_email,
+        action_plan=(
+            f"Notify {agent_name}: finalized evaluation re-edited "
+            f"(previous score {old_score}); engine recomputed the score"
+        ),
+        per_eval_note=f"Edit of finalized evaluation (ack:{evaluator_email})",
+    )
 
 
 async def list_review_queue(team_id: str) -> list[dict[str, Any]]:
@@ -1189,6 +1222,7 @@ __all__ = [
     "create_notification_coaching",
     "complete_coaching_notified",
     "create_resolution_receipt",
+    "create_edit_receipt",
     "list_review_queue",
     "get_pool",
     "build_draft_row",

--- a/qa-automation/AI-Scoring/frontend/datapoint.html
+++ b/qa-automation/AI-Scoring/frontend/datapoint.html
@@ -292,6 +292,24 @@
       <a class="dialpad-btn" id="dialpadLink" href="#" target="_blank">Review Call Recording</a>
     </div>
 
+    <!-- ScorecardActions S7 (§4.1/§4.4): lifecycle actions. This surface
+         deliberately has NO override control — overriding is an
+         approval-flow action, scorecard page only (§4.3). -->
+    <div id="actionsCard" class="card" style="display:none;">
+      <h2>Actions</h2>
+      <div style="font-size:0.7rem; color:var(--muted); margin-bottom:8px;">
+        Every action below is audited. Editing or re-scoring a finalized
+        evaluation notifies the agent by default.
+      </div>
+      <div style="display:flex; gap:8px; flex-wrap:wrap;">
+        <a class="dialpad-btn" id="editInEditorLink" href="#">Edit in Scorecard Editor</a>
+        <a class="dialpad-btn" id="rescoreBtn" href="#" onclick="rescoreEval(); return false;">Re-score (fresh AI pass)</a>
+        <a class="dialpad-btn" id="deleteBtn" href="#" style="display:none; background:#7f1d1d;"
+           onclick="deleteEval(); return false;">Delete Evaluation…</a>
+      </div>
+      <div id="actionStatus" style="font-size:0.75rem; margin-top:8px; color:var(--muted);"></div>
+    </div>
+
     <div id="historyCard" class="card" style="display:none;">
       <h2>QA Progression</h2>
       <table class="history-table">
@@ -548,6 +566,9 @@
       document.getElementById('sectionRows').innerHTML = rowsHtml;
       document.getElementById('scoresCard').style.display = '';
 
+      // ScorecardActions S7 — lifecycle action bar (no override here).
+      setupActions(eval_);
+
       // Feedback
       document.getElementById('strengths').textContent = eval_.key_strengths || 'No strengths recorded.';
       document.getElementById('improvements').textContent = eval_.improvements || 'No improvements recorded.';
@@ -583,6 +604,92 @@
       }
 
       document.getElementById('footer').textContent = `DataPoint ${callId} | ${eval_.source} evaluation`;
+    }
+
+    // ── ScorecardActions S7 — lifecycle actions (§4.1 edit, §4.2
+    // rescore, §4.4 delete). NO override on this surface (§4.3).
+    let _evalMeta = null;
+
+    async function setupActions(eval_) {
+      _evalMeta = eval_;
+      document.getElementById('editInEditorLink').href =
+        `/scorecard/${TEAM_ID}/${encodeURIComponent(callId)}`;
+      document.getElementById('actionsCard').style.display = '';
+      // Role-gated rendering (S7): Delete is privileged-only. Rendering
+      // is UX — the route still 403s + audits a denied row.
+      const who = await fetchJSON(`${API_BASE}/whoami`);
+      if (who && who.role === 'privileged') {
+        document.getElementById('deleteBtn').style.display = '';
+      }
+    }
+
+    function evaluatorEmail() {
+      let e = localStorage.getItem('qa_evaluator_email') || '';
+      if (!e) {
+        e = (prompt('Your email (recorded in the audit trail):') || '').trim();
+        if (e) localStorage.setItem('qa_evaluator_email', e);
+      }
+      return e;
+    }
+
+    async function rescoreEval() {
+      const email = evaluatorEmail();
+      if (!email) return;
+      const suppress = !window.confirm(
+        'Re-send the evaluation email (with the re-score disclaimer) when '
+        + 'the fresh pass finalizes?\n\nOK = send (default) · Cancel = suppress');
+      const st = document.getElementById('actionStatus');
+      st.textContent = 'Scheduling fresh AI pass…';
+      try {
+        const res = await fetch(
+          `${API_BASE}/score/${encodeURIComponent(callId)}/rescore`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+            body: JSON.stringify({ evaluator_email: email, suppress_email: suppress }),
+          });
+        const data = await res.json();
+        if (!res.ok) throw new Error(
+          typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+        st.textContent = `Re-score scheduled (superseding ${data.superseded_score}). `
+          + 'The fresh pass replaces this evaluation on the same row — follow it in the Scorecard Editor.';
+      } catch (err) {
+        st.textContent = `Re-score error: ${err.message}`;
+      }
+    }
+
+    async function deleteEval() {
+      // §4.4 UI: type-the-agent-name confirm.
+      const typed = prompt(
+        `PERMANENT DELETE — this removes the evaluation, its sections, and `
+        + `its stat point, and blanks the Sheets row.\n\nType the agent name `
+        + `("${_evalMeta.agent_name}") to confirm:`);
+      if (typed === null) return;
+      if (typed.trim() !== _evalMeta.agent_name) {
+        alert('Name did not match — delete cancelled.');
+        return;
+      }
+      const st = document.getElementById('actionStatus');
+      st.textContent = 'Deleting…';
+      try {
+        const res = await fetch(`${API_BASE}/score/${encodeURIComponent(callId)}`, {
+          method: 'DELETE', headers: authHeaders(),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(
+          typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+        // §4.4.1 — the response snapshot is the caller's backup; save it.
+        const blob = new Blob([JSON.stringify(data.snapshot, null, 2)],
+                              { type: 'application/json' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `eval_${data.evaluation_id}_backup.json`;
+        a.click();
+        st.textContent = `Deleted evaluation ${data.evaluation_id}. Backup downloaded`
+          + (data.tombstoned_history_row
+             ? `; Sheets row ${data.tombstoned_history_row} blanked.` : '.');
+      } catch (err) {
+        st.textContent = `Delete error: ${err.message}`;
+      }
     }
 
     (async () => {

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -375,6 +375,7 @@ function renderPanel(data) {
     scoring_status: data.scoring_status || null,
     state: data.state || null,
     overall_score: data.overall_score != null ? data.overall_score : null,
+    agent_name: data.agent_name || '',
   };
   const loadingRow = document.getElementById('loadingRow');
   if (loadingRow) loadingRow.remove();
@@ -413,6 +414,7 @@ function renderPanel(data) {
     document.getElementById('scHeaderMeta').textContent =
       `Job ${JOB_ID} — ${TEAM_ID} — finalized (read-only)`;
     injectOverrideBar(panel, data);
+    injectFinalizedActions(panel);
   }
 }
 
@@ -819,6 +821,47 @@ async function approveScorecard(jobId) {
   btn.textContent = 'Sending...';
   statusEl.textContent = 'Updating sheets and sending email...';
 
+  const payload = buildApprovalPayload(jobId);
+  payload.acknowledged = resolvingReview;  // §4.3a — the route 422s a resolution without it
+
+  try {
+    const res = await fetch(`${API_BASE}/score/${jobId}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      localStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      btn.disabled = false;
+      btn.textContent = 'Approve & Send';
+      return;
+    }
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.detail || 'Unknown error');
+    }
+
+    const data = await res.json();
+
+    btn.textContent = 'Sent';
+    btn.style.background = '#065f46';
+    statusEl.textContent = `Approved — destination row ${data.destination_row}. Email dispatched.`;
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}. You can retry.`;
+    statusEl.style.color = '#fca5a5';
+    btn.disabled = false;
+    btn.textContent = 'Retry Approve & Send';
+  }
+}
+
+// Collects the full ApprovalRequest sections payload from the DOM —
+// shared by the normal approve and the S7 edit-of-finalized re-approval.
+function buildApprovalPayload(jobId) {
+  const panel = document.getElementById(`scorecard-${jobId}`);
   const sc = _scorecardData[jobId];
 
   const sections = sc.sections.map(s => {
@@ -888,44 +931,171 @@ async function approveScorecard(jobId) {
       });
     });
 
-  const payload = {
+  return {
     sections,
     key_strengths: document.getElementById(`strengths-${jobId}`).value,
     opportunities: document.getElementById(`opportunities-${jobId}`).value,
-    acknowledged: resolvingReview,  // §4.3a — the route 422s a resolution without it
   };
+}
+
+// --------------------------------------------------------------------
+// S7 — finalized lifecycle actions: unlock-to-edit (§4.1), rescore
+// (§4.2), delete (§4.4, privileged-only rendering via /whoami).
+// --------------------------------------------------------------------
+
+function getEvaluatorEmail() {
+  let e = localStorage.getItem('qa_evaluator_email') || '';
+  if (!e) {
+    e = (prompt('Your email (recorded in the audit trail):') || '').trim();
+    if (e) localStorage.setItem('qa_evaluator_email', e);
+  }
+  return e;
+}
+
+async function injectFinalizedActions(panel) {
+  const bar = document.createElement('div');
+  bar.className = 'approve-bar';
+  bar.id = `actions-bar-${JOB_ID}`;
+  bar.innerHTML = `
+    <span class="approve-status">Lifecycle actions (audited):</span>
+    <button class="btn-approve" id="unlock-btn-${JOB_ID}"
+            onclick="unlockForEdit()">Unlock to Edit…</button>
+    <button class="btn-approve" id="rescore-btn-${JOB_ID}"
+            onclick="rescoreFromScorecard()">Re-score (fresh AI pass)</button>
+    <button class="btn-approve" id="delete-btn-${JOB_ID}" style="display:none; background:#7f1d1d;"
+            onclick="deleteFromScorecard()">Delete…</button>
+    <span class="approve-status" id="actions-status-${JOB_ID}"></span>`;
+  panel.appendChild(bar);
+  try {
+    const res = await fetch(`${API_BASE}/whoami`, { headers: authHeaders() });
+    if (res.ok) {
+      const who = await res.json();
+      if (who.role === 'privileged') {
+        document.getElementById(`delete-btn-${JOB_ID}`).style.display = '';
+      }
+    }
+  } catch (e) { /* rendering only — routes still enforce */ }
+}
+
+function unlockForEdit() {
+  if (!window.confirm(ACK_TEXT + '\n\nUnlock this finalized evaluation for editing?')) return;
+  const panel = document.getElementById(`scorecard-${JOB_ID}`);
+  panel.querySelectorAll('select, textarea').forEach(el => el.disabled = false);
+  const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+  if (btn) {
+    btn.disabled = false;
+    btn.textContent = 'Re-approve & Send';
+    btn.style.background = '#7c2d12';
+    btn.onclick = reapproveFinalized;
+  }
+  const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+  if (statusEl) {
+    statusEl.textContent =
+      'UNLOCKED (§4.3a acknowledged) — re-approving re-runs the engine and clears any manual override.';
+  }
+  const unlockBtn = document.getElementById(`unlock-btn-${JOB_ID}`);
+  if (unlockBtn) unlockBtn.disabled = true;
+}
+
+async function reapproveFinalized() {
+  const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+  const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+  const panel = document.getElementById(`scorecard-${JOB_ID}`);
+  const email = getEvaluatorEmail();
+  if (!email) return;
+  const suppress = !window.confirm(
+    'Re-send the evaluation email (with the edit disclaimer)?\n\n'
+    + 'OK = send (default) · Cancel = suppress');
+
+  btn.disabled = true;
+  btn.textContent = 'Re-approving…';
+  const payload = buildApprovalPayload(JOB_ID);
+  payload.acknowledged = true;       // §4.3a — acknowledged at unlock
+  payload.suppress_email = suppress;
+  payload.evaluator_email = email;
 
   try {
-    const res = await fetch(`${API_BASE}/score/${jobId}/approve`, {
+    const res = await fetch(`${API_BASE}/datapoints/${encodeURIComponent(JOB_ID)}/edit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify(payload),
     });
-
-    if (res.status === 401) {
-      localStorage.removeItem('qa_api_key');
-      alert('Invalid API key. Please reload and try again.');
-      btn.disabled = false;
-      btn.textContent = 'Approve & Send';
-      return;
-    }
-
-    if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.detail || 'Unknown error');
-    }
-
     const data = await res.json();
-
-    btn.textContent = 'Sent';
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    btn.textContent = 'Re-approved';
     btn.style.background = '#065f46';
-    statusEl.textContent = `Approved — destination row ${data.destination_row}. Email dispatched.`;
+    const duty = data.coaching_id
+      ? (suppress
+         ? ` Notification duty PENDING (coaching #${data.coaching_id}) — you owe the agent a conversation.`
+         : ' Agent notified via the disclaimer email.')
+      : '';
+    statusEl.textContent =
+      `Re-approved — engine score ${data.old_score} → ${data.overall_score}.${duty}`;
     panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
   } catch (err) {
     statusEl.textContent = `Error: ${err.message}. You can retry.`;
     statusEl.style.color = '#fca5a5';
     btn.disabled = false;
-    btn.textContent = 'Retry Approve & Send';
+    btn.textContent = 'Re-approve & Send';
+  }
+}
+
+async function rescoreFromScorecard() {
+  const statusEl = document.getElementById(`actions-status-${JOB_ID}`);
+  const email = getEvaluatorEmail();
+  if (!email) return;
+  if (!window.confirm(
+      'Re-score discards this AI pass and re-runs the pipeline on the same '
+      + 'call (same row, audited). Continue?')) return;
+  const suppress = !window.confirm(
+    'Re-send the evaluation email (with the re-score disclaimer) when the '
+    + 'fresh pass finalizes?\n\nOK = send (default) · Cancel = suppress');
+  statusEl.textContent = 'Scheduling fresh AI pass…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}/rescore`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ evaluator_email: email, suppress_email: suppress }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    statusEl.textContent =
+      `Re-score scheduled (superseding ${data.superseded_score}). Reload to follow the fresh pass.`;
+  } catch (err) {
+    statusEl.textContent = `Re-score error: ${err.message}`;
+  }
+}
+
+async function deleteFromScorecard() {
+  const statusEl = document.getElementById(`actions-status-${JOB_ID}`);
+  const agentName = (_scorecardData[JOB_ID] || {}).agent_name || _jobMeta.agent_name || '';
+  const typed = prompt(
+    `PERMANENT DELETE — removes the evaluation, sections, and stat point, `
+    + `and blanks the Sheets row.\n\nType the agent name ("${agentName}") to confirm:`);
+  if (typed === null) return;
+  if (typed.trim() !== agentName) {
+    alert('Name did not match — delete cancelled.');
+    return;
+  }
+  statusEl.textContent = 'Deleting…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}`, {
+      method: 'DELETE', headers: authHeaders(),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    const blob = new Blob([JSON.stringify(data.snapshot, null, 2)],
+                          { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `eval_${data.evaluation_id}_backup.json`;
+    a.click();
+    statusEl.textContent = `Deleted evaluation ${data.evaluation_id}. Backup downloaded.`;
+  } catch (err) {
+    statusEl.textContent = `Delete error: ${err.message}`;
   }
 }
 </script>

--- a/qa-automation/AI-Scoring/tests/test_frontend_actions.py
+++ b/qa-automation/AI-Scoring/tests/test_frontend_actions.py
@@ -1,0 +1,83 @@
+"""ScorecardActions S7 — frontend surface checkpoints (§9).
+
+Static assertions over the shipped HTML. These pin the DESIGN
+boundaries, not the styling: the override doorway exists on the
+scorecard page ONLY (§4.3 — an approval-flow action, not archaeology),
+the datapoint page carries the lifecycle actions with role-gated
+delete rendering, and both manual doorways surface the §4.3a
+acknowledgment text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FRONTEND = Path(__file__).resolve().parent.parent / "frontend"
+SCORECARD = (FRONTEND / "scorecard.html").read_text()
+DATAPOINT = (FRONTEND / "datapoint.html").read_text()
+
+ACK_PHRASE = "manually modified by a human"
+
+
+class TestOverrideSurfaceBoundary:
+    def test_scorecard_has_override_control(self):
+        assert "override-form" in SCORECARD
+        assert "/override" in SCORECARD
+
+    def test_datapoint_page_has_no_override_control(self):
+        """§4.3: scorecard surface ONLY. The word may appear in prose;
+        the control and its endpoint must not."""
+        assert "override-form" not in DATAPOINT
+        assert "/override" not in DATAPOINT
+        assert "submitOverride" not in DATAPOINT
+
+
+class TestAcknowledgmentProtocolSurface:
+    def test_scorecard_carries_ack_text(self):
+        assert ACK_PHRASE in SCORECARD
+
+    def test_scorecard_resolution_approve_sends_ack(self):
+        assert "payload.acknowledged = resolvingReview" in SCORECARD
+
+    def test_scorecard_unlock_to_edit_uses_ack(self):
+        assert "unlockForEdit" in SCORECARD
+        assert "/datapoints/" in SCORECARD  # re-approval posts to the edit surface
+
+
+class TestDatapointActionBar:
+    def test_lifecycle_actions_present(self):
+        assert "rescoreEval" in DATAPOINT
+        assert "deleteEval" in DATAPOINT
+        assert "editInEditorLink" in DATAPOINT
+
+    def test_delete_is_role_gated_via_whoami(self):
+        """S7 checkpoint: role-gated button rendering — delete renders
+        only after /whoami says privileged (routes still enforce)."""
+        assert "/whoami" in DATAPOINT
+        assert "privileged" in DATAPOINT
+        # Hidden until the whoami check flips it.
+        assert 'id="deleteBtn"' in DATAPOINT and "display:none" in DATAPOINT
+
+    def test_scorecard_delete_is_role_gated_too(self):
+        assert "/whoami" in SCORECARD
+        assert "privileged" in SCORECARD
+
+    def test_delete_requires_typed_agent_name(self):
+        """§4.4 UI: type-the-agent-name confirm on both surfaces."""
+        assert "Type the agent name" in DATAPOINT
+        assert "Type the agent name" in SCORECARD
+
+
+class TestGasDisclaimerTemplate:
+    GAS = Path(__file__).resolve().parent.parent.parent  # qa-automation/
+
+    def test_shared_base_renders_all_causes(self):
+        renderer = (self.GAS / "src" / "HtmlRenderer.js").read_text()
+        for cause in ("rescore_manual", "rescore_auto", "override",
+                      "review_resolution", "edit_finalized"):
+            assert cause in renderer, f"disclaimer cause {cause} missing"
+
+    def test_dopost_threads_disclaimer(self):
+        main = (self.GAS / "src" / "Main.js").read_text()
+        assert "payload.disclaimer" in main
+        assert "_processHistoryRow(entry, disclaimer)" in main

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -634,7 +634,7 @@ def _stub_engine_path(monkeypatch, captured_approvals):
         lambda config, sections: [],
     )
 
-    s6 = {"receipts": [], "completions": []}
+    s6 = {"receipts": [], "completions": [], "edit_receipts": [], "rebuilds": []}
 
     async def fake_receipt(**kw):
         s6["receipts"].append(kw)
@@ -646,6 +646,18 @@ def _stub_engine_path(monkeypatch, captured_approvals):
         s6["completions"].append({"coaching_id": coaching_id, **kw})
     monkeypatch.setattr(
         scoring_module.eval_store, "complete_coaching_notified", fake_complete)
+
+    # S7 — edit-of-finalized extras (receipt + series rebuild).
+    async def fake_edit_receipt(**kw):
+        s6["edit_receipts"].append(kw)
+        return 92
+    monkeypatch.setattr(
+        scoring_module.eval_store, "create_edit_receipt", fake_edit_receipt)
+
+    async def fake_rebuild(conn, agent_id, config):
+        s6["rebuilds"].append(agent_id)
+        return 3
+    monkeypatch.setattr(scoring_module, "rebuild_agent_series", fake_rebuild)
 
     async def fake_record_approval(config, **kw):
         captured_approvals.append(kw)
@@ -660,7 +672,9 @@ def _stub_engine_path(monkeypatch, captured_approvals):
     monkeypatch.setattr(scoring_module.eval_store, "stamp_and_finalize", fake_stamp)
 
     async def fake_pool():
-        return object()
+        # _NullPool supports acquire()/transaction() for the S7 rebuild
+        # block; defined in the S4 section below (resolved at call time).
+        return _NullPool()
     monkeypatch.setattr(scoring_module.eval_store, "get_pool", fake_pool)
 
     async def fake_project(pool, evaluation_id, config, include_history=True):
@@ -1949,3 +1963,250 @@ def test_review_queue_endpoint(client, monkeypatch):
     assert body["count"] == 1
     assert body["evaluations"][0]["id"] == 2377
     assert body["evaluations"][0]["auto_rescored_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# S7 — POST /datapoints/{call_id}/edit + GET fallback + /whoami
+# (ScorecardActionsDesign §4.1)
+# ---------------------------------------------------------------------------
+
+_EDIT_URL = "/api/member_support/datapoints/5035229460504576/edit"
+
+
+def _edit_payload(**overrides):
+    p = {"sections": [], "key_strengths": "x", "opportunities": "y",
+         "evaluator_email": "ana@landing.com"}
+    p.update(overrides)
+    return p
+
+
+def test_datapoint_edit_draft_is_plain_approval(client, monkeypatch):
+    """A draft target behaves exactly like the scorecard approve — no
+    ack, no receipt, keyed by bare call id."""
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(
+        monkeypatch, _eval_ref(state="draft", scoring_status="complete"))
+
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "finalized"
+    assert approvals[0]["resolving_review"] is False
+    assert s6["receipts"] == []
+    assert s6["edit_receipts"] == []
+    assert s6["rebuilds"] == []
+    # Cached under the bare call id (the datapoint surface's key).
+    key = scoring_module._job_key("member_support", "5035229460504576")
+    assert scoring_module._jobs[key]["status"] == "approved"
+
+
+def test_datapoint_edit_flagged_draft_keeps_resolution_protocol(client, monkeypatch):
+    """A flagged draft via the datapoint surface still runs the §4.3a
+    resolution gate + receipt."""
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    _resolve_stub(monkeypatch, _eval_ref())  # flagged_human_review draft
+
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(),
+    )
+    assert resp.status_code == 422  # no ack
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(acknowledged=True),
+    )
+    assert resp.status_code == 200, resp.text
+    assert approvals[0]["resolving_review"] is True
+    assert len(s6["receipts"]) == 1
+    assert s6["edit_receipts"] == []
+
+
+def test_datapoint_edit_finalized_requires_ack(client, monkeypatch):
+    _stub_engine_path(monkeypatch, [])
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5))
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(),
+    )
+    assert resp.status_code == 422
+    assert "acknowledged" in resp.json()["detail"]
+
+
+def test_datapoint_edit_finalized_full_round_trip(client, monkeypatch):
+    """§4.1 checkpoint: edit-of-finalized re-approval — engine re-runs,
+    series rebuilds, edit receipt books, edit_finalized disclaimer
+    dispatches and discharges the receipt, audit note records old → new."""
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    dispatches: list[dict] = []
+
+    def fake_trigger(row, team_id, disclaimer=None):
+        dispatches.append({"row": row, "disclaimer": disclaimer})
+        return {"status": "ok"}
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", fake_trigger)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5))
+
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(acknowledged=True),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "approved"
+    assert body["edited_finalized"] is True
+    assert body["old_score"] == 62.5
+    assert body["overall_score"] == 72.0  # engine recomputed (stub _Detail)
+    assert body["coaching_id"] == 92
+
+    # record_approval ran as a plain (non-resolving) re-approval.
+    assert approvals[0]["resolving_review"] is False
+    # Series rebuilt (mid-chain change), edit receipt booked + discharged.
+    assert s6["rebuilds"] == [7]
+    assert len(s6["edit_receipts"]) == 1
+    assert s6["edit_receipts"][0]["old_score"] == 62.5
+    assert s6["completions"] == [{
+        "coaching_id": 92, "completed_by": "ana@landing.com",
+        "summary": "Agent notified via edit-of-finalized disclaimer email",
+    }]
+    assert dispatches == [{"row": 321, "disclaimer": "edit_finalized"}]
+
+    approved = [r for r in client.audit_rows if r["action"] == "approved"]
+    assert len(approved) == 1
+    assert "edit_of_finalized 62.5 → 72.0" in approved[0]["notes"]
+    assert "ack:ana@landing.com" in approved[0]["notes"]
+    assert "coaching=92" in approved[0]["notes"]
+
+
+def test_datapoint_edit_finalized_suppress_email_leaves_receipt_pending(
+        client, monkeypatch):
+    approvals: list[dict] = []
+    s6 = _stub_engine_path(monkeypatch, approvals)
+    dispatches: list[dict] = []
+
+    def fake_trigger(row, team_id, disclaimer=None):
+        dispatches.append(row)
+        return {"status": "ok"}
+    monkeypatch.setattr(scoring_module, "trigger_apps_script", fake_trigger)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5))
+
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(acknowledged=True, suppress_email=True),
+    )
+    assert resp.status_code == 200, resp.text
+    assert dispatches == []
+    assert s6["completions"] == []
+    key = scoring_module._job_key("member_support", "5035229460504576")
+    assert scoring_module._jobs[key]["email_dispatch"]["status"] == "suppressed"
+
+
+def test_datapoint_edit_finalized_agentless_422(client, monkeypatch):
+    _stub_engine_path(monkeypatch, [])
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=62.5, agent_id=None))
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(acknowledged=True),
+    )
+    assert resp.status_code == 422
+    assert "coaching receipt" in resp.json()["detail"]
+
+
+def test_datapoint_edit_unrostered_team_key_403(client, monkeypatch):
+    _stub_engine_path(monkeypatch, [])
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", agent_email="ghost@landing.com"))
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(acknowledged=True),
+    )
+    assert resp.status_code == 403
+    denied = [r for r in client.audit_rows if r["action"] == "denied"]
+    assert len(denied) == 1
+
+
+def test_datapoint_edit_cross_surface_in_flight_409(client, monkeypatch):
+    """A rescore keyed <call>_<agent> must block a datapoint edit keyed
+    by the bare call id — the guard scans job payloads, not keys."""
+    _stub_engine_path(monkeypatch, [])
+    _resolve_stub(monkeypatch, _eval_ref(state="draft"))
+    other_key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    scoring_module._jobs[other_key] = {
+        "status": "scoring", "call_id": "5035229460504576"}
+
+    resp = client.post(
+        _EDIT_URL,
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json=_edit_payload(),
+    )
+    assert resp.status_code == 409
+    assert "scoring" in resp.json()["detail"]
+
+
+def test_get_score_result_restores_from_db(client, monkeypatch):
+    """S7: the scorecard page renders any evaluation forever — GET falls
+    back to the §3 seam on a _jobs miss and caches the restored job."""
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", scoring_status="complete",
+                  overall_score=88.0))
+    resp = client.get(
+        "/api/member_support/score/5035229460504576_Luis_Rubio",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["restored_from_db"] is True
+    assert body["state"] == "finalized"
+    assert body["overall_score"] == 88.0
+    key = scoring_module._job_key(
+        "member_support", "5035229460504576_Luis_Rubio")
+    assert scoring_module._jobs[key]["restored_from_db"] is True
+
+
+def test_get_score_result_miss_is_404(client, monkeypatch):
+    _resolve_stub(monkeypatch, None)
+    resp = client.get(
+        "/api/member_support/score/999_Nobody",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_whoami_reports_role(client):
+    resp = client.get(
+        "/api/member_support/whoami",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"role": "team", "team_id": "member_support"}
+    resp = client.get(
+        "/api/member_support/whoami",
+        headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
+    )
+    assert resp.json()["role"] == "privileged"

--- a/qa-automation/src/HtmlRenderer.js
+++ b/qa-automation/src/HtmlRenderer.js
@@ -14,12 +14,20 @@ class HtmlRenderer {
    * @param {ScoreCard}       scoreCard
    * @param {FeedbackCard}    feedbackCard
    * @param {ProgressionCard} progressionCard
+   * @param {string=}         disclaimer — ScorecardActionsDesign §4.2.7/
+   *                          §4.3a cause tag sent by the backend when this
+   *                          email supersedes or resolves a previous score
+   *                          (rescore_manual | rescore_auto | override |
+   *                          review_resolution | edit_finalized). Empty/
+   *                          unknown → no banner (first-pass emails are
+   *                          byte-identical to before).
    */
-  constructor(entry, scoreCard, feedbackCard, progressionCard) {
+  constructor(entry, scoreCard, feedbackCard, progressionCard, disclaimer) {
     this.entry           = entry;
     this.scoreCard       = scoreCard;
     this.feedbackCard    = feedbackCard;
     this.progressionCard = progressionCard;
+    this.disclaimer      = disclaimer || '';
   }
 
   /**
@@ -39,6 +47,9 @@ class HtmlRenderer {
 
     // ── Email header ──────────────────────────────────────────────
     html += this._renderHeader();
+
+    // ── Disclaimer banner (ScorecardActions S7) ───────────────────
+    html += this._renderDisclaimer();
 
     // ── Card slots ────────────────────────────────────────────────
     html += '<tr><td style="padding:24px;">';
@@ -61,6 +72,49 @@ class HtmlRenderer {
   // ────────────────────────────────────────────────────────────────
 
   /** @private */
+  /**
+   * The §4.2.7/§4.3a disclaimer banner — rendered only when the backend
+   * tagged the dispatch with a cause. The copy names WHY this email
+   * supersedes/resolves a previous score; unknown tags get the generic
+   * superseded text (forward-compatible with new causes).
+   * @private
+   */
+  _renderDisclaimer() {
+    if (!this.disclaimer) return '';
+    var TEXTS = {
+      rescore_manual:
+        'This call was re-evaluated at your team’s request. This email '
+        + 'replaces any previous evaluation you received for this call.',
+      rescore_auto:
+        'As part of routine quality control, the scoring system '
+        + 'automatically re-evaluated this call once. This email replaces '
+        + 'any previous evaluation you received for this call.',
+      override:
+        'The overall score in this evaluation was set by a human reviewer '
+        + 'and supersedes the automated score. Your team lead or manager '
+        + 'will follow up with you about this change.',
+      review_resolution:
+        'This evaluation was flagged for human review and has been '
+        + 'reviewed and finalized by a person before sending.',
+      edit_finalized:
+        'This evaluation was manually revised by a human reviewer after '
+        + 'its original delivery and re-finalized. This email replaces the '
+        + 'previous evaluation you received for this call.',
+    };
+    var text = TEXTS[this.disclaimer]
+      || ('This evaluation was updated after its original processing. '
+          + 'This email replaces any previous version you received for '
+          + 'this call.');
+    return '<tr><td style="'
+         + 'background:#FFF7ED;'
+         + 'border-bottom:1px solid #FDBA74;'
+         + 'padding:12px 24px;'
+         + 'font-family:Arial,sans-serif;font-size:12px;line-height:1.5;'
+         + 'color:#7C2D12;">'
+         + '<strong>Please note:</strong> ' + text
+         + '</td></tr>';
+  }
+
   _renderHeader() {
     return '<tr><td style="'
          + 'background:' + CONFIG.COLORS.DARK_NAVY + ';'

--- a/qa-automation/src/Main.js
+++ b/qa-automation/src/Main.js
@@ -13,7 +13,14 @@
  * This script is a dumb email-dispatcher.
  *
  * Payload shape:
- *   { "historyRowNumber": <int> }
+ *   { "historyRowNumber": <int>,
+ *     "disclaimer": "<cause>"?    // ScorecardActions S7 — optional tag
+ *                                 // (rescore_manual | rescore_auto |
+ *                                 //  override | review_resolution |
+ *                                 //  edit_finalized) rendered as a
+ *                                 //  banner naming why this email
+ *                                 //  supersedes a previous one
+ *   }
  *
  * Response:
  *   { "status": "ok"|"error", "message": "..." }
@@ -23,6 +30,8 @@ function doPost(e) {
   try {
     var payload = JSON.parse(e.postData.contents);
     var rowNum  = payload.historyRowNumber;
+    var disclaimer = (typeof payload.disclaimer === 'string')
+      ? payload.disclaimer : '';
 
     if (!rowNum || typeof rowNum !== 'number') {
       return _jsonResponse({
@@ -49,8 +58,11 @@ function doPost(e) {
       });
     }
 
+    if (disclaimer) {
+      Logger.log('[doPost] disclaimer cause: %s', disclaimer);
+    }
     var entry = QAEntry.fromHistoryRow(row);
-    _processHistoryRow(entry);
+    _processHistoryRow(entry, disclaimer);
 
     return _jsonResponse({
       status: 'ok',
@@ -70,9 +82,11 @@ function doPost(e) {
  * resolved the agent's email via Mails.
  *
  * @param {QAEntry} entry
+ * @param {string=} disclaimer — optional §4.2.7/§4.3a cause tag; rendered
+ *                  as a banner above the cards (see HtmlRenderer).
  * @private
  */
-function _processHistoryRow(entry) {
+function _processHistoryRow(entry, disclaimer) {
   Logger.log('[_processHistoryRow] agent=%s, overallScore=%s, agentEmail=%s',
              entry.agentName, entry.overallScore, entry.agentEmail);
 
@@ -89,7 +103,7 @@ function _processHistoryRow(entry) {
   var scoreCard       = new ScoreCard(entry);
   var feedbackCard    = new FeedbackCard(entry);
   var progressionCard = new ProgressionCard(entry, pastEntries);
-  var renderer        = new HtmlRenderer(entry, scoreCard, feedbackCard, progressionCard);
+  var renderer        = new HtmlRenderer(entry, scoreCard, feedbackCard, progressionCard, disclaimer);
 
   var sender = new EmailSender(entry);
   sender.send(renderer.renderEmail());


### PR DESCRIPTION
The final slice of **ScorecardActionsDesign v1.2** — with this, all seven slices of the design have shipped and every doorway in the tampering doctrine is built, gated, audited, and receipted.

## Datapoint edit surface (§4.1) — `POST /datapoints/{call_id}/edit`
- The approve engine is now a shared `_approve_core` (extend-don't-rebuild: the scorecard approve route is a thin wrapper over it, byte-for-byte same behavior — the pre-existing suite passes unchanged).
- **Draft target** → identical semantics to the scorecard approve, including the §4.3a gate + receipt on flagged-review resolutions. Keyed by bare call id, so it works on any evaluation after any number of restarts.
- **Finalized target** → a re-approval: `acknowledged` required (422), the engine re-runs (which **clears any standing S6 override** — `overall_score` recomputes from sections), the stat series rebuilds (a mid-chain change invalidates every later EWMA point), the §4.3a **edit coaching receipt** books, and the email re-sends with the `edit_finalized` disclaimer (`suppress_email` opts out; successful dispatch discharges the receipt). Audit note: `edit_of_finalized <old> → <new> ack:<email>; coaching=<id>`.
- Cross-surface race guard: the scorecard keys jobs as `<call>_<agent>`, this surface as the bare call id — the in-flight check scans job payloads by call id, not keys.

## Scorecard editor works forever
`GET /score/{job_id}` now falls back to the §3 DB seam on a `_jobs` miss (S1 fixed approve; the page's GET was still process-bound). Old scorecard URLs — and the datapoint page's **Edit in Scorecard Editor** link — render any evaluation, any age.

## Action bars (frontend)
- **Datapoint page**: Edit-in-Editor, Re-score (fresh AI pass, suppress-email choice), Delete (typed-agent-name confirm per §4.4, response snapshot auto-downloaded as the client-side backup). **No override control, by design** (§4.3 — approval-flow action, scorecard only) — pinned by a static test.
- **Scorecard finalized view**: Unlock-to-Edit (§4.3a confirm → editors re-enable → re-approve posts to the edit surface), Re-score, Delete.
- **Role-gated rendering** via the new `GET /whoami`: Delete renders only for privileged keys. Rendering is UX — the routes still 403 and audit denials.

## GAS disclaimer template (shared base — all team overlays)
`doPost` accepts the optional `disclaimer` key the backend has been sending since S4 and renders a cause-specific banner above the cards: `rescore_manual`, `rescore_auto`, `override`, `review_resolution`, `edit_finalized` (unknown causes get generic superseded copy — forward-compatible). First-pass emails are byte-identical to before. Staging verified with `./push.sh qa-sales --dry-run` (9 base + 3 overlay files) and `node --check` on every staged file.

**⚠ Deploy note:** GAS is not auto-deployed — after merge, run `./push.sh qa-member-support` (live — it will warn) and `./push.sh qa-sales`. Railway watch paths cover the AI-Scoring changes as usual.

## Tests
`1114 passed, 6 skipped, 3 xfailed` — 22 new: datapoint draft/flagged/finalized round-trips (suppress, agentless, roster 403, cross-surface 409), GET restore-from-DB, whoami roles, and the static frontend/GAS checkpoints (override absent on datapoint, §4.3a text on both doorways, role-gated + typed-name delete, all five disclaimer causes rendered and threaded).

## Design status
S1–S7 complete. Remaining follow-ups outside the design's scope: the audit ledger still writes to the Sheets Score_Audit tab only (the DB `qa.score_audit` path, whose CHECK migration 018 already carries, is future work), and the SOP-gap aggregation queue is deliberately deferred (§4.3 — audit search on `action='overridden'` is the v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)