### PR TITLE
Anthropic provider streams — fixes the Claude judge's 10-minute guard

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
@@ -86,7 +86,14 @@ class AnthropicTextProvider(TextModelProvider):
             kwargs["output_config"] = {
                 "format": {"type": "json_schema", "schema": json_schema}
             }
-        response = await client.messages.create(**kwargs)
+        # Always stream and collect: the SDK REFUSES non-streaming
+        # requests whose max_tokens could exceed ~10 minutes (the judge's
+        # 65k scoring budget trips it — observed live 2026-07-27:
+        # "ValueError: Streaming is required for operations that may take
+        # longer than 10 minutes"). get_final_message() gives the same
+        # Message object create() would have returned.
+        async with client.messages.stream(**kwargs) as stream:
+            response = await stream.get_final_message()
 
         if response.stop_reason == "refusal":
             raise LlmProviderError(f"model {model} refused the request")

--- a/qa-automation/AI-Scoring/tests/test_llm_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_llm_provider.py
@@ -50,7 +50,9 @@ class FakeGenaiClient:
 
 
 class FakeAnthropicClient:
-    """Mimics the anthropic SDK's messages.create; records the call."""
+    """Mimics the anthropic SDK's messages.stream (the provider always
+    streams — the SDK refuses non-streaming calls at judge-sized
+    max_tokens); records the call kwargs."""
 
     def __init__(self, stop_reason="end_turn", text="hello"):
         self.calls = []
@@ -65,10 +67,20 @@ class FakeAnthropicClient:
             content = [_Block()] if text else []
         _Resp.stop_reason = stop_reason
 
-        class _Messages:
-            async def create(self, **kwargs):
-                outer.calls.append(kwargs)
+        class _StreamManager:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get_final_message(self):
                 return _Resp()
+
+        class _Messages:
+            def stream(self, **kwargs):
+                outer.calls.append(kwargs)
+                return _StreamManager()
 
         self.messages = _Messages()
 


### PR DESCRIPTION
## What

The Railway `two_stage_shadow` failure with the Claude judge: the anthropic SDK **refuses non-streaming `messages.create` when `max_tokens` could exceed ~10 minutes** (`ValueError: Streaming is required for operations that may take longer than 10 minutes`). The judge inherits the team's `scoring_max_output_tokens: 65536`, which trips the guard — progression's 16,384 never did, which is why the seam worked everywhere until the judge ran.

**Fix:** `AnthropicTextProvider.generate` now always streams (`client.messages.stream(...)` + `get_final_message()` — the SDK-blessed pattern; same `Message` object, timeout-safe at any budget). Fakes updated to the streaming surface.

**Live-verified** at the exact failing shape: 65,536 `max_tokens` + system prompt on `claude-sonnet-5` through the seam.

Worth noting from the deploy logs: the shadow machinery behaved exactly as designed during the failure — judge error stamped to `dialpad_call_metadata.two_stage_shadow`, single-stage scoring served untouched, eval finalized normally.

## After merge
Redeploy — the Claude-judge shadow leg starts producing real compare stamps instead of error stamps. (`SCORING_MODEL_PROVIDER=anthropic` + the key already on Railway per the logs.)

## Tests
`792 passed, 6 skipped, 3 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)