### PR TITLE
Shadow report: per-judge split + dated error stamps

### DIFF
--- a/qa-automation/AI-Scoring/scripts/two_stage_shadow_report.py
+++ b/qa-automation/AI-Scoring/scripts/two_stage_shadow_report.py
@@ -1,10 +1,14 @@
 """Shadow-week report — TwoStageScoringDesign §6 (PulpoConnection §6.1 pattern).
 
 Aggregates the two_stage_shadow stamps that score_call persists to
-dialpad_call_metadata during SCORING_PIPELINE=two_stage_shadow: per-
-section agreement between the served single-stage scorecard and the
-Stage-B judge, judge errors, and latency. Markdown to stdout — paste
-into the PR / owner review that decides the two_stage flip.
+dialpad_call_metadata during SCORING_PIPELINE=two_stage_shadow —
+**split per judge**, because the shadow design is two one-variable
+comparisons: Gemini-judge rows isolate the SPLIT's effect on scores,
+Claude-judge rows isolate the MODEL's. Blending them measures nothing.
+
+Error stamps persist with the eval row, so errors from since-fixed
+deploys keep appearing for old evals — each error line carries the
+eval's date so fossils are recognizable.
 
 Usage (from qa-automation/AI-Scoring, .env loaded, DATABASE_URL set):
 
@@ -29,6 +33,40 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import asyncpg  # noqa: E402
+
+
+def _print_judge_section(judge: str, entries: list) -> None:
+    print(f"\n## Judge: {judge} — {len(entries)} evals")
+
+    latencies = sorted(s.get("elapsed_s", 0) for _, s in entries)
+    print(f"Latency: median {latencies[len(latencies) // 2]}s, "
+          f"max {latencies[-1]}s")
+
+    fully_agreeing = sum(
+        1 for _, s in entries if not s.get("mismatched_section_ids")
+    )
+    print(f"Full agreement with the served scorecard: "
+          f"{fully_agreeing}/{len(entries)} "
+          f"({100 * fully_agreeing / len(entries):.0f}%)\n")
+
+    seen: Counter = Counter()
+    mismatched: Counter = Counter()
+    examples: dict[str, list] = defaultdict(list)
+    for r, s in entries:
+        for sid in s.get("sections", {}):
+            seen[sid] += 1
+        for sid in s.get("mismatched_section_ids", []):
+            mismatched[sid] += 1
+            if len(examples[sid]) < 3:
+                examples[sid].append(str(r["dialpad_call_id"]))
+
+    print("| section | disagree | of | rate | example calls |")
+    print("|---|---|---|---|---|")
+    for sid, total in sorted(seen.items(),
+                             key=lambda kv: -mismatched[kv[0]] / kv[1]):
+        bad = mismatched[sid]
+        print(f"| {sid} | {bad} | {total} | {100 * bad / total:.0f}% | "
+              f"{', '.join(examples[sid]) or '—'} |")
 
 
 async def main() -> int:
@@ -70,44 +108,22 @@ async def main() -> int:
     print(f"# Two-stage shadow report — {args.team}, last {args.days}d")
     print(f"\nShadowed evals: **{len(stamps)}** "
           f"(judged: {len(ok)}, judge errors: {len(errored)})")
-    if not ok:
-        for r, s in errored[:10]:
-            print(f"- eval {r['id']} call {r['dialpad_call_id']}: {s['error']}")
-        return 0
 
-    judges = Counter(f"{s.get('scorer_provider')}/{s.get('scorer_model')}"
-                     for _, s in ok)
-    print("Judges: " + ", ".join(f"{j} ×{n}" for j, n in judges.most_common()))
-    latencies = sorted(s.get("elapsed_s", 0) for _, s in ok)
-    print(f"Judge latency: median {latencies[len(latencies) // 2]}s, "
-          f"max {latencies[-1]}s")
-
-    # Per-section disagreement rate (mismatched_section_ids vs sections seen)
-    seen: Counter = Counter()
-    mismatched: Counter = Counter()
-    examples: dict[str, list] = defaultdict(list)
+    # One section per judge — the two clean one-variable comparisons.
+    by_judge: dict[str, list] = defaultdict(list)
     for r, s in ok:
-        for sid in s.get("sections", {}):
-            seen[sid] += 1
-        for sid in s.get("mismatched_section_ids", []):
-            mismatched[sid] += 1
-            if len(examples[sid]) < 3:
-                examples[sid].append(str(r["dialpad_call_id"]))
-
-    fully_agreeing = sum(1 for _, s in ok if not s.get("mismatched_section_ids"))
-    print(f"Scorecards in full agreement: {fully_agreeing}/{len(ok)} "
-          f"({100 * fully_agreeing / len(ok):.0f}%)\n")
-    print("| section | disagree | of | rate | example calls |")
-    print("|---|---|---|---|---|")
-    for sid, total in sorted(seen.items(), key=lambda kv: -mismatched[kv[0]] / kv[1]):
-        bad = mismatched[sid]
-        print(f"| {sid} | {bad} | {total} | {100 * bad / total:.0f}% | "
-              f"{', '.join(examples[sid]) or '—'} |")
+        by_judge[f"{s.get('scorer_provider')}/{s.get('scorer_model')}"].append((r, s))
+    for judge in sorted(by_judge):
+        _print_judge_section(judge, by_judge[judge])
 
     if errored:
         print(f"\n## Judge errors ({len(errored)})")
-        for r, s in errored[:10]:
-            print(f"- eval {r['id']} call {r['dialpad_call_id']}: {s['error']}")
+        print("(stamps persist with the eval — errors dated before a fix "
+              "deployed are fossils, not live failures)")
+        for r, s in errored[:15]:
+            when = r["created_at"].strftime("%Y-%m-%d %H:%M")
+            print(f"- {when} eval {r['id']} call {r['dialpad_call_id']}: "
+                  f"{s['error']}")
     return 0
 
 


### PR DESCRIPTION
## What

Two fixes to `two_stage_shadow_report.py`, verified against live prod data:

1. **Per-judge split.** The report blended Gemini-judged and Claude-judged evals into one disagreement table — which defeats the shadow design's two one-variable comparisons (Gemini-judge = the split's effect; Claude-judge = the model's effect). Each judge now gets its own section: count, latency, full-agreement rate, per-section disagreement table.
2. **Dated error stamps.** Shadow stamps persist with the eval row, so judge errors from since-fixed deploys (the pre-#150 "Streaming is required" ValueErrors) keep appearing forever for those evals. Error lines now carry the eval's timestamp, and the section header says explicitly: errors dated before a fix deployed are fossils, not live failures. (All three current errors are ≤ the streaming-fix deploy; the 4 successful `claude-sonnet-5` judgments after it confirm the fix.)

## Early signal from the live run (small n — direction only)
- **Objective yn sections (greeting, caller_id) agree 100% under BOTH judges** — objective checks transfer through the annotation perfectly.
- Gemini-judge: 17% full agreement, numeric sections 33–50% disagreement → that's the *split's* baseline cost.
- Claude-judge: 0% full agreement, efficiency 100% / comms 75% disagreement, ~2× Gemini latency (30s vs 15s median) → the *model* diverges on subjective sections beyond the split baseline.
- Follow-up idea for the sign-off review: the stamp stores the judge's per-section scores and `qa.evaluation_sections` has the served ones — a delta-direction column (judge scores harsher vs kinder) is a small JOIN away if the disagreement rates alone don't settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)