### PR TITLE
fix(qa-automation): event-loop blocking during scoring + roster-scoped agent_status toasts

### DIFF
--- a/qa-automation/AI-Scoring/backend/routes/scoring.py
+++ b/qa-automation/AI-Scoring/backend/routes/scoring.py
@@ -152,8 +152,17 @@ async def _await_coro(coro) -> None:
     await coro
 
 
-def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
-                             default_disclaimer=None, suppress=False) -> None:
+async def _append_audit_row_threaded(**kwargs):
+    """Score_Audit is a sync gspread append — run it in a worker thread
+    so the Sheets round-trip never pins the event loop (2026-07-29
+    incident: sync I/O inside async paths froze webhooks, pages, and SSE
+    for the duration). Exceptions propagate unchanged — where the audit
+    append blocks an action, that's policy, not an accident."""
+    return await asyncio.to_thread(append_score_audit_row, **kwargs)
+
+
+async def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
+                                   default_disclaimer=None, suppress=False) -> None:
     """Apps Script email dispatch at the finalize seam — shared by the
     auto-flow and the approve path.
 
@@ -189,8 +198,10 @@ def _dispatch_finalize_email(job, history_row, team_id, evaluation_id,
         return
     disclaimer = f"rescore_{rescore['cause']}" if rescore else default_disclaimer
     try:
-        job["email_dispatch"] = trigger_apps_script(
-            history_row, team_id, disclaimer=disclaimer
+        # Sync httpx.post with a 60s timeout — threaded so the Apps
+        # Script round-trip never pins the event loop.
+        job["email_dispatch"] = await asyncio.to_thread(
+            trigger_apps_script, history_row, team_id, disclaimer=disclaimer
         )
     except Exception as e:
         # Visible, not swallowed-into-print-limbo: the job payload
@@ -312,7 +323,7 @@ async def _postgres_post_stage1(job, evaluation_id, scorecard, config, team_id,
         key_strengths=scorecard.key_strengths,
         opportunities=scorecard.opportunities,
     )
-    _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
+    await _dispatch_finalize_email(job, history_row, team_id, evaluation_id)
     return None
 
 
@@ -358,7 +369,7 @@ async def _maybe_auto_rescore(job, evaluation_id, score, config, team_id,
     # Machine-initiated: NOT tampering (§0.2) — audit row with the
     # triggering key's role, no evaluator, no coaching receipt. Same
     # superseded_model stamp as the S4 manual path (P3+ traceability).
-    append_score_audit_row(
+    await _append_audit_row_threaded(
         api_key_role=api_key_role,
         evaluator_email="",
         agent_email=state["agent_email"] or "",
@@ -518,7 +529,7 @@ async def score_single_call(
             identity, team_id, agent_email, is_in_roster=is_in_roster,
         )
     except HTTPException as exc:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=manager_email,
             agent_email=agent_email or "",
@@ -549,7 +560,7 @@ async def score_single_call(
         try:
             audio_bytes = await download_recording(call_id)
         except NoRecordingAvailable:
-            append_score_audit_row(
+            await _append_audit_row_threaded(
                 api_key_role=identity.role,
                 evaluator_email=manager_email,
                 agent_email=agent_email or "",
@@ -565,7 +576,7 @@ async def score_single_call(
                 detail="Call has no recording in Dialpad",
             )
         except DialpadRateLimited:
-            append_score_audit_row(
+            await _append_audit_row_threaded(
                 api_key_role=identity.role,
                 evaluator_email=manager_email,
                 agent_email=agent_email or "",
@@ -603,7 +614,7 @@ async def score_single_call(
 
     # Audit row written before the background task is scheduled so the
     # operator action is logged even if the worker crashes.
-    append_score_audit_row(
+    await _append_audit_row_threaded(
         api_key_role=identity.role,
         evaluator_email=manager_email,
         agent_email=agent_email or "",
@@ -756,7 +767,7 @@ async def score_batch(
             "manager_email": manager_email,
         }
 
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=manager_email,
             agent_email="",
@@ -994,7 +1005,7 @@ async def _approve_core(*, team_id, key, job, approval, identity,
             history_row = await project_evaluation(
                 pool, evaluation_id, config, include_history=True
             )
-            _dispatch_finalize_email(
+            await _dispatch_finalize_email(
                 job, history_row, team_id, evaluation_id,
                 default_disclaimer=(
                     "review_resolution" if resolving
@@ -1033,7 +1044,7 @@ async def _approve_core(*, team_id, key, job, approval, identity,
                 f" ack:{evaluator_email}"
                 f"; coaching={coaching_id if coaching_id is not None else 'none'}"
             )
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=evaluator_email,
             agent_email=job.get("agent_email", ""),
@@ -1197,7 +1208,7 @@ async def rescore_evaluation(
             identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
         )
     except HTTPException as exc:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
@@ -1215,7 +1226,7 @@ async def rescore_evaluation(
     try:
         audio_bytes = await download_recording(call_id)
     except NoRecordingAvailable:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
@@ -1231,7 +1242,7 @@ async def rescore_evaluation(
             detail="Call has no recording in Dialpad",
         )
     except DialpadRateLimited:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
@@ -1259,7 +1270,7 @@ async def rescore_evaluation(
     # Audit BEFORE scheduling (crash-safe receipt), with the superseded
     # score + model stamp — the cross-model traceability hook (P3+).
     old_score = "unscored" if ref.overall_score is None else ref.overall_score
-    append_score_audit_row(
+    await _append_audit_row_threaded(
         api_key_role=identity.role,
         evaluator_email=payload.evaluator_email,
         agent_email=ref.agent_email or "",
@@ -1377,7 +1388,7 @@ async def override_scorecard(
             identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
         )
     except HTTPException as exc:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=payload.evaluator_email,
             agent_email=ref.agent_email or "",
@@ -1427,7 +1438,7 @@ async def override_scorecard(
         )
         notes += f" | SOP gap: {payload.sop_gap.note}{doc}"
     notes += f" | ack:{payload.evaluator_email}"
-    append_score_audit_row(
+    await _append_audit_row_threaded(
         api_key_role=identity.role,
         evaluator_email=payload.evaluator_email,
         agent_email=ref.agent_email or "",
@@ -1443,8 +1454,8 @@ async def override_scorecard(
     email_dispatch: dict = {"status": "suppressed", "message": "suppress_email requested"}
     if not payload.suppress_email:
         try:
-            email_dispatch = trigger_apps_script(
-                history_row, team_id, disclaimer="override"
+            email_dispatch = await asyncio.to_thread(
+                trigger_apps_script, history_row, team_id, disclaimer="override"
             ) if history_row and history_row > 0 else {
                 "status": "skipped", "message": "no Analyst_History row projected",
             }
@@ -1527,7 +1538,7 @@ async def edit_datapoint(
             identity, team_id, ref.agent_email, is_in_roster=is_in_roster,
         )
     except HTTPException as exc:
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email=approval.evaluator_email or "",
             agent_email=ref.agent_email or "",
@@ -1630,7 +1641,7 @@ async def delete_evaluation(
     """
     team_id = team_id_from_path(request)
     if identity.role != "privileged":
