### PR TITLE
fix(qa-automation): one-pager tab inherits the dashboard's api key

### DIFF
--- a/qa-automation/AI-Scoring/frontend/dashboard.html
+++ b/qa-automation/AI-Scoring/frontend/dashboard.html
@@ -383,6 +383,18 @@
       const link = document.getElementById('onepagerLink');
       link.textContent = `Open the ${label} one-pager →`;
       link.href = `/dashboard/${TEAM_ID}/onepager/${encodeURIComponent(agentName)}`;
+      // sessionStorage is per-tab, so the viewer shell in the new tab
+      // can't see this tab's key and would re-prompt. Hand it over in the
+      // URL fragment: never sent to the server, stripped by the shell on
+      // arrival, and the copyable href above stays key-free (a shared
+      // link should still prompt). Assignment (not addEventListener) so
+      // re-renders never stack handlers.
+      link.onclick = function (e) {
+        const key = sessionStorage.getItem('qa_api_key');
+        if (!key) return; // plain navigation; the shell will prompt
+        e.preventDefault();
+        window.open(this.href + '#k=' + encodeURIComponent(key), '_blank', 'noopener');
+      };
       document.getElementById('onepagerCard').classList.remove('hidden');
     }
 

--- a/qa-automation/AI-Scoring/frontend/onepager.html
+++ b/qa-automation/AI-Scoring/frontend/onepager.html
@@ -31,6 +31,16 @@
     }
 
     (async function () {
+      // Key handoff from the dashboard card: the key rides the URL
+      // fragment (never sent to the server), is stored for this tab, and
+      // is stripped from the address bar/history immediately — so the
+      // operator is only ever prompted on a direct/shared visit.
+      const hk = location.hash.match(/^#k=(.+)$/);
+      if (hk) {
+        sessionStorage.setItem('qa_api_key', decodeURIComponent(hk[1]));
+        history.replaceState(null, '', location.pathname + location.search);
+      }
+
       const status = document.getElementById('status');
       const m = location.pathname.match(/^\/dashboard\/([^\/]+)\/onepager\/(.+)$/);
       if (!m) { status.textContent = 'Bad URL — expected /dashboard/{team}/onepager/{agent}.'; return; }


### PR DESCRIPTION
## Summary
- The one-pager viewer opened from the agent dashboard re-prompted for the QA API key: `sessionStorage` is per-tab, and browsers disagree on copying it into `target="_blank"` tabs (especially with `noopener`), so the new tab started keyless.
- The dashboard card's click handler now hands the key to the new tab **in the URL fragment**: never sent to the server (nothing in Railway logs / `qa.api_audit_log`), stored by the shell for its own tab, and stripped from the address bar/history immediately on arrival.
- The copyable `href` stays key-free — a directly visited or shared link still prompts, which remains the correct gate until platform RBAC (Sandy) replaces the shared-key model. Frontend-only: the whole handoff dies with the shell page when that happens.

## Test plan
- Frontend-only change (no backend touched); full pytest suite unaffected
- Post-merge: from `/dashboard/member_support/agent/<name>`, click the one-pager card → new tab renders with **no key prompt** and a clean address bar
- Paste the bare `/dashboard/member_support/onepager/<name>` URL in a fresh tab → key prompt still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)