### PR TITLE
feat(qa-automation): Pulpo SOP compendium pipeline + weekly-snapshot design

### DIFF
--- a/qa-automation/AI-Scoring/.env.example
+++ b/qa-automation/AI-Scoring/.env.example
@@ -39,6 +39,22 @@ GOOGLE_HISTORY_TAB=Analyst_History
 # handles this when the agent isn't rostered anywhere).
 # API_KEY_PRIVILEGED=
 
+# --- Pulpo (RAG provider — PulpoConnection.md §4.1) ---
+# MCP endpoint + tokens minted in the Pulpo admin console (both audiences,
+# unassigned). Never commit real tokens; revocation is instant.
+#   PULPO_MCP_TOKEN            — production scoring retrieval
+#   PULPO_MCP_BENCHMARK_TOKEN  — benchmarks / sweeps / compendium snapshot
+#                                (separate quota pool; never starves scoring)
+# PULPO_MCP_URL=https://plasticity.heypulpo.com/api/mcp
+# PULPO_MCP_TOKEN=
+# PULPO_MCP_BENCHMARK_TOKEN=
+
+# Pulpo SOP Compendium (scripts/pulpo_compendium_export.py): the EXISTING
+# user-owned Google Doc the weekly snapshot overwrites. Must be shared to the
+# service account as editor (service accounts have zero Drive storage quota
+# and can never create files — only edit).
+# PULPO_COMPENDIUM_DOC_ID=
+
 # --- Optional ---
 # Comma-separated list of allowed CORS origins. Defaults to http://localhost:8000.
 ALLOWED_ORIGINS=http://localhost:8000

--- a/qa-automation/AI-Scoring/.gitignore
+++ b/qa-automation/AI-Scoring/.gitignore
@@ -38,3 +38,5 @@ appsscript.json
 .backfill-skipped.csv
 # Stage-A annotation smoke outputs — verbatim caller speech (PII), never commit
 scripts/annotations/
+# Pulpo compendium snapshots — full internal KB contents, never commit
+scripts/.compendium/

--- a/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
+++ b/qa-automation/AI-Scoring/backend/services/rag/pulpo.py
@@ -171,6 +171,13 @@ class PulpoProvider(RagProvider):
                     return text
         return result
 
+    async def raw_tool_call(self, tool: str, arguments: dict) -> Any:
+        """Raw MCP tool passthrough for OPERATOR tooling (compendium
+        snapshot, admin audits) that needs Pulpo fields the neutral
+        types deliberately drop (created_at, owner, review cadence…).
+        Policy code must keep using the RagProvider surface."""
+        return await self._tool_call(tool, arguments)
+
     # -- shape mapping (Pulpo → neutral) -------------------------------
 
     @staticmethod

