### PR TITLE
fix(qa-automation): resolve_evaluation link-tail arm — action resolution reaches everything the datapoint page renders

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -96,6 +96,17 @@ async def _job_from_db(team_id: str, job_id: str) -> Optional[dict]:
     return _job_from_ref(ref)
 
 
+def _ref_call_id(ref) -> str:
+    """The best Dialpad call id for a resolved eval: the verified id
+    columns first, then the dialpad_link's trailing segment — rows
+    resolved via the link-tail arm (2026-07-27) may have NULL/foreign id
+    columns, and audio download + audit rows still need an id."""
+    return (
+        ref.dialpad_call_id or ref.dialpad_entry_point_call_id
+        or eval_store.call_id_from_dialpad_link(ref.dialpad_link)
+    )
+
+
 def _job_from_ref(ref) -> dict:
     """EvalRef → restored-job dict (the S1 reconstruction shape)."""
     return {
@@ -103,7 +114,7 @@ def _job_from_ref(ref) -> dict:
         "state": ref.state,
         "scoring_status": ref.scoring_status,
         "evaluation_id": ref.id,
-        "call_id": ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        "call_id": _ref_call_id(ref),
         "agent_name": ref.agent_name_raw,
         "agent_email": ref.agent_email or "",
         "overall_score": ref.overall_score,
@@ -194,10 +205,7 @@ def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
 def _sse_eval_id_from_link(link: str) -> str:
     """Trailing path segment of dialpad_link — the /datapoint route key
     (mirrors team_stats._parse_row; see the legacy approve path)."""
-    if not link:
-        return ""
-    clean = link.split("[")[0].strip().split("?")[0].strip()
-    return clean.rstrip("/").split("/")[-1]
+    return eval_store.call_id_from_dialpad_link(link)
 
 
 async def _publish_finalized_event(
@@ -1194,7 +1202,7 @@ async def rescore_evaluation(
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
             agent_name=ref.agent_name_raw,
-            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            call_id=_ref_call_id(ref),
             target_team=team_id,
             action=audit_cfg.ACTION_DENIED,
             result_row=None,
@@ -1203,7 +1211,7 @@ async def rescore_evaluation(
         raise
 
     # §4.2.1: same input, fresh pass — re-download by Dialpad call id.
-    call_id = ref.dialpad_call_id or ref.dialpad_entry_point_call_id or ""
+    call_id = _ref_call_id(ref)
     try:
         audio_bytes = await download_recording(call_id)
     except NoRecordingAvailable:
@@ -1374,7 +1382,7 @@ async def override_scorecard(
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
             agent_name=ref.agent_name_raw,
-            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            call_id=_ref_call_id(ref),
             target_team=team_id,
             action=audit_cfg.ACTION_DENIED,
             result_row=None,
@@ -1424,7 +1432,7 @@ async def override_scorecard(
         evaluator_email=payload.evaluator_email,
         agent_email=ref.agent_email or "",
         agent_name=ref.agent_name_raw,
-        call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        call_id=_ref_call_id(ref),
         target_team=team_id,
         action=audit_cfg.ACTION_OVERRIDDEN,
         result_row=history_row,
@@ -1524,7 +1532,7 @@ async def edit_datapoint(
             evaluator_email=approval.evaluator_email or "",
             agent_email=ref.agent_email or "",
             agent_name=ref.agent_name_raw,
-            call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+            call_id=_ref_call_id(ref),
             target_team=team_id,
             action=audit_cfg.ACTION_DENIED,
             result_row=None,
@@ -1696,7 +1704,7 @@ async def delete_evaluation(
         evaluator_email="",
         agent_email=ref.agent_email or "",
         agent_name=ref.agent_name_raw,
-        call_id=ref.dialpad_call_id or ref.dialpad_entry_point_call_id or "",
+        call_id=_ref_call_id(ref),
         target_team=team_id,
         action=audit_cfg.ACTION_ORPHANED,
         result_row=tombstone_row,

--- a/qa-automation/AI-Scoring/backend/services/eval_store.py
+++ b/qa-automation/AI-Scoring/backend/services/eval_store.py
@@ -817,6 +817,30 @@ def call_id_from_job_id(job_id: str) -> str:
     return head if head.isdigit() else ""
 
 
+def call_id_from_dialpad_link(link: Optional[str]) -> str:
+    """Trailing path segment of dialpad_link — the id the read surfaces
+    key on (the /datapoint URL, SSE eval_id, Analyst_History link cell).
+    Mirrors the frontends' parser: strip markdown '[' wrapping and query
+    strings, trim a trailing slash."""
+    if not link:
+        return ""
+    clean = link.split("[")[0].strip().split("?")[0].strip()
+    return clean.rstrip("/").rsplit("/", 1)[-1]
+
+
+# One literal on purpose — tests/test_schema_alignment.py reads SELECT
+# lists out of the source, so the column list must sit in a single
+# string with its FROM clause.
+_RESOLVE_SELECT = (
+    "SELECT id, team_id, state, source, scoring_status, "
+    "  agent_name_raw, agent_email, evaluator_email, "
+    "  dialpad_call_id, dialpad_entry_point_call_id, dialpad_link, "
+    "  call_summary, key_strengths, opportunities, overall_score, "
+    "  models_used, agent_id, call_duration_ms "
+    "FROM qa.evaluations "
+)
+
+
 async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
     """Resolve an action target from Postgres, not the in-memory job store.
 
@@ -828,6 +852,14 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
     picks. Unlike that read-path helper, drafts resolve too — actions
     target any lifecycle state.
 
+    THIRD arm (2026-07-27 report): the datapoint read path falls back to
+    matching the dialpad_link's TRAILING SEGMENT (routes/datapoints.py
+    365-day scan), so rows whose link-tail id matches neither id column
+    are still reachable — and were then unresolvable for actions. On an
+    id-column miss we probe by link substring and verify the exact tail
+    in Python, so anything the datapoint page can render, the actions
+    can resolve.
+
     Returns None when dual-write is off (no pool), the job_id has no
     numeric call id, or nothing matches."""
     call_id = call_id_from_job_id(job_id)
@@ -838,17 +870,24 @@ async def resolve_evaluation(team_id: str, job_id: str) -> Optional[EvalRef]:
         return None
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT id, team_id, state, source, scoring_status, "
-            "  agent_name_raw, agent_email, evaluator_email, "
-            "  dialpad_call_id, dialpad_entry_point_call_id, dialpad_link, "
-            "  call_summary, key_strengths, opportunities, overall_score, "
-            "  models_used, agent_id, call_duration_ms "
-            "FROM qa.evaluations "
+            _RESOLVE_SELECT +
             "WHERE team_id = $1 "
             "AND (dialpad_entry_point_call_id = $2 OR dialpad_call_id = $2) "
             "ORDER BY COALESCE(call_connected_at, created_at) LIMIT 1",
             team_id, call_id,
         )
+        if row is None:
+            candidates = await conn.fetch(
+                _RESOLVE_SELECT +
+                "WHERE team_id = $1 AND dialpad_link LIKE '%' || $2 || '%' "
+                "ORDER BY COALESCE(call_connected_at, created_at)",
+                team_id, call_id,
+            )
+            row = next(
+                (c for c in candidates
+                 if call_id_from_dialpad_link(c["dialpad_link"]) == call_id),
+                None,
+            )
         if row is None:
             return None
         section_rows = await conn.fetch(
@@ -1219,6 +1258,7 @@ __all__ = [
     "stamp_and_finalize",
     "resolve_evaluation",
     "call_id_from_job_id",
+    "call_id_from_dialpad_link",
     "EvalRef",
     "fetch_auto_rescore_state",
     "stamp_auto_rescored",

--- a/qa-automation/AI-Scoring/tests/test_eval_resolve.py
+++ b/qa-automation/AI-Scoring/tests/test_eval_resolve.py
@@ -97,16 +97,21 @@ def _section_rows():
 
 
 class FakeConn:
-    def __init__(self, row, sections):
+    def __init__(self, row, sections, candidates=()):
         self.row = row
         self.sections = sections
+        self.candidates = list(candidates)  # link-tail fallback results
         self.fetchrow_args = None
+        self.fallback_queries: list[tuple] = []
 
     async def fetchrow(self, query, *args):
         self.fetchrow_args = (query, args)
         return self.row
 
     async def fetch(self, query, *args):
+        if "FROM qa.evaluations" in query:
+            self.fallback_queries.append((query, args))
+            return self.candidates
         return self.sections
 
 
@@ -490,3 +495,88 @@ class TestListReviewQueue:
             return None
         monkeypatch.setattr(eval_store, "_get_pool", no_pool)
         assert await list_review_queue("member_support") == []
+
+
+# ---------------------------------------------------------------------------
+# Link-tail resolution arm (2026-07-27 report) — rows the datapoint read
+# path reaches via the dialpad_link trailing segment must resolve for
+# actions too, even when neither id column matches.
+# ---------------------------------------------------------------------------
+
+from backend.services.eval_store import call_id_from_dialpad_link  # noqa: E402
+
+
+class TestCallIdFromDialpadLink:
+
+    def test_plain_link(self):
+        assert call_id_from_dialpad_link(
+            "https://dialpad.com/callhistory/callreview/6537476115210240"
+        ) == "6537476115210240"
+
+    def test_trailing_slash_and_query_string(self):
+        assert call_id_from_dialpad_link(
+            "https://dialpad.com/callreview/123/?utm=x") == "123"
+
+    def test_markdown_wrapped_link(self):
+        # Some legacy rows store markdown-ish links; the parser mirrors
+        # the frontends' split-on-'[' handling.
+        assert call_id_from_dialpad_link(
+            "https://dialpad.com/callreview/123 [view]") == "123"
+
+    def test_empty(self):
+        assert call_id_from_dialpad_link("") == ""
+        assert call_id_from_dialpad_link(None) == ""
+
+
+@pytest.mark.asyncio
+class TestResolveLinkTailFallback:
+
+    def _wire(self, monkeypatch, conn):
+        async def fake_get_pool():
+            return FakePool(conn)
+        monkeypatch.setattr(eval_store, "_get_pool", fake_get_pool)
+
+    async def test_id_column_hit_skips_fallback(self, monkeypatch):
+        conn = FakeConn(_eval_row(), _section_rows())
+        self._wire(monkeypatch, conn)
+        ref = await resolve_evaluation("member_support", "5035229460504576")
+        assert ref is not None
+        assert conn.fallback_queries == []
+
+    async def test_link_tail_resolves_when_columns_miss(self, monkeypatch):
+        """The 2026-07-27 case: the page's call id matches the link tail
+        but NEITHER id column — the fallback arm must find it."""
+        target = _eval_row(
+            dialpad_call_id="9999999999999999",
+            dialpad_entry_point_call_id="8888888888888888",
+            dialpad_link="https://dialpad.com/callhistory/callreview/6537476115210240",
+        )
+        conn = FakeConn(None, _section_rows(), candidates=[target])
+        self._wire(monkeypatch, conn)
+        ref = await resolve_evaluation("member_support", "6537476115210240")
+        assert ref is not None
+        assert ref.id == 2377
+        # The fallback probed by link substring, team-scoped.
+        query, args = conn.fallback_queries[0]
+        assert "dialpad_link LIKE" in query
+        assert args == ("member_support", "6537476115210240")
+
+    async def test_superstring_link_does_not_false_positive(self, monkeypatch):
+        """LIKE matches substrings — the Python tail check must reject a
+        row whose link merely CONTAINS the id (e.g. id 123 vs .../91230)."""
+        decoy = _eval_row(
+            dialpad_link="https://dialpad.com/callreview/9123045")
+        conn = FakeConn(None, _section_rows(), candidates=[decoy])
+        self._wire(monkeypatch, conn)
+        assert await resolve_evaluation("member_support", "123") is None
+
+    async def test_first_matching_candidate_wins_in_scan_order(self, monkeypatch):
+        decoy = _eval_row(
+            id=1, dialpad_link="https://dialpad.com/callreview/9123045")
+        target = _eval_row(
+            id=2, dialpad_link="https://dialpad.com/callreview/123")
+        conn = FakeConn(None, _section_rows(), candidates=[decoy, target])
+        self._wire(monkeypatch, conn)
+        ref = await resolve_evaluation("member_support", "123")
+        assert ref is not None
+        assert ref.id == 2

--- a/qa-automation/AI-Scoring/tests/test_scoring_route.py
+++ b/qa-automation/AI-Scoring/tests/test_scoring_route.py
@@ -2210,3 +2210,25 @@ def test_whoami_reports_role(client):
         headers={"Authorization": f"Bearer {PRIV_TOKEN}"},
     )
     assert resp.json()["role"] == "privileged"
+
+
+def test_rescore_link_tail_row_downloads_by_link_tail(client, monkeypatch):
+    """A row resolved via the link-tail arm can have NULL/foreign id
+    columns — the fresh pass must still download audio by the link's
+    trailing segment (2026-07-27 report)."""
+    caps = _stub_rescore_pipeline(monkeypatch)
+    _resolve_stub(
+        monkeypatch,
+        _eval_ref(state="finalized", overall_score=62.5,
+                  dialpad_call_id=None, dialpad_entry_point_call_id=None,
+                  dialpad_link="https://dialpad.com/callhistory/callreview/6537476115210240"),
+    )
+    resp = client.post(
+        "/api/member_support/score/6537476115210240/rescore",
+        headers={"Authorization": f"Bearer {TEAM_TOKEN}"},
+        json={"evaluator_email": "ana@landing.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert caps["downloads"][0] == "6537476115210240"
+    rescored = [r for r in client.audit_rows if r["action"] == "rescored"]
+    assert rescored[0]["call_id"] == "6537476115210240"


### PR DESCRIPTION
Fixes the 2026-07-27 call-id mismatch report (datapoint page renders the eval; Re-score/Edit/Delete answer *No evaluation matches this call id*).

## Root cause — three identities read-side, two action-side
An evaluation is reachable by **three** ids: `dialpad_call_id`, `dialpad_entry_point_call_id`, and the **trailing segment of `dialpad_link`** — which is what the datapoint URL and the metadata card actually display. `routes/datapoints.py` covers the third via its 365-day fallback scan (`rec.eval_id == call_id`), but `resolve_evaluation` — the seam every S1–S7 action resolves through — only probed the two columns. Rows whose link tail matches neither column (older rows, Dialpad id quirks) rendered fine and 404'd on every action.

## Fix
- `resolve_evaluation` gains the third arm: on an id-column miss, probe by link substring (team-scoped) and verify the **exact** trailing segment in Python via the new shared `call_id_from_dialpad_link` (also now backing the SSE eval-id parser — one extraction, three consumers). Substring probing alone would false-positive (`123` vs `…/91230`); the Python tail check rejects that, and a test pins it. Candidate order matches the read path's scan order, so duplicates resolve to the same row every surface picks.
- `_ref_call_id` helper: downloads and audit rows use the verified id columns first, falling back to the link tail — so a link-tail-resolved row with NULL/foreign columns still re-downloads its recording for a fresh pass.
- The resolve SELECT now lives in a single `_RESOLVE_SELECT` literal, keeping the schema-alignment guard (#149) effective over both probes.

The fallback runs only when the primary probe misses, so the common case is unchanged: one indexed query.

## Tests
`1129 passed, 6 skipped, 3 xfailed` — 9 new: link-parser edge cases (markdown wrapping, query strings, trailing slash), fallback-fires-only-on-miss, superstring rejection, scan-order candidate pick, and a rescore round-trip on a link-tail row asserting the download + audit ids.

Backend-only — Railway picks it up on merge; no GAS involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)