### PR TITLE
feat(qa-automation): agent dashboard serves + links the monthly one-pager

### DIFF
--- a/qa-automation/AI-Scoring/backend/main.py
+++ b/qa-automation/AI-Scoring/backend/main.py
@@ -163,6 +163,11 @@ async def serve_agent_dashboard(team_id: str, name: str):
     return FileResponse(_frontend_dir / "dashboard.html", headers=_HTML_NO_CACHE)
 
 
+@app.get("/dashboard/{team_id}/onepager/{name:path}", include_in_schema=False)
+async def serve_onepager_page(team_id: str, name: str):
+    return FileResponse(_frontend_dir / "onepager.html", headers=_HTML_NO_CACHE)
+
+
 @app.get("/datapoint/{team_id}/{call_id}", include_in_schema=False)
 async def serve_datapoint_page(team_id: str, call_id: str):
     return FileResponse(_frontend_dir / "datapoint.html", headers=_HTML_NO_CACHE)

--- a/qa-automation/AI-Scoring/backend/routes/dashboard.py
+++ b/qa-automation/AI-Scoring/backend/routes/dashboard.py
@@ -5,16 +5,21 @@ legacy (/api/...).  team_id is extracted from the path via
 ``team_id_from_path``; legacy routes default to ``member_support``.
 """
 
+import re
 from datetime import date, datetime, time, timezone
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
 from backend.config.team_config import get_team_config
 from backend.middleware.auth import team_id_from_path
 from backend.models.dashboard import EvaluationRecord, ProgressionAssessment
 from backend.services.data_provider import get_provider
+from backend.services.onepager import last_closed_month, render_month_onepager
 from backend.services.progression_service import get_progression
 
 router = APIRouter(tags=["dashboard"])
+
+_MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
 
 # Mirrors the team-route cap (see backend/routes/team.py:_MAX_RANGE_DAYS).
 _MAX_RANGE_DAYS = 730
@@ -94,6 +99,32 @@ async def agent_history(
     if not records:
         raise HTTPException(404, f"No evaluations found for '{name}' in the last {days} days")
     return records
+
+
+@router.get("/agents/{name}/onepager", response_class=HTMLResponse)
+async def agent_onepager(
+    request: Request,
+    name: str,
+    month: str | None = Query(default=None),
+):
+    """Serve the agent's monthly one-pager as standalone HTML.
+
+    Defaults to the last closed bucket-TZ month, so the artifact rolls
+    forward automatically on the 1st — in step with the monthly workbook
+    export. Renders with the *persisted* month assessment only (never
+    generates): page views must stay cost-free; the operator's monthly
+    ``export_onepager.py`` run is what fills the assessment slot.
+    """
+    team_id = team_id_from_path(request)
+    config = get_team_config(team_id)
+    if month is None:
+        month = last_closed_month()
+    elif not _MONTH_RE.match(month):
+        raise HTTPException(422, "month must be YYYY-MM")
+    page = await render_month_onepager(config, name, month)
+    if page is None:
+        raise HTTPException(404, f"No evaluations for '{name}' in {month}")
+    return HTMLResponse(page)
 
 
 @router.get("/agents/{name}/progression", response_model=ProgressionAssessment)

--- a/qa-automation/AI-Scoring/backend/services/onepager.py
+++ b/qa-automation/AI-Scoring/backend/services/onepager.py
@@ -1,0 +1,298 @@
+"""Agent one-pager rendering — the print-ready monthly HTML (JulyR2R3 §3).
+
+Moved verbatim from ``scripts/export_onepager.py`` so the dashboard can
+serve the same artifact on demand; the script stays the CLI wrapper for
+the operator's monthly file export (and is the only caller that
+*generates* assessments — see ``render_month_onepager``).
+
+Two entry layers:
+
+- Pure render pieces (``frame_to_render`` … ``render``): dataframe slice
+  in, standalone HTML out. No I/O, unit-testable.
+- ``render_month_onepager``: the route-facing orchestrator — fetches the
+  analytics frame (same row-source + bucket-TZ month semantics as the
+  dashboard), slices one agent+month, attaches the *persisted* month
+  assessment (``generate=False`` default: a page view must never spend a
+  Gemini call), and renders. Returns None when the agent has no rows in
+  the month.
+"""
+
+from __future__ import annotations
+
+import html
+import statistics
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+from backend.config.team_config import TeamConfig
+from backend.services.team_stats import BUCKET_TZ_NAME
+
+_BUCKET_TZ = ZoneInfo(BUCKET_TZ_NAME)
+
+# Landing brand palette (qa-automation/teams/*/Branding.js)
+NAVY = "#15192D"
+BLUE = "#1A61D9"
+LIGHT_BLUE = "#E7EFFB"
+GREEN = "#28A745"
+AMBER = "#E8A317"
+RED = "#D9534F"
+GRAY = "#4A4A4A"
+
+_YN_VALUES = {"Yes": 1.0, "Y": 1.0, "No": 0.0, "N": 0.0}
+
+
+def last_closed_month(now: datetime | None = None) -> str:
+    """``YYYY-MM`` of the most recently completed bucket-TZ month — what
+    the dashboard link and the monthly exports both mean by "the month":
+    on the 1st it rolls forward together with the workbook export."""
+    local = (now or datetime.now(_BUCKET_TZ)).astimezone(_BUCKET_TZ)
+    if local.month == 1:
+        return f"{local.year - 1}-12"
+    return f"{local.year}-{local.month - 1:02d}"
+
+
+def frame_to_render(df_month: pd.DataFrame, agent: str, config):
+    """One agent's month slice of the analytics frame → the render shape
+    (display-label columns, canonical section order). The frame's yn cells
+    are already the Y/N/NA/'' vocabulary _section_stats understands;
+    numeric NAs arrive as NaN (the frame collapses the sheet-era
+    'Not Applicable' string — the NA count column reflects yn sections
+    only, a known fidelity trade)."""
+    g = df_month[df_month["agent"] == agent].sort_values("timestamp")
+    out = pd.DataFrame({
+        "Agent Name": g["agent"].values,
+        "_ts": g["timestamp"].values,
+        "Overall Score": g["overall_score"].values,
+    })
+    section_cols = []
+    for sec in config.sections_by_number:
+        h = sec.history_id
+        if h in g.columns:
+            out[sec.name] = g[h].values
+            section_cols.append(sec.name)
+    return out, section_cols
+
+
+def assessment_html(assessment: dict | None) -> str:
+    """The AI-Assessment slot: the persisted qa.assessments row, or the
+    reserved-slot placeholder when none exists."""
+    if assessment is None:
+        return (
+            '<div class="assessment"><strong>AI Assessment</strong><br>'
+            '<span class="muted">No persisted assessment for this window — '
+            "the monthly export run creates one.</span></div>"
+        )
+    lines = []
+    for s in assessment.get("sections", []):
+        arrow = {"improving": ("▲", GREEN), "declining": ("▼", RED)}.get(
+            s["trend"], ("→", GRAY))
+        lines.append(
+            f'<div class="a-sec"><span style="color:{arrow[1]}">{arrow[0]}</span> '
+            f"<strong>{html.escape(s['section_name'])}</strong> — "
+            f"{html.escape(s['coaching_tip'])}</div>"
+        )
+    gen = assessment.get("generated_at")
+    stamp = gen.strftime("%Y-%m-%d") if hasattr(gen, "strftime") else ""
+    return (
+        '<div class="assessment"><strong>AI Assessment</strong> '
+        f'<span class="muted">({assessment.get("evaluations_included", "?")} evaluations'
+        f'{" · " + stamp if stamp else ""} · {html.escape(str(assessment.get("rubric_version", "")))})</span>'
+        f'<p style="margin:6px 0 8px">{html.escape(assessment["overall_assessment"])}</p>'
+        f"{''.join(lines)}</div>"
+    )
+
+
+def _section_stats(df: pd.DataFrame, col: str) -> dict:
+    values = df[col].astype(str).str.strip()
+    numeric = pd.to_numeric(values, errors="coerce")
+    is_binary = values.isin(_YN_VALUES).any()
+    midpoint = len(df) // 2
+    out = {"name": col, "na": int(values.isin(["Not Applicable", "NA"]).sum())}
+    if is_binary:
+        mapped = values.map(_YN_VALUES).dropna()
+        out["kind"] = "binary"
+        out["avg"] = round(mapped.mean() * 100, 1) if len(mapped) else None
+        first, second = mapped.iloc[:midpoint], mapped.iloc[midpoint:]
+        out["delta"] = (
+            round((second.mean() - first.mean()) * 100, 1)
+            if len(first) and len(second) else None
+        )
+    else:
+        scores = numeric.dropna()
+        out["kind"] = "numeric"
+        out["avg"] = round(scores.mean(), 2) if len(scores) else None
+        first, second = scores.iloc[:midpoint], scores.iloc[midpoint:]
+        out["delta"] = (
+            round(second.mean() - first.mean(), 2)
+            if len(first) and len(second) else None
+        )
+    return out
+
+
+def _trend_arrow(delta) -> tuple[str, str]:
+    if delta is None:
+        return "—", GRAY
+    if delta > 0.05:
+        return f"▲ +{delta:g}", GREEN
+    if delta < -0.05:
+        return f"▼ {delta:g}", RED
+    return "→ steady", GRAY
+
+
+def _sparkline(scores: list[float], width=560, height=64) -> str:
+    """Inline SVG polyline of per-call overall scores."""
+    if len(scores) < 2:
+        return ""
+    lo, hi = min(scores + [60]), max(scores + [100])
+    span = (hi - lo) or 1
+    step = width / (len(scores) - 1)
+    points = [
+        (round(i * step, 1), round(height - (s - lo) / span * (height - 8) - 4, 1))
+        for i, s in enumerate(scores)
+    ]
+    polyline = " ".join(f"{x},{y}" for x, y in points)
+    dots = "".join(
+        f'<circle cx="{x}" cy="{y}" r="2.5" fill="{BLUE}"/>' for x, y in points
+    )
+    return (
+        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}">'
+        f'<polyline points="{polyline}" fill="none" stroke="{BLUE}" stroke-width="2"/>'
+        f"{dots}</svg>"
+    )
+
+
+def _bar(stat: dict) -> str:
+    if stat["avg"] is None:
+        return ""
+    pct = stat["avg"] if stat["kind"] == "binary" else stat["avg"] / 5 * 100
+    color = GREEN if pct >= 80 else AMBER if pct >= 60 else RED
+    return (
+        f'<div class="bar"><div class="fill" '
+        f'style="width:{pct:.0f}%;background:{color}"></div></div>'
+    )
+
+
+def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str],
+           assessment: dict | None = None,
+           team_label: str = "Member Support") -> str:
+    overall = pd.to_numeric(df["Overall Score"], errors="coerce").dropna().tolist()
+    n = len(overall)
+    mean = statistics.fmean(overall)
+    std = statistics.stdev(overall) if n > 1 else 0.0
+    month_label = datetime.strptime(month, "%Y-%m").strftime("%B %Y")
+    stats = [_section_stats(df, c) for c in section_cols]
+
+    rows = []
+    for s in stats:
+        arrow, color = _trend_arrow(s["delta"])
+        if s["avg"] is None:
+            avg_cell = "—"
+        elif s["kind"] == "binary":
+            avg_cell = f"{s['avg']:g}% Yes"
+        else:
+            avg_cell = f"{s['avg']:g} / 5"
+        na_cell = f'{s["na"]} NA' if s["na"] else ""
+        rows.append(
+            f"<tr><td>{html.escape(s['name'])}</td>"
+            f'<td class="num">{avg_cell}</td>'
+            f"<td>{_bar(s)}</td>"
+            f'<td class="num" style="color:{color}">{arrow}</td>'
+            f'<td class="num muted">{na_cell}</td></tr>'
+        )
+
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>{html.escape(agent)} — QA {month_label}</title>
+<style>
+  @page {{ size: letter portrait; margin: 0.55in; }}
+  * {{ box-sizing: border-box; margin: 0; }}
+  body {{ font: 13px/1.45 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+         color: {GRAY}; max-width: 7.4in; margin: 0 auto; padding: 24px 8px; }}
+  header {{ background: {NAVY}; color: #fff; border-radius: 10px;
+            padding: 18px 22px; display: flex; justify-content: space-between;
+            align-items: baseline; }}
+  header h1 {{ font-size: 21px; font-weight: 650; }}
+  header .brand {{ color: {LIGHT_BLUE}; font-size: 12px; letter-spacing: 0.12em;
+                   text-transform: uppercase; }}
+  .cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
+            margin: 14px 0; }}
+  .card {{ background: {LIGHT_BLUE}; border-radius: 8px; padding: 12px 14px; }}
+  .card .v {{ font-size: 26px; font-weight: 700; color: {NAVY};
+              font-variant-numeric: tabular-nums; }}
+  .card .l {{ font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; }}
+  h2 {{ font-size: 12px; color: {NAVY}; text-transform: uppercase;
+        letter-spacing: 0.1em; margin: 18px 0 8px; }}
+  table {{ width: 100%; border-collapse: collapse; }}
+  td {{ padding: 5px 8px; border-bottom: 1px solid #eceff4; }}
+  td.num {{ text-align: right; white-space: nowrap;
+            font-variant-numeric: tabular-nums; }}
+  .muted {{ color: #9aa3af; font-size: 11px; }}
+  .bar {{ width: 130px; height: 7px; background: #e8ebf0; border-radius: 4px; }}
+  .fill {{ height: 100%; border-radius: 4px; }}
+  .assessment {{ border: 1.5px dashed {BLUE}; border-radius: 10px; padding: 14px 16px;
+                 margin-top: 16px; color: {NAVY}; background: #fbfcff; }}
+  .a-sec {{ font-size: 11.5px; margin: 2px 0; }}
+  footer {{ margin-top: 18px; font-size: 10.5px; color: #9aa3af; }}
+</style></head><body>
+<header>
+  <div><h1>{html.escape(agent)}</h1>
+  <div style="color:{LIGHT_BLUE}">{html.escape(team_label)} — QA Performance</div></div>
+  <div style="text-align:right"><div class="brand">Landing · QA</div>
+  <div style="font-size:15px;font-weight:600">{month_label}</div></div>
+</header>
+
+<div class="cards">
+  <div class="card"><div class="v">{mean:.1f}</div><div class="l">Avg overall score</div></div>
+  <div class="card"><div class="v">{n}</div><div class="l">Calls evaluated</div></div>
+  <div class="card"><div class="v">{std:.1f}</div><div class="l">Std deviation</div></div>
+  <div class="card"><div class="v">{min(overall):.0f}–{max(overall):.0f}</div><div class="l">Score range</div></div>
+</div>
+
+<h2>Score progression — {month_label}</h2>
+{_sparkline(overall)}
+
+<h2>Per-section performance</h2>
+<table><tbody>
+{chr(10).join(rows)}
+</tbody></table>
+
+{assessment_html(assessment)}
+
+<footer>Generated {datetime.now().strftime("%Y-%m-%d %H:%M")} · Source: qa.evaluations
+({n} finalized evaluations, {month_label}) · Trend = second-half vs first-half average
+· Scores computed by the Landing QA engine</footer>
+</body></html>"""
+
+
+async def render_month_onepager(
+    config: TeamConfig,
+    agent: str,
+    month: str,
+    *,
+    generate: bool = False,
+) -> str | None:
+    """Fetch, slice, and render one agent's month one-pager.
+
+    ``generate=False`` (the route default) never spends a Gemini call: the
+    assessment slot shows whatever the monthly export run persisted, or
+    the placeholder. Only the operator CLI passes ``generate=True``.
+    Returns None when the agent has no rows in the bucket-TZ month — the
+    active-roster lens is deliberately NOT applied (a departed agent's
+    page can still serve their closing month).
+    """
+    from backend.services.assessment_store import get_or_generate_month_assessment
+    from backend.services.team_source import fetch_history_frame
+    from backend.services.team_stats import _months_in_bucket_tz
+
+    df = await fetch_history_frame(config)
+    if df.empty:
+        return None
+    dm = df[_months_in_bucket_tz(df["timestamp"]) == month]
+    rdf, section_cols = frame_to_render(dm, agent, config)
+    if rdf.empty:
+        return None
+    assessment = await get_or_generate_month_assessment(
+        config, agent, month, generate=generate)
+    return render(rdf, agent, month, section_cols, assessment,
+                  team_label=config.display_name)