--- a/qa-automation/AI-Scoring/references/PulpoCompendium.md
+++ b/qa-automation/AI-Scoring/references/PulpoCompendium.md
@@ -1,0 +1,211 @@
+# PulpoCompendium — weekly SOP snapshot → Google Doc + T2 ack chiclet
+
+> The one-off Pulpo SOP Compendium (2026-07-30: 114 docs, full contents,
+> clickable index, delivered into a user-owned Google Doc) becomes a
+> weekly institution: every Monday 05:00 America/Mexico_City the backend
+> re-snapshots the corpus, refreshes the Doc, and surfaces a **T2
+> chiclet on the QA dashboard** with a change résumé that a manager must
+> acknowledge. The chiclet is written to the REAL Command Center ledger
+> (`command_center.chiclets`) — this feature is the first live writer of
+> the CC chiclet data model, so the future CC alert rail inherits its
+> history unchanged.
+
+| | |
+|---|---|
+| **Status** | v1.0 — 2026-07-31, §6 open questions PENDING owner |
+| **First consumer** | MS managers on `/dashboard/member_support` |
+| **Artifact** | the `PULPO_COMPENDIUM_DOC_ID` Google Doc (user-owned; SA is editor — service accounts have zero Drive quota and can NEVER create files, only edit) |
+| **Pipeline** | `scripts/pulpo_compendium_export.py` (landed with this doc): extract → diff → build → deliver, all stages pytest-covered where pure |
+| **Chiclet semantics** | LandingOpsCommandCenter.md §4 (T2 = ack-required, amber), §6 SSE contract; ack gate mirrors ScorecardActionsDesign §4.3a (`acknowledged: true` or 422) |
+| **Related** | PulpoConnection.md (provider seam, quota citizenship), `disposition_pull.py` (lifespan-task pattern), `event_bus.py` (QA SSE) |
+
+## 1. What exists today (verified in-repo 2026-07-31)
+
+- **Pipeline**: `scripts/pulpo_compendium_export.py` — full-corpus
+  enumeration (trending-90d ∪ tag transitive closure ∪ semantic sweep
+  looped until twice-dry; ~465 rate units on the benchmark token ≈ ¼ of
+  its daily quota), raw `get_document` payloads (created_at, owner,
+  review cadence — fields the neutral RagProvider types deliberately
+  drop; the script uses `PulpoProvider.raw_tool_call`), HTML build
+  (`<a name>` anchors — the ONE form Drive's importer converts to real
+  bookmarks; `id=` variants convert to dead links), delivery via Drive
+  `files.update` + HTML conversion, and a docx-export verification that
+  every internal link resolves. `diff_corpora`/`diff_resume` produce
+  the change résumé.
+- **QA dashboard SSE**: `event_bus.py` (in-memory, per-team fanout) →
+  `GET /api/{team_id}/events/stream` (`routes/events.py`) → inline JS in
+  `frontend/team_dashboard.html` (`openEventStream()`, per-event-name
+  listeners). ONE event exists today (`eval_approved`); the toast stack
+  is hardcoded to its shape.
+- **CC chiclets**: schema only. `command_center.chiclets` +
+  `chiclet_events` (migration 005, constraint-tested) with a `type`
+  CHECK that does NOT include a compendium type. No chiclet runtime, no
+  `cc_event_bus`, no ack endpoint, no CC frontend exists anywhere.
+  NOTE: the `command_center` Python package does not import in prod
+  (Railway root is `qa-automation/AI-Scoring`), but the TABLES are
+  reachable — `backend/services/cc_context.py` already reads
+  `command_center.*` through the shared pool. We follow that pattern.
+- **Scheduling**: `disposition_pull.run_periodic_pull` — env-gated
+  asyncio task spawned in the FastAPI lifespan. Fixed-interval only;
+  no clock-aligned cron exists yet. `America/Mexico_City` (no DST) is
+  already the house TZ constant in three services.
+
+## 2. Principles
+
+1. **The Doc is the artifact; the chiclet is the receipt.** The weekly
+   job never touches the scoring path and never blocks it — failures
+   log and wait for next Monday (non-fatal doctrine, cc_context-style).
+2. **Write the real ledger.** Chiclet rows go to
+   `command_center.chiclets` (type CHECK widened by migration), events
+   to `chiclet_events`, SSE payloads follow the LandingOpsCommandCenter
+   §6 contract verbatim — published on the QA team bus only until the
+   designed `/cc/{team}/events` stream exists, at which point the
+   publish site moves and history is already in place.
+3. **Ack is a duty gate, §4.3a style.** `acknowledged: true` in the
+   request or 422. One manager ack resolves the chiclet team-wide
+   (chiclets are team-scoped rows; CC doctrine §4).
+4. **Quota citizenship.** Benchmark token, Monday 05:00 (quietest
+   window), the script's existing pacing. Steady-state cost is known:
+   ~465 units against 2,000/day.
+5. **Env-gated, off by default** (the `CC_STATS_PULL_INTERVAL_MIN`
+   pattern): unset `PULPO_COMPENDIUM_WEEKLY` = feature absent. Flip is
+   a Railway env change, no deploy.
+
+## 3. Design
+
+### 3.1 Migration 019
+
+- `command_center.chiclets`: widen `chiclets_type_check` to add
+  **`compendium_update`** (the 018 pattern — drop + re-add CHECK).
+- **`qa.pulpo_compendium_snapshots`**: `id IDENTITY, taken_at
+  TIMESTAMPTZ NOT NULL DEFAULT NOW(), doc_count INT NOT NULL, doc_url
+  TEXT NOT NULL, summary JSONB NOT NULL` — `summary` is the lean
+  per-doc census `[{id, title, updated_at, open_flag_count, status,
+  tags}]` (~40 KB/week, permanent retention), the diff base for the
+  next run AND the missed-run watermark. The full corpus JSON is not
+  stored server-side: the Google Doc is the artifact.
+
+### 3.2 `backend/services/pulpo_compendium.py` (stages move in-repo)
+
+The script's stage functions (`extract_corpus`, `merged_entries`,
+`diff_corpora`, `diff_resume`, `build_html`, `deliver_html`) move here;
+`scripts/pulpo_compendium_export.py` becomes a thin CLI over the same
+module (single source of truth; existing tests re-point). New:
+`snapshot_summary(corpus)` (census for the table) and
+`run_snapshot(pool)` orchestrating: extract → load last summary → diff
+→ build → deliver (verify) → insert snapshot row → chiclet write +
+SSE publish per team. Delivery-verification failure aborts BEFORE the
+snapshot insert, so the next successful run diffs against the last
+GOOD delivery.
+
+### 3.3 Weekly scheduler — `run_weekly()` lifespan task
+
+- Clock-aligned, not interval: sleep until next Monday 05:00
+  `America/Mexico_City` (zoneinfo; no-DST TZ makes the arithmetic
+  boring — still computed via zoneinfo, never a fixed offset).
+- **Missed-run catch-up**: on startup, if the latest
+  `pulpo_compendium_snapshots.taken_at` is > 8 days old (or the table
+  is empty and the env gate is on), run once immediately — Railway
+  restarts and deploy timing must not silently skip a week.
+- Spawned/cancelled in `main.py` lifespan exactly like the disposition
+  pull; gated on `PULPO_COMPENDIUM_WEEKLY=1` AND
+  `PULPO_COMPENDIUM_DOC_ID` present.
+
+### 3.4 Chiclet write + SSE
+
+Per team in `PULPO_COMPENDIUM_NOTIFY_TEAMS` (comma list, default
+`member_support`):
+
+- INSERT `command_center.chiclets`: `type='compendium_update'`,
+  `tier='T2'`, `status='active'`, `summary=<diff_resume string>`,
+  `data={doc_url, diff:{added,removed,updated,flag_changes,total_docs},
+  stats:{rate_units, fetched}}`.
+- INSERT `chiclet_events` (`event_type='created'`, payload = SSE data).
+- `get_event_bus().publish(team_id, "chiclet_created", {"id", "tier": 2,
+  "type": "compendium_update", "chiclet": {"title": "Pulpo Compendium
+  updated", "summary": <résumé>, "doc_url": …, "created_at": …}})` —
+  the §6 CC contract shape (integer tier in SSE, `T2` string in SQL,
+  matching the doc's own convention).
+- First-ever run (no previous snapshot): résumé reads
+  `"first snapshot: N docs"` — no fake diff against an empty corpus.
+
+### 3.5 Routes — `backend/routes/chiclets.py` (mounted `/api/{team_id}`, team auth)
+
+- `GET /chiclets?status=active` → team's chiclets (dashboard boot
+  re-render; SSE alone is not durable — the bus drops on full queues).
+- `POST /chiclets/{id}/ack` body `{acknowledged: true, evaluator_email}`
+  → 422 unless `acknowledged is True` (§4.3a gate verbatim); UPDATE
+  `status='resolved', resolved_at=NOW(), resolved_by=<email>` (the 005
+  resolved-pair CHECK enforces completeness); INSERT `chiclet_events`
+  (`'resolved'`); publish `chiclet_resolved` `{"id", "resolved_by":
+  "manual_ack"}`. Idempotent: acking an already-resolved chiclet
+  returns 200 with current state. 404 on team mismatch.
+
+### 3.6 Dashboard UI (`frontend/team_dashboard.html` only)
+
+- Generalize `showToast` to also accept a system shape
+  `{title, summary, href}` (existing eval shape untouched).
+- New SSE listeners: `chiclet_created` → render pinned card + toast
+  ("Pulpo Compendium updated" + résumé); `chiclet_resolved` → remove
+  card (any manager's ack clears every open dashboard).
+- Pinned **T2 card**: amber left-border (CC §4 tier vocabulary), fixed
+  above the toast container; title, résumé, `[Open compendium]`
+  (doc_url, new tab), `[Acknowledge]` → POST ack with
+  `evaluator_email` prompted once and cached in
+  `sessionStorage['qa_evaluator_email']` (scorecard-page convention).
+  NOT auto-dismissed — it outlives reloads via the boot fetch.
+- Boot: after `openEventStream()`, `GET /chiclets?status=active` →
+  render pending cards.
+
+### 3.7 Env (+ `.env.example`, Railway)
+
+```
+PULPO_COMPENDIUM_WEEKLY=1          # gate; unset = feature off
+PULPO_COMPENDIUM_DOC_ID=…          # existing user-owned Doc (SA editor)
+PULPO_COMPENDIUM_NOTIFY_TEAMS=member_support
+PULPO_MCP_BENCHMARK_TOKEN=…        # already provisioned
+```
+
+## 4. Failure semantics
+
+| Failure | Behavior |
+|---|---|
+| extract/deliver error (incl. link-verification) | log loudly; NO snapshot row, NO chiclet; next Monday (or restart catch-up) retries |
+| chiclet insert fails after delivery | log; Doc is fresh, receipt missing — next run's diff is unaffected (snapshot row committed) |
+| SSE publish fails / queue full | non-fatal; the chiclet ROW is the truth, boot fetch renders it |
+| backend down at Monday 05:00 | §3.3 catch-up on next startup |
+
+## 5. Rollout
+
+`unset` (today) → set the three env vars in Railway → next Monday runs
+live; or set locally + run the CLI once (`--corpus` reuse for dry
+runs). Watch-paths note: all changes live under
+`qa-automation/AI-Scoring/`, so merges auto-deploy.
+
+## 6. Open questions (owner)
+
+1. **Notify teams** — `member_support` only at launch, Sales later?
+2. **Ack scope** — one manager's ack resolves team-wide (CC doctrine;
+   recommended). Alternative (per-manager acks) needs a table 005
+   doesn't have.
+3. **Ledger** — writing `command_center.chiclets` via CHECK-widening
+   (recommended: first real writer of the scoped CC data model) vs. a
+   QA-side table (rejected: duplicate vocabulary, orphaned history when
+   the CC rail ships).
+4. **Catch-up window** — run-on-startup when the last snapshot is > 8
+   days old (recommended) vs. strictly-Monday-only.
+5. **Ack identity** — prompted + cached `evaluator_email` (scorecard
+   convention) vs. no identity (plain click). §4.3a spirit says named.
+
+## 7. Build plan (each slice one PR, pytest-gated)
+
+| # | Slice | Checkpoint |
+|---|---|---|
+| C1 | Migration 019 (+down) | integration tests: widened type CHECK accepts `compendium_update`, snapshots-table constraints |
+| C2 | Stages → `backend/services/pulpo_compendium.py`; script becomes thin CLI | existing `test_pulpo_compendium.py` re-pointed and green; CLI smoke (`--corpus … --skip-deliver`) |
+| C3 | `run_weekly` scheduler + `run_snapshot` wiring (env-gated) | unit: next-Monday-05:00 computation, catch-up predicate; job test with mocked provider + Drive |
+| C4 | Chiclet write + routes + SSE publish | route tests: ack gate 422, resolved-pair invariant, team scoping, idempotent re-ack, `chiclet_created`/`chiclet_resolved` on the bus |
+| C5 | Dashboard card + generalized toast + boot fetch | manual smoke on `/dashboard/member_support`; SSE contract pinned by C4 tests |
+
+C1–C2 are risk-free (no runtime change); C3 is inert until the env
+gate flips; C4–C5 land the visible feature.

