### PR TITLE
fix(qa-automation): hr_export exclusion carries the qa.* roster spelling

### DIFF
--- a/qa-automation/AI-Scoring/backend/config/teams/member_support.json
+++ b/qa-automation/AI-Scoring/backend/config/teams/member_support.json
@@ -19,7 +19,7 @@
       {"id": "efficiency",        "hr_label": "Efficiency & Call Handling"},
       {"id": "cri",               "hr_label": "CRI"}
     ],
-    "excluded_agents": ["maximiliano perez", "maximiliano.perez"]
+    "excluded_agents": ["maximiliano perez", "maximiliano.perez", "max pérez", "max perez"]
   },
 
   "stats": {

--- a/qa-automation/AI-Scoring/references/HRBonusSheet.md
+++ b/qa-automation/AI-Scoring/references/HRBonusSheet.md
@@ -108,7 +108,7 @@ The export list lives in the team config JSON — **not** in code — as a new `
     {"id": "efficiency",        "hr_label": "Efficiency & Call Handling"},
     {"id": "cri",               "hr_label": "CRI"}
   ],
-  "excluded_agents": ["maximiliano perez", "maximiliano.perez"]
+  "excluded_agents": ["maximiliano perez", "maximiliano.perez", "max pérez", "max perez"]
 }
 ```
 
@@ -251,5 +251,8 @@ made in this spec.
 
 None blocking. One conscious default, flagged for visibility:
 
-1. `excluded_agents` matches on raw name (mockup parity). If roster names ever collide with an
-   excluded name, switch the match to `qa.agents.email`.
+1. `excluded_agents` matches on raw name (mockup parity), exact-after-lowercase — no accent
+   stripping. The July 2026 run showed how this bites: the qa.* roster spelling "Max Pérez"
+   missed the mockup-era entries, so the list now carries every observed spelling. If roster
+   names ever collide with an excluded name (or spelling drift recurs), switch the match to
+   `qa.agents.email`.

--- a/qa-automation/AI-Scoring/tests/test_hr_bonus.py
+++ b/qa-automation/AI-Scoring/tests/test_hr_bonus.py
@@ -218,6 +218,17 @@ def test_excluded_agents_filtered_case_insensitively(ms_config):
     assert [a["name"] for a in payload["agents"]] == ["Ana"]
 
 
+def test_qa_roster_spelling_of_operator_is_excluded(ms_config):
+    # Matching is exact-after-lowercase (no accent stripping): the qa.*
+    # roster spells the operator "Max Pérez", which the mockup-era entries
+    # missed — caught live in the July 2026 export. The shipped config must
+    # carry the roster spelling explicitly.
+    evals = [_eval_row(1, "Ana", _june(10)),
+             _eval_row(2, "Max Pérez", _june(11))]
+    payload = build_payload_from_rows(ms_config, "2026-06", evals, {})
+    assert [a["name"] for a in payload["agents"]] == ["Ana"]
+
+
 def test_agents_sorted_case_insensitively(ms_config):
     evals = [_eval_row(1, "zoe", _june(10)),
              _eval_row(2, "Ana", _june(11)),


### PR DESCRIPTION
## Summary
- The July 2026 HR-bonus payload exposed **Max Pérez** (the operator) to the HR export: `excluded_agents` held only the mockup-era CSV spellings (`maximiliano perez`, `maximiliano.perez`), and matching is exact-after-lowercase with **no accent stripping**, so the qa.* roster spelling slipped through.
- Adds `max pérez` (observed roster spelling) + `max perez` (unaccented guard) to `member_support.json`.
- Pins the shipped config with a regression test (`test_qa_roster_spelling_of_operator_is_excluded`).
- Syncs the spec: §3 example config + §9 conscious-default note now record the failure mode and the email-match fallback if spelling drift recurs.

Caught during the P4 supervised first run (HRBonusSheet.md §7) before anything was written to the HR workbook — the GAS export for July is intentionally held until this deploys.

## Test plan
- `pytest tests/test_hr_bonus.py` — 24 passed (23 existing + new regression test)
- Post-merge: re-hit `GET /api/member_support/hr-bonus/2026-07` on Railway and confirm Max Pérez is absent from the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)