-        append_score_audit_row(
+        await _append_audit_row_threaded(
             api_key_role=identity.role,
             evaluator_email="",
             agent_email="",
@@ -1699,7 +1710,7 @@ async def delete_evaluation(
 
     # Post-commit, both retryable/visible rather than delete-blocking:
     tombstone_row = await tombstone_evaluation(ref.dialpad_link or "", config)
-    append_score_audit_row(
+    await _append_audit_row_threaded(
         api_key_role=identity.role,
         evaluator_email="",
         agent_email=ref.agent_email or "",

--- a/qa-automation/AI-Scoring/backend/services/audio_service.py
+++ b/qa-automation/AI-Scoring/backend/services/audio_service.py
@@ -139,8 +139,13 @@ async def score_audio(
         tmp.write(audio_bytes)
         tmp_path = tmp.name
 
+    uploaded = None
     try:
-        uploaded = client.files.upload(
+        # client.aio ONLY in this module — the sync surface pins the sole
+        # uvicorn event loop for the whole upload/generation (2026-07-29
+        # incident: webhooks, pages, and SSE froze for minutes per scored
+        # call, then flushed in a burst when generation returned).
+        uploaded = await client.aio.files.upload(
             file=tmp_path,
             config=types.UploadFileConfig(mime_type=mime_type, display_name=filename),
         )
@@ -155,7 +160,7 @@ async def score_audio(
             call_context_text=call_context_text,
         )
 
-        response = client.models.generate_content(
+        response = await client.aio.models.generate_content(
             model=config.gemini.scoring_model,
             contents=[
                 types.Content(
@@ -180,12 +185,14 @@ async def score_audio(
         )
 
     finally:
-        # Clean up temp file and Gemini upload
+        # Clean up temp file and Gemini upload. `uploaded` guard: an
+        # upload failure used to NameError here and mask the real error.
         Path(tmp_path).unlink(missing_ok=True)
-        try:
-            client.files.delete(name=uploaded.name)
-        except Exception:
-            pass
+        if uploaded is not None:
+            try:
+                await client.aio.files.delete(name=uploaded.name)
+            except Exception:
+                pass
 
 
 DEFAULT_ANNOTATOR_MODEL = "gemini-2.5-flash"
@@ -409,7 +416,7 @@ async def annotate_audio(
 
     uploaded = None
     try:
-        uploaded = client.files.upload(
+        uploaded = await client.aio.files.upload(
             file=tmp_path,
             config=types.UploadFileConfig(mime_type=mime_type, display_name=filename),
         )
@@ -448,6 +455,6 @@ async def annotate_audio(
         Path(tmp_path).unlink(missing_ok=True)
         if uploaded is not None:
             try:
-                client.files.delete(name=uploaded.name)
+                await client.aio.files.delete(name=uploaded.name)
             except Exception:
                 pass

--- a/qa-automation/AI-Scoring/backend/services/sheets_projection.py
+++ b/qa-automation/AI-Scoring/backend/services/sheets_projection.py
@@ -21,6 +21,7 @@ retryable — callers log and continue; the nightly reproject sweep
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any, Optional
@@ -205,13 +206,22 @@ async def project_evaluation(
 
     if include_history:
         try:
-            history_sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
-            history_row_num = _write_row(history_sheet, row, link, config)
+            # gspread is sync HTTP — threaded so the Sheets round trips
+            # (find + write) never pin the event loop.
+            history_row_num = await asyncio.to_thread(
+                _project_history_sync, config, row, link
+            )
         except Exception:
             logger.exception("projection: Analyst_History write failed for eval %s — retryable",
                              evaluation_id)
 
     return history_row_num
+
+
+def _project_history_sync(config: "TeamConfig", row: list[str], link: str) -> int:
+    """The blocking sheet leg of project_evaluation (worker-thread body)."""
+    history_sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
+    return _write_row(history_sheet, row, link, config)
 
 
 async def tombstone_evaluation(dialpad_link: str, config: "TeamConfig") -> Optional[int]:
@@ -235,19 +245,24 @@ async def tombstone_evaluation(dialpad_link: str, config: "TeamConfig") -> Optio
                        config.team_id)
         return None
     try:
-        sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
-        existing = _find_row_by_dialpad_link(sheet, dialpad_link)
-        if existing is None:
-            return None
-        width = config.history_layout.total_width
-        end_letter = col_index_to_letter(width - 1)
-        sheet.update(f"A{existing}:{end_letter}{existing}", [[""] * width],
-                     value_input_option="USER_ENTERED")
-        return existing
+        return await asyncio.to_thread(_tombstone_sync, config, dialpad_link)
     except Exception:
         logger.exception("tombstone: Analyst_History blank failed for link %s — "
                          "sheet row is stale until manually cleared", dialpad_link)
         return None
+
+
+def _tombstone_sync(config: "TeamConfig", dialpad_link: str) -> Optional[int]:
+    """The blocking sheet leg of tombstone_evaluation (worker-thread body)."""
+    sheet = _get_sheet(config, config.sheets.analyst_history.tab_name)
+    existing = _find_row_by_dialpad_link(sheet, dialpad_link)
+    if existing is None:
+        return None
+    width = config.history_layout.total_width
+    end_letter = col_index_to_letter(width - 1)
+    sheet.update(f"A{existing}:{end_letter}{existing}", [[""] * width],
+                 value_input_option="USER_ENTERED")
+    return existing
 
 
 __all__ = ["project_evaluation", "build_projection_row", "tombstone_evaluation"]

--- a/qa-automation/AI-Scoring/command_center/routes/webhooks.py
+++ b/qa-automation/AI-Scoring/command_center/routes/webhooks.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
@@ -25,12 +26,19 @@ from fastapi import APIRouter, HTTPException, Request
 from command_center.services import fold, store
 
 # App-side seam ONLY here in the route adapter: fold/store stay
-# framework-free (Sandy carries them verbatim); the event bus is the
-# hosting app's live-dashboard plumbing and is re-pointed at re-platform
-# time along with the subscription URL.
+# framework-free (Sandy carries them verbatim); the event bus and the
+# qa.agents roster lookup are the hosting app's plumbing and are
+# re-pointed at re-platform time along with the subscription URL.
 from backend.services.event_bus import get_event_bus
+from backend.services.data_normalization import strip_accents
 
 logger = logging.getLogger(__name__)
+
+# Roster cache TTL for agent_status → team scoping. Roster churn is
+# human-paced (import_agents runs / departures) — 5 min staleness is
+# invisible next to a toast's 4s TTL.
+_ROSTER_TTL_S = 300.0
+_roster_cache: Optional[tuple[float, dict[str, set], dict[str, set]]] = None
 
 router = APIRouter()
 
@@ -126,14 +134,55 @@ async def dialpad_webhook(request: Request) -> dict:
     return {"status": status}
 
 
-async def _publish_agent_status(team_id: str, ev: fold.NormalizedEvent) -> None:
-    """SSE 'agent_status' → the team dashboard's toast rail.
+async def _roster_maps() -> Optional[tuple[dict[str, set], dict[str, set]]]:
+    """(dialpad_agent_id → {team_id}, folded name → {team_id}) over the
+    ACTIVE qa.agents roster, TTL-cached. None when no DB is configured
+    or the read fails — callers fall back to the resolve_team() team so
+    local dev (no DATABASE_URL) still toasts."""
+    global _roster_cache
+    now = time.monotonic()
+    if _roster_cache is not None and now - _roster_cache[0] < _ROSTER_TTL_S:
+        return _roster_cache[1], _roster_cache[2]
+    pool = await store.get_pool()
+    if pool is None:
+        return None
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT team_id, name, canonical_name, dialpad_agent_id "
+                "FROM qa.agents WHERE active"
+            )
+    except Exception:
+        logger.exception("cc.webhooks: roster read failed — agent_status "
+                         "falls back to single-team publish")
+        return None
+    by_id: dict[str, set] = {}
+    by_name: dict[str, set] = {}
+    for r in rows:
+        if r["dialpad_agent_id"]:
+            by_id.setdefault(str(r["dialpad_agent_id"]), set()).add(r["team_id"])
+        for n in (r["name"], r["canonical_name"]):
+            if n:
+                key = strip_accents(str(n)).lower().strip()
+                by_name.setdefault(key, set()).add(r["team_id"])
+    _roster_cache = (now, by_id, by_name)
+    return by_id, by_name
+
+
+async def _publish_agent_status(fallback_team_id: str, ev: fold.NormalizedEvent) -> None:
+    """SSE 'agent_status' → the toast rail of the agent's OWN team(s).
+
+    The agent-status subscription covers agents org-wide (Verifications
+    etc. arrived on the MS dashboard via the single-team fallback), so
+    the publish is scoped by qa.agents roster match: dialpad_agent_id
+    first (§3.11 eager-resolve), accent-folded name second. No roster
+    match → no toast (the event is still stored). Roster unavailable
+    (no DB / read failure) → legacy single-team publish.
 
     Payload-shape defensiveness mirrors DispositionDesign §9: the agent
     display name is target.name when the target is the user, with
-    payload-level name fields as fallbacks; the status label is the
-    event's state. Both may be blank on shapes we haven't observed —
-    the client renders placeholders rather than dropping the event.
+    payload-level name fields as fallbacks; blanks render placeholders
+    client-side rather than dropping the event.
     """
     payload = ev.payload
     target = payload.get("target") or {}
@@ -144,16 +193,32 @@ async def _publish_agent_status(team_id: str, ev: fold.NormalizedEvent) -> None:
         name = str(payload.get("name") or payload.get("display_name") or "")
     status_label = str(ev.state or payload.get("agent_state") or "")
 
+    maps = await _roster_maps()
+    if maps is None:
+        teams = {fallback_team_id}
+    else:
+        by_id, by_name = maps
+        teams = set()
+        if ev.dialpad_agent_id:
+            teams |= by_id.get(ev.dialpad_agent_id, set())
+        if not teams and name:
+            teams |= by_name.get(strip_accents(name).lower().strip(), set())
+
     logger.info(
-        "cc.webhooks: agent_status agent=%s state=%s keys=%s",
-        ev.dialpad_agent_id, status_label or "?", sorted(payload.keys()),
+        "cc.webhooks: agent_status agent=%s state=%s teams=%s keys=%s",
+        ev.dialpad_agent_id, status_label or "?",
+        sorted(teams) or "-", sorted(payload.keys()),
     )
+    if not teams:
+        return
     try:
-        await get_event_bus().publish(team_id, "agent_status", {
-            "agent_id": ev.dialpad_agent_id,
-            "agent": name,
-            "status": status_label,
-            "at": ev.event_timestamp.isoformat(),
-        })
+        bus = get_event_bus()
+        for team in sorted(teams):
+            await bus.publish(team, "agent_status", {
+                "agent_id": ev.dialpad_agent_id,
+                "agent": name,
+                "status": status_label,
+                "at": ev.event_timestamp.isoformat(),
+            })
     except Exception:
         logger.exception("cc.webhooks: agent_status publish failed (non-fatal)")

--- a/qa-automation/AI-Scoring/command_center/services/store.py
+++ b/qa-automation/AI-Scoring/command_center/services/store.py
@@ -62,6 +62,13 @@ async def _get_pool():
     return _pool
 
 
+async def get_pool():
+    """Public accessor for integrations riding the CC pool (e.g. the
+    roster lookup behind the agent_status SSE publish). None when
+    DATABASE_URL is unset."""
+    return await _get_pool()
+
+
 async def close_pool() -> None:
     """Lifespan teardown."""
     global _pool

--- a/qa-automation/AI-Scoring/tests/test_annotator.py
+++ b/qa-automation/AI-Scoring/tests/test_annotator.py
@@ -187,14 +187,14 @@ def _fake_genai_client(*payload_texts, finish_reason=None):
         uri = "files/fake"
         name = "files/fake"
 
-    class _Files:
+    class _AioFiles:
         def __init__(self):
             self.deleted = []
 
-        def upload(self, *, file, config):
+        async def upload(self, *, file, config):
             return _Uploaded()
 
-        def delete(self, *, name):
+        async def delete(self, *, name):
             self.deleted.append(name)
 
     class _AioModels:
@@ -216,10 +216,10 @@ def _fake_genai_client(*payload_texts, finish_reason=None):
     class _Aio:
         def __init__(self):
             self.models = _AioModels()
+            self.files = _AioFiles()
 
     class _Client:
         def __init__(self):
-            self.files = _Files()
             self.aio = _Aio()
 
     return _Client()
@@ -244,7 +244,7 @@ def test_annotate_audio_parses_and_cleans_up(monkeypatch):
         b"bytes", "call.mp3", transcript_text="hi", moments_display=[],
     ))
     assert annotation.schema_version == "gemini_annotate_v1"
-    assert client.files.deleted == ["files/fake"]   # upload cleaned up
+    assert client.aio.files.deleted == ["files/fake"]   # upload cleaned up
     # Constrained decoding requested (the bilingual-call fix)
     (config,) = client.aio.models.attempts
     assert config.response_mime_type == "application/json"
@@ -266,7 +266,7 @@ def test_annotate_audio_retries_once_with_bumped_temperature(monkeypatch):
     first, second = client.aio.models.attempts
     assert first.temperature == 0.0
     assert second.temperature == 0.2
-    assert client.files.deleted == ["files/fake"]   # cleanup after retries too
+    assert client.aio.files.deleted == ["files/fake"]   # cleanup after retries too
 
 
 def test_annotate_audio_invalid_json_raises_after_both_attempts(monkeypatch):
@@ -379,21 +379,21 @@ def test_annotate_audio_fails_fast_on_deterministic_400(monkeypatch):
                 400, {"error": {"message": "Request contains an invalid argument."}}
             )
 
-    class _Aio:
-        models = _AioModels()
-
-    class _Files:
-        def upload(self, *, file, config):
+    class _AioFiles:
+        async def upload(self, *, file, config):
             class _Up:
                 uri = "files/fake"
                 name = "files/fake"
             return _Up()
 
-        def delete(self, *, name):
+        async def delete(self, *, name):
             pass
 
+    class _Aio:
+        models = _AioModels()
+        files = _AioFiles()
+
     class _Client:
-        files = _Files()
         aio = _Aio()
 
     monkeypatch.setattr(audio_service, "_get_client", lambda: _Client())

--- a/qa-automation/AI-Scoring/tests/test_cc_agent_status_publish.py
+++ b/qa-automation/AI-Scoring/tests/test_cc_agent_status_publish.py
@@ -162,6 +162,63 @@ def test_live_shape_publishes_unknown_status(harness):
     assert data["at"] == T0.isoformat()
 
 
+def _roster(by_id=None, by_name=None):
+    async def _maps():
+        return (by_id or {}, by_name or {})
+    return _maps
+
+
+def test_roster_scopes_publish_to_agents_team(harness, monkeypatch):
+    """A Sales agent's status toasts on /dashboard/sales only — never on
+    the resolve_team fallback team (member_support)."""
+    client, bus, _ = harness
+    monkeypatch.setattr(
+        webhooks_module, "_roster_maps",
+        _roster(by_id={"9876543210": {"sales"}}),
+    )
+    resp = client.post("/api/webhooks/dialpad", content=_signed(_agent_status_payload()))
+    assert resp.status_code == 200
+    assert [(t, e) for t, e, _ in bus.published] == [("sales", "agent_status")]
+
+
+def test_roster_no_match_drops_toast(harness, monkeypatch):
+    """Off-roster agents (e.g. Verifications) are stored but never
+    toasted anywhere."""
+    client, bus, _ = harness
+    monkeypatch.setattr(webhooks_module, "_roster_maps", _roster())
+    resp = client.post("/api/webhooks/dialpad", content=_signed(_agent_status_payload()))
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "appended"}   # still stored
+    assert bus.published == []
+
+
+def test_roster_name_fallback_is_accent_folded(harness, monkeypatch):
+    """No dialpad_agent_id match → accent-folded name match ('Ana López'
+    ↔ 'ana lopez')."""
+    client, bus, _ = harness
+    monkeypatch.setattr(
+        webhooks_module, "_roster_maps",
+        _roster(by_name={"ana lopez": {"member_support"}}),
+    )
+    resp = client.post("/api/webhooks/dialpad", content=_signed(_agent_status_payload()))
+    assert resp.status_code == 200
+    assert [(t, e) for t, e, _ in bus.published] == [("member_support", "agent_status")]
+
+
+def test_roster_unavailable_falls_back_to_resolved_team(harness, monkeypatch):
+    """No DB (local dev) or roster read failure → legacy single-team
+    publish, so dev without DATABASE_URL still toasts."""
+    client, bus, _ = harness
+
+    async def _none():
+        return None
+
+    monkeypatch.setattr(webhooks_module, "_roster_maps", _none)
+    resp = client.post("/api/webhooks/dialpad", content=_signed(_agent_status_payload()))
+    assert resp.status_code == 200
+    assert [(t, e) for t, e, _ in bus.published] == [("member_support", "agent_status")]
+
+
 def test_bad_signature_publishes_nothing(harness):
     client, bus, _ = harness
     body = pyjwt.encode(_agent_status_payload(), "wrong-secret", algorithm="HS256")


### PR DESCRIPTION
## The stall-then-frenzy, root-caused
`score_audio` is an `async def` calling the **synchronous** google-genai surface (`files.upload` / `models.generate_content` / `files.delete`) — on the single uvicorn event loop that also serves webhooks, pages, and SSE. Every `single`-pipeline scoring run (Sales' default + the judge-failure fallback) froze the process for the entire upload+generation; the accept-queue then flushed at once ("webhooks arrived in a frenzy"). `annotate_audio`'s sync upload/delete caused the same freeze in seconds-doses on `two_stage`, and the finalize path piled on: `trigger_apps_script` is sync `httpx.post` with a **60s timeout** called from async code, plus sync gspread writes (Analyst_History projection, Score_Audit appends).

## Commit 1 — unblock the loop
- **audio_service**: all five genai calls → `client.aio` (the file already used it for Stage-A generation — line-of-sight precedent). Also fixes a latent bug: `score_audio`'s `finally` NameError'd on `uploaded` when the upload itself raised, masking the real error.
- **scoring routes**: `trigger_apps_script` + `append_score_audit_row` call sites wrapped in `asyncio.to_thread` (semantics unchanged — where the audit append blocks an action, that's policy and exceptions still propagate); `_dispatch_finalize_email` now async.
- **sheets_projection**: projection/tombstone sheet legs run in worker threads.

## Commit 2 — roster-scoped `agent_status` toasts
Publish now targets the agent's own team(s) via the ACTIVE `qa.agents` roster — `dialpad_agent_id` first (§3.11 eager-resolve), accent-folded name fallback — TTL-cached 5 min on the CC pool. Route-based scoping falls out naturally: `/dashboard/sales` and `/dashboard/member_support` each subscribe to their own SSE stream. Off-roster agents (Verifications) are stored but not toasted; no DB → legacy single-team fallback (local dev still works). No env vars needed — the roster already carries the team mapping.

## Verification
- Suite: **887 passed, 6 skipped, 3 xfailed** (test fakes moved to the `aio.files` surface; sync route-test fakes untouched by design — that's why to_thread over an async rewrite).
- Installed SDK verified: `google-genai 1.73.1` exposes `AsyncFiles.upload/delete`. Zero sync genai calls remain (grep-clean).
- **Post-deploy check**: score a call while curling `/api/health` in a loop — it should stay fast throughout, webhook rows should keep landing mid-scoring, and the dashboard should stay navigable. Sales toasts should appear only on `/dashboard/sales`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)