### PR TITLE
fix(qa-automation): judge structured output + trailing-comma salvage + max_tokens diagnostics

### DIFF
--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -59,6 +59,41 @@ def _get_mime_type(filename: str) -> str:
     return SUPPORTED_MIME_TYPES[ext]
 
 
+def _strip_trailing_commas(json_str: str) -> str:
+    """Drop commas that directly precede a closing brace/bracket, outside
+    string literals — models occasionally emit ``, }`` (observed live on a
+    Claude judgment, eval 2444). String contents pass through untouched
+    (same in_str/esc walk as _salvage_truncated_annotation)."""
+    out: list[str] = []
+    in_str = esc = False
+    i, n = 0, len(json_str)
+    while i < n:
+        ch = json_str[i]
+        if in_str:
+            out.append(ch)
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+            out.append(ch)
+        elif ch == ",":
+            j = i + 1
+            while j < n and json_str[j] in " \t\r\n":
+                j += 1
+            if j < n and json_str[j] in "}]":
+                i += 1          # drop the comma; ws + bracket emit later
+                continue
+            out.append(ch)
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _extract_json(text: str) -> dict:
     text = re.sub(r"^```(?:json)?\s*", "", text.strip(), flags=re.IGNORECASE)
     text = re.sub(r"\s*```$", "", text.strip())
@@ -69,8 +104,16 @@ def _extract_json(text: str) -> dict:
     json_str = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text[start:end])
     try:
         return json.loads(json_str)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"JSON parse failed: {e}\n\nSnippet:\n{json_str[:500]}")