--- a/qa-automation/AI-Scoring/frontend/dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/dashboard.html
@@ -230,6 +230,20 @@
       </div>
     </div>
 
+    <div id="onepagerCard" class="card hidden">
+      <h2>Monthly One-Pager</h2>
+      <p style="font-size:0.85rem;color:var(--muted);margin:0 0 10px;">
+        Print-ready QA summary for <strong id="onepagerMonth">the last closed month</strong> —
+        evaluation count and score stats, the score-progression sparkline, per-section
+        performance with trends, and the monthly AI assessment. Refreshes automatically on
+        the 1st of each month, in step with the monthly workbook export.
+      </p>
+      <a id="onepagerLink" href="#" target="_blank" rel="noopener"
+         style="font-family:'DM Mono',monospace;font-size:0.85rem;display:inline-block;padding:8px 18px;background:var(--accent);color:#fff;border-radius:6px;text-decoration:none;">
+        Open one-pager →
+      </a>
+    </div>
+
     <div id="assessmentCard" class="card">
       <h2>AI Progression Assessment</h2>
       <div id="assessmentPlaceholder" style="text-align:center;padding:20px;">
@@ -347,12 +361,37 @@
 
     const currentAgent = getAgentFromURL();
 
+    // --- Monthly one-pager card ---
+    // "Last closed month" in the project bucket TZ (America/Los_Angeles),
+    // mirroring the backend's last_closed_month(): the label and link roll
+    // forward automatically on the 1st, in step with the workbook export.
+    const MONTH_NAMES = ['January','February','March','April','May','June',
+                         'July','August','September','October','November','December'];
+    function lastClosedMonthLA() {
+      const parts = new Intl.DateTimeFormat('en-US',
+        { timeZone: 'America/Los_Angeles', year: 'numeric', month: 'numeric' }
+      ).formatToParts(new Date());
+      let y = +parts.find(p => p.type === 'year').value;
+      let m = +parts.find(p => p.type === 'month').value - 1;
+      if (m === 0) { m = 12; y -= 1; }
+      return { label: `${MONTH_NAMES[m - 1]} ${y}`, y, m };
+    }
+
+    function renderOnepagerCard(agentName) {
+      const { label } = lastClosedMonthLA();
+      document.getElementById('onepagerMonth').textContent = label;
+      const link = document.getElementById('onepagerLink');
+      link.textContent = `Open the ${label} one-pager →`;
+      link.href = `/dashboard/${TEAM_ID}/onepager/${encodeURIComponent(agentName)}`;
+      document.getElementById('onepagerCard').classList.remove('hidden');
+    }
+
     async function loadDashboard(agentName) {
       if (!agentName) return;
 
       document.getElementById('placeholder').textContent = 'Loading...';
       document.getElementById('placeholder').classList.remove('hidden');
-      ['statsCard', 'trendCard', 'sectionCard'].forEach(id =>
+      ['statsCard', 'trendCard', 'sectionCard', 'onepagerCard'].forEach(id =>
         document.getElementById(id).classList.add('hidden')
       );
       // Reset AI assessment
@@ -389,6 +428,7 @@
       renderStats(history);
       renderTrendChart(history);
       renderSectionChart(history);
+      renderOnepagerCard(agentName);
 
       const windowLabel = customActive ? `${dateFrom} – ${dateTo}` : `Last ${selectedDays} days`;
       document.getElementById('footer').textContent =

--- a/qa-automation/AI-Scoring/frontend/onepager.html
+++ b/qa-automation/AI-Scoring/frontend/onepager.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!-- Monthly one-pager viewer shell (/dashboard/{team_id}/onepager/{agent}).
+
+     The one-pager itself is rendered by the backend
+     (GET /api/{team_id}/agents/{name}/onepager — auth required), so this
+     shell only holds the api-key handshake shared by every dashboard
+     page, fetches the HTML, and swaps it in via document.write so the
+     result stays a standalone, print-ready document. -->
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Monthly One-Pager</title>
+  <style>
+    body { font: 14px/1.5 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+           color: #4A4A4A; text-align: center; padding: 60px 20px; }
+    .err { color: #D9534F; }
+    a { color: #1A61D9; }
+  </style>
+</head>
+<body>
+  <p id="status">Loading one-pager…</p>
+  <script>
+    function getApiKey() {
+      let key = sessionStorage.getItem('qa_api_key');
+      if (!key) {
+        key = prompt('Enter your QA API key:');
+        if (key) sessionStorage.setItem('qa_api_key', key);
+      }
+      return key;
+    }
+
+    (async function () {
+      const status = document.getElementById('status');
+      const m = location.pathname.match(/^\/dashboard\/([^\/]+)\/onepager\/(.+)$/);
+      if (!m) { status.textContent = 'Bad URL — expected /dashboard/{team}/onepager/{agent}.'; return; }
+      const [, teamId, rawAgent] = m;
+      const agent = decodeURIComponent(rawAgent);
+      const month = new URLSearchParams(location.search).get('month');
+
+      const key = getApiKey();
+      if (!key) { status.textContent = 'An API key is required to view this page.'; return; }
+
+      const url = `${location.origin}/api/${teamId}/agents/${encodeURIComponent(agent)}/onepager`
+        + (month ? `?month=${encodeURIComponent(month)}` : '');
+      let res;
+      try {
+        res = await fetch(url, { headers: { 'Authorization': 'Bearer ' + key } });
+      } catch (e) {
+        status.innerHTML = '<span class="err">Network error loading the one-pager.</span>';
+        return;
+      }
+      if (res.status === 401) {
+        sessionStorage.removeItem('qa_api_key');
+        status.innerHTML = '<span class="err">Invalid API key.</span> ' +
+          '<a href="javascript:location.reload()">Reload to retry</a>.';
+        return;
+      }
+      if (res.status === 404) {
+        status.textContent = `No evaluations for "${agent}"` +
+          (month ? ` in ${month}.` : ' in the last closed month yet.');
+        return;
+      }
+      if (!res.ok) {
+        status.innerHTML = `<span class="err">Backend returned HTTP ${res.status}.</span>`;
+        return;
+      }
+      const html = await res.text();
+      document.open();
+      document.write(html);
+      document.close();
+    })();
+  </script>
+</body>
+</html>

--- a/qa-automation/AI-Scoring/scripts/export_onepager.py
+++ b/qa-automation/AI-Scoring/scripts/export_onepager.py
@@ -8,6 +8,11 @@ the R3 writer when none exists (``--no-generate`` skips that for
 cost-free re-renders). One HTML per agent, print-to-PDF ready (Letter
 portrait).
 
+The render machinery lives in ``backend/services/onepager.py`` (shared
+with the dashboard's on-demand one-pager route); this script is the
+operator CLI that writes the monthly files and is the only caller that
+generates assessments.
+
 Usage:
     cd qa-automation/AI-Scoring
     python3 scripts/export_onepager.py --team member_support --month 2026-06 \\
@@ -19,13 +24,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import html
-import statistics
 import sys
-from datetime import datetime
 from pathlib import Path
 
-import pandas as pd
 from dotenv import load_dotenv
 
 _AI_SCORING = Path(__file__).resolve().parent.parent
@@ -34,232 +35,11 @@ load_dotenv(_AI_SCORING / ".env")
 if str(_AI_SCORING) not in sys.path:
     sys.path.insert(0, str(_AI_SCORING))
 
-# Landing brand palette (qa-automation/teams/*/Branding.js)
-NAVY = "#15192D"
-BLUE = "#1A61D9"
-LIGHT_BLUE = "#E7EFFB"
-GREEN = "#28A745"
-AMBER = "#E8A317"
-RED = "#D9534F"
-GRAY = "#4A4A4A"
-
-_YN_VALUES = {"Yes": 1.0, "Y": 1.0, "No": 0.0, "N": 0.0}
-
-
-def frame_to_render(df_month: pd.DataFrame, agent: str, config):
-    """One agent's month slice of the analytics frame → the render shape
-    (display-label columns, canonical section order). The frame's yn cells
-    are already the Y/N/NA/'' vocabulary _section_stats understands;
-    numeric NAs arrive as NaN (the frame collapses the sheet-era
-    'Not Applicable' string — the NA count column reflects yn sections
-    only, a known fidelity trade)."""
-    g = df_month[df_month["agent"] == agent].sort_values("timestamp")
-    out = pd.DataFrame({
-        "Agent Name": g["agent"].values,
-        "_ts": g["timestamp"].values,
-        "Overall Score": g["overall_score"].values,
-    })
-    section_cols = []
-    for sec in config.sections_by_number:
-        h = sec.history_id
-        if h in g.columns:
-            out[sec.name] = g[h].values
-            section_cols.append(sec.name)
-    return out, section_cols
-
-
-def assessment_html(assessment: dict | None) -> str:
-    """The AI-Assessment slot: the persisted qa.assessments row, or the
-    reserved-slot placeholder when none exists."""
-    if assessment is None:
-        return (
-            '<div class="assessment"><strong>AI Assessment</strong><br>'
-            '<span class="muted">No persisted assessment for this window — '
-            "run without --no-generate to create one.</span></div>"
-        )
-    lines = []
-    for s in assessment.get("sections", []):
-        arrow = {"improving": ("▲", GREEN), "declining": ("▼", RED)}.get(
-            s["trend"], ("→", GRAY))
-        lines.append(
-            f'<div class="a-sec"><span style="color:{arrow[1]}">{arrow[0]}</span> '
-            f"<strong>{html.escape(s['section_name'])}</strong> — "
-            f"{html.escape(s['coaching_tip'])}</div>"
-        )
-    gen = assessment.get("generated_at")
-    stamp = gen.strftime("%Y-%m-%d") if hasattr(gen, "strftime") else ""
-    return (
-        '<div class="assessment"><strong>AI Assessment</strong> '
-        f'<span class="muted">({assessment.get("evaluations_included", "?")} evaluations'
-        f'{" · " + stamp if stamp else ""} · {html.escape(str(assessment.get("rubric_version", "")))})</span>'
-        f'<p style="margin:6px 0 8px">{html.escape(assessment["overall_assessment"])}</p>'
-        f"{''.join(lines)}</div>"
-    )
-
-
-def _section_stats(df: pd.DataFrame, col: str) -> dict:
-    values = df[col].astype(str).str.strip()
-    numeric = pd.to_numeric(values, errors="coerce")
-    is_binary = values.isin(_YN_VALUES).any()
-    midpoint = len(df) // 2
-    out = {"name": col, "na": int(values.isin(["Not Applicable", "NA"]).sum())}
-    if is_binary:
-        mapped = values.map(_YN_VALUES).dropna()
-        out["kind"] = "binary"
-        out["avg"] = round(mapped.mean() * 100, 1) if len(mapped) else None
-        first, second = mapped.iloc[:midpoint], mapped.iloc[midpoint:]
-        out["delta"] = (
-            round((second.mean() - first.mean()) * 100, 1)
-            if len(first) and len(second) else None
-        )
-    else:
-        scores = numeric.dropna()
-        out["kind"] = "numeric"
-        out["avg"] = round(scores.mean(), 2) if len(scores) else None
-        first, second = scores.iloc[:midpoint], scores.iloc[midpoint:]
-        out["delta"] = (
-            round(second.mean() - first.mean(), 2)
-            if len(first) and len(second) else None
-        )
-    return out
-
-
-def _trend_arrow(delta) -> tuple[str, str]:
-    if delta is None:
-        return "—", GRAY
-    if delta > 0.05:
-        return f"▲ +{delta:g}", GREEN
-    if delta < -0.05:
-        return f"▼ {delta:g}", RED
-    return "→ steady", GRAY
-
-
-def _sparkline(scores: list[float], width=560, height=64) -> str:
-    """Inline SVG polyline of per-call overall scores."""
-    if len(scores) < 2:
-        return ""
-    lo, hi = min(scores + [60]), max(scores + [100])
-    span = (hi - lo) or 1
-    step = width / (len(scores) - 1)
-    points = [
-        (round(i * step, 1), round(height - (s - lo) / span * (height - 8) - 4, 1))
-        for i, s in enumerate(scores)
-    ]
-    polyline = " ".join(f"{x},{y}" for x, y in points)
-    dots = "".join(
-        f'<circle cx="{x}" cy="{y}" r="2.5" fill="{BLUE}"/>' for x, y in points
-    )
-    return (
-        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}">'
-        f'<polyline points="{polyline}" fill="none" stroke="{BLUE}" stroke-width="2"/>'
-        f"{dots}</svg>"
-    )
-
-
-def _bar(stat: dict) -> str:
-    if stat["avg"] is None:
-        return ""
-    pct = stat["avg"] if stat["kind"] == "binary" else stat["avg"] / 5 * 100
-    color = GREEN if pct >= 80 else AMBER if pct >= 60 else RED
-    return (
-        f'<div class="bar"><div class="fill" '
-        f'style="width:{pct:.0f}%;background:{color}"></div></div>'
-    )
-
-
-def render(df: pd.DataFrame, agent: str, month: str, section_cols: list[str],
-           assessment: dict | None = None) -> str:
-    overall = pd.to_numeric(df["Overall Score"], errors="coerce").dropna().tolist()
-    n = len(overall)
-    mean = statistics.fmean(overall)
-    std = statistics.stdev(overall) if n > 1 else 0.0
-    month_label = datetime.strptime(month, "%Y-%m").strftime("%B %Y")
-    stats = [_section_stats(df, c) for c in section_cols]
-
-    rows = []
-    for s in stats:
-        arrow, color = _trend_arrow(s["delta"])
-        if s["avg"] is None:
-            avg_cell = "—"
-        elif s["kind"] == "binary":
-            avg_cell = f"{s['avg']:g}% Yes"
-        else:
-            avg_cell = f"{s['avg']:g} / 5"
-        na_cell = f'{s["na"]} NA' if s["na"] else ""
-        rows.append(
-            f"<tr><td>{html.escape(s['name'])}</td>"
-            f'<td class="num">{avg_cell}</td>'
-            f"<td>{_bar(s)}</td>"
-            f'<td class="num" style="color:{color}">{arrow}</td>'
-            f'<td class="num muted">{na_cell}</td></tr>'
-        )
-
-    return f"""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>{html.escape(agent)} — QA {month_label}</title>
-<style>
-  @page {{ size: letter portrait; margin: 0.55in; }}
-  * {{ box-sizing: border-box; margin: 0; }}
-  body {{ font: 13px/1.45 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-         color: {GRAY}; max-width: 7.4in; margin: 0 auto; padding: 24px 8px; }}
-  header {{ background: {NAVY}; color: #fff; border-radius: 10px;
-            padding: 18px 22px; display: flex; justify-content: space-between;
-            align-items: baseline; }}
-  header h1 {{ font-size: 21px; font-weight: 650; }}
-  header .brand {{ color: {LIGHT_BLUE}; font-size: 12px; letter-spacing: 0.12em;
-                   text-transform: uppercase; }}
-  .cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
-            margin: 14px 0; }}
-  .card {{ background: {LIGHT_BLUE}; border-radius: 8px; padding: 12px 14px; }}
-  .card .v {{ font-size: 26px; font-weight: 700; color: {NAVY};
-              font-variant-numeric: tabular-nums; }}
-  .card .l {{ font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; }}
-  h2 {{ font-size: 12px; color: {NAVY}; text-transform: uppercase;
-        letter-spacing: 0.1em; margin: 18px 0 8px; }}
-  table {{ width: 100%; border-collapse: collapse; }}
-  td {{ padding: 5px 8px; border-bottom: 1px solid #eceff4; }}
-  td.num {{ text-align: right; white-space: nowrap;
-            font-variant-numeric: tabular-nums; }}
-  .muted {{ color: #9aa3af; font-size: 11px; }}
-  .bar {{ width: 130px; height: 7px; background: #e8ebf0; border-radius: 4px; }}
-  .fill {{ height: 100%; border-radius: 4px; }}
-  .assessment {{ border: 1.5px dashed {BLUE}; border-radius: 10px; padding: 14px 16px;
-                 margin-top: 16px; color: {NAVY}; background: #fbfcff; }}
-  .a-sec {{ font-size: 11.5px; margin: 2px 0; }}
-  footer {{ margin-top: 18px; font-size: 10.5px; color: #9aa3af; }}
-</style></head><body>
-<header>
-  <div><h1>{html.escape(agent)}</h1>
-  <div style="color:{LIGHT_BLUE}">Member Support — QA Performance</div></div>
-  <div style="text-align:right"><div class="brand">Landing · QA</div>
-  <div style="font-size:15px;font-weight:600">{month_label}</div></div>
-</header>
-
-<div class="cards">
-  <div class="card"><div class="v">{mean:.1f}</div><div class="l">Avg overall score</div></div>
-  <div class="card"><div class="v">{n}</div><div class="l">Calls evaluated</div></div>
-  <div class="card"><div class="v">{std:.1f}</div><div class="l">Std deviation</div></div>
-  <div class="card"><div class="v">{min(overall):.0f}–{max(overall):.0f}</div><div class="l">Score range</div></div>
-</div>
-
-<h2>Score progression — {month_label}</h2>
-{_sparkline(overall)}
-
-<h2>Per-section performance</h2>
-<table><tbody>
-{chr(10).join(rows)}
-</tbody></table>
-
-{assessment_html(assessment)}
-
-<footer>Generated {datetime.now().strftime("%Y-%m-%d %H:%M")} · Source: qa.evaluations
-({n} finalized evaluations, {month_label}) · Trend = second-half vs first-half average
-· Scores computed by the Landing QA engine</footer>
-</body></html>"""
-
 
 async def run(args) -> int:
     from backend.config.team_config import get_team_config
     from backend.services.assessment_store import get_or_generate_month_assessment
+    from backend.services.onepager import frame_to_render, render
     from backend.services.team_source import fetch_history_frame
     from backend.services.team_stats import _months_in_bucket_tz
 
@@ -286,7 +66,8 @@ async def run(args) -> int:
             config, agent, args.month, generate=not args.no_generate)
         slug = "_".join(agent.replace("/", " ").split())
         out = out_dir / f"onepager_{slug}_{args.month}.html"
-        out.write_text(render(rdf, agent, args.month, section_cols, assessment),
+        out.write_text(render(rdf, agent, args.month, section_cols, assessment,
+                              team_label=config.display_name),
                        encoding="utf-8")
         written += 1
         print(f"  {agent}: {len(rdf)} evals"

--- a/qa-automation/AI-Scoring/tests/test_onepager.py
+++ b/qa-automation/AI-Scoring/tests/test_onepager.py
@@ -8,19 +8,12 @@ no-generate flows (DB + Gemini faked).
 from __future__ import annotations
 
 import asyncio
-import importlib.util
 from datetime import datetime, timezone
-from pathlib import Path
 
 import backend.services.assessment_store as astore
+import backend.services.onepager as onepager
 from backend.services.team_stats import load_and_clean
 from tests.conftest import make_history_sheet, make_mails_sheet, load_test_config
-
-_spec = importlib.util.spec_from_file_location(
-    "export_onepager",
-    Path(__file__).resolve().parent.parent / "scripts" / "export_onepager.py")
-onepager = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(onepager)
 
 
 # ---------------------------------------------------------------------------

--- a/qa-automation/AI-Scoring/tests/test_onepager_route.py
+++ b/qa-automation/AI-Scoring/tests/test_onepager_route.py
@@ -1,0 +1,186 @@
+"""Dashboard one-pager serving — service orchestrator + route.
+
+The render machinery moved into backend/services/onepager.py so the
+dashboard can serve the artifact on demand (test_onepager.py covers the
+render pieces). This file covers what the move added: last-closed-month
+semantics (bucket TZ, not UTC), the month/agent slice in
+render_month_onepager, the no-Gemini-on-page-view guarantee, and the
+route contract (default month, override, 422/404, team-key auth).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.middleware import auth
+from backend.middleware.auth import KeyIdentity, TEAM_AUTH_DEPENDENCY
+from backend.routes import dashboard as dashboard_route
+from backend.services import assessment_store, team_source
+from backend.services.onepager import last_closed_month, render_month_onepager
+from tests.conftest import load_test_config
+
+_LA = ZoneInfo("America/Los_Angeles")
+
+
+# ---------------------------------------------------------------------------
+# last_closed_month
+# ---------------------------------------------------------------------------
+
+def test_last_closed_month_mid_month():
+    assert last_closed_month(datetime(2026, 8, 14, 12, 0, tzinfo=_LA)) == "2026-07"
+
+
+def test_last_closed_month_january_rolls_the_year():
+    assert last_closed_month(datetime(2027, 1, 1, 6, 0, tzinfo=_LA)) == "2026-12"
+
+
+def test_last_closed_month_is_bucket_tz_not_utc():
+    # Aug 1, 06:00 UTC is still Jul 31 in LA — the closed month is June.
+    assert last_closed_month(datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc)) == "2026-06"
+
+
+# ---------------------------------------------------------------------------
+# render_month_onepager
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ms_config():
+    return load_test_config("member_support")
+
+
+def _frame(ms_config):
+    """Minimal analytics frame: naive-UTC timestamps (the frame
+    convention), two July evals for Ana, one for Bo."""
+    numeric_id = next(
+        sec.history_id for sec in ms_config.sections_by_number
+        if sec.score_type in ("numeric", "manual")
+    )
+    df = pd.DataFrame({
+        "agent": ["Ana", "Ana", "Bo"],
+        "timestamp": [
+            datetime(2026, 7, 10, 18, 0),
+            datetime(2026, 7, 20, 21, 0),
+            datetime(2026, 7, 12, 17, 0),
+        ],
+        "overall_score": [88.0, 92.0, 70.0],
+    })
+    df[numeric_id] = [4, 5, 3]
+    return df
+
+
+@pytest.fixture
+def patched_sources(ms_config, monkeypatch):
+    """Fake the frame + assessment sources; capture the generate flag."""
+    captured = {}
+
+    async def fake_frame(config):
+        return _frame(ms_config)
+
+    async def fake_assessment(config, agent, month, generate=True):
+        captured["generate"] = generate
+        return None
+
+    monkeypatch.setattr(team_source, "fetch_history_frame", fake_frame)
+    monkeypatch.setattr(
+        assessment_store, "get_or_generate_month_assessment", fake_assessment)
+    return captured
+
+
+def test_renders_month_slice(ms_config, patched_sources):
+    page = asyncio.run(render_month_onepager(ms_config, "Ana", "2026-07"))
+    assert page is not None
+    assert "Ana" in page
+    assert "July 2026" in page
+    assert ms_config.display_name in page
+
+
+def test_page_view_never_generates(ms_config, patched_sources):
+    asyncio.run(render_month_onepager(ms_config, "Ana", "2026-07"))
+    assert patched_sources["generate"] is False
+
+
+def test_cli_generate_flag_passes_through(ms_config, patched_sources):
+    asyncio.run(render_month_onepager(ms_config, "Ana", "2026-07", generate=True))
+    assert patched_sources["generate"] is True
+
+
+def test_none_when_agent_has_no_rows_in_month(ms_config, patched_sources):
+    assert asyncio.run(render_month_onepager(ms_config, "Ana", "2026-06")) is None
+    assert asyncio.run(render_month_onepager(ms_config, "Nadie", "2026-07")) is None
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+MS_TOKEN = "team-ms-tok"
+SALES_TOKEN = "team-sales-tok"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(auth, "_KEY_MAP", {
+        MS_TOKEN: KeyIdentity(role="team", team_id="member_support"),
+        SALES_TOKEN: KeyIdentity(role="team", team_id="sales"),
+    })
+    app = FastAPI()
+    app.include_router(
+        dashboard_route.router,
+        prefix="/api/{team_id}",
+        dependencies=TEAM_AUTH_DEPENDENCY,
+    )
+    return TestClient(app)
+
+
+def _get(client, team, name, token, month=None):
+    return client.get(
+        f"/api/{team}/agents/{name}/onepager"
+        + (f"?month={month}" if month else ""),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_route_serves_html_with_default_month(client, monkeypatch):
+    async def fake_render(config, agent, month, **kwargs):
+        return f"<!DOCTYPE html><html><body>{agent} {month}</body></html>"
+    monkeypatch.setattr(dashboard_route, "render_month_onepager", fake_render)
+    monkeypatch.setattr(dashboard_route, "last_closed_month", lambda: "2026-07")
+    resp = _get(client, "member_support", "Ana", MS_TOKEN)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "Ana 2026-07" in resp.text  # default month = last closed
+
+
+def test_route_month_override(client, monkeypatch):
+    async def fake_render(config, agent, month, **kwargs):
+        return f"<html>{month}</html>"
+    monkeypatch.setattr(dashboard_route, "render_month_onepager", fake_render)
+    resp = _get(client, "member_support", "Ana", MS_TOKEN, month="2026-05")
+    assert resp.status_code == 200
+    assert "2026-05" in resp.text
+
+
+def test_route_rejects_malformed_month(client):
+    for bad in ("2026-13", "junk", "2026-7", "2026-07-01"):
+        resp = _get(client, "member_support", "Ana", MS_TOKEN, month=bad)
+        assert resp.status_code == 422, bad
+
+
+def test_route_404s_when_no_rows(client, monkeypatch):
+    async def fake_render(config, agent, month, **kwargs):
+        return None
+    monkeypatch.setattr(dashboard_route, "render_month_onepager", fake_render)
+    resp = _get(client, "member_support", "Ana", MS_TOKEN, month="2026-07")
+    assert resp.status_code == 404
+
+
+def test_route_requires_matching_team_key(client):
+    resp = _get(client, "member_support", "Ana", SALES_TOKEN, month="2026-07")
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- Moves the one-pager render machinery from `scripts/export_onepager.py` into `backend/services/onepager.py` (verbatim; script stays the operator CLI and the only assessment-generating caller).
- **New API route** `GET /api/{team_id}/agents/{name}/onepager` — renders the standalone print-ready HTML on demand for the **last closed bucket-TZ month** by default (`?month=YYYY-MM` override). Persisted assessment only — a page view never spends a Gemini call. 404 when the agent has no rows in the month.
- **New viewer page** `/dashboard/{team_id}/onepager/{agent}` — shell reusing the dashboard api-key handshake; fetches with auth and swaps the document in, so the result stays print-ready.
- **Agent dashboard card** between *Per-Section Averages* and *AI Progression Assessment*: describes the artifact and links it, labeled with the month. Because the default month is computed server-side as last-closed, the link rolls forward automatically on the 1st — in step with the monthly HR workbook export, no cron needed.
- `render()` team label now comes from `config.display_name` (was hardcoded "Member Support") — Sales inherits this surface for free once enabled.

## Test plan
- `pytest tests/test_onepager.py tests/test_onepager_route.py` — 18 passed (render pieces repointed at the service; new coverage: last-closed-month bucket-TZ semantics incl. UTC boundary + January rollover, month/agent slicing, the never-generate guarantee, route default/override/422/404/team-key auth)
- Full suite: **906 passed**, 6 skipped, 3 xfailed
- `export_onepager.py --help` parses; July file export ran on pre-refactor main immediately before this branch
- Post-merge: open `/dashboard/member_support/agent/<name>` and click through to the July one-pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)