--- a/qa-automation/AI-Scoring/requirements.txt
+++ b/qa-automation/AI-Scoring/requirements.txt
@@ -9,5 +9,6 @@ python-dotenv>=1.0.0
 pandas>=2.0.0
 numpy>=1.24.0
 asyncpg>=0.30.0
+markdown>=3.6
 pyjwt>=2.8.0
 anthropic>=0.120.0

--- a/qa-automation/AI-Scoring/scripts/pulpo_compendium_export.py
+++ b/qa-automation/AI-Scoring/scripts/pulpo_compendium_export.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""Pulpo SOP Compendium — full-corpus snapshot → Google Doc.
+
+Read-only against Pulpo (benchmark token by default — separate quota
+pool, never starves production scoring). Three stages, each skippable:
+
+  extract   enumerate the ENTIRE corpus (union of trending-90d, tag
+            transitive closure, and a semantic sweep looped until
+            twice-dry), then one raw get_document per id. Raw payloads
+            are preserved — created_at/owner/review fields included.
+  build     corpus JSON → compendium HTML: clickable index (the ONE
+            anchor form Drive's importer converts to real bookmarks is
+            <a name>), tag map, untagged section, full contents with
+            metadata tables, open-flag callouts, Mermaid flowcharts.
+  deliver   Drive files.update with HTML→Doc conversion into an
+            EXISTING Google Doc (service accounts have zero Drive
+            storage quota — they can never files.create; the target
+            doc must be user-owned, shared to the SA as editor), then
+            a docx-export verification that every internal link
+            resolves to a real bookmark.
+
+Also computes a change résumé vs a previous corpus snapshot (--prev):
+added / removed / updated docs, flag and status deltas — the weekly
+job's chiclet body.
+
+Usage:
+    cd qa-automation/AI-Scoring
+    python3 scripts/pulpo_compendium_export.py                # full run
+        [--doc-id …]          target Google Doc (default:
+                              $PULPO_COMPENDIUM_DOC_ID)
+        [--out-dir …]         artifacts dir (default: scripts/.compendium)
+        [--corpus path.json]  skip extract, reuse a snapshot
+        [--prev path.json]    previous snapshot for the change résumé
+        [--skip-deliver]      stop after build (writes HTML only)
+        [--token-env NAME]    default PULPO_MCP_BENCHMARK_TOKEN
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import html as htmlmod
+import io
+import json
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_AI_SCORING))
+load_dotenv(_AI_SCORING / ".env")
+
+GENERATED_TZ = "America/Mexico_City"
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+
+SEED_TAGS = [
+    "nmt", "ota", "verifications", "sofia", "member_support",
+    "coach-card", "onboarding", "sales", "qa", "billing", "payments",
+    "maintenance", "cleaning", "standby", "transfers", "renewals",
+    "engineering", "troubleshooting", "how-to", "policies",
+]
+
+TOPIC_PROBES = [
+    "standby cancellation policy and refunds",
+    "security deposit and damages",
+    "member verification steps",
+    "reservation extension and renewal",
+    "OTA booking change or cancellation",
+    "maintenance request escalation",
+    "cleaning and housekeeping standards",
+    "payment failure and collections",
+    "move-in and move-out process",
+    "transfer to another unit",
+    "lease and membership terms",
+    "pricing discounts and promotions",
+    "escalation to supervisor",
+    "pet policy",
+    "parking policy",
+    "wifi and utilities setup",
+    "lockout and key access",
+    "furniture and appliance issues",
+    "pest control",
+    "noise complaint handling",
+    "refund processing timeline",
+    "chargeback dispute",
+    "identity fraud check",
+    "background check requirements",
+    "corporate housing accounts",
+    "guest policy",
+    "early termination fees",
+    "billing cycle and invoices",
+    "app troubleshooting",
+    "is Landing legit",
+    "customer trust and safety",
+    "emergency after hours support",
+    "sales pitch and objection handling",
+    "tour scheduling",
+    "waitlist process",
+    "referral program",
+    "credit and promo codes",
+    "insurance requirements",
+    "smoking policy violation",
+    "package delivery and mail",
+]
+
+RATE_LIMIT_WAIT_S = 65
+PACE_EVERY = 10          # spend ~10 rate units, then pause
+PACE_SLEEP_S = 12
+HARVEST_STOP_WORDS = {"landing", "with", "from", "your", "this", "that",
+                      "sops", "what"}
+
+
+class _Pacer:
+    """60/min per token, and the limiter rejects bursts exceeding the
+    REMAINING minute allowance (observed live 2026-07-22): small spends
+    with pauses beat big bursts."""
+
+    def __init__(self):
+        self._since_pause = 0
+        self.total = 0
+
+    async def spend(self, units: int):
+        self._since_pause += units
+        self.total += units
+        if self._since_pause >= PACE_EVERY:
+            await asyncio.sleep(PACE_SLEEP_S)
+            self._since_pause = 0
+
+
+async def _call(provider, pacer, tool, args, units=1):
+    await pacer.spend(units)
+    try:
+        return await provider.raw_tool_call(tool, args)
+    except Exception as e:
+        if "rate_limited" not in str(e):
+            raise
+        print(f"  rate-limited on {tool} — waiting {RATE_LIMIT_WAIT_S}s", flush=True)
+        await asyncio.sleep(RATE_LIMIT_WAIT_S)
+        return await provider.raw_tool_call(tool, args)
+
+
+def _norm_results(payload):
+    if not isinstance(payload, dict):
+        return []
+    if "documents" in payload:
+        return payload.get("documents") or []
+    if "results" in payload:
+        return payload.get("results") or []
+    if "batches" in payload:
+        out = []
+        for b in payload.get("batches") or []:
+            out.extend(b.get("results") or [])
+        return out
+    return []
+
+
+async def _disposition_labels() -> list[str]:
+    """Same source as the coverage probe; non-fatal fallback to []."""
+    try:
+        import asyncpg
+        conn = await asyncpg.connect(os.environ["DATABASE_URL"], timeout=10)
+        try:
+            rows = await conn.fetch(
+                """
+                SELECT DISTINCT disposition_category, disposition
+                FROM command_center.calls
+                WHERE disposition_category IS NOT NULL
+                """
+            )
+        finally:
+            await conn.close()
+        return [f"{r['disposition_category']} — {r['disposition']}"
+                if r["disposition"] else r["disposition_category"]
+                for r in rows]
+    except Exception as e:
+        print(f"  disposition labels unavailable ({e!r:.80}) — sweep "
+              f"proceeds without them", flush=True)
+        return []
+
+
+async def extract_corpus(provider) -> dict:
+    """Enumerate + fetch the whole corpus. Returns the snapshot dict
+    (raw listing + raw get_document payload per doc)."""
+    pacer = _Pacer()
+    docs: dict[str, dict] = {}
+    sources: dict[str, list] = {}
+    tags_seen: set[str] = set(SEED_TAGS)
+    tags_listed: set[str] = set()
+    queries_sent: set[str] = set()
+
+    def absorb(results, source):
+        new = 0
+        for r in results:
+            rid = str(r.get("id", ""))
+            if not rid:
+                continue
+            if rid not in docs:
+                docs[rid] = dict(r)
+                sources[rid] = []
+                new += 1
+            else:
+                for k, v in r.items():
+                    if v not in (None, "", [], 0) and not docs[rid].get(k):
+                        docs[rid][k] = v
+            if source not in sources[rid]:
+                sources[rid].append(source)
+            for t in (r.get("tags") or []):
+                tags_seen.add(str(t).lower())
+        return new
+
+    async def list_pending_tags():
+        added = 0
+        while True:
+            pending = sorted(tags_seen - tags_listed)
+            if not pending:
+                return added
+            for tag in pending:
+                tags_listed.add(tag)
+                payload = await _call(provider, pacer, "list_documents_by_tag",
+                                      {"tags": [tag], "limit": 50})
+                results = _norm_results(payload)
+                if len(results) == 50:
+                    print(f"  WARNING tag {tag!r} returned exactly 50 — "
+                          f"possible truncation", flush=True)
+                added += absorb(results, f"tag:{tag}")
+
+    async def sweep(queries, round_name):
+        fresh = [q[:500] for q in queries if q and q not in queries_sent]
+        added = 0
+        for i in range(0, len(fresh), 10):
+            chunk = fresh[i:i + 10]
+            queries_sent.update(chunk)
+            payload = await _call(provider, pacer, "search_knowledge_base",
+                                  {"queries": chunk, "limit": 20, "rerank": False},
+                                  units=len(chunk))
+            for b in (payload.get("batches") or []) if isinstance(payload, dict) else []:
+                added += absorb(b.get("results") or [],
+                                f"search:{b.get('query', '?')[:60]}")
+        print(f"  sweep {round_name!r}: {len(fresh)} queries, +{added} new "
+              f"(total {len(docs)})", flush=True)
+        return added
+
+    print("extract: trending (90d)", flush=True)
+    payload = await _call(provider, pacer, "get_trending_documents",
+                          {"window_days": 90, "limit": 50})
+    absorb(_norm_results(payload), "trending:90d")
+
+    print("extract: tag closure", flush=True)
+    await list_pending_tags()
+
+    print("extract: search sweep", flush=True)
+    await sweep(await _disposition_labels(), "dispositions")
+    await sweep(TOPIC_PROBES, "topic probes")
+    await sweep([t.replace("-", " ").replace("_", " ")
+                 for t in sorted(tags_seen)], "tag names")
+
+    dry, round_no = 0, 0
+    while dry < 2:
+        round_no += 1
+        words = {w.lower()
+                 for d in docs.values()
+                 for w in re.findall(r"[A-Za-z]{4,}", d.get("title", ""))}
+        harvest = sorted(w for w in words
+                         if w not in HARVEST_STOP_WORDS and w not in queries_sent)
+        if not harvest:
+            break
+        added = await sweep(harvest[:60], f"harvest-{round_no}")
+        added += await list_pending_tags()
+        dry = dry + 1 if added == 0 else 0
+
+    print(f"extract: get_document x {len(docs)}", flush=True)
+    full: dict[str, dict] = {}
+    for i, rid in enumerate(sorted(docs)):
+        payload = await _call(provider, pacer, "get_document", {"id": rid})
+        raw = (payload.get("document")
+               if isinstance(payload, dict) and isinstance(payload.get("document"), dict)
+               else payload)
+        if isinstance(raw, dict) and raw.get("id"):
+            full[rid] = raw
+        else:
+            print(f"  WARNING get_document({rid}) → unusable payload", flush=True)
+        if (i + 1) % 20 == 0:
+            print(f"  {i + 1}/{len(docs)}", flush=True)
+
+    return {
+        "generated_note": "raw Pulpo MCP payloads; listing metadata under "
+                          "'listing', full get_document under 'document'",
+        "stats": {
+            "unique_docs": len(docs),
+            "fetched": len(full),
+            "tags_listed": sorted(tags_listed),
+            "queries_sent": len(queries_sent),
+            "rate_units_spent": pacer.total,
+        },
+        "docs": [{"id": rid, "listing": docs[rid], "sources": sources[rid],
+                  "document": full.get(rid)}
+                 for rid in sorted(docs)],
+    }
+
+
+# ---------------------------------------------------------------------------
+# diff (the weekly chiclet's résumé)
+# ---------------------------------------------------------------------------
+
+def merged_entries(corpus: dict) -> list[dict]:
+    """listing ∪ document (document wins), sorted by title."""
+    entries = []
+    for row in corpus["docs"]:
+        listing = row.get("listing") or {}
+        doc = row.get("document") or {}
+        merged = {**listing,
+                  **{k: v for k, v in doc.items() if v not in (None, "", [], {})}}
+        if merged.get("id"):
+            entries.append(merged)
+    entries.sort(key=lambda d: (d.get("title") or "").lower())
+    return entries
+
+
+def diff_corpora(prev: dict, curr: dict) -> dict:
+    """Change résumé between two snapshots: what a manager should skim."""
+    old = {d["id"]: d for d in merged_entries(prev)}
+    new = {d["id"]: d for d in merged_entries(curr)}
+    added = [new[i]["title"] for i in new if i not in old]
+    removed = [old[i]["title"] for i in old if i not in new]
+    updated, flag_changes = [], []
+    for i in set(old) & set(new):
+        if (new[i].get("updated_at") or "") != (old[i].get("updated_at") or ""):
+            updated.append(new[i]["title"])
+        old_flags = len(old[i].get("open_flags") or [])
+        new_flags = len(new[i].get("open_flags") or [])
+        if new_flags != old_flags:
+            flag_changes.append(
+                f"{new[i]['title']} ({old_flags}→{new_flags} open flags)")
+    return {
+        "added": sorted(added),
+        "removed": sorted(removed),
+        "updated": sorted(updated),
+        "flag_changes": sorted(flag_changes),
+        "total_docs": len(new),
+    }
+
+
+def diff_resume(diff: dict, limit: int = 3) -> str:
+    """One-liner résumé for the toast/chiclet body."""
+
+    def clip(names):
+        head = ", ".join(names[:limit])
+        more = len(names) - limit
+        return head + (f" +{more} more" if more > 0 else "")
+
+    parts = []
+    if diff["added"]:
+        parts.append(f"{len(diff['added'])} new: {clip(diff['added'])}")
+    if diff["updated"]:
+        parts.append(f"{len(diff['updated'])} updated: {clip(diff['updated'])}")
+    if diff["removed"]:
+        parts.append(f"{len(diff['removed'])} removed: {clip(diff['removed'])}")
+    if diff["flag_changes"]:
+        parts.append(f"flags: {clip(diff['flag_changes'])}")
+    if not parts:
+        parts.append("no changes")
+    return f"{diff['total_docs']} docs — " + "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# build
+# ---------------------------------------------------------------------------
+
+MD_EXT = ["tables", "fenced_code", "sane_lists"]
+
+
+def _esc(s):
+    return htmlmod.escape(str(s or ""), quote=True)
+
+
+def _date(v):
+    s = str(v or "").strip()
+    if not s:
+        return "—"
+    m = re.match(r"(\d{4}-\d{2}-\d{2})[T ]?(\d{2}:\d{2})?", s)
+    if m:
+        return m.group(1) + (f" {m.group(2)}" if m.group(2) else "")
+    return s[:32]
+
+
+def build_html(corpus: dict, generated_on: str) -> str:
+    import markdown
+
+    entries = merged_entries(corpus)
+    tagged = [d for d in entries if d.get("tags")]
+    untagged = [d for d in entries if not d.get("tags")]
+    open_flagged = [d for d in entries if d.get("open_flags")]
+    flowcharts = [d for d in entries if d.get("body_format") == "flowchart"]
+    status_flagged = [d for d in entries if d.get("status") == "flagged"]
+
+    tag_map: dict[str, list] = {}
+    for d in entries:
+        for t in (d.get("tags") or []):
+            tag_map.setdefault(str(t).lower(), []).append(d)
+
+    anchor = {d["id"]: f"doc-{i+1}" for i, d in enumerate(entries)}
+
+    p = ["<h1>Pulpo SOP Compendium</h1>"]
+    p.append(
+        f"<p><b>Generated {generated_on}</b> from the live Pulpo knowledge "
+        f"base (plasticity.heypulpo.com) over MCP, using the QA benchmark "
+        f"token (both audiences, unassigned — the reproducible QA view: "
+        f"every published doc, no person-private docs).</p>")
+    p.append("<table border='1' cellpadding='4'>")
+    p.append(f"<tr><td>Total documents</td><td>{len(entries)}</td></tr>")
+    p.append(f"<tr><td>Tagged / untagged</td><td>{len(tagged)} / {len(untagged)}</td></tr>")
+    p.append(f"<tr><td>Distinct tags</td><td>{len(tag_map)}</td></tr>")
+    p.append(f"<tr><td>Verification status</td><td>"
+             f"{sum(1 for d in entries if d.get('status') == 'verified')} verified, "
+             f"{len(status_flagged)} flagged</td></tr>")
+    p.append(f"<tr><td>Docs with open review flags</td><td>{len(open_flagged)}</td></tr>")
+    p.append(f"<tr><td>Flowchart (Mermaid) documents</td><td>{len(flowcharts)}</td></tr>")
+    p.append(f"<tr><td>Audiences</td><td>"
+             f"{sum(1 for d in entries if 'customer' in (d.get('audiences') or []))} "
+             f"customer-readable, rest internal-only</td></tr>")
+    p.append("</table>")
+    p.append(
+        "<p><i>Method: union of trending-documents (90-day window), full tag "
+        "transitive closure, and a semantic search sweep looped until twice "
+        "dry. Contents are verbatim document bodies from get_document. "
+        "Timestamps are as exposed by the platform (UTC).</i></p>")
+
+    p.append("<h1>Index</h1>")
+    p.append("<table border='1' cellpadding='4'>")
+    p.append("<tr><th>#</th><th>Title</th><th>Tags</th><th>Created</th>"
+             "<th>Updated</th><th>⚑</th></tr>")
+    for i, d in enumerate(entries):
+        marks = []
+        if d.get("open_flags"):
+            marks.append(f"⚑{len(d['open_flags'])}")
+        if d.get("status") == "flagged":
+            marks.append("status:flagged")
+        p.append(
+            f"<tr><td>{i+1}</td>"
+            f"<td><a href='#{anchor[d['id']]}'>{_esc(d.get('title'))}</a></td>"
+            f"<td>{_esc(', '.join(d.get('tags') or []) or '—')}</td>"
+            f"<td>{_date(d.get('created_at'))}</td>"
+            f"<td>{_date(d.get('updated_at'))}</td>"
+            f"<td>{' '.join(marks)}</td></tr>")
+    p.append("</table>")
+
+    p.append("<h2>Documents by tag</h2>")
+    for t in sorted(tag_map):
+        links = " · ".join(f"<a href='#{anchor[d['id']]}'>{_esc(d.get('title'))}</a>"
+                           for d in tag_map[t])
+        p.append(f"<p><b>{_esc(t)}</b> ({len(tag_map[t])}): {links}</p>")
+    if untagged:
+        links = " · ".join(f"<a href='#{anchor[d['id']]}'>{_esc(d.get('title'))}</a>"
+                           for d in untagged)
+        p.append(f"<p><b>UNTAGGED</b> ({len(untagged)}): {links}</p>")
+
+    p.append("<h1>Contents</h1>")
+    for i, d in enumerate(entries):
+        # <a name> is the ONE anchor form Drive's HTML importer turns into
+        # a real Docs bookmark (id= variants convert to dead links).
+        p.append(f"<h2><a name='{anchor[d['id']]}'></a>{i+1}. "
+                 f"{_esc(d.get('title'))}</h2>")
+        p.append("<table border='1' cellpadding='4'>")
+        p.append(f"<tr><td>Tags</td><td>"
+                 f"{_esc(', '.join(d.get('tags') or []) or '(untagged)')}</td></tr>")
+        p.append(f"<tr><td>Created</td><td>{_date(d.get('created_at'))}</td></tr>")
+        p.append(f"<tr><td>Last updated</td><td>{_date(d.get('updated_at'))}</td></tr>")
+        cad = d.get("review_cadence") or ""
+        p.append(f"<tr><td>Verification</td><td>status: "
+                 f"{_esc(d.get('status') or '?')} · last verified "
+                 f"{_date(d.get('last_verified_at'))} · next review "
+                 f"{_date(d.get('next_review_at'))}"
+                 f"{' (' + _esc(cad) + ')' if cad else ''}</td></tr>")
+        if d.get("owner_name"):
+            p.append(f"<tr><td>Owner</td><td>{_esc(d['owner_name'])}</td></tr>")
+        p.append(f"<tr><td>Audiences</td><td>"
+                 f"{_esc(', '.join(d.get('audiences') or []) or 'internal')}</td></tr>")
+        if d.get("body_format") == "flowchart":
+            p.append("<tr><td>Format</td><td>flowchart (Mermaid)</td></tr>")
+        if d.get("url"):
+            p.append(f"<tr><td>Pulpo link</td><td><a href='{_esc(d['url'])}'>"
+                     f"{_esc(d['url'])}</a></td></tr>")
+        p.append(f"<tr><td>Document id</td><td>{_esc(d['id'])}</td></tr>")
+        p.append("</table>")
+
+        if d.get("summary"):
+            p.append(f"<p><i><b>Summary:</b> {_esc(d['summary'])}</i></p>")
+
+        open_flags = d.get("open_flags") or []
+        if open_flags:
+            p.append(f"<p><b>⚑ {len(open_flags)} open review flag(s) — "
+                     "verify flagged passages before acting:</b></p>")
+            for f in open_flags:
+                line = f"<blockquote>“{_esc(f.get('quote'))}”"
+                if f.get("body"):
+                    line += f"<br><b>Concern:</b> {_esc(f['body'])}"
+                if f.get("suggestion"):
+                    line += f"<br><b>Suggested fix:</b> {_esc(f['suggestion'])}"
+                p.append(line + "</blockquote>")
+
+        body = d.get("body") or ""
+        if d.get("body_format") == "flowchart":
+            p.append("<p><i>Process flowchart stored as Mermaid source — read "
+                     "as a decision graph. %% def lines carry each node's full "
+                     "rule; %% always / %% never lines are doc-wide "
+                     "guardrails.</i></p>")
+            p.append(f"<pre>{_esc(body)}</pre>")
+        elif body:
+            p.append(markdown.markdown(body, extensions=MD_EXT))
+        else:
+            p.append("<p><i>(empty body)</i></p>")
+        p.append("<hr>")
+
+    return ("<html><head><meta charset='utf-8'>"
+            "<title>Pulpo SOP Compendium</title></head><body>"
+            + "\n".join(p) + "</body></html>")
+
+
+# ---------------------------------------------------------------------------
+# deliver
+# ---------------------------------------------------------------------------
+
+def _sa_headers() -> dict:
+    import google.auth.transport.requests
+    from google.oauth2.service_account import Credentials
+
+    raw = os.environ["GOOGLE_SERVICE_ACCOUNT_JSON"]
+    scopes = ["https://www.googleapis.com/auth/drive"]
+    if raw.strip().startswith("{"):
+        creds = Credentials.from_service_account_info(json.loads(raw), scopes=scopes)
+    else:
+        creds = Credentials.from_service_account_file(raw, scopes=scopes)
+    creds.refresh(google.auth.transport.requests.Request())
+    return {"Authorization": f"Bearer {creds.token}"}
+
+
+def deliver_html(doc_id: str, html: str) -> dict:
+    """Replace the target Google Doc's content with `html` (Drive
+    update-with-conversion), then verify via docx export that every
+    internal link resolves to a real bookmark. Returns a report dict;
+    raises RuntimeError on hard failure."""
+    import httpx
+
+    headers = _sa_headers()
+    r = httpx.get(f"https://www.googleapis.com/drive/v3/files/{doc_id}",
+                  params={"supportsAllDrives": "true",
+                          "fields": "id,name,mimeType,capabilities(canModifyContent)"},
+                  headers=headers, timeout=30)
+    if r.status_code != 200:
+        raise RuntimeError(f"files.get failed HTTP {r.status_code}: {r.text[:200]}")
+    meta = r.json()
+    if meta["mimeType"] != "application/vnd.google-apps.document":
+        raise RuntimeError(f"target {doc_id} is not a Google Doc")
+    if not meta.get("capabilities", {}).get("canModifyContent"):
+        raise RuntimeError("service account cannot modify this doc")
+
+    boundary = "B0UNDARYpulpo"
+    body = (
+        f"--{boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n"
+        + json.dumps({"mimeType": "application/vnd.google-apps.document"})
+        + f"\r\n--{boundary}\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n"
+    ).encode() + html.encode() + f"\r\n--{boundary}--".encode()
+    r = httpx.patch(
+        f"https://www.googleapis.com/upload/drive/v3/files/{doc_id}",
+        params={"uploadType": "multipart", "supportsAllDrives": "true"},
+        headers={**headers,
+                 "Content-Type": f"multipart/related; boundary={boundary}"},
+        content=body, timeout=180)
+    if r.status_code != 200:
+        raise RuntimeError(f"update failed HTTP {r.status_code}: {r.text[:300]}")
+
+    # Verify via docx export — the HTML export omits bookmark elements,
+    # so bookmarks vs hyperlink anchors in the OOXML is the ground truth.
+    r = httpx.get(
+        f"https://www.googleapis.com/drive/v3/files/{doc_id}/export",
+        params={"mimeType": "application/vnd.openxmlformats-officedocument"
+                            ".wordprocessingml.document"},
+        headers=headers, timeout=300)
+    if r.status_code != 200:
+        raise RuntimeError(f"verify export failed HTTP {r.status_code}")
+    xml = zipfile.ZipFile(io.BytesIO(r.content)).read("word/document.xml").decode()
+    bookmarks = set(re.findall(r'w:bookmarkStart[^>]*w:name="([^"]+)"', xml))
+    anchors = re.findall(r'w:hyperlink[^>]*w:anchor="([^"]+)"', xml)
+    resolved = sum(1 for a in anchors if a in bookmarks)
+    expected = len(set(re.findall(r"<a name='(doc-[^']*)'", html)))
+    report = {
+        "doc_name": meta["name"],
+        "sections": expected,
+        "bookmarks": len(bookmarks),
+        "internal_links": len(anchors),
+        "resolved": resolved,
+        "links_ok": bool(anchors) and resolved == len(anchors)
+                    and len(bookmarks) >= expected,
+        "url": f"https://docs.google.com/document/d/{doc_id}/edit",
+    }
+    if not report["links_ok"]:
+        raise RuntimeError(f"internal-link verification failed: {report}")
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+async def _amain() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0], allow_abbrev=False)
+    ap.add_argument("--doc-id", default=os.environ.get("PULPO_COMPENDIUM_DOC_ID", ""))
+    ap.add_argument("--out-dir", default=str(_AI_SCORING / "scripts" / ".compendium"))
+    ap.add_argument("--corpus", default=None,
+                    help="reuse an existing snapshot JSON (skip extract)")
+    ap.add_argument("--prev", default=None,
+                    help="previous snapshot JSON for the change résumé")
+    ap.add_argument("--skip-deliver", action="store_true")
+    ap.add_argument("--token-env", default="PULPO_MCP_BENCHMARK_TOKEN")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    now = datetime.now(ZoneInfo(GENERATED_TZ))
+    stamp = now.strftime("%Y-%m-%d")
+
+    if args.corpus:
+        corpus = json.loads(Path(args.corpus).read_text(encoding="utf-8"))
+        print(f"corpus: reused {args.corpus} "
+              f"({corpus['stats']['fetched']} docs)")
+    else:
+        from backend.services.rag.pulpo import build_from_env
+        provider = build_from_env(args.token_env)
+        if provider is None:
+            print(f"ERROR: PULPO_MCP_URL / {args.token_env} not set")
+            return 1
+        try:
+            corpus = await extract_corpus(provider)
+        finally:
+            await provider.aclose()
+        corpus_path = out_dir / f"pulpo_corpus_{stamp}.json"
+        corpus_path.write_text(json.dumps(corpus, indent=1, ensure_ascii=False),
+                               encoding="utf-8")
+        print(f"corpus: {corpus['stats']['fetched']} docs, "
+              f"{corpus['stats']['rate_units_spent']} rate units → {corpus_path}")
+
+    if args.prev:
+        prev = json.loads(Path(args.prev).read_text(encoding="utf-8"))
+        resume = diff_resume(diff_corpora(prev, corpus))
+        print(f"changes vs previous: {resume}")
+
+    html = build_html(corpus, generated_on=now.strftime("%Y-%m-%d %H:%M %Z"))
+    html_path = out_dir / f"compendium_{stamp}.html"
+    html_path.write_text(html, encoding="utf-8")
+    print(f"html: {len(html)} chars → {html_path}")
+    if len(html) > 900_000:
+        print("WARNING: nearing Google Docs' ~1.02M char ceiling")
+
+    if args.skip_deliver:
+        return 0
+    if not args.doc_id:
+        print("ERROR: no --doc-id and PULPO_COMPENDIUM_DOC_ID unset")
+        return 1
+    report = deliver_html(args.doc_id, html)
+    print(f"delivered to {report['doc_name']!r}: "
+          f"{report['resolved']}/{report['internal_links']} links resolve "
+          f"across {report['bookmarks']} bookmarks")
+    print(f"doc url: {report['url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_amain()))

--- a/qa-automation/AI-Scoring/tests/test_pulpo_compendium.py
+++ b/qa-automation/AI-Scoring/tests/test_pulpo_compendium.py
@@ -1,0 +1,111 @@
+"""Pure-stage tests for scripts/pulpo_compendium_export.py — diff/résumé
+logic and the HTML build invariants that make the Google Doc's index
+actually clickable (the <a name> bookmark contract)."""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+_AI_SCORING = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "pulpo_compendium_export",
+    _AI_SCORING / "scripts" / "pulpo_compendium_export.py",
+)
+comp = importlib.util.module_from_spec(_spec)
+sys.modules["pulpo_compendium_export"] = comp
+_spec.loader.exec_module(comp)
+
+
+def _corpus(docs):
+    return {"stats": {"fetched": len(docs)},
+            "docs": [{"id": d["id"], "listing": {}, "sources": [],
+                      "document": d} for d in docs]}
+
+
+def _doc(i, **over):
+    d = {
+        "id": f"id-{i}",
+        "title": f"Doc {i}",
+        "body": f"Body of doc {i}",
+        "tags": ["nmt"],
+        "created_at": "2026-07-01T00:00:00Z",
+        "updated_at": "2026-07-02T00:00:00Z",
+        "last_verified_at": "2026-07-02T00:00:00Z",
+        "next_review_at": "2026-08-02T00:00:00Z",
+        "review_cadence": "monthly",
+        "status": "verified",
+        "owner_name": "Owner",
+        "audiences": ["internal"],
+        "open_flags": [],
+        "url": f"https://example.test/docs/id-{i}",
+        "body_format": "markdown",
+    }
+    d.update(over)
+    return d
+
+
+# -- diff / résumé -----------------------------------------------------
+
+def test_diff_detects_added_removed_updated_and_flags():
+    prev = _corpus([_doc(1), _doc(2), _doc(3)])
+    curr = _corpus([
+        _doc(1),                                              # unchanged
+        _doc(2, updated_at="2026-07-30T00:00:00Z",            # updated
+             open_flags=[{"quote": "q", "body": "b"}]),       # + flag
+        _doc(4),                                              # added
+    ])                                                        # 3 removed
+    d = comp.diff_corpora(prev, curr)
+    assert d["added"] == ["Doc 4"]
+    assert d["removed"] == ["Doc 3"]
+    assert d["updated"] == ["Doc 2"]
+    assert d["flag_changes"] == ["Doc 2 (0→1 open flags)"]
+    assert d["total_docs"] == 3
+
+
+def test_diff_resume_no_changes():
+    c = _corpus([_doc(1)])
+    assert comp.diff_resume(comp.diff_corpora(c, c)) == "1 docs — no changes"
+
+
+def test_diff_resume_clips_long_lists():
+    prev = _corpus([])
+    curr = _corpus([_doc(i) for i in range(1, 7)])
+    resume = comp.diff_resume(comp.diff_corpora(prev, curr))
+    assert "6 new" in resume
+    assert "+3 more" in resume
+
+
+# -- build invariants --------------------------------------------------
+
+def test_build_html_anchor_contract():
+    """Every doc gets exactly one <a name='doc-N'> bookmark, and every
+    internal href targets an emitted bookmark (index + tag map)."""
+    corpus = _corpus([_doc(1), _doc(2, tags=[]),
+                      _doc(3, body_format="flowchart", body="flowchart TD")])
+    html = comp.build_html(corpus, generated_on="2026-07-31")
+    names = re.findall(r"<a name='(doc-\d+)'></a>", html)
+    assert names == ["doc-1", "doc-2", "doc-3"]
+    hrefs = set(re.findall(r"href='#(doc-\d+)'", html))
+    assert hrefs == set(names)
+
+
+def test_build_html_untagged_and_flowchart_sections():
+    corpus = _corpus([_doc(1, tags=[]),
+                      _doc(2, body_format="flowchart",
+                           body="flowchart TD\n  A --> B")])
+    html = comp.build_html(corpus, generated_on="2026-07-31")
+    assert "UNTAGGED" in html
+    assert "<pre>flowchart TD" in html          # Mermaid stays source, escaped
+    assert "flowchart (Mermaid)" in html
+
+
+def test_build_html_escapes_titles_and_renders_flags():
+    corpus = _corpus([_doc(1, title="A <b>& risky</b> title",
+                           open_flags=[{"quote": "the quote",
+                                        "body": "why",
+                                        "suggestion": "fix it"}])])
+    html = comp.build_html(corpus, generated_on="2026-07-31")
+    assert "A &lt;b&gt;&amp; risky&lt;/b&gt; title" in html
+    assert "the quote" in html and "fix it" in html
+    assert "open review flag" in html