+    except json.JSONDecodeError as first_err:
+        # One salvage pass for the trailing-comma slip; anything still
+        # broken re-raises the ORIGINAL error (what the model actually
+        # emitted), same message shape the shadow stamps already carry.
+        try:
+            return json.loads(_strip_trailing_commas(json_str))
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"JSON parse failed: {first_err}\n\nSnippet:\n{json_str[:500]}"
+            ) from first_err
 
 
 async def score_audio(

--- a/qa-automation/AI-Scoring/backend/services/judge_service.py
+++ b/qa-automation/AI-Scoring/backend/services/judge_service.py
@@ -59,11 +59,22 @@ async def score_annotation(
     )
 
     stage = resolve_stage("scoring", config)
+    kwargs: dict = {}
+    if stage.provider.supports_json_schema:
+        # Provider-enforced structured output where available: guarantees
+        # syntactically valid JSON, eliminating the free-text slip class
+        # observed live (a trailing comma killed an otherwise-complete
+        # Claude judgment, eval 2444). The schema IS the validation model
+        # below — zero drift by construction. Providers without the
+        # capability (Gemini) keep the prompt-schema + fence-tolerant
+        # parse path unchanged.
+        kwargs["json_schema"] = Scorecard.model_json_schema()
     result = await stage.provider.generate(
         prompt,
         model=stage.model,
         max_output_tokens=stage.max_output_tokens,
         system=build_judge_system_prompt(config),
+        **kwargs,
     )
 
     sections_by_id = {s.id: s for s in config.sections}

--- a/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/anthropic.py
@@ -25,8 +25,27 @@ from backend.services.llm.provider import (
 )
 
 
+def _close_object_schemas(node):
+    """Anthropic structured output REQUIRES ``additionalProperties: false``
+    on every object node (400 otherwise — probed live 2026-07-28); pydantic's
+    model_json_schema() omits it. Returns a closed COPY (walks $defs,
+    properties, items, anyOf alike); the caller's schema is never mutated.
+    Closing is the only accepted shape, so this is dialect adaptation, not
+    a semantic choice — the Gemini modules do the mirror-image dance for
+    Gemini's response_schema subset."""
+    if isinstance(node, dict):
+        node = {k: _close_object_schemas(v) for k, v in node.items()}
+        if node.get("type") == "object":
+            node.setdefault("additionalProperties", False)
+        return node
+    if isinstance(node, list):
+        return [_close_object_schemas(v) for v in node]
+    return node
+
+
 class AnthropicTextProvider(TextModelProvider):
     name = "anthropic"
+    supports_json_schema = True
 
     def __init__(self, client=None):
         """*client* is a test seam; production constructs lazily from env
@@ -84,7 +103,10 @@ class AnthropicTextProvider(TextModelProvider):
             # Provider-enforced structured output — replaces markdown-fence
             # stripping entirely on this path (guaranteed-valid JSON).
             kwargs["output_config"] = {
-                "format": {"type": "json_schema", "schema": json_schema}
+                "format": {
+                    "type": "json_schema",
+                    "schema": _close_object_schemas(json_schema),
+                }
             }
         # Always stream and collect: the SDK REFUSES non-streaming
         # requests whose max_tokens could exceed ~10 minutes (the judge's
@@ -97,6 +119,18 @@ class AnthropicTextProvider(TextModelProvider):
 
         if response.stop_reason == "refusal":
             raise LlmProviderError(f"model {model} refused the request")
+        if response.stop_reason == "max_tokens":
+            # Truncated output would otherwise surface downstream as a
+            # confusing parse error — name the budget exhaustion here,
+            # with token usage, same lesson the annotator's
+            # _finish_diagnostics already paid for on the Gemini leg.
+            usage = getattr(response, "usage", None)
+            raise LlmProviderError(
+                f"model {model} exhausted the {max_output_tokens}-token "
+                f"output budget (stop_reason='max_tokens'"
+                + (f", usage={usage}" if usage is not None else "")
+                + ") — output truncated"
+            )
         text = "".join(
             block.text for block in response.content if block.type == "text"
         )

--- a/qa-automation/AI-Scoring/backend/services/llm/gemini.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/gemini.py
@@ -23,6 +23,7 @@ from backend.services.llm.provider import (
 
 class GeminiTextProvider(TextModelProvider):
     name = "gemini"
+    supports_json_schema = False    # generate() raises on json_schema, below
 
     def __init__(self, temperature: Optional[float] = None, client=None):
         """*temperature* is a Gemini-specific knob mapped at construction

--- a/qa-automation/AI-Scoring/backend/services/llm/provider.py
+++ b/qa-automation/AI-Scoring/backend/services/llm/provider.py
@@ -36,6 +36,14 @@ class TextModelProvider(ABC):
 
     name: str = "unknown"
 
+    # Whether generate() can ENFORCE json_schema (provider-side constrained
+    # decoding). Callers holding a schema consult this flag instead of
+    # try/except — passing json_schema to a provider that can't enforce it
+    # raises LlmProviderError by contract (see generate()), which is the
+    # wrong outcome when the caller has a perfectly good prompt-schema +
+    # parse path to fall back on.
+    supports_json_schema: bool = False
+
     @abstractmethod
     async def generate(
         self,

--- a/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
+++ b/qa-automation/AI-Scoring/references/TwoStageScoringDesign.md
@@ -1,8 +1,33 @@
 # TwoStageScoringDesign — Gemini annotates, any LLM scores
 
-**Status:** v1.3 — P1 (#140), P2 (#142 + hardening #143), **P3 built**:
+**Status:** v1.4 — P1 (#140), P2 (#142 + hardening #143), **P3 built**:
 Stage-B judge + `two_stage_shadow` / `two_stage` are live code.
-**Date:** 2026-07-24 (v1) … 2026-07-26 (v1.2), 2026-07-29 (v1.3)
+**Date:** 2026-07-24 (v1) … 2026-07-26 (v1.2), 2026-07-29 (v1.3),
+2026-07-28 (v1.4)
+
+**v1.4 amendments (judge output hardening — the "later tightening"
+v1.3 promised):**
+- Provider-enforced structured output on the judge, capability-gated:
+  `TextModelProvider.supports_json_schema` (anthropic True / gemini
+  False — its dialect still can't express ours). When True, the judge
+  passes `Scorecard.model_json_schema()` — the schema IS the
+  validation model, zero drift by construction. Motivated by a live
+  shadow error (eval 2444): a trailing comma killed an
+  otherwise-complete Claude judgment (~1/29 of Claude shadow samples).
+- Anthropic dialect adaptation lives in the provider:
+  `_close_object_schemas` sets `additionalProperties: false` on every
+  object node — the API 400s without it (probed live 2026-07-28) and
+  pydantic omits it. Mirror-image of the Gemini modules' hand-authored
+  `ANNOTATOR_RESPONSE_SCHEMA` dance. Live-verified round-trip:
+  `llm_smoke.py --scorecard-schema` → API accepts →
+  `Scorecard.model_validate` passes.
+- Belt-and-suspenders: `_extract_json` gains a string-literal-aware
+  trailing-comma salvage pass (both providers, judge AND single-stage);
+  anything still broken raises the original error, same stamp shape.
+- `AnthropicTextProvider` names budget exhaustion:
+  `stop_reason='max_tokens'` → `LlmProviderError` with token usage,
+  instead of a baffling downstream parse error on truncated JSON (the
+  annotator's `_finish_diagnostics` lesson, applied to the text leg).
 
 **v1.3 amendments (P3):**
 - Judge resolution: `SCORING_MODEL_PROVIDER` = gemini (default) |

--- a/qa-automation/AI-Scoring/scripts/llm_smoke.py
+++ b/qa-automation/AI-Scoring/scripts/llm_smoke.py
@@ -5,10 +5,15 @@ Usage (from qa-automation/AI-Scoring, .env loaded):
     .venv/bin/python scripts/llm_smoke.py                    # gemini
     .venv/bin/python scripts/llm_smoke.py --provider anthropic
     .venv/bin/python scripts/llm_smoke.py --provider anthropic --json
+    .venv/bin/python scripts/llm_smoke.py --provider anthropic --scorecard-schema
 
 Gemini works today; anthropic needs ANTHROPIC_API_KEY (owner adds it —
 TwoStageScoringDesign §10.1). --json exercises the structured-output
-path (anthropic only until the Gemini mapping lands with P3).
+path with a toy schema (anthropic only until the Gemini mapping lands);
+--scorecard-schema sends the REAL Scorecard.model_json_schema() the
+judge now passes and round-trips the reply through
+Scorecard.model_validate — proves the API accepts pydantic's schema
+dialect end-to-end.
 """
 
 from __future__ import annotations
@@ -39,6 +44,14 @@ _SCHEMA = {
     "additionalProperties": False,
 }
 _MODELS = {"gemini": "gemini-2.5-flash", "anthropic": "claude-sonnet-5"}
+_SCORECARD_PROMPT = (
+    "Produce a demo scorecard for a flawless IMAGINARY support call: "
+    "two sections — id 'greeting' (name 'Greeting', score_type 'yn', "
+    "yn_value 'Y', score null) and id 'comms' (name 'Communication', "
+    "score_type 'numeric', score 5, yn_value null) — each with "
+    "confidence 'high' and one-sentence reasoning; brief call_summary, "
+    "key_strengths, opportunities."
+)
 
 
 async def main() -> int:
@@ -48,7 +61,10 @@ async def main() -> int:
     parser.add_argument("--model", default=None,
                         help=f"override the default ({_MODELS})")
     parser.add_argument("--json", action="store_true",
-                        help="exercise the structured-output path")
+                        help="exercise the structured-output path (toy schema)")
+    parser.add_argument("--scorecard-schema", action="store_true",
+                        help="structured output with the REAL judge schema "
+                             "(Scorecard.model_json_schema) + validate reply")
     args = parser.parse_args()
 
     provider = (GeminiTextProvider() if args.provider == "gemini"
@@ -57,14 +73,26 @@ async def main() -> int:
 
     kwargs: dict = {"model": model, "max_output_tokens": 1024}
     prompt = _PROMPT
-    if args.json:
+    if args.scorecard_schema:
+        from backend.models.scorecard import Scorecard
+        kwargs["json_schema"] = Scorecard.model_json_schema()
+        kwargs["max_output_tokens"] = 8192
+        prompt = _SCORECARD_PROMPT
+    elif args.json:
         kwargs["json_schema"] = _SCHEMA
         prompt = _JSON_PROMPT
 
-    print(f"→ {args.provider} / {model} (json={args.json})")
+    print(f"→ {args.provider} / {model} "
+          f"(json={args.json or args.scorecard_schema})")
     result = await provider.generate(prompt, **kwargs)
     print(f"← provider={result.provider} model={result.model}")
     print(result.text)
+    if args.scorecard_schema:
+        import json as _json
+        from backend.models.scorecard import Scorecard
+        scorecard = Scorecard.model_validate(_json.loads(result.text))
+        print(f"✓ Scorecard.model_validate passed "
+              f"({len(scorecard.sections)} sections)")
     return 0
 
 

--- a/qa-automation/AI-Scoring/tests/test_judge.py
+++ b/qa-automation/AI-Scoring/tests/test_judge.py
@@ -154,7 +154,8 @@ class FakeJudgeProvider(TextModelProvider):
 
     async def generate(self, prompt, *, model, max_output_tokens,
                        json_schema=None, system=None):
-        self.calls.append({"prompt": prompt, "model": model, "system": system})
+        self.calls.append({"prompt": prompt, "model": model,
+                           "system": system, "json_schema": json_schema})
         return LlmResult(text=self._text, provider="anthropic", model=model)
 
 
@@ -193,6 +194,55 @@ def test_score_annotation_surfaces_parse_failure(monkeypatch, config):
     )
     with pytest.raises(ValueError):
         asyncio.run(judge_service.score_annotation(_annotation(), config))
+
+
+def test_judge_passes_schema_only_when_provider_supports_it(monkeypatch, config):
+    """Capability-aware structured output: a provider that can enforce
+    json_schema receives the Scorecard's own pydantic schema (zero drift
+    with the validation model); one that can't (Gemini raises on
+    json_schema by contract) keeps the prompt-schema path — None."""
+    from backend.models.scorecard import Scorecard
+    from backend.services import judge_service
+    from backend.services.llm.factory import StageModel
+
+    raw = json.dumps(make_gemini_scoring_json(config))
+
+    class StructuredFake(FakeJudgeProvider):
+        supports_json_schema = True
+
+    for fake, expected in (
+        (StructuredFake(raw), Scorecard.model_json_schema()),
+        (FakeJudgeProvider(raw), None),
+    ):
+        monkeypatch.setattr(
+            judge_service, "resolve_stage",
+            lambda stage, cfg, fake=fake: StageModel(
+                provider=fake, model="m", max_output_tokens=8192),
+        )
+        asyncio.run(judge_service.score_annotation(_annotation(), config))
+        (call,) = fake.calls
+        assert call["json_schema"] == expected
+
+
+# ---------------------------------------------------------------------------
+# _extract_json — trailing-comma salvage (the eval-2444 failure class)
+# ---------------------------------------------------------------------------
+
+def test_extract_json_salvages_trailing_commas():
+    from backend.services.audio_service import _extract_json
+    assert _extract_json('{"a": 1, "b": [1, 2,], }') == {"a": 1, "b": [1, 2]}
+
+
+def test_extract_json_never_touches_string_contents():
+    from backend.services.audio_service import _extract_json
+    parsed = _extract_json('{"note": "clear, }", "x": 1,}')
+    assert parsed == {"note": "clear, }", "x": 1}
+
+
+def test_extract_json_still_raises_on_broken_json():
+    from backend.services.audio_service import _extract_json
+    with pytest.raises(ValueError, match="JSON parse failed"):
+        _extract_json('{"a": nope}')
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_llm_provider.py
+++ b/qa-automation/AI-Scoring/tests/test_llm_provider.py
@@ -184,8 +184,48 @@ def test_anthropic_json_schema_sets_structured_output():
     ))
     (call,) = fake.calls
     assert call["output_config"] == {
-        "format": {"type": "json_schema", "schema": {"type": "object"}}
+        "format": {"type": "json_schema",
+                   "schema": {"type": "object", "additionalProperties": False}}
     }
+
+
+def test_anthropic_closes_every_object_node_for_the_api():
+    """The API 400s unless every object sets additionalProperties: false
+    (probed live) — pydantic schemas omit it, the provider closes them,
+    recursively, without mutating the caller's dict."""
+    fake = FakeAnthropicClient(text="{}")
+    provider = AnthropicTextProvider(client=fake)
+    original = {"type": "object", "properties": {
+        "s": {"type": "object", "properties": {}}}}
+    asyncio.run(provider.generate(
+        "x", model="claude-sonnet-5", max_output_tokens=10,
+        json_schema=original,
+    ))
+    (call,) = fake.calls
+    schema = call["output_config"]["format"]["schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["s"]["additionalProperties"] is False
+    assert "additionalProperties" not in original    # caller's copy intact
+
+
+def test_structured_output_capability_flags():
+    """The judge consults this flag to decide whether to send a schema —
+    a provider that raises on json_schema must advertise False."""
+    assert AnthropicTextProvider.supports_json_schema is True
+    assert GeminiTextProvider.supports_json_schema is False
+
+
+def test_anthropic_max_tokens_raises_named_budget_error():
+    """Truncated output must fail HERE with a named budget error, not
+    downstream as a baffling JSON parse error — even when partial text
+    came back (it did: the fake carries text)."""
+    provider = AnthropicTextProvider(
+        client=FakeAnthropicClient(stop_reason="max_tokens")
+    )
+    with pytest.raises(LlmProviderError, match="output budget"):
+        asyncio.run(provider.generate(
+            "x", model="claude-sonnet-5", max_output_tokens=1,
+        ))
 
 
 def test_anthropic_refusal_raises():


### PR DESCRIPTION
## What

The three model-abstraction gaps surfaced by the shadow report (motivated by the one live post-#150 error, **eval 2444** — a trailing comma killed an otherwise-complete Claude judgment, ~1/29 Claude shadow samples):

1. **Capability-gated structured output on the judge.** `TextModelProvider.supports_json_schema` (anthropic `True` / gemini `False` — its dialect raises by contract). When supported, `judge_service` passes `Scorecard.model_json_schema()` — the schema **is** the validation model, so drift is impossible. Gemini keeps the prompt-schema + fence-tolerant parse path unchanged.
2. **Trailing-comma salvage in `_extract_json`** (belt-and-suspenders, both providers, judge AND single-stage): a string-literal-aware walker (same `in_str`/`esc` pattern as `_salvage_truncated_annotation`) drops `, }` / `, ]` outside strings, one retry; still-broken JSON re-raises the **original** error with the same stamp shape the shadow report greps.
3. **Named budget errors on the Claude leg**: `stop_reason='max_tokens'` now raises `LlmProviderError` with token usage instead of surfacing downstream as a baffling parse error on truncated JSON — the `_finish_diagnostics` lesson applied to the text leg.

## Dialect gotcha (probed live)

Anthropic structured output **400s unless every object node sets `additionalProperties: false`**; pydantic omits it. `_close_object_schemas` in the provider adapts (recursive, copy-not-mutate) — mirror-image of the Gemini modules' hand-authored `ANNOTATOR_RESPONSE_SCHEMA` dance.

## Verification

- Full suite: **1136 passed** (new pins: capability flags, schema-only-when-supported wiring, recursive closing, max_tokens error, salvage + string-preservation + still-raises).
- **Live round-trip** on claude-sonnet-5: `scripts/llm_smoke.py --provider anthropic --scorecard-schema` (new flag) → API accepts the real judge schema → reply passes `Scorecard.model_validate`. ✓

Doc: TwoStageScoringDesign **v1.4** — the "later tightening" the v1.3 amendment explicitly promised.

Once deployed, Claude shadow judgments become syntactically guaranteed — the sign-off week's data stops leaking samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)