### PR TITLE
fix(qa-automation): S7 prod bugs — call_duration_ms column + override form theming

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -842,7 +842,7 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
             "  agent_name_raw, agent_email, evaluator_email, "
             "  dialpad_call_id, dialpad_entry_point_call_id, dialpad_link, "
             "  call_summary, key_strengths, opportunities, overall_score, "
-            "  models_used, agent_id, duration_ms "
+            "  models_used, agent_id, call_duration_ms "
             "FROM qa.evaluations "
             "WHERE team_id = $1 "
             "AND (dialpad_entry_point_call_id = $2 OR dialpad_call_id = $2) "
@@ -902,8 +902,12 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
         model=model,
         sections=sections,
         agent_id=row["agent_id"],
+        # Column is call_duration_ms (migration 006) — the EvalRef field
+        # keeps the scorecard-model name. The 2026-07-27 prod incident:
+        # SELECTing the model-side name 500'd every §3 resolution.
         duration_ms=(
-            float(row["duration_ms"]) if row["duration_ms"] is not None else None
+            float(row["call_duration_ms"])
+            if row["call_duration_ms"] is not None else None
         ),
     )
 
@@ -922,7 +926,7 @@ async def fetch_auto_rescore_state(evaluation_id: int) -> Optional[dict[str, Any
         return None
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT source, auto_rescored_at, agent_id, duration_ms, "
+            "SELECT source, auto_rescored_at, agent_id, call_duration_ms, "
             "  dialpad_call_id, dialpad_entry_point_call_id, "
             "  agent_name_raw, agent_email, models_used "
             "FROM qa.evaluations WHERE id = $1",
@@ -935,7 +939,8 @@ async def fetch_auto_rescore_state(evaluation_id: int) -> Optional[dict[str, Any
         "auto_rescored_at": row["auto_rescored_at"],
         "agent_id": row["agent_id"],
         "duration_ms": (
-            float(row["duration_ms"]) if row["duration_ms"] is not None else None
+            float(row["call_duration_ms"])
+            if row["call_duration_ms"] is not None else None
         ),
         "dialpad_call_id": row["dialpad_call_id"],
         "dialpad_entry_point_call_id": row["dialpad_entry_point_call_id"],

--- a/qa-automation/AI-Scoring/frontend/scorecard.html
+++ b/qa-automation/AI-Scoring/frontend/scorecard.html
@@ -233,6 +233,27 @@
     .btn-approve:hover { background: #245a42; }
     .btn-approve:disabled { background: var(--border); cursor: not-allowed; }
     .approve-status { font-size: 0.78rem; color: rgba(255,255,255,0.7); }
+    /* S7 override form — lives on the dark approve-bar, so every text
+       element needs explicit light color (body text is dark and labels
+       would otherwise inherit it: invisible dark-on-dark, the 2026-07-27
+       report). Inputs get explicit white bg + dark text. */
+    .override-form {
+      display: none; width: 100%; margin-top: 0.75rem; padding: 0.75rem;
+      border: 1px solid rgba(255,255,255,0.25); border-radius: 8px;
+      background: rgba(255,255,255,0.05);
+    }
+    .override-form label {
+      font-size: 0.8rem; color: rgba(255,255,255,0.85);
+    }
+    .override-form input[type="number"],
+    .override-form input[type="email"],
+    .override-form select,
+    .override-form textarea {
+      background: #ffffff; color: #1a2238;
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 4px 6px; font-family: inherit; font-size: 0.8rem;
+    }
+    .override-form input[type="checkbox"] { accent-color: #7c2d12; }
   </style>
 </head>
 <body>
@@ -433,41 +454,41 @@ function injectOverrideBar(panel, data) {
   const bar = document.createElement('div');
   bar.className = 'approve-bar';
   bar.id = `override-bar-${JOB_ID}`;
+  bar.style.flexWrap = 'wrap';
   bar.innerHTML = `
     <span class="approve-status">Wrong score? A human can stand behind a different one.</span>
     <button class="btn-approve" style="background:#7c2d12;" id="override-toggle-${JOB_ID}"
             onclick="toggleOverrideForm()">Override Score…</button>
-    <div id="override-form-${JOB_ID}" style="display:none; width:100%; margin-top:0.75rem;
-         padding:0.75rem; border:1px solid var(--border); border-radius:8px;">
+    <div class="override-form" id="override-form-${JOB_ID}">
       <div style="display:flex; gap:0.75rem; flex-wrap:wrap; margin-bottom:0.5rem;">
-        <label style="font-size:0.8rem;">New score (0–100)
+        <label>New score (0–100)
           <input type="number" id="ov-score-${JOB_ID}" min="0" max="100" step="0.1"
-                 style="width:6rem; display:block;">
+                 style="width:6rem; display:block; margin-top:2px;">
         </label>
-        <label style="font-size:0.8rem;">Your role
-          <select id="ov-role-${JOB_ID}" style="display:block;">
+        <label>Your role
+          <select id="ov-role-${JOB_ID}" style="display:block; margin-top:2px;">
             <option value="team_lead">Team lead</option>
             <option value="manager" selected>Manager</option>
             <option value="hr">HR</option>
             <option value="external">External</option>
           </select>
         </label>
-        <label style="font-size:0.8rem;">Your email
+        <label>Your email
           <input type="email" id="ov-email-${JOB_ID}" placeholder="you@landing.com"
-                 style="display:block; width:14rem;">
+                 style="display:block; width:14rem; margin-top:2px;">
         </label>
       </div>
-      <label style="font-size:0.8rem; display:block; margin-bottom:0.5rem;">Reasoning (required — this is the audit record)
-        <textarea id="ov-reasoning-${JOB_ID}" rows="2" style="width:100%;"></textarea>
+      <label style="display:block; margin-bottom:0.5rem;">Reasoning (required — this is the audit record)
+        <textarea id="ov-reasoning-${JOB_ID}" rows="2" style="width:100%; margin-top:2px;"></textarea>
       </label>
-      <label style="font-size:0.8rem; display:block; margin-bottom:0.5rem;">SOP gap (optional — outdated/missing SOP evidence)
-        <textarea id="ov-sopgap-${JOB_ID}" rows="1" style="width:100%;"></textarea>
+      <label style="display:block; margin-bottom:0.5rem;">SOP gap (optional — outdated/missing SOP evidence)
+        <textarea id="ov-sopgap-${JOB_ID}" rows="1" style="width:100%; margin-top:2px;"></textarea>
       </label>
-      <label style="font-size:0.8rem; display:block; margin-bottom:0.35rem;">
+      <label style="display:block; margin-bottom:0.35rem;">
         <input type="checkbox" id="ov-suppress-${JOB_ID}"> Do NOT re-send the evaluation email
         (leaves your notification duty pending)
       </label>
-      <label style="font-size:0.8rem; display:block; margin-bottom:0.6rem;">
+      <label style="display:block; margin-bottom:0.6rem;">
         <input type="checkbox" id="ov-ack-${JOB_ID}"> ${ACK_TEXT}
       </label>
       <button class="btn-approve" style="background:#7c2d12;" id="ov-submit-${JOB_ID}"
@@ -480,8 +501,10 @@ function injectOverrideBar(panel, data) {
 }
 
 function toggleOverrideForm() {
+  // The CSS class hides the form by default (inline style starts empty),
+  // so key off the explicit 'block' rather than comparing to 'none'.
   const form = document.getElementById(`override-form-${JOB_ID}`);
-  if (form) form.style.display = form.style.display === 'none' ? 'block' : 'none';
+  if (form) form.style.display = form.style.display === 'block' ? 'none' : 'block';
 }
 
 async function submitOverride() {

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -68,7 +68,7 @@ def _eval_row(**overrides):
             {"text": {"provider": "gemini", "model": "gemini-2.5-flash"}}
         ),
         "agent_id": 7,
-        "duration_ms": 180000,
+        "call_duration_ms": 180000,
     }
     row.update(overrides)
     return row
@@ -232,7 +232,7 @@ class TestAutoRescoreHelpers:
     async def test_fetch_state_maps_row(self, monkeypatch):
         conn = _S5Conn(row={
             "source": "ai", "auto_rescored_at": None, "agent_id": 7,
-            "duration_ms": 180000, "dialpad_call_id": "503",
+            "call_duration_ms": 180000, "dialpad_call_id": "503",
             "dialpad_entry_point_call_id": "610",
             "agent_name_raw": "Juan Celso", "agent_email": "j@landing.com",
             "models_used": json.dumps({"text": {"model": "claude-sonnet-5"}}),

--- a/qa-automation/AI-Scoring/tests/test_frontend_actions.py
+++ b/qa-automation/AI-Scoring/tests/test_frontend_actions.py
@@ -81,3 +81,23 @@ class TestGasDisclaimerTemplate:
         main = (self.GAS / "src" / "Main.js").read_text()
         assert "payload.disclaimer" in main
         assert "_processHistoryRow(entry, disclaimer)" in main
+
+
+class TestOverrideFormTheming:
+    """2026-07-27 report: the override form's unstyled labels inherited
+    the page's dark body color onto the dark approve-bar — invisible
+    dark-on-dark, including the §4.3a acknowledgment text. The form must
+    carry the explicit light-on-dark theme class."""
+
+    def test_override_form_uses_theme_class(self):
+        assert 'class="override-form"' in SCORECARD
+
+    def test_theme_class_styles_labels_and_inputs(self):
+        assert ".override-form label" in SCORECARD
+        assert "color: rgba(255,255,255,0.85)" in SCORECARD
+        assert ".override-form textarea" in SCORECARD
+
+    def test_toggle_keys_off_explicit_block(self):
+        # Class-based display:none leaves inline style empty — comparing
+        # to 'none' would invert the first click.
+        assert "form.style.display === 'block' ? 'none' : 'block'" in SCORECARD

--- a/qa-automation/AI-Scoring/tests/test_schema_alignment.py
+++ b/qa-automation/AI-Scoring/tests/test_schema_alignment.py
@@ -1,0 +1,129 @@
+"""Schema-drift guard — eval_store SQL vs the migrations' actual columns.
+
+Born from the 2026-07-27 prod incident: S4 SELECTed ``duration_ms`` from
+qa.evaluations, but migration 006 named the column ``call_duration_ms``.
+Every unit test passed (fake connections don't validate identifiers) and
+every §3 resolution 500'd in prod — rescore, delete, and the restored
+scorecard editor all broke at once.
+
+This test derives the real qa.evaluations column set from the migration
+files (CREATE TABLE + every ALTER TABLE ... ADD COLUMN) and asserts that
+each column referenced by eval_store's qa.evaluations queries exists.
+It reads the SQL out of the source file, so a new query with a bad
+column fails here before it ever reaches a database.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATIONS = _REPO_ROOT / "database" / "migrations"
+_EVAL_STORE = (
+    Path(__file__).resolve().parents[1] / "backend" / "services" / "eval_store.py"
+)
+
+_NON_COLUMN_PREFIXES = (
+    "CONSTRAINT", "PRIMARY", "FOREIGN", "UNIQUE", "CHECK", "LIKE", "--",
+)
+
+
+def evaluations_columns() -> set[str]:
+    """qa.evaluations columns per the migrations (create + alters)."""
+    cols: set[str] = set()
+    create_sql = (_MIGRATIONS / "006_qa_tables.sql").read_text()
+    m = re.search(r"CREATE TABLE qa\.evaluations\s*\((.*?)\n\);", create_sql, re.S)
+    assert m, "CREATE TABLE qa.evaluations not found in migration 006"
+    for raw in m.group(1).splitlines():
+        line = raw.strip()
+        if not line or line.upper().startswith(_NON_COLUMN_PREFIXES):
+            continue
+        name = line.split()[0].strip('",')
+        if name.isidentifier():
+            cols.add(name)
+    for path in sorted(_MIGRATIONS.glob("*.sql")):
+        text = path.read_text()
+        for stmt in re.finditer(
+                r"ALTER TABLE qa\.evaluations\b[\s\S]*?;", text):
+            for add in re.finditer(
+                    r"ADD COLUMN (?:IF NOT EXISTS )?(\w+)", stmt.group(0)):
+                cols.add(add.group(1))
+            for drop in re.finditer(
+                    r"DROP COLUMN (?:IF EXISTS )?(\w+)", stmt.group(0)):
+                # Down migrations live in *_down.sql — only honor drops
+                # from forward migrations.
+                if not path.name.endswith("_down.sql"):
+                    cols.discard(drop.group(1))
+    return cols
+
+
+def eval_store_evaluations_select_columns() -> dict[str, set[str]]:
+    """Column identifiers in each ``SELECT ... FROM qa.evaluations``
+    inside eval_store.py, keyed by a snippet of the statement."""
+    src = _EVAL_STORE.read_text()
+    # Stitch adjacent string literals the way Python does, then find the
+    # SELECT ... FROM qa.evaluations statements.
+    sql_blobs = re.findall(r'"((?:[^"\\]|\\.)*)"', src)
+    stitched = " ".join(sql_blobs)
+    out: dict[str, set[str]] = {}
+    for m in re.finditer(
+            r"SELECT\s+((?:(?!SELECT|INSERT|UPDATE|DELETE\s|FROM\s).)*?)"
+            r"\s+FROM qa\.evaluations\b", stitched, re.S):
+        col_list = m.group(1)
+        if "*" in col_list:
+            continue
+        cols = set()
+        for tok in col_list.split(","):
+            tok = tok.strip()
+            # Skip function calls / qualified names; plain identifiers only.
+            if tok.isidentifier():
+                cols.add(tok)
+        out[col_list[:60]] = cols
+    assert out, "no qa.evaluations SELECTs found — regex drift?"
+    return out
+
+
+def eval_store_evaluations_update_columns() -> set[str]:
+    """Columns assigned in ``UPDATE qa.evaluations SET ...`` statements."""
+    src = _EVAL_STORE.read_text()
+    sql_blobs = re.findall(r'"((?:[^"\\]|\\.)*)"', src)
+    stitched = " ".join(sql_blobs)
+    cols: set[str] = set()
+    for m in re.finditer(
+            r"UPDATE qa\.evaluations(?:\s+\w+)?\s+SET\s+(.*?)\s+WHERE",
+            stitched, re.S):
+        for assign in re.finditer(r"(\w+)\s*=", m.group(1)):
+            if assign.group(1).isidentifier():
+                cols.add(assign.group(1))
+    return cols
+
+
+def test_migrations_expose_expected_anchor_columns():
+    cols = evaluations_columns()
+    # Anchors that other code depends on — if parsing breaks, fail here
+    # with a clear message rather than passing vacuously.
+    for anchor in ("id", "team_id", "overall_score", "call_duration_ms",
+                   "auto_rescored_at", "human_review_required_at"):
+        assert anchor in cols, f"schema parse lost anchor column {anchor}"
+    # The S4 bug: the model-side name must NOT be a real column.
+    assert "duration_ms" not in cols
+
+
+def test_eval_store_selects_only_real_columns():
+    schema = evaluations_columns()
+    for snippet, cols in eval_store_evaluations_select_columns().items():
+        unknown = cols - schema
+        assert not unknown, (
+            f"eval_store SELECT references non-existent qa.evaluations "
+            f"column(s) {sorted(unknown)} in: SELECT {snippet}…"
+        )
+
+
+def test_eval_store_updates_only_real_columns():
+    schema = evaluations_columns()
+    unknown = eval_store_evaluations_update_columns() - schema
+    assert not unknown, (
+        f"eval_store UPDATE assigns non-existent qa.evaluations "
+        f"column(s): {sorted(unknown)}"
+    )


### PR DESCRIPTION
Fixes both 2026-07-27 prod reports.

## 1. Rescore / Delete / Edit-in-Editor all 500 (`UndefinedColumnError: duration_ms`)
One root cause for all three: S4's `resolve_evaluation` — the seam every scorecard action resolves through — SELECTed `qa.evaluations.duration_ms`, but migration 006 named the column **`call_duration_ms`** (the model-side field is `duration_ms`; the row-dict key in `build_draft_row` maps it, which is where the confusion crept in). S5's `fetch_auto_rescore_state` had the same bug, extra-latent because that fetch only runs when a finalize lands ≤ threshold — so the auto-rescore trigger would also have errored jobs on the first genuinely low score.

Both SELECTs now use `call_duration_ms`; `EvalRef.duration_ms` keeps its name.

**Why the suite stayed green:** every eval_store test runs against fake connections, which can't validate SQL identifiers. So this PR adds a **schema-drift guard** (`tests/test_schema_alignment.py`): it derives the real `qa.evaluations` column set from the migration files (CREATE TABLE + every ADD/DROP COLUMN) and asserts that every column referenced in eval_store's `qa.evaluations` SELECT/UPDATE statements exists. The whole bug class now fails in CI before touching a database — with anchor assertions pinning `call_duration_ms` as real and `duration_ms` as not-a-column, so the guard itself can't silently rot.

## 2. Override form invisible text (dark-on-dark)
The injected form sits on the navy `.approve-bar`, and its unstyled labels inherited the page's dark body color — every label, including the §4.3a acknowledgment text next to the checkbox, rendered invisible. The form now carries an explicit `.override-form` theme class: light labels, white inputs/selects/textareas with dark text, and a wrap-friendly bar so the form drops below the button instead of squeezing beside it. Also fixed: the show/hide toggle compared the inline style to `'none'`, which inverts the first click once hiding moved to the CSS class — it now keys off the explicit `'block'`.

Static tests pin the theme class, the label/input styling, and the toggle semantics alongside the existing surface checkpoints.

## Tests
`1120 passed, 6 skipped, 3 xfailed` — 6 new (3 schema-guard, 3 theming/toggle).

## Deploy
Backend + frontend only — Railway watch paths pick it up on merge. **No GAS changes; no re-`push.sh` needed.** The datapoint page needed no changes: its actions were casualties of the shared resolution seam, not their own code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)