### PR DESCRIPTION
## What

**Graduates the Pulpo SOP Compendium pipeline** (one-off run 2026-07-30: 114 docs → Google Doc with verified clickable index) into `scripts/pulpo_compendium_export.py`, and adds `references/PulpoCompendium.md` — the design doc for making it a weekly institution with a manager-acknowledged T2 chiclet on the QA dashboard.

### Pipeline (`scripts/pulpo_compendium_export.py`)
- **extract** — full-corpus enumeration: trending-90d ∪ tag transitive closure ∪ semantic sweep looped until twice-dry; raw `get_document` payloads (created_at/owner/review-cadence fields the neutral types drop); paced to rate limits on the benchmark token (~465 units ≈ ¼ daily quota)
- **diff** — `diff_corpora`/`diff_resume`: added/removed/updated/flag-delta résumé (the future chiclet body)
- **build** — clickable index + tag map + untagged section + full contents; `<a name>` anchors (the one form Drive's HTML importer converts to real Docs bookmarks — `id=` variants convert to dead links, discovered the hard way)
- **deliver** — Drive `files.update` + HTML conversion into the existing user-owned Doc (service accounts have zero Drive storage quota and can never `files.create`), then docx-export verification that every internal link resolves to a real bookmark
- `PulpoProvider.raw_tool_call` passthrough added for operator tooling; policy code keeps the neutral `RagProvider` surface

### Design doc (`references/PulpoCompendium.md`)
Weekly Monday 05:00 America/Mexico_City lifespan task (disposition-pull pattern, env-gated off by default), `qa.pulpo_compendium_snapshots` as diff base + missed-run watermark, and a **T2 ack chiclet written to `command_center.chiclets`** (the first real writer of the CC ledger — type CHECK widened by migration 019) surfaced through the QA dashboard's existing SSE bus with the LandingOpsCommandCenter §6 payload contract. §6 open questions pending owner; build plan C1–C5.

## Tests
- `tests/test_pulpo_compendium.py`: diff/résumé logic + HTML build invariants (anchor contract, untagged/flowchart sections, escaping, flag callouts)
- Full suite: **1135 passed, 6 skipped, 3 xfailed**
- Offline CLI smoke: `--corpus <snapshot> --skip-deliver` reproduces the delivered doc byte-comparable modulo timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3zjEqVyjZK6vGNzByxxyP