### PR TITLE
feat(sandy-qa): dashboard + evals pages, stats engine at FULL parity, live SSE (gates 2+3)

### DIFF
--- a/sandy-qa/.gitignore
+++ b/sandy-qa/.gitignore
@@ -3,3 +3,5 @@ dist/
 app.zip
 _release/
 .wrangler/
+parity/fixture.json
+parity/lib.mjs

--- a/sandy-qa/pages/static/header.css
+++ b/sandy-qa/pages/static/header.css
@@ -1,0 +1,189 @@
+/* Shared persistent header for team_dashboard.html + dashboard.html.
+   Markup is rendered by /static/header.js into <div id="appHeader">.
+   Page-specific styles (tab-bar, cards, etc.) stay in each page's
+   <style> block. Color variables are duplicated locally on each page
+   so this file can render correctly even before a page's own :root
+   declarations cascade. */
+
+.qa-header :where(*, *::before, *::after) {
+  box-sizing: border-box;
+}
+
+.qa-header {
+  background: var(--navy, #15192D);
+  color: #fff;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-family: 'DM Mono', monospace;
+}
+
+.qa-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.qa-header h1 {
+  font-family: 'Fraunces', serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* Nav buttons (Scoring / Team View / Lookup). Single style so the
+   chrome reads the same across both pages — replaces the per-page
+   inline styling that drifted (one used 6px 14px, the other 4px 12px). */
+.qa-nav-btn {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.82rem;
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  color: #fff;
+  text-decoration: none;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+.qa-nav-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+.qa-nav-btn[hidden] { display: none; }
+
+.qa-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  position: relative;  /* anchor for the custom-range popover */
+}
+
+/* Active Only toggle + supervisor select share styling for the dark
+   header. Both render on every page; the agent view gets `disabled`
+   added so they appear identical but inert. */
+.qa-toggle-btn,
+.qa-header select {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.85rem;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+}
+.qa-header select option {
+  background: var(--navy, #15192D);
+  color: #fff;
+}
+.qa-toggle-btn.active {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+}
+.qa-toggle-btn:disabled,
+.qa-header select:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Time-window chiclets (1w / 1mo / 3mo / 6mo / All / Custom …) */
+.qa-time-buttons {
+  display: flex;
+  gap: 4px;
+}
+.qa-time-buttons button {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+.qa-time-buttons button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+.qa-time-buttons button.active {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+  color: #fff;
+}
+
+/* Custom range popover. Anchored under .qa-header-controls; toggled by
+   header.js (hidden attr). Light surface inside the dark header — manager
+   workflow is "pick two dates, hit Apply", so it borrows the page's
+   neutral surface to look like a dialog, not part of the dark bar. */
+.qa-custom-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  background: var(--surface, #ffffff);
+  color: var(--text, #15192D);
+  border: 1px solid var(--border, #c9d5e8);
+  border-radius: 10px;
+  padding: 14px;
+  box-shadow: 0 8px 24px rgba(21, 25, 45, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 260px;
+}
+.qa-custom-popover[hidden] { display: none; }
+.qa-custom-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+}
+.qa-custom-row label {
+  width: 48px;
+  color: var(--muted, #5a6478);
+}
+.qa-custom-row input[type="date"] {
+  flex: 1;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  border: 1px solid var(--border, #c9d5e8);
+  border-radius: 6px;
+  background: var(--bg, #E7EFFB);
+  color: var(--text, #15192D);
+}
+.qa-custom-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+}
+.qa-custom-actions button {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.78rem;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #c9d5e8);
+  background: var(--surface, #ffffff);
+  color: var(--text, #15192D);
+  cursor: pointer;
+}
+.qa-custom-actions .qa-custom-apply {
+  background: var(--accent, #1A61D9);
+  border-color: var(--accent, #1A61D9);
+  color: #fff;
+}
+.qa-custom-error {
+  font-size: 0.72rem;
+  color: var(--red, #D9534F);
+  min-height: 1em;
+}
+
+@media (max-width: 640px) {
+  .qa-header { padding: 12px 16px; }
+  .qa-custom-popover { right: 0; left: 0; }
+}

--- a/sandy-qa/pages/static/header.js
+++ b/sandy-qa/pages/static/header.js
@@ -1,0 +1,342 @@
+/* Shared persistent header for team_dashboard.html + dashboard.html.
+   Exposes window.QAHeader.init(opts) — opts shape:
+     {
+       page:        'team' | 'agent',
+       team:        team_id string (e.g. 'member_support'),
+       agent:       agent display name (agent page only),
+       title:       string shown as <h1> (team page passes team title; agent
+                    page passes the agent name),
+       supervisors: list of supervisor names (team page only; populates the
+                    <select>),
+       onChange:    callback fired on every control change with
+                    { days, dateFrom, dateTo, activeOnly, supervisor }
+     }
+
+   State is read from the URL on init (?days=, ?from=&to=, ?supervisor=,
+   ?activeOnly=) so navigating Team↔Agent via the nav buttons carries the
+   chosen window. On every change we rewrite the URL and the nav-button
+   hrefs to keep that round-trip working. */
+
+(function () {
+  'use strict';
+
+  const PRESETS = [
+    { label: '1w',  days: 7   },
+    { label: '1mo', days: 30  },
+    { label: '3mo', days: 90  },
+    { label: '6mo', days: 180 },
+    { label: 'All', days: 0   },
+  ];
+  const DEFAULT_DAYS = 30;
+  const MAX_RANGE_DAYS = 730;
+
+  // --- URL state ----------------------------------------------------------
+  function readUrlState() {
+    const u = new URL(window.location.href);
+    const q = u.searchParams;
+    const from = q.get('from');
+    const to   = q.get('to');
+    const daysRaw = q.get('days');
+    const days = daysRaw != null && daysRaw !== '' ? parseInt(daysRaw, 10) : null;
+    return {
+      dateFrom: from || null,
+      dateTo:   to   || null,
+      // Custom range wins when both dates present; otherwise the
+      // ?days= value (if valid); otherwise the default.
+      days: (from && to)
+        ? null
+        : (Number.isFinite(days) && days >= 0 ? days : DEFAULT_DAYS),
+      activeOnly: q.get('activeOnly') !== '0',  // default true
+      supervisor: q.get('supervisor') || '',
+    };
+  }
+
+  function writeUrlState(state) {
+    const u = new URL(window.location.href);
+    const q = u.searchParams;
+    if (state.dateFrom && state.dateTo) {
+      q.set('from', state.dateFrom);
+      q.set('to',   state.dateTo);
+      q.delete('days');
+    } else {
+      q.delete('from');
+      q.delete('to');
+      if (state.days != null) q.set('days', String(state.days));
+      else q.delete('days');
+    }
+    // Only persist supervisor/activeOnly on the team page — agent page
+    // ignores them and we don't want them sticking in the URL.
+    if (state.page === 'team') {
+      if (state.supervisor) q.set('supervisor', state.supervisor);
+      else q.delete('supervisor');
+      // activeOnly defaults true; only persist the non-default.
+      if (state.activeOnly === false) q.set('activeOnly', '0');
+      else q.delete('activeOnly');
+    }
+    window.history.replaceState({}, '', u.toString());
+  }
+
+  // Rewrite nav-button hrefs to carry the current window across pages.
+  function buildNavHref(base, state) {
+    const u = new URL(base, window.location.origin);
+    if (state.dateFrom && state.dateTo) {
+      u.searchParams.set('from', state.dateFrom);
+      u.searchParams.set('to',   state.dateTo);
+    } else if (state.days != null && state.days !== DEFAULT_DAYS) {
+      u.searchParams.set('days', String(state.days));
+    }
+    return u.pathname + (u.search ? u.search : '');
+  }
+
+  // --- Markup -------------------------------------------------------------
+  function renderInto(host, opts) {
+    const navLinks = [
+      { key: 'scoring',  label: 'Batch Scoring', href: `/score/${opts.team}`,     showOn: 'both'  },
+      { key: 'teamview', label: 'Team View',     href: `/dashboard/${opts.team}`, showOn: 'agent' },
+      { key: 'lookup',   label: 'Lookup',        href: `/lookup/${opts.team}`,    showOn: 'both'  },
+    ];
+    // Batch Scoring stays exposed on both views — it's the entry point to
+    // the bulk-scoring flow, which is being extended later and shouldn't
+    // be reachable only from the agent page. Team View is hidden on the
+    // team page itself (it IS the current page).
+    const navHtml = navLinks
+      .filter(n => n.showOn === 'both' || n.showOn === opts.page)
+      .map(n => `<a class="qa-nav-btn" data-nav="${n.key}" href="${n.href}">${n.label}</a>`)
+      .join('');
+
+    const supervisorOpts = (opts.supervisors || [])
+      .map(s => `<option value="${escapeAttr(s)}">${escapeHtml(s)}</option>`)
+      .join('');
+
+    const presetBtns = PRESETS
+      .map(p => `<button type="button" data-days="${p.days}">${p.label}</button>`)
+      .join('');
+
+    host.classList.add('qa-header');
+    host.innerHTML = `
+      <div class="qa-header-nav">
+        ${navHtml}
+        <h1 id="qaHeaderTitle">${escapeHtml(opts.title || '')}</h1>
+      </div>
+      <div class="qa-header-controls">
+        <button type="button" class="qa-toggle-btn" data-role="active-only">Active Only</button>
+        <select data-role="supervisor">
+          <option value="">All Supervisors</option>
+          ${supervisorOpts}
+        </select>
+        <div class="qa-time-buttons" data-role="time-buttons">
+          ${presetBtns}
+          <button type="button" data-role="custom">Custom …</button>
+        </div>
+        <div class="qa-custom-popover" data-role="custom-popover" hidden>
+          <div class="qa-custom-row">
+            <label for="qaCustomFrom">From</label>
+            <input type="date" id="qaCustomFrom" />
+          </div>
+          <div class="qa-custom-row">
+            <label for="qaCustomTo">To</label>
+            <input type="date" id="qaCustomTo" />
+          </div>
+          <div class="qa-custom-error" data-role="custom-error"></div>
+          <div class="qa-custom-actions">
+            <button type="button" class="qa-custom-clear">Clear</button>
+            <button type="button" class="qa-custom-apply">Apply</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function escapeHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+  function escapeAttr(s) { return escapeHtml(s).replace(/"/g, '&quot;'); }
+
+  // --- Public API ---------------------------------------------------------
+  function init(opts) {
+    const host = document.getElementById('appHeader');
+    if (!host) {
+      console.error('QAHeader.init: <div id="appHeader"></div> not found');
+      return;
+    }
+
+    const state = Object.assign(
+      { page: opts.page, supervisor: '', activeOnly: true, days: DEFAULT_DAYS, dateFrom: null, dateTo: null },
+      readUrlState()
+    );
+
+    renderInto(host, opts);
+
+    const $ = sel => host.querySelector(sel);
+    const $$ = sel => Array.from(host.querySelectorAll(sel));
+
+    // Hydrate controls from URL state.
+    const supervisorSel = $('select[data-role="supervisor"]');
+    if (state.supervisor) supervisorSel.value = state.supervisor;
+
+    const activeBtn = $('[data-role="active-only"]');
+    activeBtn.classList.toggle('active', state.activeOnly);
+    activeBtn.textContent = state.activeOnly ? 'Active Only' : 'All Agents';
+
+    // On the agent page, Active Only / Supervisor are visually identical
+    // but inert — the controls are meaningless for one agent. Keeps the
+    // banner chrome consistent between views.
+    if (opts.page === 'agent') {
+      activeBtn.disabled = true;
+      activeBtn.title = 'Not applicable on agent view';
+      supervisorSel.disabled = true;
+      supervisorSel.title = 'Not applicable on agent view';
+    }
+
+    markActiveChiclet(host, state);
+
+    // Persist + propagate ----------------------------------------------------
+    function emit() {
+      writeUrlState(Object.assign({ page: opts.page }, state));
+      // Rewrite nav-button hrefs so navigation carries the window.
+      $$('.qa-nav-btn').forEach(a => {
+        const base = a.getAttribute('href').split('?')[0];
+        a.setAttribute('href', buildNavHref(base, state));
+      });
+      if (typeof opts.onChange === 'function') {
+        opts.onChange({
+          days:       state.days,
+          dateFrom:   state.dateFrom,
+          dateTo:     state.dateTo,
+          activeOnly: state.activeOnly,
+          supervisor: state.supervisor,
+        });
+      }
+    }
+
+    // Wire up controls -------------------------------------------------------
+    activeBtn.addEventListener('click', () => {
+      if (activeBtn.disabled) return;
+      state.activeOnly = !state.activeOnly;
+      activeBtn.classList.toggle('active', state.activeOnly);
+      activeBtn.textContent = state.activeOnly ? 'Active Only' : 'All Agents';
+      emit();
+    });
+
+    supervisorSel.addEventListener('change', () => {
+      state.supervisor = supervisorSel.value;
+      emit();
+    });
+
+    $$('.qa-time-buttons button[data-days]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.days = parseInt(btn.dataset.days, 10);
+        state.dateFrom = null;
+        state.dateTo = null;
+        markActiveChiclet(host, state);
+        emit();
+      });
+    });
+
+    // Custom popover --------------------------------------------------------
+    const popover = $('[data-role="custom-popover"]');
+    const customBtn = $('[data-role="custom"]');
+    const fromInput = $('#qaCustomFrom');
+    const toInput   = $('#qaCustomTo');
+    const errLabel  = $('[data-role="custom-error"]');
+    const applyBtn  = $('.qa-custom-apply');
+    const clearBtn  = $('.qa-custom-clear');
+
+    function openPopover() {
+      // Pre-fill with current range if active, otherwise leave blank.
+      fromInput.value = state.dateFrom || '';
+      toInput.value   = state.dateTo   || '';
+      errLabel.textContent = '';
+      popover.hidden = false;
+    }
+    function closePopover() { popover.hidden = true; }
+
+    customBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      if (popover.hidden) openPopover(); else closePopover();
+    });
+
+    // Click-outside dismisses the popover (but not on the chiclet itself).
+    document.addEventListener('click', e => {
+      if (popover.hidden) return;
+      if (popover.contains(e.target) || customBtn.contains(e.target)) return;
+      closePopover();
+    });
+
+    applyBtn.addEventListener('click', () => {
+      const f = fromInput.value;
+      const t = toInput.value;
+      if (!f || !t) { errLabel.textContent = 'Pick both dates.'; return; }
+      if (t < f)    { errLabel.textContent = 'To must be on or after From.'; return; }
+      // Span check matches the backend cap.
+      const spanDays = Math.round(
+        (new Date(t) - new Date(f)) / (1000 * 60 * 60 * 24)
+      ) + 1;
+      if (spanDays > MAX_RANGE_DAYS) {
+        errLabel.textContent = `Range exceeds ${MAX_RANGE_DAYS}-day cap.`;
+        return;
+      }
+      state.dateFrom = f;
+      state.dateTo   = t;
+      state.days     = null;
+      markActiveChiclet(host, state);
+      closePopover();
+      emit();
+    });
+
+    clearBtn.addEventListener('click', () => {
+      state.dateFrom = null;
+      state.dateTo   = null;
+      state.days     = DEFAULT_DAYS;
+      markActiveChiclet(host, state);
+      closePopover();
+      emit();
+    });
+
+    // Initial fire so the page can fetch with the URL-resolved window.
+    // Rewrites nav hrefs even when state matches default.
+    emit();
+
+    // Expose a tiny update API so the team page can populate supervisors
+    // after fetching them async (Mails sheet is loaded after init).
+    return {
+      setSupervisors(list) {
+        const cur = supervisorSel.value;
+        supervisorSel.innerHTML =
+          '<option value="">All Supervisors</option>' +
+          (list || []).map(s => `<option value="${escapeAttr(s)}">${escapeHtml(s)}</option>`).join('');
+        // Restore prior selection if it's still in the list.
+        if (cur && [...supervisorSel.options].some(o => o.value === cur)) {
+          supervisorSel.value = cur;
+        }
+      },
+      setTitle(t) {
+        const h = host.querySelector('#qaHeaderTitle');
+        if (h) h.textContent = t;
+      },
+      getState() { return Object.assign({}, state); },
+    };
+  }
+
+  function markActiveChiclet(host, state) {
+    const btns = host.querySelectorAll('.qa-time-buttons button');
+    btns.forEach(b => b.classList.remove('active'));
+    if (state.dateFrom && state.dateTo) {
+      const custom = host.querySelector('[data-role="custom"]');
+      if (custom) {
+        custom.classList.add('active');
+        custom.textContent = `Custom: ${state.dateFrom} – ${state.dateTo}`;
+      }
+      return;
+    }
+    // Reset custom label when a preset is active.
+    const custom = host.querySelector('[data-role="custom"]');
+    if (custom) custom.textContent = 'Custom …';
+    const match = host.querySelector(`.qa-time-buttons button[data-days="${state.days}"]`);
+    if (match) match.classList.add('active');
+  }
+
+  window.QAHeader = { init };
+})();

--- a/sandy-qa/pages/team_dashboard.html
+++ b/sandy-qa/pages/team_dashboard.html
@@ -1,0 +1,1485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Team Analytics Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/header.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <style>
+    :root {
+      --navy: #15192D; --accent: #1A61D9; --bg: #E7EFFB; --surface: #ffffff;
+      --border: #c9d5e8; --text: #15192D; --muted: #5a6478;
+      --green: #28A745; --amber: #E8A317; --red: #D9534F;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    /* Header CSS lives in /static/header.css (shared with dashboard.html). */
+
+    /* Tabs */
+    .tab-bar {
+      background: var(--navy); display: flex; gap: 0; padding: 0 24px; overflow-x: auto;
+    }
+    .tab-btn {
+      font-family: 'DM Mono', monospace; padding: 10px 20px; border: none; background: transparent;
+      color: rgba(255,255,255,0.6); cursor: pointer; font-size: 0.85rem; border-bottom: 3px solid transparent;
+      white-space: nowrap; transition: color 0.2s, border-color 0.2s;
+    }
+    .tab-btn:hover { color: #fff; }
+    .tab-btn.active { color: #fff; border-bottom-color: var(--accent); }
+
+    /* Layout */
+    .container { max-width: 1200px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: flex; flex-direction: column; gap: 20px; }
+
+    /* Cards */
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+    .card h3 { font-size: 1rem; margin-bottom: 12px; color: var(--text); }
+
+    /* KPI row */
+    .kpi-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+    .kpi-box {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; text-align: center;
+    }
+    .kpi-box .label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .kpi-box .value { font-family: 'Fraunces', serif; font-size: 2rem; font-weight: 700; margin: 4px 0; }
+    .kpi-box .sub { font-size: 0.75rem; color: var(--muted); }
+
+    /* Call-time initiative (PR-3) — single annotation under the chiclet
+       row + inline note in the SPC card title so management and analysts
+       can spot that monthly buckets are now anchored on call-connected
+       time, not eval-approval time. See references/CallTimeOnAnalystHistory.md. */
+    .bucket-hint {
+      margin: -4px 0 4px 4px; padding: 4px 0;
+      font-size: 0.72rem; color: var(--muted);
+      cursor: help;
+    }
+    .bucket-hint strong { color: var(--text); font-weight: 600; }
+    .bucket-hint-inline {
+      font-family: 'DM Mono', monospace;
+      font-size: 0.65rem; font-weight: 500; color: var(--muted);
+      text-transform: uppercase; letter-spacing: 0.05em;
+      margin-left: 8px; cursor: help;
+    }
+
+    /* Three top-of-overview chiclets — last month, current month, and
+       Recent Evals. Shared three-row layout:
+         header line:  LABEL: count   (with click-arrow tucked top-right)
+         hero number:  big primary metric + thin secondary
+         footer line:  context (month, time-ago)
+       Last/Current navigate to /dashboard/<team>/evals?month=…
+       Recent Evals toggles an expandable panel below the row. */
+    .chiclet-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+    .chiclet {
+      position: relative;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+      padding: 16px 20px; cursor: pointer; text-decoration: none; color: inherit;
+      display: flex; flex-direction: column; gap: 10px;
+      transition: border-color 0.15s, transform 0.15s;
+      font-family: inherit; font-size: inherit;
+      text-align: left;  /* button default-centers text on some browsers */
+    }
+    .chiclet:hover { border-color: var(--accent); transform: translateY(-1px); }
+    .chiclet.chiclet-active { border-color: var(--accent); }
+
+    /* Header line: "LAST MONTH: 121 evals" + arrow */
+    .chiclet-header {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-size: 0.7rem; color: var(--muted);
+      text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .chiclet-header .chiclet-count-inline {
+      color: var(--text); font-weight: 600;
+      /* slightly less muted than the label so the count reads */
+    }
+    .chiclet-arrow { color: var(--accent); font-size: 1rem; line-height: 1; }
+
+    /* Hero row: big mean / score, thin secondary inline */
+    .chiclet-hero {
+      display: flex; align-items: baseline; gap: 8px;
+      font-family: 'Fraunces', serif;
+    }
+    .chiclet-hero .chiclet-primary {
+      font-size: 2.4rem; font-weight: 700; line-height: 1.05;
+    }
+    .chiclet-hero .chiclet-secondary {
+      font-size: 1rem; font-weight: 400; color: var(--muted);
+      letter-spacing: 0.01em;
+    }
+    .chiclet-hero .chiclet-agent {
+      font-size: 0.95rem; font-weight: 500; color: var(--text);
+      font-family: 'DM Mono', monospace;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      min-width: 0; flex: 1;
+    }
+
+    /* Footer line: month or time-ago, plus an optional uppercase mini-label */
+    .chiclet-footer {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-size: 0.72rem; color: var(--muted);
+    }
+    .chiclet-footer .chiclet-mini-label {
+      text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.65rem;
+    }
+    .chiclet-footer .chiclet-when {
+      font-size: 0.78rem; color: var(--text);
+    }
+    /* Empty-state placeholder (Recent Evals before first eval) */
+    .chiclet-hero .chiclet-empty {
+      font-family: 'DM Mono', monospace; font-size: 1.1rem;
+      color: var(--muted); font-weight: 400;
+    }
+
+    /* Expanded panel beneath the chiclet row (Recent Evals drill-down) */
+    .recent-evals-panel {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+      padding: 14px 16px; margin-top: -4px;  /* visually attach to the row above */
+    }
+    .recent-evals-panel-header {
+      display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px;
+    }
+    .recent-evals-panel-header .label {
+      font-family: 'Fraunces', serif; font-size: 0.95rem; font-weight: 700;
+    }
+    .recent-evals-panel-header .sub { font-size: 0.72rem; color: var(--muted); }
+    .recent-evals-list { max-height: 320px; overflow-y: auto; }
+    .recent-evals-item {
+      display: grid; grid-template-columns: 70px 1fr 130px; align-items: center;
+      gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--border);
+      font-size: 0.8rem;
+    }
+    .recent-evals-item:last-child { border-bottom: none; }
+    .recent-evals-item .re-score { font-family: 'Fraunces', serif; font-weight: 700; text-align: left; }
+    .recent-evals-item .re-agent { font-weight: 600; }
+    .recent-evals-item .re-evaluator {
+      font-size: 0.7rem; color: var(--muted); margin-top: 2px;
+    }
+    .recent-evals-item .re-time { color: var(--muted); font-size: 0.72rem; text-align: right; }
+    .recent-evals-empty { padding: 12px 0; color: var(--muted); font-size: 0.8rem; text-align: center; }
+
+    @media (max-width: 900px) {
+      .chiclet-row { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 640px) {
+      .chiclet-row { grid-template-columns: 1fr; }
+      .recent-evals-item { grid-template-columns: 60px 1fr 90px; }
+    }
+
+    /* Charts grid */
+    .charts-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+
+    /* Tables */
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    th, td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    th {
+      font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+      cursor: pointer; user-select: none; position: sticky; top: 0; background: var(--surface);
+    }
+    th:hover { color: var(--text); }
+    tr:hover { background: var(--bg); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* Badges */
+    .badge {
+      display: inline-block; padding: 2px 8px; border-radius: 9999px; font-size: 0.7rem; font-weight: 500;
+    }
+    .badge-excellent { background: #dcfce7; color: #166534; }
+    .badge-good { background: #dbeafe; color: #1e40af; }
+    .badge-watch { background: #fef3c7; color: #92400e; }
+    .badge-at_risk, .badge-at-risk { background: #fee2e2; color: #991b1b; }
+    .badge-exceptional { background: #dcfce7; color: #166534; }
+    .badge-concerning { background: #fee2e2; color: #991b1b; }
+    .badge-high { background: #fee2e2; color: #991b1b; }
+    .badge-medium { background: #fef3c7; color: #92400e; }
+    .badge-low { background: #dbeafe; color: #1e40af; }
+
+    /* Trend arrows */
+    .trend-up { color: var(--green); }
+    .trend-down { color: var(--red); }
+    .trend-flat { color: var(--muted); }
+
+    /* Loading */
+    .loading { text-align: center; padding: 60px; color: var(--muted); font-size: 0.9rem; }
+
+    /* EWMA drill-down (clickable bar → expand evals list below the chart) */
+    .ewma-drill-header {
+      display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+      padding: 10px 12px; background: var(--bg); border-radius: 8px 8px 0 0;
+      border: 1px solid var(--border); border-bottom: none;
+    }
+    .ewma-drill-agent { font-family: 'Fraunces', serif; font-size: 1.05rem; font-weight: 700; }
+    .ewma-drill-sub { font-size: 0.75rem; color: var(--muted); }
+    .ewma-drill-close {
+      margin-left: auto; background: transparent; border: 1px solid var(--border);
+      color: var(--muted); border-radius: 6px; padding: 4px 10px; font-size: 0.75rem;
+      cursor: pointer; font-family: 'DM Mono', monospace;
+    }
+    .ewma-drill-close:hover { color: var(--text); border-color: var(--muted); }
+    .ewma-drill-table {
+      width: 100%; border-collapse: collapse; font-size: 0.78rem;
+      border: 1px solid var(--border); border-radius: 0 0 8px 8px; overflow: hidden;
+    }
+    .ewma-drill-table th, .ewma-drill-table td {
+      padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border);
+    }
+    .ewma-drill-table th {
+      font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--muted); background: var(--surface); position: static;
+    }
+    .ewma-drill-table tr:last-child td { border-bottom: none; }
+    .ewma-drill-table .score-link { font-weight: 700; }
+    .ewma-drill-empty {
+      padding: 20px; text-align: center; color: var(--muted); font-size: 0.8rem;
+      border: 1px solid var(--border); border-radius: 0 0 8px 8px;
+    }
+
+    /* Toast (SSE eval_approved notifications) */
+    .toast-container {
+      position: fixed; bottom: 24px; right: 24px; z-index: 1000;
+      display: flex; flex-direction: column; gap: 10px; max-width: 360px;
+    }
+    .toast {
+      background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--accent);
+      border-radius: 10px; padding: 12px 14px; box-shadow: 0 6px 20px rgba(21,25,45,0.18);
+      cursor: pointer; transition: transform 0.18s, opacity 0.18s;
+      animation: toast-slide-in 0.22s ease-out;
+    }
+    .toast:hover { transform: translateX(-3px); }
+    .toast.dismissing { opacity: 0; transform: translateX(20px); }
+    .toast .toast-row {
+      display: flex; align-items: baseline; gap: 8px; font-size: 0.8rem;
+    }
+    .toast .toast-agent { font-weight: 600; color: var(--text); }
+    .toast .toast-score {
+      font-family: 'Fraunces', serif; font-weight: 700; font-size: 0.95rem; margin-left: auto;
+    }
+    .toast .toast-summary {
+      font-size: 0.75rem; color: var(--muted); margin-top: 6px; line-height: 1.4;
+      overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    }
+    @keyframes toast-slide-in {
+      from { opacity: 0; transform: translateX(40px); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+    /* Compact variant: agent_status pulses (SSE). One line, muted accent,
+       shorter-lived than eval_approved toasts. */
+    .toast.toast-status {
+      border-left-color: var(--muted); padding: 7px 12px;
+    }
+    .toast.toast-status .toast-row { font-size: 0.72rem; }
+    .toast.toast-status .toast-status-label {
+      color: var(--muted); margin-left: auto; font-weight: 600;
+      text-transform: capitalize;
+    }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      .kpi-row { grid-template-columns: repeat(2, 1fr); }
+      .charts-grid { grid-template-columns: 1fr; }
+      .container { padding: 16px; }
+      .tab-btn { padding: 8px 12px; font-size: 0.75rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div id="appHeader"></div>
+
+<div class="tab-bar">
+  <button class="tab-btn active" onclick="switchTab('overview')">Overview</button>
+  <button class="tab-btn" onclick="switchTab('roster')">Agent Roster</button>
+  <button class="tab-btn" onclick="switchTab('outliers')">Outliers</button>
+  <button class="tab-btn" onclick="switchTab('sections')">Section Analysis</button>
+  <button class="tab-btn" onclick="switchTab('supervisors')">Supervisors</button>
+</div>
+
+<div class="container">
+  <!-- Overview Tab -->
+  <div class="tab-panel active" id="panel-overview">
+    <div class="chiclet-row" id="chicletRow"></div>
+    <div class="bucket-hint" title="Months reflect when calls actually connected (Dialpad date_connected). Score_Audit retains the eval-approval times.">
+      &#9432; Months bucketed by <strong>call date</strong>, not eval-approval date
+    </div>
+    <div class="recent-evals-panel" id="recentEvalsPanel" style="display:none;"></div>
+    <div class="kpi-row" id="kpiRow"></div>
+    <div class="charts-grid">
+      <div class="card">
+        <h3>SPC Control Chart <span class="bucket-hint-inline" title="Each month's mean is computed over calls that connected in that month.">&#9432; by call date</span></h3>
+        <canvas id="spcCanvas"></canvas>
+      </div>
+      <div class="card"><h3>Score Distribution</h3><canvas id="distCanvas" style="cursor:pointer;"></canvas><div id="distDrillDown" style="display:none;"></div></div>
+    </div>
+    <div class="card">
+      <h3>EWMA by Agent</h3>
+      <canvas id="ewmaCanvas" style="cursor:pointer;"></canvas>
+      <div id="ewmaDrillDown" style="display:none; margin-top:16px;"></div>
+    </div>
+  </div>
+
+  <!-- Agent Roster Tab -->
+  <div class="tab-panel" id="panel-roster">
+    <div class="card">
+      <h3>Agent Roster</h3>
+      <div style="overflow-x:auto"><table id="rosterTable"><thead><tr id="rosterHeaderRow">
+        <th data-col="agent">Agent</th><th data-col="n">Evals</th>
+        <th data-col="mean">Mean</th><th data-col="std">Std</th>
+        <th data-col="ewma">EWMA</th><th data-col="trend">Trend</th>
+        <!-- One <th> per Y/N section is injected here at render time, between Trend and Status. -->
+        <th data-col="status">Status</th><th>Weak Sections</th>
+      </tr></thead><tbody></tbody></table></div>
+    </div>
+  </div>
+
+  <!-- Outliers Tab -->
+  <div class="tab-panel" id="panel-outliers">
+    <div class="card">
+      <h3>Outliers</h3>
+      <div style="overflow-x:auto"><table id="outliersTable"><thead><tr>
+        <th data-col="agent">Agent</th><th data-col="date">Date</th>
+        <th data-col="score">Score</th><th data-col="agent_median">Agent Median</th>
+        <th data-col="modified_z">Modified Z</th><th data-col="classification">Type</th>
+      </tr></thead><tbody></tbody></table></div>
+    </div>
+  </div>
+
+  <!-- Section Analysis Tab -->
+  <div class="tab-panel" id="panel-sections">
+    <div class="charts-grid">
+      <div class="card"><h3>Section Averages</h3><canvas id="sectionAvgCanvas"></canvas></div>
+      <div class="card"><h3>Section Variability</h3><canvas id="sectionVarCanvas"></canvas></div>
+    </div>
+    <div class="kpi-row" style="grid-template-columns: repeat(2, 1fr);" id="binaryStats"></div>
+    <div class="card">
+      <h3>Training Opportunities</h3>
+      <div style="overflow-x:auto"><table id="trainingTable"><thead><tr>
+        <th data-col="agent">Agent</th><th data-col="section">Section</th>
+        <th data-col="agent_avg">Agent Avg</th><th data-col="team_avg">Team Avg</th>
+        <th data-col="gap">Gap</th><th data-col="priority">Priority</th>
+      </tr></thead><tbody></tbody></table></div>
+    </div>
+  </div>
+
+  <!-- Toast container for SSE eval_approved notifications -->
+  <div class="toast-container" id="toastContainer"></div>
+
+  <!-- Supervisors Tab -->
+  <div class="tab-panel" id="panel-supervisors">
+    <div class="card"><h3>Supervisor Comparison</h3><canvas id="supervisorCanvas"></canvas></div>
+    <div class="card">
+      <h3>Supervisor Summary</h3>
+      <div style="overflow-x:auto"><table id="supervisorTable"><thead><tr>
+        <th data-col="supervisor">Supervisor</th><th data-col="avg_score">Avg Score</th>
+        <th data-col="std_score">Std</th><th data-col="eval_count">Eval Count</th>
+        <th data-col="agent_count">Agent Count</th>
+      </tr></thead><tbody></tbody></table></div>
+    </div>
+  </div>
+</div>
+
+<script src="/static/header.js"></script>
+<script>
+// --- Auth (Sandy port): the Google SSO wall authenticates every request;
+// the legacy API-key plumbing is vestigial. Keep the function shapes so the
+// rest of the file stays byte-identical to the Railway original.
+function getApiKey() { return 'sso'; }
+function authHeaders() { return {}; }
+
+const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+
+// Filter state owned by QAHeader (header.js). Hydrated from the URL on
+// init and emitted via the onChange callback we wire in below. Defaults
+// match QAHeader's DEFAULT_DAYS so the first paint and the first /team/stats
+// fetch agree on which chiclet is active.
+let selectedDays = 30;
+let dateFrom = null;
+let dateTo = null;
+let activeOnly = true;
+let selectedSupervisor = '';
+let qaHeader = null;
+let teamData = null;
+let currentTab = 'overview';
+let sortState = {};
+
+let spcChart = null, distChart = null, ewmaChart = null;
+let sectionAvgChart = null, sectionVarChart = null, supervisorChart = null;
+
+// --- Fetch ---
+async function fetchTeamStats() {
+  collapseDistDrill();  // collapse drill-down on timeframe/filter change
+  const params = new URLSearchParams({ active_only: activeOnly });
+  // Custom-range chiclet (dateFrom + dateTo) takes precedence over `days`.
+  if (dateFrom && dateTo) {
+    params.set('date_from', dateFrom);
+    params.set('date_to', dateTo);
+  } else {
+    params.set('days', selectedDays);
+  }
+  if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+  try {
+    const r = await fetch(`${API_BASE}/team/stats?${params}`, { headers: authHeaders() });
+    if (r.status === 401) {
+      sessionStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      return;
+    }
+    if (!r.ok) throw new Error(r.statusText);
+    teamData = await r.json();
+    renderTab(currentTab);
+    // Initial-populate the Recent Evals ring buffer on first successful
+    // /team/stats response — the response carries monthly.current.year_month
+    // which we need to call /team/evals. Subsequent stats refetches skip
+    // this (the SSE feed is now the source of truth).
+    initRecentEvalsBuffer();
+  } catch (e) {
+    console.error('Failed to fetch team stats:', e);
+  }
+}
+
+async function fetchMails() {
+  try {
+    const r = await fetch(`${API_BASE}/team/mails`, { headers: authHeaders() });
+    if (r.status === 401) {
+      sessionStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      return;
+    }
+    if (!r.ok) return;
+    const mails = await r.json();
+    const supervisors = [...new Set(mails.map(m => m.supervisor).filter(Boolean))].sort();
+    if (qaHeader) qaHeader.setSupervisors(supervisors);
+  } catch (e) { console.error('Failed to fetch mails:', e); }
+}
+
+// QAHeader (header.js) owns the chiclets / Active Only / Supervisor /
+// custom-range popover. It emits a single onChange with the resolved
+// filter state; we mirror it into the page-level locals + refetch.
+
+// --- Tabs ---
+function switchTab(tab) {
+  currentTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  event.target.classList.add('active');
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  document.getElementById('panel-' + tab).classList.add('active');
+  if (teamData) renderTab(tab);
+}
+
+function renderTab(tab) {
+  if (!teamData) return;
+  const renderers = {
+    overview: renderOverview, roster: renderRoster, outliers: renderOutliers,
+    sections: renderSections, supervisors: renderSupervisors
+  };
+  renderers[tab]?.();
+}
+
+// --- Helpers ---
+function scoreColor(v) { return v >= 85 ? '#28A745' : v >= 70 ? '#E8A317' : '#D9534F'; }
+function sectionScoreColor(v) { return v >= 4.25 ? '#28A745' : v >= 3.5 ? '#E8A317' : '#D9534F'; }
+function varColor(v) { return v > 1.1 ? '#D9534F' : v > 0.9 ? '#E8A317' : '#28A745'; }
+function destroyChart(c) { if (c) c.destroy(); return null; }
+function fmt(v, d = 1) { return v != null ? Number(v).toFixed(d) : '--'; }
+function pctFmt(v) { return v != null ? Number(v).toFixed(1) + '%' : '--'; }
+function escapeHtml(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+
+function trendHtml(t) {
+  if (t === 'improving') return '<span class="trend-up">&#9650;</span>';
+  if (t === 'declining') return '<span class="trend-down">&#9660;</span>';
+  return '<span class="trend-flat">&#9679;</span>';
+}
+
+function statusBadge(s) {
+  if (!s) return '';
+  return `<span class="badge badge-${s}">${s.replace('_', ' ')}</span>`;
+}
+
+function priorityBadge(p) {
+  if (!p) return '';
+  return `<span class="badge badge-${p}">${p}</span>`;
+}
+
+// --- Sort ---
+// data-col supports dot-paths (e.g. "binary_pcts.contact_verification")
+// so dynamically-injected nested columns (Y/N percentages per section)
+// sort the same way as flat fields.
+function _readPath(obj, path) {
+  return path.split('.').reduce((o, k) => (o == null ? null : o[k]), obj);
+}
+function attachSort(tableId, data, renderFn) {
+  const table = document.getElementById(tableId);
+  if (!table) return;
+  table.querySelectorAll('th[data-col]').forEach(th => {
+    th.onclick = () => {
+      const col = th.dataset.col;
+      const key = tableId + '.' + col;
+      const asc = sortState[key] === 'asc' ? 'desc' : 'asc';
+      sortState[key] = asc;
+      data.sort((a, b) => {
+        let va = _readPath(a, col), vb = _readPath(b, col);
+        if (va == null) return 1; if (vb == null) return -1;
+        if (typeof va === 'string') return asc === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
+        return asc === 'asc' ? va - vb : vb - va;
+      });
+      renderFn(data);
+    };
+  });
+}
+
+// --- Overview ---
+function renderOverview() {
+  renderChiclets();
+
+  const k = teamData.kpis || {};
+  document.getElementById('kpiRow').innerHTML = [
+    { label: 'Total Evals', value: k.total_evals ?? '--' },
+    { label: 'Avg Score', value: fmt(k.avg_score), color: scoreColor(k.avg_score) },
+    { label: 'Std Dev', value: fmt(k.std_score) },
+    { label: 'Active Analysts', value: k.analyst_count ?? '--' }
+  ].map(kpi => `<div class="kpi-box">
+    <div class="label">${kpi.label}</div>
+    <div class="value" ${kpi.color ? `style="color:${kpi.color}"` : ''}>${kpi.value}</div>
+  </div>`).join('');
+
+  renderSpcChart();
+  renderDistChart();
+  renderEwmaChart();
+}
+
+function renderChiclets() {
+  const monthly = teamData.monthly || {};
+  const target = document.getElementById('chicletRow');
+  if (!target) return;
+
+  function _chiclet(label, m) {
+    if (!m) return '';
+    // Drill-down preserves the page's active/supervisor filters; the month
+    // string is the time window so the days filter is not propagated.
+    const params = new URLSearchParams({
+      month: m.year_month,
+      active_only: activeOnly,
+    });
+    if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+    const href = `/dashboard/${TEAM_ID}/evals?${params.toString()}`;
+
+    const meanLabel = m.mean != null ? fmt(m.mean) : '—';
+    const stdLabel = m.std != null ? `± ${fmt(m.std)}` : '';
+    const meanColor = m.mean != null ? scoreColor(m.mean) : 'var(--muted)';
+
+    return `<a class="chiclet" href="${href}">
+      <div class="chiclet-header">
+        <span>${label}: <span class="chiclet-count-inline">${m.count} eval${m.count === 1 ? '' : 's'}</span></span>
+        <span class="chiclet-arrow">&rsaquo;</span>
+      </div>
+      <div class="chiclet-hero">
+        <span class="chiclet-primary" style="color:${meanColor}">${meanLabel}</span>
+        ${stdLabel ? `<span class="chiclet-secondary">${stdLabel}</span>` : ''}
+      </div>
+      <div class="chiclet-footer">
+        <span class="chiclet-when">${_monthDisplay(m.year_month)}</span>
+        <span class="chiclet-mini-label">mean ± std</span>
+      </div>
+    </a>`;
+  }
+
+  target.innerHTML =
+    _chiclet('Last Month', monthly.last) +
+    _chiclet('Current Month', monthly.current) +
+    _recentEvalsChiclet();
+}
+
+// ---------------------------------------------------------------------------
+// Recent Evals chiclet (Phase F of LiveDashboard.md)
+//
+// Third chiclet on the row. Collapsed: count + most-recent agent/score.
+// Expanded: scrollable list of up to RECENT_EVALS_VISIBLE rows beneath the
+// chiclet row (same visual register as the EWMA drill-down).
+//
+// Source of truth is a client-side ring buffer (max 50 entries). On dashboard
+// load the buffer is initial-populated via /team/evals?year_month=<current>
+// (already shipped in Phase A). After that, every SSE eval_approved event
+// prepends. The buffer survives /team/stats refetches; only a hard page
+// reload empties it (acceptable — the Sheet is one fetch away).
+// ---------------------------------------------------------------------------
+const RECENT_EVALS_MAX = 50;
+const RECENT_EVALS_VISIBLE = 10;
+let _recentEvalsBuffer = [];           // newest first; all-time log (caps at 50)
+let _recentEvalsInitialized = false;
+let _recentEvalsExpanded = false;
+let _midnightTimer = null;             // re-renders the chiclet at next local midnight
+
+function _recentEvalsChiclet() {
+  // The displayed "count" reflects TODAY only (user's local midnight boundary).
+  // The full buffer still drives the expanded panel — so "5 today" in the
+  // header but clicking through shows the last 10 across all time.
+  const todayCount = _recentEvalsBuffer.filter(r => _isToday(r.timestamp)).length;
+  const countLabel = `${todayCount} today`;
+
+  const latest = _recentEvalsBuffer[0];
+  let heroHtml;
+  let footerWhen;
+  if (latest && latest.overall_score != null) {
+    const color = scoreColor(latest.overall_score);
+    heroHtml = `
+      <span class="chiclet-primary" style="color:${color}">${fmt(latest.overall_score)}</span>
+      <span class="chiclet-agent">${escapeHtml(latest.agent || '—')}</span>
+    `;
+    footerWhen = _timeAgo(latest.timestamp);
+  } else {
+    heroHtml = '<span class="chiclet-empty">awaiting first eval…</span>';
+    footerWhen = '—';
+  }
+
+  return `<button type="button"
+                  class="chiclet ${_recentEvalsExpanded ? 'chiclet-active' : ''}"
+                  onclick="toggleRecentEvals()">
+    <div class="chiclet-header">
+      <span>RECENT EVALS: <span class="chiclet-count-inline">${countLabel}</span></span>
+      <span class="chiclet-arrow">${_recentEvalsExpanded ? '&#9662;' : '&rsaquo;'}</span>
+    </div>
+    <div class="chiclet-hero">${heroHtml}</div>
+    <div class="chiclet-footer">
+      <span class="chiclet-when">${footerWhen}</span>
+      <span class="chiclet-mini-label">latest</span>
+    </div>
+  </button>`;
+}
+
+function toggleRecentEvals() {
+  _recentEvalsExpanded = !_recentEvalsExpanded;
+  renderChiclets();
+  renderRecentEvalsPanel();
+}
+
+function renderRecentEvalsPanel() {
+  const panel = document.getElementById('recentEvalsPanel');
+  if (!panel) return;
+  if (!_recentEvalsExpanded) { panel.style.display = 'none'; panel.innerHTML = ''; return; }
+  panel.style.display = 'block';
+
+  const visible = _recentEvalsBuffer.slice(0, RECENT_EVALS_VISIBLE);
+  const subText = _recentEvalsBuffer.length === 0
+    ? 'Waiting for new evaluations…'
+    : `showing ${visible.length} of ${_recentEvalsBuffer.length}`;
+
+  const itemsHtml = visible.length === 0
+    ? '<div class="recent-evals-empty">No recent evaluations yet.</div>'
+    : visible.map(r => {
+        const color = scoreColor(r.overall_score);
+        const scoreCell = r.eval_id
+          ? `<a class="re-score" href="/datapoint/${TEAM_ID}/${encodeURIComponent(r.eval_id)}" style="color:${color};">${fmt(r.overall_score)}</a>`
+          : `<span class="re-score" style="color:${color};">${fmt(r.overall_score)}</span>`;
+        const evaluatorLine = r.evaluator_email
+          ? `<div class="re-evaluator">by ${escapeHtml(_displayNameFromEmail(r.evaluator_email))}</div>`
+          : '';
+        return `<div class="recent-evals-item">
+          <div>${scoreCell}</div>
+          <div>
+            <div class="re-agent">${escapeHtml(r.agent || '—')}</div>
+            ${evaluatorLine}
+          </div>
+          <div class="re-time">${_timeAgo(r.timestamp)}</div>
+        </div>`;
+      }).join('');
+
+  panel.innerHTML = `
+    <div class="recent-evals-panel-header">
+      <span class="label">Recent Evaluations</span>
+      <span class="sub">${subText}</span>
+    </div>
+    <div class="recent-evals-list">${itemsHtml}</div>
+  `;
+}
+
+async function initRecentEvalsBuffer() {
+  // Idempotent: only runs once per page load. The SSE handler is the
+  // ongoing feed afterwards.
+  if (_recentEvalsInitialized) return;
+  _recentEvalsInitialized = true;
+
+  const ym = teamData?.monthly?.current?.year_month;
+  if (!ym) return;
+
+  try {
+    // active_only=false: the chiclet is the "log of toasts" — toasts ignore
+    // dashboard filters, so this should too. Otherwise initial-population
+    // and SSE feed would disagree (toast shows an agent who's filtered out
+    // of the chart, then chiclet wouldn't pre-fill them).
+    const r = await fetch(
+      `${API_BASE}/team/evals?year_month=${encodeURIComponent(ym)}&active_only=false`,
+      { headers: authHeaders() },
+    );
+    if (!r.ok) return;
+    const data = await r.json();
+    // For the Recent Evals chiclet specifically, "time-ago" means time
+    // since approval, not time since the call connected — this is the
+    // one place where the eval clock takes the front seat. /team/evals
+    // post-PR-3 returns `timestamp` (call date, for the drill-down
+    // page's "Call Date" column) and `eval_approved_at` (eval-approval
+    // clock). We prefer eval_approved_at so initial-populate matches
+    // SSE-fed entries (the SSE `timestamp` field is already set to
+    // `datetime.now(UTC)` at publish time). Fall back to call time only
+    // when an old client/sheet didn't carry eval_approved_at.
+    const _evalClock = (row) => row.eval_approved_at || row.timestamp;
+    const rows = (data.rows || [])
+      .slice()
+      .sort((a, b) => new Date(_evalClock(b)) - new Date(_evalClock(a)))
+      .slice(0, RECENT_EVALS_MAX)
+      .map(r => ({
+        agent: r.agent,
+        overall_score: r.overall_score,
+        timestamp: _evalClock(r),
+        eval_id: r.eval_id,
+        evaluator_email: r.evaluator_email,
+      }));
+    _recentEvalsBuffer = rows;
+    renderChiclets();
+    if (_recentEvalsExpanded) renderRecentEvalsPanel();
+  } catch (e) {
+    console.error('Failed to init recent-evals buffer:', e);
+  }
+}
+
+function prependRecentEval(data) {
+  // De-dupe: an approval handler that publishes twice would otherwise duplicate
+  // the entry. Keyed on eval_id when present (call_id fallback for older shape).
+  const key = data.eval_id || data.call_id;
+  if (key) {
+    _recentEvalsBuffer = _recentEvalsBuffer.filter(r => (r.eval_id || r.call_id) !== key);
+  }
+  _recentEvalsBuffer.unshift({
+    agent: data.agent,
+    overall_score: data.overall_score,
+    timestamp: data.timestamp,
+    eval_id: data.eval_id || data.call_id,
+    call_id: data.call_id,
+    evaluator_email: data.evaluator_email,
+  });
+  if (_recentEvalsBuffer.length > RECENT_EVALS_MAX) {
+    _recentEvalsBuffer.length = RECENT_EVALS_MAX;
+  }
+  renderChiclets();
+  if (_recentEvalsExpanded) renderRecentEvalsPanel();
+}
+
+function _monthDisplay(yyyy_mm) {
+  // "2026-04" → "Apr, 2026". Falls back to the raw string for unparseable
+  // inputs (defensive — should never happen for a /team/stats response).
+  if (!yyyy_mm || !/^\d{4}-\d{2}$/.test(yyyy_mm)) return yyyy_mm || '';
+  const [yStr, mStr] = yyyy_mm.split('-');
+  const monthIdx = parseInt(mStr, 10) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return yyyy_mm;
+  // Construct a UTC date so the month name doesn't drift on a tz boundary.
+  const d = new Date(Date.UTC(parseInt(yStr, 10), monthIdx, 1));
+  const name = d.toLocaleDateString(undefined, { month: 'short', timeZone: 'UTC' });
+  return `${name}, ${yStr}`;
+}
+
+function _isToday(iso) {
+  // Local-time "today" boundary so the chiclet matches the viewer's
+  // experience of the day. Midnight rollover is handled by
+  // _scheduleMidnightRerender (no polling).
+  if (!iso) return false;
+  const t = new Date(iso);
+  if (isNaN(t)) return false;
+  const now = new Date();
+  return t.getFullYear() === now.getFullYear()
+      && t.getMonth() === now.getMonth()
+      && t.getDate() === now.getDate();
+}
+
+function _scheduleMidnightRerender() {
+  // setTimeout exactly to the next local midnight; on fire, re-render the
+  // chiclets (so "today" counts reset) and re-schedule. Avoids polling.
+  // Cap the delay at 24h to defend against system-clock drift edge cases
+  // where the next-midnight calculation lands further out than expected.
+  if (_midnightTimer) clearTimeout(_midnightTimer);
+  const now = new Date();
+  const tomorrowMidnight = new Date(
+    now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 50
+  );
+  const delay = Math.min(24 * 3600 * 1000, tomorrowMidnight.getTime() - now.getTime());
+  _midnightTimer = setTimeout(() => {
+    _midnightTimer = null;
+    if (teamData) renderChiclets();
+    _scheduleMidnightRerender();
+  }, Math.max(1000, delay));  // floor at 1s for clock-skew edge cases
+}
+
+function _displayNameFromEmail(email) {
+  // Mirrors backend/src/QAEntry.managerNameFromEmail: "max.perez@landing.com"
+  // → "Max Perez". The full email is verbose for a row in the chiclet panel.
+  if (!email) return '';
+  const local = email.split('@')[0] || '';
+  if (!local) return email;
+  return local.split(/[._-]/)
+    .filter(Boolean)
+    .map(p => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function _timeAgo(iso) {
+  if (!iso) return '—';
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return '—';
+  const secs = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  // For older entries, fall back to a short date instead of "12 weeks ago".
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: '2-digit' });
+}
+
+function renderSpcChart() {
+  spcChart = destroyChart(spcChart);
+  const spc = teamData.spc;
+  if (!spc || !spc.months || !spc.months.length) return;
+  const labels = spc.months.map(m => m.month);
+  const means = spc.months.map(m => m.mean);
+  const pointColors = means.map(m => (m > spc.ucl || m < spc.lcl) ? '#D9534F' : '#1A61D9');
+  spcChart = new Chart(document.getElementById('spcCanvas'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Monthly Mean', data: means, borderColor: '#1A61D9', fill: false, tension: 0.2, pointBackgroundColor: pointColors, pointRadius: 5 },
+        { label: 'UCL', data: labels.map(() => spc.ucl), borderColor: '#D9534F', borderDash: [6, 4], pointRadius: 0, borderWidth: 1.5 },
+        { label: 'LCL', data: labels.map(() => spc.lcl), borderColor: '#D9534F', borderDash: [6, 4], pointRadius: 0, borderWidth: 1.5 },
+        { label: 'Center', data: labels.map(() => spc.center), borderColor: '#5a6478', borderDash: [4, 4], pointRadius: 0, borderWidth: 1.5 }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: { y: { min: 60, max: 100, ticks: { stepSize: 5 } } },
+      plugins: { legend: { position: 'bottom' } },
+      // Phase E (LiveDashboard.md): clicking a monthly-mean point opens
+      // the same /evals?month=YYYY-MM page the chiclets use, preserving
+      // the dashboard's active_only + supervisor filters. Closes the
+      // loop: viewer can drill from any trend point to its underlying
+      // evals without leaving the app.
+      onHover: (e, items) => {
+        e.native && (e.native.target.style.cursor = items.length ? 'pointer' : 'default');
+      },
+      onClick: (event, activeElements) => {
+        if (!activeElements.length) return;
+        // Only react to the Monthly Mean dataset (index 0). Clicking on
+        // UCL/LCL/Center lines (datasets 1–3) is meaningless.
+        const hit = activeElements.find(a => a.datasetIndex === 0);
+        if (!hit) return;
+        const m = spc.months[hit.index];
+        if (!m || !m.month) return;
+        const params = new URLSearchParams({
+          month: m.month,
+          active_only: activeOnly,
+        });
+        if (selectedSupervisor) params.set('supervisor', selectedSupervisor);
+        location.href = `/dashboard/${TEAM_ID}/evals?${params.toString()}`;
+      },
+    },
+  });
+}
+
+function renderDistChart() {
+  distChart = destroyChart(distChart);
+  const bins = teamData.distribution;
+  if (!bins?.length) return;
+  const colors = bins.map(b => {
+    const lo = parseInt(b.bin);
+    if (lo >= 91) return '#28A745';
+    if (lo >= 81) return '#1A61D9';
+    if (lo >= 71) return '#E8A317';
+    return '#D9534F';
+  });
+  distChart = new Chart(document.getElementById('distCanvas'), {
+    type: 'bar',
+    data: { labels: bins.map(b => b.bin), datasets: [{ label: 'Count', data: bins.map(b => b.count), backgroundColor: colors, borderColor: colors, borderWidth: 1 }] },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
+      onClick: (event, activeElements) => {
+        if (!activeElements.length) return;
+        const idx = activeElements[0].index;
+        const bin = bins[idx].bin;
+        loadDistDrillDown(bin);
+      }
+    }
+  });
+}
+
+// --- Distribution drill-down ---
+let _distDrillData = null;
+let _distDrillBin = null;
+let _distSortKey = 'score';
+let _distSortAsc = false;
+
+function collapseDistDrill() {
+  const el = document.getElementById('distDrillDown');
+  el.style.display = 'none';
+  el.innerHTML = '';
+  _distDrillData = null;
+  _distDrillBin = null;
+}
+
+function sortDistDrill(key) {
+  if (_distSortKey === key) {
+    _distSortAsc = !_distSortAsc;
+  } else {
+    _distSortKey = key;
+    _distSortAsc = key === 'agent';  // default asc for agent, desc for score/date
+  }
+  renderDistDrillTable();
+}
+
+function renderDistDrillTable() {
+  if (!_distDrillData) return;
+  const drillEl = document.getElementById('distDrillDown');
+
+  const sorted = [..._distDrillData].sort((a, b) => {
+    let va, vb;
+    if (_distSortKey === 'agent') { va = a.agent_name.toLowerCase(); vb = b.agent_name.toLowerCase(); }
+    else if (_distSortKey === 'date') { va = a.timestamp; vb = b.timestamp; }
+    else { va = a.overall_score; vb = b.overall_score; }
+    if (va < vb) return _distSortAsc ? -1 : 1;
+    if (va > vb) return _distSortAsc ? 1 : -1;
+    return 0;
+  });
+
+  const arrow = (key) => _distSortKey === key ? (_distSortAsc ? ' &#9650;' : ' &#9660;') : '';
+  const thStyle = 'padding:6px;cursor:pointer;user-select:none;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted);';
+
+  drillEl.innerHTML = `
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:10px 6px 4px;">
+      <span style="font-size:0.78rem;font-weight:500;color:var(--navy);">${_distDrillBin} — ${sorted.length} evaluations</span>
+      <span onclick="collapseDistDrill()" style="cursor:pointer;font-size:0.8rem;color:var(--muted);padding:2px 8px;" title="Collapse">&#9660;</span>
+    </div>
+    <table style="width:100%;font-size:0.78rem;border-collapse:collapse;">
+      <tr style="border-bottom:2px solid var(--border);">
+        <th style="${thStyle}text-align:left;" onclick="sortDistDrill('agent')">Agent${arrow('agent')}</th>
+        <th style="${thStyle}" onclick="sortDistDrill('date')">Date${arrow('date')}</th>
+        <th style="${thStyle}" onclick="sortDistDrill('score')">Score${arrow('score')}</th>
+        <th style="${thStyle}">Call</th>
+      </tr>
+      ${sorted.map(e => `<tr style="border-bottom:1px solid var(--border);">
+        <td style="padding:6px;"><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(e.agent_name)}">${e.agent_name}</a></td>
+        <td style="padding:6px;text-align:center;">${new Date(e.timestamp).toLocaleDateString('en-US',{month:'short',day:'numeric'})}</td>
+        <td style="padding:6px;text-align:center;color:${e.overall_score>=85?'var(--green)':e.overall_score>=70?'var(--amber)':'var(--red)'};font-weight:500;">${e.overall_score.toFixed(1)}</td>
+        <td style="padding:6px;text-align:center;">${e.eval_id ? `<a href="/datapoint/${TEAM_ID}/${e.eval_id}">View</a>` : ''}</td>
+      </tr>`).join('')}
+    </table>`;
+}
+
+async function loadDistDrillDown(bin) {
+  const drillEl = document.getElementById('distDrillDown');
+
+  // If same bin clicked, toggle collapse
+  if (_distDrillBin === bin && drillEl.style.display !== 'none') {
+    collapseDistDrill();
+    return;
+  }
+
+  _distDrillBin = bin;
+  _distSortKey = 'score';
+  _distSortAsc = false;
+  drillEl.style.display = '';
+  drillEl.innerHTML = `<p style="color:var(--muted);font-size:0.8rem;padding:10px 6px;">Loading evaluations in ${bin}...</p>`;
+
+  try {
+    const r = await fetch(`${API_BASE}/datapoints?bin=${bin}&days=${selectedDays}&active_only=${activeOnly}`, { headers: authHeaders() });
+    if (!r.ok) { drillEl.innerHTML = `<p style="color:var(--red);font-size:0.8rem;padding:8px;">Failed to load.</p>`; return; }
+    _distDrillData = await r.json();
+    if (!_distDrillData.length) { drillEl.innerHTML = `<p style="color:var(--muted);font-size:0.8rem;padding:10px 6px;">No evaluations in ${bin}.</p>`; return; }
+    renderDistDrillTable();
+  } catch (err) {
+    drillEl.innerHTML = `<p style="color:var(--red);font-size:0.8rem;padding:8px;">Error: ${err.message}</p>`;
+  }
+}
+
+// Tracks which agent's EWMA drill-down is currently expanded so a second
+// click on the same bar collapses (and a click on a different bar swaps).
+let _ewmaExpandedAgent = null;
+
+function renderEwmaChart() {
+  ewmaChart = destroyChart(ewmaChart);
+  const data = teamData.ewma;
+  if (!data?.length) {
+    // Collapse drill-down when the underlying chart goes empty (e.g. after
+    // a filter change that produces no agents).
+    collapseEwmaDrill();
+    return;
+  }
+  const colors = data.map(d => d.current_ewma >= 90 ? '#28A745' : d.current_ewma >= 80 ? '#1A61D9' : d.current_ewma >= 70 ? '#E8A317' : '#D9534F');
+  ewmaChart = new Chart(document.getElementById('ewmaCanvas'), {
+    type: 'bar',
+    data: { labels: data.map(d => d.agent), datasets: [{ label: 'EWMA', data: data.map(d => d.current_ewma), backgroundColor: colors, borderColor: colors, borderWidth: 1 }] },
+    options: {
+      indexAxis: 'y', responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { x: { min: 0, max: 100 } },
+      onClick: (event, activeElements) => {
+        if (!activeElements.length) return;
+        const idx = activeElements[0].index;
+        const entry = data[idx];
+        if (!entry) return;
+        // Same bar again → collapse. Different bar → swap.
+        if (_ewmaExpandedAgent === entry.agent) {
+          collapseEwmaDrill();
+        } else {
+          openEwmaDrill(entry);
+        }
+      },
+    },
+  });
+
+  // Restore a previously-open drill-down if the user just refetched
+  // /team/stats while it was visible (e.g. via the SSE debounce).
+  if (_ewmaExpandedAgent && data.some(d => d.agent === _ewmaExpandedAgent)) {
+    const entry = data.find(d => d.agent === _ewmaExpandedAgent);
+    openEwmaDrill(entry);
+  } else if (_ewmaExpandedAgent) {
+    // Agent dropped out of the result set under the new filters.
+    collapseEwmaDrill();
+  }
+}
+
+function collapseEwmaDrill() {
+  _ewmaExpandedAgent = null;
+  const el = document.getElementById('ewmaDrillDown');
+  if (el) { el.style.display = 'none'; el.innerHTML = ''; }
+}
+
+async function openEwmaDrill(ewmaEntry) {
+  _ewmaExpandedAgent = ewmaEntry.agent;
+  const el = document.getElementById('ewmaDrillDown');
+  if (!el) return;
+  el.style.display = 'block';
+
+  // The "evals comprising this EWMA" are every evaluation for this agent
+  // in the dashboard's current time window. EWMA is recency-weighted but
+  // mathematically includes the entire window, so listing all of them is
+  // accurate. /agents/{name}/history already returns EvaluationRecord
+  // with timestamp + caller_name + eval_id + overall_score.
+  const trendArrow = ewmaEntry.trend === 'improving' ? '▲'
+                    : ewmaEntry.trend === 'declining' ? '▼' : '●';
+  // Agent name links to the per-agent dashboard so the EWMA drill-down
+  // becomes a launchpad: bar → expand evals → click name to see the
+  // full progression view for that agent.
+  const agentHref = `/dashboard/${TEAM_ID}/agent/${encodeURIComponent(ewmaEntry.agent)}`;
+  el.innerHTML = `
+    <div class="ewma-drill-header">
+      <a class="ewma-drill-agent" href="${agentHref}" style="color:var(--text);">${escapeHtml(ewmaEntry.agent)}</a>
+      <div class="ewma-drill-sub">
+        EWMA ${fmt(ewmaEntry.current_ewma)} ·
+        <span class="trend-${ewmaEntry.trend === 'improving' ? 'up' : ewmaEntry.trend === 'declining' ? 'down' : 'flat'}">${trendArrow} ${ewmaEntry.trend}</span> ·
+        ${ewmaEntry.eval_count} eval${ewmaEntry.eval_count === 1 ? '' : 's'}
+      </div>
+      <button class="ewma-drill-close" onclick="collapseEwmaDrill()">Close ×</button>
+    </div>
+    <div class="ewma-drill-empty" id="ewmaDrillBody">Loading…</div>
+  `;
+
+  // Time window respects the dashboard's current filter: a preset chiclet
+  // (days), the custom range (date_from/date_to), or "All" (days=0 → 730 cap).
+  const params = new URLSearchParams();
+  if (dateFrom && dateTo) {
+    params.set('date_from', dateFrom);
+    params.set('date_to', dateTo);
+  } else {
+    params.set('days', selectedDays && selectedDays > 0 ? selectedDays : 730);
+  }
+  try {
+    const r = await fetch(
+      `${API_BASE}/agents/${encodeURIComponent(ewmaEntry.agent)}/history?${params}`,
+      { headers: authHeaders() }
+    );
+    if (r.status === 404) {
+      // No history for this agent in the window — render the empty state.
+      // (Shouldn't happen often since the agent appears in EWMA only if
+      // there were evals in the window, but filters could narrow.)
+      document.getElementById('ewmaDrillBody').textContent =
+        'No evaluations found for this agent in the current time window.';
+      return;
+    }
+    if (!r.ok) throw new Error(r.statusText);
+    const records = await r.json();
+    // Newest first so the list opens on the most recent eval.
+    records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    renderEwmaDrillBody(records);
+  } catch (err) {
+    console.error('Failed to fetch agent history:', err);
+    document.getElementById('ewmaDrillBody').textContent =
+      'Failed to load evaluations. Check console.';
+  }
+}
+
+function renderEwmaDrillBody(records) {
+  const body = document.getElementById('ewmaDrillBody');
+  if (!body) return;
+  if (!records.length) {
+    body.className = 'ewma-drill-empty';
+    body.textContent = 'No evaluations found for this agent in the current time window.';
+    return;
+  }
+  body.outerHTML = `
+    <table class="ewma-drill-table" id="ewmaDrillBody">
+      <thead>
+        <tr>
+          <th style="width:90px;">Score</th>
+          <th>Call Date</th>
+          <th>Caller</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${records.map(r => {
+          const dt = new Date(r.timestamp);
+          const dateStr = isNaN(dt) ? (r.timestamp || '—')
+            : dt.toLocaleString(undefined, { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+          const color = scoreColor(r.overall_score);
+          const scoreCell = r.eval_id
+            ? `<a class="score-link" href="/datapoint/${TEAM_ID}/${encodeURIComponent(r.eval_id)}" style="color:${color};">${fmt(r.overall_score)}</a>`
+            : `<span class="score-link" style="color:${color};">${fmt(r.overall_score)}</span>`;
+          return `<tr>
+            <td>${scoreCell}</td>
+            <td>${escapeHtml(dateStr)}</td>
+            <td>${escapeHtml(r.caller_name || '—')}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+// --- Roster ---
+// Roster columns are partially dynamic: every Y/N section configured for
+// the team gets its own column between Trend and Status. The (section_id,
+// label) pairs come from teamData.binary_stats so the table adapts to
+// whichever rubric is loaded.
+function rosterBinaryColumns() {
+  return (teamData?.binary_stats || []).map(b => ({
+    sectionId: b.section_id,
+    label: b.label,
+  }));
+}
+
+function rebuildRosterHeader() {
+  const headerRow = document.getElementById('rosterHeaderRow');
+  if (!headerRow) return;
+  // Strip any previously-injected binary headers (data-binary marker)
+  Array.from(headerRow.querySelectorAll('th[data-binary]')).forEach(th => th.remove());
+  const statusTh = headerRow.querySelector('th[data-col="status"]');
+  if (!statusTh) return;
+  for (const col of rosterBinaryColumns()) {
+    const th = document.createElement('th');
+    th.dataset.col = `binary_pcts.${col.sectionId}`;
+    th.dataset.binary = '1';
+    th.textContent = `${col.label} %`;
+    headerRow.insertBefore(th, statusTh);
+  }
+}
+
+function renderRoster() {
+  const roster = teamData.roster || [];
+  rebuildRosterHeader();
+  attachSort('rosterTable', roster, fillRoster);
+  fillRoster(roster);
+}
+
+function fillRoster(data) {
+  const binCols = rosterBinaryColumns();
+  document.querySelector('#rosterTable tbody').innerHTML = data.map(r => {
+    const binCells = binCols
+      .map(c => `<td>${pctFmt((r.binary_pcts || {})[c.sectionId])}</td>`)
+      .join('');
+    return `<tr>
+      <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(r.agent)}">${escapeHtml(r.agent)}</a></td>
+      <td>${r.n ?? ''}</td><td style="color:${scoreColor(r.mean)}">${fmt(r.mean)}</td><td>${fmt(r.std)}</td>
+      <td style="color:${scoreColor(r.ewma)}">${fmt(r.ewma)}</td><td>${trendHtml(r.trend)}</td>
+      ${binCells}
+      <td>${statusBadge(r.status)}</td><td>${(r.weak_sections || []).join(', ')}</td>
+    </tr>`;
+  }).join('');
+}
+
+// --- Outliers ---
+function renderOutliers() {
+  const outliers = teamData.outliers || [];
+  attachSort('outliersTable', outliers, fillOutliers);
+  fillOutliers(outliers);
+}
+
+function fillOutliers(data) {
+  document.querySelector('#outliersTable tbody').innerHTML = data.map(o => `<tr>
+    <td><a href="/dashboard/${TEAM_ID}/agent/${encodeURIComponent(o.agent)}">${escapeHtml(o.agent)}</a></td>
+    <td>${o.date || ''}</td><td>${o.eval_id ? `<a href="/datapoint/${TEAM_ID}/${o.eval_id}" style="color:${scoreColor(o.score)};font-weight:500;">${fmt(o.score, 0)}</a>` : `<span style="color:${scoreColor(o.score)}">${fmt(o.score, 0)}</span>`}</td>
+    <td>${fmt(o.agent_median)}</td><td>${fmt(o.modified_z, 2)}</td>
+    <td><span class="badge badge-${o.classification}">${o.classification}</span></td>
+  </tr>`).join('');
+}
+
+// --- Section Analysis ---
+function renderSections() {
+  renderSectionAvgChart();
+  renderSectionVarChart();
+  renderBinaryStats();
+  renderTraining();
+}
+
+function renderSectionAvgChart() {
+  sectionAvgChart = destroyChart(sectionAvgChart);
+  const sa = teamData.section_analysis;
+  if (!sa || !sa.team_means) return;
+  const sections = Object.keys(sa.team_means);
+  const data = sections.map(s => sa.team_means[s]);
+  const colors = data.map(v => sectionScoreColor(v));
+  sectionAvgChart = new Chart(document.getElementById('sectionAvgCanvas'), {
+    type: 'bar',
+    data: { labels: sections, datasets: [{ label: 'Avg', data: data, backgroundColor: colors, borderColor: colors, borderWidth: 1 }] },
+    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { min: 3, max: 5, ticks: { stepSize: 0.25 } } } }
+  });
+}
+
+function renderSectionVarChart() {
+  sectionVarChart = destroyChart(sectionVarChart);
+  const sa = teamData.section_analysis;
+  if (!sa || !sa.team_stds) return;
+  const sections = Object.keys(sa.team_stds);
+  const data = sections.map(s => sa.team_stds[s]);
+  const colors = data.map(v => varColor(v));
+  sectionVarChart = new Chart(document.getElementById('sectionVarCanvas'), {
+    type: 'bar',
+    data: { labels: sections, datasets: [{ label: 'Std Dev', data: data, backgroundColor: colors, borderColor: colors, borderWidth: 1 }] },
+    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
+  });
+}
+
+function renderBinaryStats() {
+  const bs = teamData.binary_stats || [];
+  const container = document.getElementById('binaryStats');
+  if (!bs.length) {
+    container.innerHTML = '';
+    return;
+  }
+  // auto-fit + minmax wraps to multiple rows when the team has many
+  // binary sections (Sales has 13, MS has 2). 160px min keeps the
+  // label readable.
+  container.style.gridTemplateColumns = 'repeat(auto-fit, minmax(160px, 1fr))';
+  container.innerHTML = bs.map(section => {
+    const pct = section.team_pct;
+    return `<div class="kpi-box">
+      <div class="label">${escapeHtml(section.label)} %</div>
+      <div class="value" style="color:${scoreColor(pct || 0)}">${pctFmt(pct)}</div>
+    </div>`;
+  }).join('');
+}
+
+function renderTraining() {
+  const sa = teamData.section_analysis || {};
+  const t = sa.training_opportunities || [];
+  attachSort('trainingTable', t, fillTraining);
+  fillTraining(t);
+}
+
+function fillTraining(data) {
+  document.querySelector('#trainingTable tbody').innerHTML = data.map(r => `<tr>
+    <td>${escapeHtml(r.agent)}</td><td>${escapeHtml(r.section)}</td><td>${fmt(r.agent_avg)}</td>
+    <td>${fmt(r.team_avg)}</td><td>${fmt(r.gap)}</td><td>${priorityBadge(r.priority)}</td>
+  </tr>`).join('');
+}
+
+// --- Supervisors ---
+function renderSupervisors() {
+  renderSupervisorChart();
+  renderSupervisorTable();
+}
+
+function renderSupervisorChart() {
+  supervisorChart = destroyChart(supervisorChart);
+  const data = teamData.supervisor_stats || [];
+  if (!data.length) return;
+  const colors = data.map(d => scoreColor(d.avg_score));
+  supervisorChart = new Chart(document.getElementById('supervisorCanvas'), {
+    type: 'bar',
+    data: { labels: data.map(d => d.supervisor), datasets: [{ label: 'Avg Score', data: data.map(d => d.avg_score), backgroundColor: colors, borderColor: colors, borderWidth: 1 }] },
+    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { min: 60, max: 100 } } }
+  });
+}
+
+function renderSupervisorTable() {
+  const data = teamData.supervisor_stats || [];
+  attachSort('supervisorTable', data, fillSupervisorTable);
+  fillSupervisorTable(data);
+}
+
+function fillSupervisorTable(data) {
+  document.querySelector('#supervisorTable tbody').innerHTML = data.map(s => `<tr>
+    <td>${escapeHtml(s.supervisor)}</td><td style="color:${scoreColor(s.avg_score)}">${fmt(s.avg_score)}</td><td>${fmt(s.std_score)}</td>
+    <td>${s.eval_count ?? ''}</td><td>${s.agent_count ?? ''}</td>
+  </tr>`).join('');
+}
+
+// --- Live updates via SSE (Phases B–C + E from LiveDashboard.md) ---
+//
+// On dashboard load, open a long-lived EventSource. The server publishes
+// `eval_approved` events on `/api/<team>/events/stream` whenever an
+// approval completes Stage 4 (Analyst_History row finalized).
+//
+// On each event:
+//   - render a toast (max 3 concurrent, 6s auto-dismiss, FIFO drop);
+//   - schedule a 3s-debounced re-fetch of /team/stats so every chart
+//     (top-3 KPIs, SPC, EWMA, Distribution, etc.) reflects the new data
+//     without manual refresh.
+//
+// Auth: EventSource cannot set Authorization headers, so the API key
+// rides along as ?api_key=... (Phase 0 added the fallback in
+// backend/middleware/auth.py).
+let _eventSource = null;
+let _refetchTimer = null;
+const MAX_TOASTS = 3;
+const TOAST_TTL_MS = 6000;
+const STATUS_TOAST_TTL_MS = 4000;
+
+function openEventStream() {
+  if (_eventSource) return;  // idempotent if init runs twice
+  const key = getApiKey();
+  if (!key) return;
+  const url = `${API_BASE}/events/stream?api_key=${encodeURIComponent(key)}`;
+  _eventSource = new EventSource(url);
+  _eventSource.addEventListener('eval_approved', e => {
+    try {
+      const data = JSON.parse(e.data);
+      showToast(data);
+      prependRecentEval(data);
+      scheduleStatsRefetch();
+    } catch (err) {
+      console.error('Failed to parse eval_approved payload:', err);
+    }
+  });
+  // Agent availability pulses from the Dialpad agent-status webhook
+  // subscription — a small one-line toast, no stats refetch (status
+  // changes don't move any chart).
+  _eventSource.addEventListener('agent_status', e => {
+    try {
+      showStatusToast(JSON.parse(e.data));
+    } catch (err) {
+      console.error('Failed to parse agent_status payload:', err);
+    }
+  });
+  // EventSource auto-reconnects on its own; no manual cap (per design Q3).
+  _eventSource.addEventListener('error', () => {
+    // Browser will retry. Log so devtools shows a breadcrumb.
+    console.warn('SSE connection error; browser will retry.');
+  });
+}
+
+function scheduleStatsRefetch() {
+  if (_refetchTimer) clearTimeout(_refetchTimer);
+  _refetchTimer = setTimeout(() => {
+    _refetchTimer = null;
+    fetchTeamStats();
+  }, 3000);
+}
+
+function showToast(data) {
+  const container = document.getElementById('toastContainer');
+  if (!container) return;
+
+  // FIFO drop: when 3 toasts already showing, evict the oldest before
+  // adding the new one. Predictable footprint, no infinite stack.
+  while (container.children.length >= MAX_TOASTS) {
+    container.firstElementChild.remove();
+  }
+
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  // Prefer eval_id (entry_point_call_id parsed from dialpad_link) — that's
+  // how every other path on the dashboard keys /datapoint URLs (see
+  // services/team_stats.py:_parse_row + the /team/evals drill-down). Falls
+  // back to master call_id when an older event lacks eval_id.
+  const datapointKey = data.eval_id || data.call_id;
+  const linkHref = datapointKey
+    ? `/datapoint/${TEAM_ID}/${encodeURIComponent(datapointKey)}`
+    : null;
+
+  const scoreColored = data.overall_score != null
+    ? `<span class="toast-score" style="color:${scoreColor(data.overall_score)}">${fmt(data.overall_score)}</span>`
+    : '';
+
+  toast.innerHTML = `
+    <div class="toast-row">
+      <span class="toast-agent">${escapeHtml(data.agent || '—')}</span>
+      ${scoreColored}
+    </div>
+    <div class="toast-summary">${escapeHtml(data.summary || '')}</div>
+  `;
+  // Whole toast is clickable when we have a call_id. Don't wrap in <a>
+  // because the score span has its own coloring; use a JS handler.
+  if (linkHref) {
+    toast.style.cursor = 'pointer';
+    toast.addEventListener('click', () => { location.href = linkHref; });
+  } else {
+    toast.addEventListener('click', () => dismissToast(toast));
+  }
+  container.appendChild(toast);
+
+  setTimeout(() => dismissToast(toast), TOAST_TTL_MS);
+}
+
+function showStatusToast(data) {
+  const container = document.getElementById('toastContainer');
+  if (!container) return;
+  while (container.children.length >= MAX_TOASTS) {
+    container.firstElementChild.remove();
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast toast-status';
+  toast.innerHTML = `
+    <div class="toast-row">
+      <span class="toast-agent">${escapeHtml(data.agent || 'Agent')}</span>
+      <span class="toast-status-label">${escapeHtml(data.status || 'status changed')}</span>
+    </div>`;
+  toast.addEventListener('click', () => dismissToast(toast));
+  container.appendChild(toast);
+  setTimeout(() => dismissToast(toast), STATUS_TOAST_TTL_MS);
+}
+
+function dismissToast(toast) {
+  if (!toast || !toast.parentElement) return;
+  toast.classList.add('dismissing');
+  setTimeout(() => toast.remove(), 200);
+}
+
+// --- Init ---
+qaHeader = window.QAHeader.init({
+  page: 'team',
+  team: TEAM_ID,
+  title: 'Team Analytics Dashboard',
+  onChange: ({ days, dateFrom: f, dateTo: t, activeOnly: a, supervisor: s }) => {
+    // Detect whether anything that changes the data window actually changed.
+    // The initial emit fires once with the URL-resolved defaults; skipping
+    // the no-op refetch would require tracking "first call", which is more
+    // moving parts than just letting it fetch once.
+    selectedDays = days;
+    dateFrom = f;
+    dateTo = t;
+    activeOnly = a;
+    selectedSupervisor = s;
+    fetchTeamStats();
+  },
+});
+fetchMails();
+openEventStream();
+_scheduleMidnightRerender();
+</script>
+</body>
+</html>

--- a/sandy-qa/pages/team_evals.html
+++ b/sandy-qa/pages/team_evals.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Month Evaluations — Team Analytics</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --navy: #15192D; --accent: #1A61D9; --bg: #E7EFFB; --surface: #ffffff;
+      --border: #c9d5e8; --text: #15192D; --muted: #5a6478;
+      --green: #28A745; --amber: #E8A317; --red: #D9534F;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    .header {
+      background: var(--navy); color: #fff; padding: 16px 24px;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    .header-left { display: flex; align-items: center; gap: 16px; }
+    .header h1 { font-size: 1.2rem; font-weight: 600; }
+    .header a.back {
+      font-family: 'DM Mono', monospace; font-size: 0.82rem; padding: 6px 14px;
+      border: 1px solid rgba(255,255,255,0.3); border-radius: 6px; color: #fff;
+      text-decoration: none; transition: background 0.2s;
+    }
+    .header a.back:hover { background: rgba(255,255,255,0.1); }
+    .meta { font-size: 0.8rem; color: rgba(255,255,255,0.7); }
+
+    .container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+    .summary { display: flex; gap: 24px; align-items: baseline; margin-bottom: 16px; flex-wrap: wrap; }
+    .summary .count {
+      font-family: 'Fraunces', serif; font-size: 1.8rem; font-weight: 700;
+    }
+    .summary .meanstd { font-size: 0.9rem; color: var(--muted); }
+    .summary .filters { margin-left: auto; font-size: 0.75rem; color: var(--muted); }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    th, td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    th {
+      font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+      cursor: pointer; user-select: none; position: sticky; top: 0; background: var(--surface);
+    }
+    th:hover { color: var(--text); }
+    tr:hover { background: var(--bg); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .score { font-weight: 700; }
+    .loading, .empty { text-align: center; padding: 60px; color: var(--muted); font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-left">
+    <a class="back" id="backLink" href="#">&larr; Dashboard</a>
+    <h1 id="pageTitle">Month Evaluations</h1>
+  </div>
+  <div class="meta" id="metaLine"></div>
+</div>
+
+<div class="container">
+  <div class="card">
+    <div class="summary" id="summary"></div>
+    <div style="overflow-x:auto">
+      <table id="evalsTable">
+        <thead>
+          <tr>
+            <th data-col="timestamp">Call Date</th>
+            <th data-col="agent">Agent</th>
+            <th data-col="supervisor">Supervisor</th>
+            <th data-col="overall_score">Score</th>
+            <th>Dialpad</th>
+          </tr>
+        </thead>
+        <tbody id="evalsBody"></tbody>
+      </table>
+    </div>
+    <div id="emptyState" class="empty" style="display:none;">No evaluations for this month under the current filters.</div>
+    <div id="loadingState" class="loading">Loading…</div>
+  </div>
+</div>
+
+<script>
+// --- Auth (Sandy port): the Google SSO wall authenticates every request;
+// the legacy API-key plumbing is vestigial. Keep the function shapes so the
+// rest of the file stays byte-identical to the Railway original.
+function getApiKey() { return 'sso'; }
+function authHeaders() { return {}; }
+
+const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+
+const url = new URL(location.href);
+const month = url.searchParams.get('month') || '';
+const activeOnly = url.searchParams.get('active_only') !== 'false';
+const supervisor = url.searchParams.get('supervisor') || '';
+
+document.getElementById('backLink').href = `/dashboard/${TEAM_ID}`;
+document.getElementById('pageTitle').textContent = `Evaluations — ${month || '—'}`;
+
+const metaBits = [];
+metaBits.push(activeOnly ? 'Active analysts' : 'All analysts');
+if (supervisor) metaBits.push(`Supervisor: ${supervisor}`);
+document.getElementById('metaLine').textContent = metaBits.join(' · ');
+
+let _rows = [];
+let _sortKey = 'timestamp';
+let _sortAsc = false;
+
+function fmt(v, d = 1) { return v != null ? Number(v).toFixed(d) : '—'; }
+function scoreColor(v) { return v >= 85 ? '#28A745' : v >= 70 ? '#E8A317' : '#D9534F'; }
+function escapeHtml(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+function fmtDate(iso) {
+  const d = new Date(iso);
+  if (isNaN(d)) return iso || '—';
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function renderTable() {
+  const tbody = document.getElementById('evalsBody');
+  if (!_rows.length) {
+    tbody.innerHTML = '';
+    document.getElementById('emptyState').style.display = 'block';
+    return;
+  }
+  document.getElementById('emptyState').style.display = 'none';
+
+  const sorted = [..._rows].sort((a, b) => {
+    let va = a[_sortKey], vb = b[_sortKey];
+    if (va == null) return 1; if (vb == null) return -1;
+    if (typeof va === 'string') return _sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+    if (_sortKey === 'timestamp') { va = new Date(va).getTime(); vb = new Date(vb).getTime(); }
+    return _sortAsc ? va - vb : vb - va;
+  });
+
+  tbody.innerHTML = sorted.map(r => {
+    // Score links to this call's /datapoint page — closes the loop so a
+    // viewer can drill from "month list → individual eval breakdown"
+    // without leaving the app. eval_id is the call_id parsed out of the
+    // Dialpad link upstream (services/team_stats.py:_parse_row).
+    const scoreCell = r.eval_id
+      ? `<a href="/datapoint/${TEAM_ID}/${encodeURIComponent(r.eval_id)}"
+            class="score" style="color:${scoreColor(r.overall_score)};">${fmt(r.overall_score)}</a>`
+      : `<span class="score" style="color:${scoreColor(r.overall_score)};">${fmt(r.overall_score)}</span>`;
+    return `
+    <tr>
+      <td>${fmtDate(r.timestamp)}</td>
+      <td>${escapeHtml(r.agent)}</td>
+      <td>${escapeHtml(r.supervisor || '')}</td>
+      <td>${scoreCell}</td>
+      <td>${r.dialpad_link ? `<a href="${escapeHtml(r.dialpad_link)}" target="_blank" rel="noopener">Open &rsaquo;</a>` : ''}</td>
+    </tr>
+  `;}).join('');
+}
+
+document.querySelectorAll('th[data-col]').forEach(th => {
+  th.onclick = () => {
+    const col = th.dataset.col;
+    if (_sortKey === col) _sortAsc = !_sortAsc;
+    else { _sortKey = col; _sortAsc = false; }
+    renderTable();
+  };
+});
+
+async function fetchEvals() {
+  if (!month) {
+    document.getElementById('loadingState').textContent = 'No month specified.';
+    return;
+  }
+  try {
+    const params = new URLSearchParams({ year_month: month, active_only: activeOnly });
+    if (supervisor) params.set('supervisor', supervisor);
+    const r = await fetch(`${API_BASE}/team/evals?${params}`, { headers: authHeaders() });
+    if (r.status === 401) {
+      sessionStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      return;
+    }
+    if (!r.ok) throw new Error(r.statusText);
+    const data = await r.json();
+    _rows = data.rows || [];
+
+    // Summary line
+    const meanList = _rows.map(r => r.overall_score).filter(v => v != null);
+    const n = _rows.length;
+    const mean = n ? meanList.reduce((a, b) => a + b, 0) / n : null;
+    const variance = n > 1 ? meanList.reduce((a, b) => a + (b - mean) ** 2, 0) / (n - 1) : null;
+    const std = variance != null ? Math.sqrt(variance) : null;
+    document.getElementById('summary').innerHTML = `
+      <div class="count">${n} eval${n === 1 ? '' : 's'}</div>
+      <div class="meanstd">${mean != null ? `mean ${fmt(mean)} ± ${fmt(std)}` : ''}</div>
+      <div class="filters">${month}</div>
+    `;
+
+    document.getElementById('loadingState').style.display = 'none';
+    renderTable();
+  } catch (e) {
+    console.error('Failed to fetch evals:', e);
+    document.getElementById('loadingState').textContent = 'Failed to load evaluations.';
+  }
+}
+
+fetchEvals();
+</script>
+</body>
+</html>

--- a/sandy-qa/parity/capture_fixture.py
+++ b/sandy-qa/parity/capture_fixture.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Golden-fixture capture for the team-stats parity gate (PortManifest §11.3).
+
+Runs the PYTHON oracle (team_source + team_stats, the exact production code)
+against Railway Postgres, pinned to --max-eval-id (the D1 snapshot boundary)
+and a single captured `now`, and writes the full /team/stats + /team/evals
+response payloads per team to a fixture JSON. The node runner
+(run_parity.mjs) replays the TypeScript port against D1 with the same pins
+and diffs the outputs.
+
+Run from qa-automation/AI-Scoring:
+    .venv/bin/python ../../sandy-qa/parity/capture_fixture.py --max-eval-id 2525 \
+        --out ../../sandy-qa/parity/fixture.json
+"""
+
+import argparse
+import asyncio
+import json
+import math
+import pathlib
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, ".")
+
+import asyncpg  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from backend.config.team_config import get_team_config  # noqa: E402
+from backend.services import team_stats  # noqa: E402
+from backend.services.team_source import (  # noqa: E402
+    _section_alias_map,
+    frame_from_rows,
+)
+
+TEAMS = ("member_support", "sales")
+DAYS_VARIANTS = (90, 0)
+
+
+def env_value(key: str) -> str:
+    for line in pathlib.Path(".env").read_text().splitlines():
+        if line.strip().startswith(key + "="):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    raise SystemExit(f"{key} not in .env")
+
+
+def _clean(o):
+    """JSON-safe: NaN/NaT → None, datetimes/Timestamps → ISO-Z strings."""
+    if isinstance(o, dict):
+        return {k: _clean(v) for k, v in o.items()}
+    if isinstance(o, (list, tuple)):
+        return [_clean(v) for v in o]
+    if isinstance(o, float) and math.isnan(o):
+        return None
+    if isinstance(o, pd.Timestamp):
+        if pd.isna(o):
+            return None
+        return o.to_pydatetime().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(o, datetime):
+        d = o if o.tzinfo else o.replace(tzinfo=timezone.utc)
+        return d.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return o
+
+
+def serialize_frame(df: pd.DataFrame, config) -> list:
+    rows = []
+    for r in df.to_dict(orient="records"):
+        rows.append(_clean({
+            "agent": r["agent"],
+            "ts": r["timestamp"],
+            "eval_approved_at": r["eval_approved_at"],
+            "overall_score": r["overall_score"],
+            "manager_email": r["manager_email"],
+            "is_active": bool(r["is_active"]),
+            "supervisor": r["supervisor"],
+            "eval_id": r["eval_id"],
+            "num": {h: r.get(h) for h in config.numeric_history_ids},
+            "yn": {h: r.get(h) for h in config.yn_history_ids},
+        }))
+    return rows
+
+
+def stats_payload(df: pd.DataFrame, config, days: int, now_naive_utc: datetime) -> dict:
+    """Replicates backend/routes/team.py::team_stats filter order exactly
+    (active_only=True, no supervisor, no custom window)."""
+    filters = {"days": days, "active_only": True, "supervisor": "",
+               "date_from": None, "date_to": None}
+    if df.empty:
+        raise SystemExit("empty frame — refusing to capture a vacuous fixture")
+    df = df[df["is_active"]]
+    monthly = team_stats.compute_monthly_summary(df)
+    if days > 0:
+        df = df[df["timestamp"] >= now_naive_utc - timedelta(days=days)]
+    kpis = {
+        "total_evals": len(df),
+        "avg_score": round(float(df["overall_score"].mean()), 1) if len(df) > 0 else 0,
+        "std_score": round(float(df["overall_score"].std(ddof=1)), 1) if len(df) > 1 else 0,
+        "analyst_count": df["agent"].nunique(),
+    }
+    return _clean({
+        "team_id": config.team_id,
+        "rubric_version": config.rubric_version,
+        "coverage_regime": "manager_sample",
+        "kpis": kpis,
+        "monthly": monthly,
+        "roster": team_stats.compute_agent_roster(df, config),
+        "outliers": team_stats.compute_outliers(df, config.stats),
+        "spc": team_stats.compute_monthly_spc(df, config.stats),
+        "section_analysis": team_stats.compute_section_analysis(df, config),
+        "binary_stats": team_stats.compute_binary_stats(df, config.yn_section_labels),
+        "supervisor_stats": team_stats.compute_supervisor_stats(df),
+        "ewma": team_stats.compute_ewma(df, config.stats),
+        "distribution": team_stats.compute_distribution(df),
+        "filters_applied": filters,
+    })
+
+
+def evals_payload(df: pd.DataFrame, config, year_month: str) -> dict:
+    """Replicates backend/routes/team.py::team_month_evals (active_only=True)."""
+    df = df[df["is_active"]]
+    months = team_stats._months_in_bucket_tz(df["timestamp"])
+    df = df[months == year_month].sort_values("timestamp", ascending=False)
+    rows = [_clean({
+        "agent": str(r["agent"]),
+        "timestamp": r["timestamp"],
+        "eval_approved_at": r.get("eval_approved_at"),
+        "overall_score": float(r["overall_score"]),
+        "dialpad_link": (f"https://dialpad.com/callhistory/callreview/{r['eval_id']}"
+                         if r.get("eval_id") else ""),
+        "eval_id": str(r.get("eval_id", "")),
+        "supervisor": str(r.get("supervisor", "")) or None,
+        "evaluator_email": str(r.get("manager_email", "")) or None,
+    }) for r in df.to_dict(orient="records")]
+    return {"team_id": config.team_id, "year_month": year_month, "rows": rows,
+            "filters_applied": {"active_only": True, "supervisor": ""}}
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--max-eval-id", type=int, required=True)
+    ap.add_argument("--out", type=pathlib.Path, required=True)
+    args = ap.parse_args()
+
+    now_utc = datetime.now(timezone.utc)
+    now_naive = now_utc.replace(tzinfo=None)
+    # Pin the monthly current/last labels to the captured instant.
+    team_stats._now_in_bucket_tz = lambda: now_utc.astimezone(team_stats._BUCKET_TZ)
+
+    conn = await asyncpg.connect(env_value("DATABASE_URL"), timeout=30)
+    fixture = {
+        "captured_at": now_utc.isoformat().replace("+00:00", "Z"),
+        "max_eval_id": args.max_eval_id,
+        "bucket_tz": team_stats.BUCKET_TZ_NAME,
+        "teams": {},
+    }
+    try:
+        for team_id in TEAMS:
+            config = get_team_config(team_id)
+            alias_map = await _section_alias_map(conn, config)
+            eval_rows = await conn.fetch(
+                "SELECT e.id, e.agent_id, e.agent_name_raw, e.evaluator_email, "
+                "  e.overall_score, e.dialpad_link, e.dialpad_entry_point_call_id, "
+                "  e.dialpad_call_metadata, "
+                "  COALESCE(e.call_connected_at, e.approved_at) AS ts, e.approved_at, "
+                "  COALESCE(a.canonical_name, a.name, e.agent_name_raw) AS agent_display, "
+                "  COALESCE(a.active, FALSE) AS is_active, "
+                "  COALESCE(a.supervisor_email, '') AS supervisor "
+                "FROM qa.evaluations e LEFT JOIN qa.agents a ON a.id = e.agent_id "
+                "WHERE e.team_id = $1 AND e.state = 'finalized' AND e.id <= $2 "
+                "ORDER BY e.id",
+                team_id, args.max_eval_id)
+            # Deterministic collision convention: when an archived rubric
+            # position-aliases an old id into a column that a direct
+            # current-id row also writes (sales_v1 value_uplift@6 vs
+            # landing_guarantee), the DIRECT row must win. Production Python
+            # relies on unordered heap row order here (nondeterministic —
+            # 2 of 41 Sales collision rows resolve the other way after
+            # section edits reordered their rows); the port pins the
+            # convention explicitly, so the fixture does too: direct rows
+            # ordered last → last-write-wins = direct-wins.
+            current_ids = [s.id for s in config.sections_by_number]
+            section_rows = await conn.fetch(
+                "SELECT evaluation_id, section_id, numeric_score, binary_value "
+                "FROM qa.v_history_long WHERE team_id = $1 AND evaluation_id <= $2 "
+                "ORDER BY evaluation_id, (section_id = ANY($3::text[]))::int",
+                team_id, args.max_eval_id, current_ids)
+            agent_rows = await conn.fetch(
+                "SELECT name, canonical_name, active, supervisor_email "
+                "FROM qa.agents WHERE team_id = $1", team_id)
+            df = frame_from_rows(config, eval_rows, section_rows, alias_map, agent_rows)
+            current_ym = str(pd.Period(now_utc.astimezone(team_stats._BUCKET_TZ), freq="M"))
+            fixture["teams"][team_id] = {
+                "rubric_version": config.rubric_version,
+                "frame_rows": len(df),
+                "frame": serialize_frame(df, config),
+                "stats": {str(d): stats_payload(df.copy(), config, d, now_naive)
+                          for d in DAYS_VARIANTS},
+                "evals_current_month": evals_payload(df.copy(), config, current_ym),
+            }
+            print(f"{team_id}: frame={len(df)} rows captured")
+    finally:
+        await conn.close()
+
+    args.out.write_text(json.dumps(fixture, indent=1))
+    print(f"fixture written: {args.out} ({args.out.stat().st_size} bytes), "
+          f"now={fixture['captured_at']}, pin={args.max_eval_id}")
+
+
+asyncio.run(main())

--- a/sandy-qa/parity/entry.ts
+++ b/sandy-qa/parity/entry.ts
@@ -1,0 +1,4 @@
+// esbuild entry for the parity runner — exposes the worker's own modules.
+export { loadTeamConfig } from "../src/lib/teamConfig.js";
+export { fetchHistoryFrame } from "../src/lib/historyFrame.js";
+export { assembleTeamStats, assembleTeamEvals } from "../src/lib/teamStats.js";

--- a/sandy-qa/parity/run_parity.mjs
+++ b/sandy-qa/parity/run_parity.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Golden-fixture parity runner (PortManifest §11.3).
+//
+// Replays the WORKER'S OWN code (loadTeamConfig + fetchHistoryFrame +
+// assembleTeamStats/Evals, bundled from src/ via esbuild) against the real
+// D1 — through a db shim that routes every prepared statement to
+// `sandy.py db query` — pinned to the fixture's max_eval_id and captured
+// clock, then deep-diffs the outputs against the Python oracle fixture.
+//
+//   node parity/run_parity.mjs parity/fixture.json
+//
+// Exit 0 = parity; exit 2 = diffs (printed, capped).
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const APP_ID = "a2cc5b5a-df29-4ae7-9dbb-e270052015e7";
+const SANDY = join(homedir(), ".claude/commands/scripts/sandy.py");
+const lib = await import(new URL("./lib.mjs", import.meta.url));
+
+const fixture = JSON.parse(readFileSync(process.argv[2] ?? "parity/fixture.json", "utf8"));
+const PIN = fixture.max_eval_id;
+const NOW = new Date(fixture.captured_at);
+
+function d1Query(sql) {
+  const out = execFileSync("python3", [SANDY, "db", "query", APP_ID, sql], {
+    encoding: "utf8", maxBuffer: 256 * 1024 * 1024, timeout: 180_000,
+  });
+  return JSON.parse(out).data[0].results;
+}
+
+// D1Database shim: interpolates bind params, pins the eval-id snapshot.
+const db = {
+  prepare(sql) {
+    return {
+      bind(...params) {
+        let final = sql;
+        for (const p of params) {
+          const litv = typeof p === "number" ? String(p) : `'${String(p).replace(/'/g, "''")}'`;
+          final = final.replace("?", litv);
+        }
+        if (final.includes("FROM qa_evaluations e"))
+          final = final.replace("ORDER BY e.id", `AND e.id <= ${PIN} ORDER BY e.id`);
+        if (final.includes("FROM qa_v_history_long"))
+          final += ` AND evaluation_id <= ${PIN}`;
+        return {
+          all: async () => ({ results: d1Query(final) }),
+          first: async () => d1Query(final)[0] ?? null,
+        };
+      },
+    };
+  },
+};
+
+// ── deep diff with datetime + float tolerance ───────────────────────────────
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:/;
+const IGNORE_KEYS = new Set(["generated_at"]);
+const diffs = [];
+
+function record(path, a, b) {
+  if (diffs.length < 40) diffs.push(`${path}: py=${JSON.stringify(a)} ts=${JSON.stringify(b)}`);
+  else diffs.length === 40 && diffs.push("… (more diffs suppressed)");
+}
+
+function cmp(a, b, path) {
+  if (a === null || a === undefined) {
+    if (b === null || b === undefined) return;
+    return record(path, a, b);
+  }
+  if (typeof a === "string" && typeof b === "string" && ISO_RE.test(a) && ISO_RE.test(b)) {
+    if (Math.abs(Date.parse(a) - Date.parse(b)) > 1) record(path, a, b);
+    return;
+  }
+  if (typeof a === "number" && typeof b === "number") {
+    if (Math.abs(a - b) > 1e-9) record(path, a, b);
+    return;
+  }
+  if (typeof a === "boolean" || typeof b === "boolean") {
+    if (Boolean(a) !== Boolean(b)) record(path, a, b);
+    return;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return record(`${path}.length`, a.length, b.length);
+    a.forEach((v, i) => cmp(v, b[i], `${path}[${i}]`));
+    return;
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      if (IGNORE_KEYS.has(k)) continue;
+      cmp(a[k], b[k], `${path}.${k}`);
+    }
+    return;
+  }
+  if (a !== b) record(path, a, b);
+}
+
+// frame rows from the TS side, serialized to the fixture's shape
+function serializeTsFrame(rows) {
+  const iso = (ms) => (ms === null ? null : new Date(ms).toISOString());
+  return rows.map((r) => ({
+    agent: r.agent, ts: iso(r.ts), eval_approved_at: iso(r.eval_approved_at),
+    overall_score: r.overall_score, manager_email: r.manager_email,
+    is_active: r.is_active, supervisor: r.supervisor, eval_id: r.eval_id,
+    num: r.num, yn: r.yn,
+  }));
+}
+
+let total = 0;
+for (const [teamId, ref] of Object.entries(fixture.teams)) {
+  const before = diffs.length;
+  const config = await lib.loadTeamConfig(db, teamId);
+  cmp(ref.rubric_version, config.rubric_version, `${teamId}.rubric_version`);
+  const frame = await lib.fetchHistoryFrame(db, config);
+  cmp(ref.frame.length, frame.length, `${teamId}.frame.length`);
+  cmp(ref.frame, serializeTsFrame(frame), `${teamId}.frame`);
+  for (const [days, refStats] of Object.entries(ref.stats)) {
+    const got = lib.assembleTeamStats(frame, config, {
+      days: Number(days), active_only: true, supervisor: "",
+      date_from: null, date_to: null,
+    }, NOW);
+    cmp(refStats, got, `${teamId}.stats[days=${days}]`);
+  }
+  const gotEvals = lib.assembleTeamEvals(
+    frame, config, ref.evals_current_month.year_month, true, "");
+  cmp(ref.evals_current_month, gotEvals, `${teamId}.evals`);
+  total += diffs.length - before;
+  console.log(`${teamId}: frame=${frame.length} rows, ${diffs.length - before} diff(s)`);
+}
+
+if (diffs.length) {
+  console.log("\n== DIFFS ==");
+  for (const d of diffs) console.log(" ", d);
+  console.log(`\nRESULT: ${diffs.length} mismatch(es)`);
+  process.exit(2);
+}
+console.log("\nRESULT: FULL PARITY — Python oracle == TypeScript port");

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -11,6 +11,7 @@ import { createDb, items, workflowRuns } from "./db.js";
 import { desc, eq } from "drizzle-orm";
 import { listTriggerableWorkflows, triggerWorkflow, triggerWorkflowWithCallback, type WorkflowInfo } from "./workflow.js";
 import { serveFont } from "./design-system/fonts.js";
+import { handleTeamRoutes } from "./routes/teamApi.js";
 
 export interface Env {
   DB: D1Database;
@@ -34,6 +35,10 @@ export default {
       const fontResponse = serveFont(url.pathname);
       if (fontResponse) return fontResponse;
     }
+
+    // ── Ported QA pages + team analytics APIs (PortManifest §3/§4/§6.1) ──
+    const teamRes = await handleTeamRoutes(request, env.DB, url);
+    if (teamRes) return teamRes;
 
     // ── SSE transport spike (PortManifest §"SSE on Sandy") ───────────────
     // Answers one question empirically: does the Sandy edge stack

--- a/sandy-qa/src/lib/historyFrame.ts
+++ b/sandy-qa/src/lib/historyFrame.ts
@@ -1,0 +1,194 @@
+// The analytics "history frame" — worker-side port of
+// backend/services/team_source.py (frame_from_rows + fetch_history_frame +
+// _section_alias_map + _roster_maps). One row per finalized evaluation, wide
+// form; numeric sections null when missing (pandas NaN), yn sections ''.
+
+import type { TeamConfig } from "./teamConfig.js";
+
+export interface FrameRow {
+  agent: string;
+  ts: number; // epoch ms (naive-UTC wall clock)
+  eval_approved_at: number | null;
+  overall_score: number;
+  manager_email: string;
+  is_active: boolean;
+  supervisor: string;
+  eval_id: string;
+  num: Record<string, number | null>;
+  yn: Record<string, string>;
+}
+
+export function stripAccents(s: string): string {
+  return s.normalize("NFKD").replace(/\p{M}/gu, "");
+}
+
+function evalIdFromLink(link: string): string {
+  if (!link) return "";
+  const clean = link.split("[")[0].trim().split("?")[0].trim();
+  return clean.replace(/\/+$/, "").split("/").pop() ?? "";
+}
+
+// D1 TEXT timestamps are ISO-8601 UTC ("...Z"). Parse to epoch ms.
+function parseTs(v: string | null): number | null {
+  if (!v) return null;
+  const t = Date.parse(v.includes("T") ? v : v.replace(" ", "T") + "Z");
+  return Number.isNaN(t) ? null : t;
+}
+
+function aliasMap(config: TeamConfig): Map<string, string> {
+  const alias = new Map<string, string>();
+  for (const s of config.sections_by_number) {
+    alias.set(s.history_id, s.history_id);
+    alias.set(s.id, s.history_id);
+  }
+  const currentByNumber = new Map(
+    config.sections_by_number.map((s) => [s.section_number, s.history_id])
+  );
+  for (const rubric of config.archived_rubrics) {
+    for (const s of rubric.sections ?? []) {
+      const target = currentByNumber.get(s.section_number);
+      if (target === undefined) continue;
+      if (!alias.has(s.id)) alias.set(s.id, target);
+      const hid = s.history_id ?? s.id;
+      if (!alias.has(hid)) alias.set(hid, target);
+    }
+  }
+  return alias;
+}
+
+export async function fetchHistoryFrame(
+  db: D1Database,
+  config: TeamConfig
+): Promise<FrameRow[]> {
+  const [evals, sections, agents] = await Promise.all([
+    db
+      .prepare(
+        `SELECT e.id, e.agent_id, e.agent_name_raw, e.evaluator_email, e.overall_score,
+                e.dialpad_link, e.dialpad_entry_point_call_id, e.dialpad_call_metadata,
+                COALESCE(e.call_connected_at, e.approved_at) AS ts, e.approved_at,
+                COALESCE(a.canonical_name, a.name, e.agent_name_raw) AS agent_display,
+                COALESCE(a.active, 0) AS is_active,
+                COALESCE(a.supervisor_email, '') AS supervisor
+         FROM qa_evaluations e LEFT JOIN qa_agents a ON a.id = e.agent_id
+         WHERE e.team_id = ? AND e.state = 'finalized' ORDER BY e.id`
+      )
+      .bind(config.team_id)
+      .all<any>(),
+    db
+      .prepare(
+        "SELECT evaluation_id, section_id, numeric_score, binary_value FROM qa_v_history_long WHERE team_id = ?"
+      )
+      .bind(config.team_id)
+      .all<any>(),
+    db
+      .prepare(
+        "SELECT name, canonical_name, active, supervisor_email FROM qa_agents WHERE team_id = ?"
+      )
+      .bind(config.team_id)
+      .all<any>(),
+  ]);
+
+  const numericIds = new Set(config.numeric_history_ids);
+  const ynIds = new Set(config.yn_history_ids);
+  const excluded = new Set(
+    config.excluded_test_agents.map((a) => a.trim().toLowerCase())
+  );
+  const alias = aliasMap(config);
+
+  // roster maps from ACTIVE agents (read-time identity fallback)
+  const canonicalMap = new Map<string, string>();
+  const supervisorMap = new Map<string, string>();
+  const activeSet = new Set<string>();
+  for (const a of agents.results) {
+    if (!a.active) continue;
+    const name = (a.name ?? "").trim();
+    if (!name) continue;
+    const canonical = (a.canonical_name ?? "").trim() || name;
+    canonicalMap.set(name.toLowerCase(), canonical);
+    canonicalMap.set(stripAccents(name).toLowerCase(), canonical);
+    canonicalMap.set(canonical.toLowerCase(), canonical);
+    canonicalMap.set(stripAccents(canonical).toLowerCase(), canonical);
+    supervisorMap.set(canonical.toLowerCase(), a.supervisor_email ?? "");
+    activeSet.add(canonical.toLowerCase());
+  }
+
+  // Section values per evaluation, keyed by resolved history_id.
+  //
+  // Collision rule: an archived rubric can position-alias an old id into a
+  // column that current-id rows ALSO write (observed: sales_v1 value_uplift@6
+  // → sales_v2 landing_guarantee@6, while v1 evals carry a real
+  // landing_guarantee row too). Python's last-write-wins outcome depends on
+  // Postgres row order (insertion order → the DIRECT row lands last and
+  // wins). Encode that outcome explicitly: direct current-id matches always
+  // beat position-aliased writes; aliased writes never overwrite anything.
+  const currentIds = new Set(config.sections_by_number.map((s) => s.id));
+  const byEval = new Map<number, Record<string, number | string | null>>();
+  const directWrite = new Map<number, Set<string>>();
+  for (const s of sections.results) {
+    const hid = alias.get(s.section_id);
+    if (hid === undefined || (!numericIds.has(hid) && !ynIds.has(hid))) continue;
+    const val = numericIds.has(hid)
+      ? s.numeric_score !== null
+        ? Number(s.numeric_score)
+        : null // pandas NaN
+      : s.binary_value ?? "";
+    const isDirect = currentIds.has(s.section_id);
+    let rec = byEval.get(s.evaluation_id);
+    if (!rec) {
+      byEval.set(s.evaluation_id, (rec = {}));
+      directWrite.set(s.evaluation_id, new Set());
+    }
+    const directs = directWrite.get(s.evaluation_id)!;
+    if (hid in rec) {
+      if (!isDirect || directs.has(hid)) continue; // aliased never overwrites
+    }
+    rec[hid] = val;
+    if (isDirect) directs.add(hid);
+  }
+
+  const rows: FrameRow[] = [];
+  for (const ev of evals.results) {
+    let agent = (ev.agent_display ?? ev.agent_name_raw ?? "").trim();
+    let isActive = !!ev.is_active;
+    let supervisor = ev.supervisor ?? "";
+    if (ev.agent_id === null && agent) {
+      const canonical =
+        canonicalMap.get(agent.toLowerCase()) ??
+        canonicalMap.get(stripAccents(agent).toLowerCase());
+      if (canonical !== undefined) {
+        agent = canonical;
+        isActive = activeSet.has(canonical.toLowerCase());
+        supervisor = supervisorMap.get(canonical.toLowerCase()) ?? "";
+      }
+    }
+    if (!agent || excluded.has(agent.toLowerCase())) continue;
+    const ts = parseTs(ev.ts);
+    if (ts === null || new Date(ts).getUTCFullYear() < 2020) continue;
+    const meta = ev.dialpad_call_metadata ? JSON.parse(ev.dialpad_call_metadata) : {};
+    const link =
+      ev.dialpad_link || meta?.backfill?.superseded_dialpad_link || "";
+    const evalId = evalIdFromLink(link) || (ev.dialpad_entry_point_call_id ?? "");
+
+    const secVals = byEval.get(ev.id) ?? {};
+    const num: Record<string, number | null> = {};
+    for (const hid of config.numeric_history_ids)
+      num[hid] = (secVals[hid] as number | null | undefined) ?? null;
+    const yn: Record<string, string> = {};
+    for (const hid of config.yn_history_ids)
+      yn[hid] = (secVals[hid] as string | undefined) ?? "";
+
+    rows.push({
+      agent,
+      ts,
+      eval_approved_at: parseTs(ev.approved_at),
+      overall_score: Number(ev.overall_score),
+      manager_email: (ev.evaluator_email ?? "").toLowerCase(),
+      is_active: isActive,
+      supervisor,
+      eval_id: evalId,
+      num,
+      yn,
+    });
+  }
+  return rows;
+}

--- a/sandy-qa/src/lib/teamConfig.ts
+++ b/sandy-qa/src/lib/teamConfig.ts
@@ -1,0 +1,118 @@
+// Team configuration from D1 — the worker-side equivalent of
+// backend/config/team_config.py, sourced from the `teams` row (operational
+// config, migration 010) and the team's CURRENT qa_rubric_versions row.
+
+export interface SectionDef {
+  id: string;
+  history_id: string;
+  name: string;
+  section_number: number;
+  score_type: string;
+  score_range: [number, number] | null;
+  audio_dependent: boolean;
+  na_applicable: boolean;
+  auto_value: string | null;
+}
+
+export interface StatsConfig {
+  min_evals_for_outlier: number;
+  outlier_z_threshold: number;
+  ewma_span: number;
+  ewma_min_evals: number;
+  ewma_trend_delta: number;
+  spc_sigma_multiplier: number;
+}
+
+export interface TeamConfig {
+  team_id: string;
+  rubric_version: string;
+  sections_by_number: SectionDef[];
+  numeric_history_ids: string[];
+  yn_history_ids: string[];
+  section_labels: Record<string, string>;      // history_id -> name (numeric)
+  yn_section_labels: Record<string, string>;   // history_id -> name (yn)
+  history_id_to_section: Record<string, SectionDef>;
+  stats: StatsConfig;
+  excluded_test_agents: string[];
+  archived_rubrics: any[]; // parsed rubric_json of EVERY rubric row (alias map)
+}
+
+// yn iff the score_type ends in "yn" (yn / manual_yn); numeric iff it carries
+// a score_range (numeric / manual / manual_numeric). Mirrors team_config.py.
+function isYn(s: any): boolean {
+  return typeof s.score_type === "string" && s.score_type.endsWith("yn");
+}
+function isNumeric(s: any): boolean {
+  return !isYn(s) && Array.isArray(s.score_range) && s.score_range.length === 2;
+}
+
+export async function loadTeamConfig(db: D1Database, teamId: string): Promise<TeamConfig> {
+  const team = await db
+    .prepare("SELECT stats_config, excluded_test_agents FROM teams WHERE id = ?")
+    .bind(teamId)
+    .first<{ stats_config: string | null; excluded_test_agents: string }>();
+  if (!team) throw new Error(`unknown team ${teamId}`);
+
+  // Alias-map iteration order = insertion order (id ASC) — matches the
+  // Python oracle's unordered SELECT on a heap table, where setdefault makes
+  // first-seen win. Current rubric = newest effective_from.
+  const rubricRows = (
+    await db
+      .prepare(
+        "SELECT rubric_json, effective_from FROM qa_rubric_versions WHERE team_id = ? ORDER BY id"
+      )
+      .bind(teamId)
+      .all<{ rubric_json: string; effective_from: string }>()
+  ).results;
+  if (!rubricRows.length) throw new Error(`no rubric_versions row for ${teamId}`);
+  const rubrics = rubricRows.map((r) => JSON.parse(r.rubric_json));
+  const current =
+    rubrics[
+      rubricRows.reduce(
+        (best, r, i) =>
+          r.effective_from > rubricRows[best].effective_from ? i : best,
+        0
+      )
+    ];
+
+  const sections: SectionDef[] = (current.sections as any[])
+    .map((s) => ({
+      id: s.id,
+      history_id: s.history_id ?? s.id,
+      name: s.name,
+      section_number: s.section_number,
+      score_type: s.score_type,
+      score_range: Array.isArray(s.score_range) ? (s.score_range as [number, number]) : null,
+      audio_dependent: !!s.audio_dependent,
+      na_applicable: !!s.na_applicable,
+      auto_value: s.auto_value ?? null,
+    }))
+    .sort((a, b) => a.section_number - b.section_number);
+
+  const numeric = sections.filter((s) => isNumeric(s));
+  const yn = sections.filter((s) => isYn(s));
+
+  const stats: StatsConfig = {
+    min_evals_for_outlier: 5,
+    outlier_z_threshold: 3.5,
+    ewma_span: 5,
+    ewma_min_evals: 3,
+    ewma_trend_delta: 3.0,
+    spc_sigma_multiplier: 2.0,
+    ...(team.stats_config ? JSON.parse(team.stats_config) : {}),
+  };
+
+  return {
+    team_id: teamId,
+    rubric_version: current.rubric_version,
+    sections_by_number: sections,
+    numeric_history_ids: numeric.map((s) => s.history_id),
+    yn_history_ids: yn.map((s) => s.history_id),
+    section_labels: Object.fromEntries(numeric.map((s) => [s.history_id, s.name])),
+    yn_section_labels: Object.fromEntries(yn.map((s) => [s.history_id, s.name])),
+    history_id_to_section: Object.fromEntries(sections.map((s) => [s.history_id, s])),
+    stats,
+    excluded_test_agents: JSON.parse(team.excluded_test_agents || "[]"),
+    archived_rubrics: rubrics,
+  };
+}

--- a/sandy-qa/src/lib/teamStats.ts
+++ b/sandy-qa/src/lib/teamStats.ts
@@ -1,0 +1,552 @@
+// Port of backend/services/team_stats.py — pure computation, no I/O.
+// Pandas/numpy semantics reproduced deliberately:
+//   - round(x, d) is Python round-half-EVEN (banker's), not toFixed
+//   - Series.std / np.std(ddof=1) — sample std
+//   - np.median — average of the two middle values on even n
+//   - Series.ewm(span).mean() — adjust=True weighting
+//   - groupby iterates keys in SORTED order; sorts are stable (ES2019)
+//   - month bucketing converts naive-UTC to America/Los_Angeles (BUCKET_TZ)
+// `now` is injectable everywhere time enters — the golden-fixture parity
+// harness pins it to the instant the Python fixture was captured.
+
+import type { FrameRow } from "./historyFrame.js";
+import type { StatsConfig, TeamConfig } from "./teamConfig.js";
+
+export const BUCKET_TZ = "America/Los_Angeles";
+
+const GAP_LOW_FRAC = 0.125;
+const GAP_MED_FRAC = 0.25;
+const GAP_HIGH_FRAC = 0.375;
+
+// ── numeric helpers ─────────────────────────────────────────────────────────
+
+export function pyRound(x: number, d = 0): number {
+  if (!Number.isFinite(x)) return x;
+  // Python's round() rounds the TRUE binary value, half-even only on exact
+  // ties. An epsilon on x*10^d misclassifies near-halves (82.949999999999)
+  // as ties — instead read the exact decimal expansion via toFixed and
+  // decide from the digits beyond position d.
+  const neg = x < 0;
+  const abs = Math.abs(x);
+  const s = abs.toFixed(Math.min(20, d + 18));
+  const dot = s.indexOf(".");
+  const intPart = s.slice(0, dot);
+  const frac = s.slice(dot + 1);
+  const kept = frac.slice(0, d);
+  const rest = frac.slice(d);
+  let base = BigInt(intPart + kept); // value scaled by 10^d, truncated
+  const half = "5" + "0".repeat(rest.length - 1);
+  if (rest > half) base += 1n;
+  else if (rest === half) {
+    if (base % 2n === 1n) base += 1n; // half-even
+  }
+  const out = Number(base) / 10 ** d;
+  const signed = neg ? -out : out;
+  return signed === 0 ? 0 : signed;
+}
+
+// numpy's pairwise summation (umath pairwise_sum, blocksize 128, 8-way
+// unroll) — reproduced so float accumulation order matches the oracle
+// bit-for-bit; sequential reduce differs by ulps and flips values sitting
+// exactly on a rounding boundary (observed: one roster mean at 80.35).
+function npSum(a: number[], lo = 0, n = a.length): number {
+  if (n < 8) {
+    let res = 0;
+    for (let i = lo; i < lo + n; i++) res += a[i];
+    return res;
+  }
+  if (n <= 128) {
+    const r = [
+      a[lo], a[lo + 1], a[lo + 2], a[lo + 3],
+      a[lo + 4], a[lo + 5], a[lo + 6], a[lo + 7],
+    ];
+    let i = 8;
+    for (; i + 8 <= n; i += 8)
+      for (let j = 0; j < 8; j++) r[j] += a[lo + i + j];
+    let res = ((r[0] + r[1]) + (r[2] + r[3])) + ((r[4] + r[5]) + (r[6] + r[7]));
+    for (; i < n; i++) res += a[lo + i];
+    return res;
+  }
+  let n2 = n >> 1;
+  n2 -= n2 % 8;
+  return npSum(a, lo, n2) + npSum(a, lo + n2, n - n2);
+}
+
+function mean(xs: number[]): number {
+  return npSum(xs) / xs.length;
+}
+
+function stdSample(xs: number[]): number {
+  const m = mean(xs);
+  return Math.sqrt(npSum(xs.map((x) => (x - m) ** 2)) / (xs.length - 1));
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+// pandas ewm(span).mean() with adjust=True:
+// y_t = Σ_{i=0..t} (1-α)^i · x_{t-i} / Σ_{i=0..t} (1-α)^i, α = 2/(span+1)
+function ewmaSeries(xs: number[], span: number): number[] {
+  const alpha = 2 / (span + 1);
+  const out: number[] = [];
+  let num = 0;
+  let den = 0;
+  const decay = 1 - alpha;
+  for (const x of xs) {
+    num = num * decay + x;
+    den = den * decay + 1;
+    out.push(num / den);
+  }
+  return out;
+}
+
+function groupByAgent(rows: FrameRow[]): Map<string, FrameRow[]> {
+  const groups = new Map<string, FrameRow[]>();
+  for (const r of rows) {
+    let g = groups.get(r.agent);
+    if (!g) groups.set(r.agent, (g = []));
+    g.push(r);
+  }
+  return new Map([...groups.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}
+
+// ── month bucketing (BUCKET_TZ seam) ────────────────────────────────────────
+
+const _ymFmt = new Intl.DateTimeFormat("en-CA", {
+  timeZone: BUCKET_TZ,
+  year: "numeric",
+  month: "2-digit",
+});
+
+export function monthInBucketTz(tsMs: number): string {
+  return _ymFmt.format(new Date(tsMs)).slice(0, 7); // "YYYY-MM"
+}
+
+function currentAndLastYm(now: Date): { current: string; last: string } {
+  const current = monthInBucketTz(now.getTime());
+  const [y, m] = current.split("-").map(Number);
+  const lastY = m === 1 ? y - 1 : y;
+  const lastM = m === 1 ? 12 : m - 1;
+  return { current, last: `${lastY}-${String(lastM).padStart(2, "0")}` };
+}
+
+// ── the compute_* ports ─────────────────────────────────────────────────────
+
+export function computeOutliers(rows: FrameRow[], stats: StatsConfig): any[] {
+  if (!rows.length) return [];
+  const results: any[] = [];
+  for (const [agent, group] of groupByAgent(rows)) {
+    if (group.length < stats.min_evals_for_outlier) continue;
+    const scores = group.map((r) => r.overall_score);
+    const med = median(scores);
+    const mad = median(scores.map((s) => Math.abs(s - med)));
+    if (mad === 0) continue;
+    for (const row of group) {
+      const z = (0.6745 * (row.overall_score - med)) / mad;
+      if (Math.abs(z) > stats.outlier_z_threshold) {
+        results.push({
+          agent,
+          date: new Date(row.ts).toISOString().slice(0, 10),
+          score: pyRound(row.overall_score, 1),
+          agent_median: pyRound(med, 1),
+          modified_z: pyRound(z, 2),
+          classification: z > 0 ? "exceptional" : "concerning",
+          eval_id: row.eval_id,
+        });
+      }
+    }
+  }
+  results.sort((a, b) => Math.abs(b.modified_z) - Math.abs(a.modified_z));
+  return results;
+}
+
+export function computeEwma(rows: FrameRow[], stats: StatsConfig): any[] {
+  if (!rows.length) return [];
+  const { ewma_span: span, ewma_min_evals: minEvals, ewma_trend_delta: delta } = stats;
+  const results: any[] = [];
+  for (const [agent, groupUnsorted] of groupByAgent(rows)) {
+    const group = [...groupUnsorted].sort((a, b) => a.ts - b.ts);
+    if (group.length < minEvals) continue;
+    const series = ewmaSeries(group.map((r) => r.overall_score), span);
+    const current = series[series.length - 1];
+    const past = series[Math.max(0, series.length - span - 1)];
+    const diff = current - past;
+    results.push({
+      agent,
+      current_ewma: pyRound(current, 1),
+      trend: diff > delta ? "improving" : diff < -delta ? "declining" : "flat",
+      eval_count: group.length,
+    });
+  }
+  results.sort((a, b) => a.current_ewma - b.current_ewma);
+  return results;
+}
+
+export function computeMonthlySummary(rows: FrameRow[], now: Date): any {
+  const { current: currentYm, last: lastYm } = currentAndLastYm(now);
+  const empty = (ym: string) => ({ year_month: ym, count: 0, mean: null, std: null });
+  if (!rows.length) return { last: empty(lastYm), current: empty(currentYm) };
+  const months = rows.map((r) => monthInBucketTz(r.ts));
+  const bucket = (ym: string) => {
+    const scores = rows.filter((_, i) => months[i] === ym).map((r) => r.overall_score);
+    if (!scores.length) return empty(ym);
+    return {
+      year_month: ym,
+      count: scores.length,
+      mean: pyRound(mean(scores), 1),
+      std: scores.length > 1 ? pyRound(stdSample(scores), 1) : null,
+    };
+  };
+  return { last: bucket(lastYm), current: bucket(currentYm) };
+}
+
+export function computeMonthlySpc(rows: FrameRow[], stats: StatsConfig): any {
+  if (!rows.length) return { months: [], ucl: 0, lcl: 0, center: 0 };
+  const byMonth = new Map<string, number[]>();
+  for (const r of rows) {
+    const ym = monthInBucketTz(r.ts);
+    let g = byMonth.get(ym);
+    if (!g) byMonth.set(ym, (g = []));
+    g.push(r.overall_score);
+  }
+  const sorted = [...byMonth.entries()].sort(([a], [b]) => (a < b ? -1 : 1));
+  const means = sorted.map(([, scores]) => mean(scores));
+  const center = mean(means);
+  const sigma = means.length > 1 ? stdSample(means) : 0;
+  const k = stats.spc_sigma_multiplier;
+  return {
+    months: sorted.map(([ym, scores]) => ({
+      month: ym,
+      mean: pyRound(mean(scores), 1),
+      count: scores.length,
+    })),
+    ucl: pyRound(center + k * sigma, 1),
+    lcl: pyRound(center - k * sigma, 1),
+    center: pyRound(center, 1),
+  };
+}
+
+function sectionRangeSize(config: TeamConfig, hid: string, dflt = 4): number {
+  const sec = config.history_id_to_section[hid];
+  if (sec?.score_range) return sec.score_range[1] - sec.score_range[0];
+  return dflt;
+}
+
+function numVals(group: FrameRow[], hid: string): number[] {
+  return group.map((r) => r.num[hid]).filter((v): v is number => v !== null && v !== undefined && !Number.isNaN(v));
+}
+
+export function computeSectionAnalysis(rows: FrameRow[], config: TeamConfig): any {
+  if (!rows.length)
+    return { team_means: {}, team_stds: {}, training_opportunities: [] };
+  const teamMeansById: Record<string, number> = {};
+  const teamMeansRounded: Record<string, number> = {};
+  const teamStds: Record<string, number> = {};
+  for (const hid of config.numeric_history_ids) {
+    const vals = numVals(rows, hid);
+    teamMeansById[hid] = vals.length ? mean(vals) : 0;
+    teamMeansRounded[hid] = vals.length ? pyRound(mean(vals), 2) : 0;
+    teamStds[hid] = vals.length > 1 ? pyRound(stdSample(vals), 2) : 0;
+  }
+  const opportunities: any[] = [];
+  for (const [agent, group] of groupByAgent(rows)) {
+    for (const hid of config.numeric_history_ids) {
+      const agentVals = numVals(group, hid);
+      if (agentVals.length < 2) continue;
+      const agentAvg = mean(agentVals);
+      // Python compares against the ROUNDED team mean (team_means dict holds
+      // round(...,2) values) — keep that quirk for parity.
+      const tAvg = teamMeansRounded[hid] ?? 0;
+      const gap = tAvg - agentAvg;
+      const rangeSize = sectionRangeSize(config, hid);
+      if (gap > GAP_LOW_FRAC * rangeSize) {
+        const priority =
+          gap >= GAP_HIGH_FRAC * rangeSize
+            ? "high"
+            : gap >= GAP_MED_FRAC * rangeSize
+              ? "medium"
+              : "low";
+        opportunities.push({
+          agent,
+          section: config.section_labels[hid] ?? hid,
+          agent_avg: pyRound(agentAvg, 2),
+          team_avg: pyRound(tAvg, 2),
+          gap: pyRound(gap, 2),
+          n: agentVals.length,
+          priority,
+        });
+      }
+    }
+  }
+  opportunities.sort((a, b) => b.gap - a.gap);
+  return {
+    team_means: Object.fromEntries(
+      config.numeric_history_ids.map((hid) => [
+        config.section_labels[hid] ?? hid,
+        teamMeansRounded[hid],
+      ])
+    ),
+    team_stds: Object.fromEntries(
+      config.numeric_history_ids.map((hid) => [
+        config.section_labels[hid] ?? hid,
+        teamStds[hid],
+      ])
+    ),
+    training_opportunities: opportunities,
+  };
+}
+
+function binaryPct(vals: string[]): number {
+  const yes = vals.filter((v) => v === "Y").length;
+  const total = vals.filter((v) => v === "Y" || v === "N").length;
+  return total > 0 ? pyRound((100.0 * yes) / total, 1) : 0.0;
+}
+
+export function computeBinaryStats(
+  rows: FrameRow[],
+  ynSectionLabels: Record<string, string>
+): any[] {
+  const result: any[] = [];
+  for (const [sectionId, label] of Object.entries(ynSectionLabels)) {
+    if (!rows.length) {
+      result.push({ section_id: sectionId, label, team_pct: 0.0, agents: [] });
+      continue;
+    }
+    const teamPct = binaryPct(rows.map((r) => r.yn[sectionId] ?? ""));
+    const agents: any[] = [];
+    for (const [agent, group] of groupByAgent(rows)) {
+      const vals = group.map((r) => r.yn[sectionId] ?? "");
+      const total = vals.filter((v) => v === "Y" || v === "N").length;
+      if (total > 0) {
+        agents.push({
+          agent,
+          pct: binaryPct(vals),
+          yes: vals.filter((v) => v === "Y").length,
+          total,
+        });
+      }
+    }
+    agents.sort((a, b) => a.pct - b.pct);
+    result.push({ section_id: sectionId, label, team_pct: teamPct, agents });
+  }
+  return result;
+}
+
+export function computeSupervisorStats(rows: FrameRow[]): any[] {
+  const filtered = rows.filter((r) => r.supervisor.trim() !== "");
+  if (!filtered.length) return [];
+  const groups = new Map<string, FrameRow[]>();
+  for (const r of filtered) {
+    let g = groups.get(r.supervisor);
+    if (!g) groups.set(r.supervisor, (g = []));
+    g.push(r);
+  }
+  const results: any[] = [];
+  for (const [sup, group] of [...groups.entries()].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    const scores = group.map((r) => r.overall_score);
+    results.push({
+      supervisor: sup,
+      avg_score: pyRound(mean(scores), 1),
+      std_score: scores.length > 1 ? pyRound(stdSample(scores), 1) : 0,
+      eval_count: group.length,
+      agent_count: new Set(group.map((r) => r.agent)).size,
+    });
+  }
+  results.sort((a, b) => b.avg_score - a.avg_score);
+  return results;
+}
+
+export function computeAgentRoster(rows: FrameRow[], config: TeamConfig): any[] {
+  if (!rows.length) return [];
+  const teamMeans: Record<string, number> = {};
+  for (const hid of config.numeric_history_ids) {
+    const vals = numVals(rows, hid);
+    teamMeans[hid] = vals.length ? mean(vals) : 0;
+  }
+  const ewmaLookup = new Map(
+    computeEwma(rows, config.stats).map((e) => [e.agent, e])
+  );
+  const results: any[] = [];
+  for (const [agent, group] of groupByAgent(rows)) {
+    const scores = group.map((r) => r.overall_score);
+    const meanScore = mean(scores);
+    const stdScore = scores.length > 1 ? stdSample(scores) : 0;
+    const ewmaData = ewmaLookup.get(agent);
+    const ewmaVal = ewmaData ? ewmaData.current_ewma : null;
+    const trend = ewmaData ? ewmaData.trend : "flat";
+    const ref = ewmaVal !== null ? ewmaVal : meanScore;
+    const status =
+      ref >= 90 ? "excellent" : ref >= 80 ? "good" : ref >= 70 ? "watch" : "at_risk";
+    const binaryPcts: Record<string, number> = {};
+    for (const ynId of config.yn_history_ids)
+      binaryPcts[ynId] = binaryPct(group.map((r) => r.yn[ynId] ?? ""));
+    const weak: string[] = [];
+    for (const hid of config.numeric_history_ids) {
+      const agentVals = numVals(group, hid);
+      if (agentVals.length < 2) continue;
+      if (
+        (teamMeans[hid] ?? 0) - mean(agentVals) >
+        GAP_LOW_FRAC * sectionRangeSize(config, hid)
+      )
+        weak.push(config.section_labels[hid] ?? hid);
+    }
+    results.push({
+      agent,
+      n: group.length,
+      mean: pyRound(meanScore, 1),
+      std: pyRound(stdScore, 1),
+      ewma: ewmaVal,
+      trend,
+      binary_pcts: binaryPcts,
+      status,
+      weak_sections: weak,
+      is_active: group[0].is_active,
+      supervisor: group[0].supervisor,
+    });
+  }
+  results.sort((a, b) => b.mean - a.mean);
+  return results;
+}
+
+export function computeDistribution(rows: FrameRow[]): any[] {
+  if (!rows.length) return [];
+  const bins: [number, number, string][] = [
+    [0, 20, "0-20"],
+    [21, 40, "21-40"],
+    [41, 60, "41-60"],
+    [61, 70, "61-70"],
+    [71, 80, "71-80"],
+    [81, 90, "81-90"],
+    [91, 100, "91-100"],
+  ];
+  return bins.map(([lo, hi, label]) => ({
+    bin: label,
+    count: rows.filter((r) => r.overall_score >= lo && r.overall_score <= hi).length,
+  }));
+}
+
+// ── response assembly (route logic from backend/routes/team.py) ─────────────
+
+export interface StatsFilters {
+  days: number;
+  active_only: boolean;
+  supervisor: string;
+  date_from: string | null;
+  date_to: string | null;
+}
+
+export function assembleTeamStats(
+  frame: FrameRow[],
+  config: TeamConfig,
+  filters: StatsFilters,
+  now: Date
+): any {
+  const base = {
+    team_id: config.team_id,
+    rubric_version: config.rubric_version,
+    generated_at: now.toISOString(),
+    coverage_regime: "manager_sample",
+    filters_applied: filters,
+  };
+  if (!frame.length) {
+    return {
+      ...base,
+      kpis: { total_evals: 0, avg_score: 0, std_score: 0, analyst_count: 0 },
+      monthly: computeMonthlySummary([], now),
+      roster: [],
+      outliers: [],
+      spc: { months: [], ucl: 0, lcl: 0, center: 0 },
+      section_analysis: { team_means: {}, team_stds: {}, training_opportunities: [] },
+      binary_stats: Object.entries(config.yn_section_labels).map(([sid, label]) => ({
+        section_id: sid,
+        label,
+        team_pct: 0.0,
+        agents: [],
+      })),
+      supervisor_stats: [],
+      ewma: [],
+      distribution: [],
+    };
+  }
+
+  let df = frame;
+  if (filters.active_only) df = df.filter((r) => r.is_active);
+  if (filters.supervisor) {
+    const sup = filters.supervisor.trim().toLowerCase();
+    df = df.filter((r) => r.supervisor.toLowerCase() === sup);
+  }
+
+  // monthly chiclets honor active/supervisor but NOT the days filter
+  const monthly = computeMonthlySummary(df, now);
+
+  if (filters.date_from && filters.date_to) {
+    const from = Date.parse(`${filters.date_from}T00:00:00Z`);
+    const to = Date.parse(`${filters.date_to}T23:59:59.999Z`);
+    df = df.filter((r) => r.ts >= from && r.ts <= to);
+  } else if (filters.days > 0) {
+    const cutoff = now.getTime() - filters.days * 86_400_000;
+    df = df.filter((r) => r.ts >= cutoff);
+  }
+
+  const scores = df.map((r) => r.overall_score);
+  const kpis = {
+    total_evals: df.length,
+    avg_score: df.length > 0 ? pyRound(mean(scores), 1) : 0,
+    std_score: df.length > 1 ? pyRound(stdSample(scores), 1) : 0,
+    analyst_count: new Set(df.map((r) => r.agent)).size,
+  };
+
+  return {
+    ...base,
+    kpis,
+    monthly,
+    roster: computeAgentRoster(df, config),
+    outliers: computeOutliers(df, config.stats),
+    spc: computeMonthlySpc(df, config.stats),
+    section_analysis: computeSectionAnalysis(df, config),
+    binary_stats: computeBinaryStats(df, config.yn_section_labels),
+    supervisor_stats: computeSupervisorStats(df),
+    ewma: computeEwma(df, config.stats),
+    distribution: computeDistribution(df),
+  };
+}
+
+export function assembleTeamEvals(
+  frame: FrameRow[],
+  config: TeamConfig,
+  yearMonth: string,
+  activeOnly: boolean,
+  supervisor: string
+): any {
+  const filters = { active_only: activeOnly, supervisor };
+  let df = frame;
+  if (activeOnly) df = df.filter((r) => r.is_active);
+  if (supervisor) {
+    const sup = supervisor.trim().toLowerCase();
+    df = df.filter((r) => r.supervisor.toLowerCase() === sup);
+  }
+  df = df.filter((r) => monthInBucketTz(r.ts) === yearMonth);
+  df = [...df].sort((a, b) => b.ts - a.ts); // stable, newest first
+  const iso = (ms: number | null) =>
+    ms === null ? null : new Date(ms).toISOString();
+  return {
+    team_id: config.team_id,
+    year_month: yearMonth,
+    rows: df.map((r) => ({
+      agent: r.agent,
+      timestamp: iso(r.ts),
+      eval_approved_at: iso(r.eval_approved_at),
+      overall_score: r.overall_score,
+      dialpad_link: r.eval_id
+        ? `https://dialpad.com/callhistory/callreview/${r.eval_id}`
+        : "",
+      eval_id: r.eval_id,
+      supervisor: r.supervisor || null,
+      evaluator_email: r.manager_email || null,
+    })),
+    filters_applied: filters,
+  };
+}

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -1,0 +1,210 @@
+// Worker routes for the ported QA pages + team analytics APIs.
+// Pages are the Railway originals served verbatim (?raw imports) — visual
+// parity by construction; the APIs they consume are implemented here against
+// D1 (PortManifest §4/§5). SSE is the §6.1 D1-as-bus design.
+
+import { loadTeamConfig } from "../lib/teamConfig.js";
+import { fetchHistoryFrame } from "../lib/historyFrame.js";
+import { assembleTeamEvals, assembleTeamStats } from "../lib/teamStats.js";
+// @ts-ignore vite ?raw
+import teamDashboardHtml from "../../pages/team_dashboard.html?raw";
+// @ts-ignore vite ?raw
+import teamEvalsHtml from "../../pages/team_evals.html?raw";
+// @ts-ignore vite ?raw
+import headerCss from "../../pages/static/header.css?raw";
+// @ts-ignore vite ?raw
+import headerJs from "../../pages/static/header.js?raw";
+
+const RAILWAY_BASE = "https://hellolanding-qa.up.railway.app";
+const KNOWN_TEAMS = new Set(["member_support", "sales"]);
+
+const html = (body: string) =>
+  new Response(body, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+export async function handleTeamRoutes(
+  request: Request,
+  db: D1Database,
+  url: URL
+): Promise<Response | null> {
+  const path = url.pathname;
+
+  // ── static assets shared by the ported pages ──────────────────────────────
+  if (path === "/static/header.css")
+    return new Response(headerCss, { headers: { "Content-Type": "text/css" } });
+  if (path === "/static/header.js")
+    return new Response(headerJs, {
+      headers: { "Content-Type": "text/javascript" },
+    });
+
+  // ── pages ────────────────────────────────────────────────────────────────
+  let m = path.match(/^\/dashboard\/([^/]+)\/evals$/);
+  if (m && KNOWN_TEAMS.has(m[1])) return html(teamEvalsHtml);
+  m = path.match(/^\/dashboard\/([^/]+)$/);
+  if (m && KNOWN_TEAMS.has(m[1])) return html(teamDashboardHtml);
+
+  // Interim: datapoint drill-down ports in the next slice. Keep the link
+  // graph honest — page exists, explains itself, links to Railway.
+  m = path.match(/^\/datapoint\/([^/]+)\/([^/]+)$/);
+  if (m) {
+    const target = `${RAILWAY_BASE}/datapoint/${m[1]}/${encodeURIComponent(m[2])}`;
+    return html(
+      `<!DOCTYPE html><html><head><title>Datapoint — porting</title></head>
+<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
+<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:520px">
+<h2 style="margin-top:0">Datapoint drill-down: next port slice</h2>
+<p>This page hasn't moved to Sandy yet (strangler order: dashboards → stats → datapoint).</p>
+<p><a href="${target}" style="color:#1A61D9">Open this datapoint on Railway &rsaquo;</a></p>
+<p><a href="javascript:history.back()" style="color:#5a6478">&larr; Back</a></p>
+</div></body></html>`
+    );
+  }
+
+  // ── team APIs: /api/{team}/team/* ─────────────────────────────────────────
+  m = path.match(/^\/api\/([^/]+)\/(team\/[a-z_]+|events\/stream)$/);
+  if (!m) return null;
+  const teamId = m[1];
+  const sub = m[2];
+  if (!KNOWN_TEAMS.has(teamId)) return json({ detail: "unknown team" }, 404);
+
+  if (sub === "events/stream") return sseStream(db, teamId, request);
+
+  const config = await loadTeamConfig(db, teamId);
+
+  if (sub === "team/sections") {
+    return json(
+      config.sections_by_number.map((s) => ({
+        id: s.id,
+        history_id: s.history_id,
+        name: s.name,
+        section_number: s.section_number,
+        score_type: s.score_type,
+        audio_dependent: s.audio_dependent,
+        na_applicable: s.na_applicable,
+        auto_value: s.auto_value,
+      }))
+    );
+  }
+
+  if (sub === "team/mails") {
+    const rows = await db
+      .prepare(
+        "SELECT name, email, supervisor_email, canonical_name FROM qa_agents WHERE team_id = ? AND active = 1 ORDER BY id"
+      )
+      .bind(teamId)
+      .all<any>();
+    return json(
+      rows.results.map((r) => ({
+        agent_name: r.name,
+        email: r.email ?? "",
+        supervisor: r.supervisor_email || null,
+        canonical_name: r.canonical_name || null,
+      }))
+    );
+  }
+
+  if (sub === "team/stats") {
+    const p = url.searchParams;
+    const days = Math.min(730, Math.max(0, parseInt(p.get("days") ?? "90", 10) || 0));
+    const filters = {
+      days,
+      active_only: p.get("active_only") !== "false",
+      supervisor: p.get("supervisor") ?? "",
+      date_from: p.get("date_from"),
+      date_to: p.get("date_to"),
+    };
+    const frame = await fetchHistoryFrame(db, config);
+    return json(assembleTeamStats(frame, config, filters, new Date()));
+  }
+
+  if (sub === "team/evals") {
+    const p = url.searchParams;
+    const ym = p.get("year_month") ?? "";
+    if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(ym))
+      return json({ detail: "year_month must be YYYY-MM" }, 422);
+    const frame = await fetchHistoryFrame(db, config);
+    return json(
+      assembleTeamEvals(
+        frame,
+        config,
+        ym,
+        p.get("active_only") !== "false",
+        p.get("supervisor") ?? ""
+      )
+    );
+  }
+
+  return null;
+}
+
+// ── SSE: D1-tailed event stream (PortManifest §6.1) ─────────────────────────
+// Bounded ~50 s stream; EventSource auto-reconnects with Last-Event-ID so no
+// event is missed across stream lifetimes. Initial cursor = current max(id)
+// (only NEW events push; page data comes from the APIs).
+
+const SSE_LIFETIME_MS = 50_000;
+const SSE_POLL_MS = 3_000;
+
+async function sseStream(
+  db: D1Database,
+  teamId: string,
+  request: Request
+): Promise<Response> {
+  const lastEventId =
+    request.headers.get("Last-Event-ID") ??
+    new URL(request.url).searchParams.get("cursor");
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (s: string) => controller.enqueue(encoder.encode(s));
+      send(": connected\n\n");
+      let cursor: number;
+      if (lastEventId !== null && /^\d+$/.test(lastEventId)) {
+        cursor = parseInt(lastEventId, 10);
+      } else {
+        const row = await db
+          .prepare("SELECT COALESCE(max(id), 0) AS m FROM qa_events WHERE team_id = ?")
+          .bind(teamId)
+          .first<{ m: number }>();
+        cursor = row?.m ?? 0;
+      }
+      const deadline = Date.now() + SSE_LIFETIME_MS;
+      try {
+        while (Date.now() < deadline) {
+          const events = await db
+            .prepare(
+              "SELECT id, type, payload FROM qa_events WHERE team_id = ? AND id > ? ORDER BY id LIMIT 50"
+            )
+            .bind(teamId, cursor)
+            .all<{ id: number; type: string; payload: string }>();
+          if (events.results.length) {
+            for (const e of events.results) {
+              send(`id: ${e.id}\nevent: ${e.type}\ndata: ${e.payload.replace(/\n/g, " ")}\n\n`);
+              cursor = e.id;
+            }
+          } else {
+            send(": heartbeat\n\n");
+          }
+          await new Promise((r) => setTimeout(r, SSE_POLL_MS));
+        }
+      } catch {
+        // client went away or D1 hiccup — end the stream; EventSource reconnects
+      }
+      try {
+        controller.close();
+      } catch {}
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}


### PR DESCRIPTION
## What this is

Port-order **gates 2 + 3** from the signed-off PortManifest: the first user-visible pages on Sandy, the §5.2 stats engine with the golden-fixture parity gate **passing at zero diffs**, and the §6.1 live SSE feed.

**See it live (SSO):**
- https://qa-scoring.sandy.hellolanding.tech/dashboard/member_support — the main team dashboard (floor-TV view), all five tabs
- https://qa-scoring.sandy.hellolanding.tech/dashboard/member_support/evals?month=2026-07 — month drill-down
- Same for `/dashboard/sales`

## Approach: the Railway pages ARE the port

`team_dashboard.html`, `team_evals.html`, and the header assets are served **verbatim** from the worker (`?raw` imports) — the only change is a 4-line shim replacing the API-key prompt (Google SSO owns auth now). Visual parity is by construction; the manifest's SSR-React target is deliberately deferred. The real port is underneath: the JSON APIs these pages consume.

## The stats engine (§5.2 — the pandas port)

`src/lib/{teamConfig,historyFrame,teamStats}.ts` reproduce `team_source.py` + `team_stats.py` with the numeric semantics that actually matter:
- Python `round()` half-even via exact decimal expansion (epsilon approaches misclassify near-halves)
- **numpy pairwise summation** (8-way unroll, blocksize 128) — sequential reduce differs by ulps and flipped a roster mean sitting exactly on 80.35
- `ewm(adjust=True)`, `ddof=1`, sorted groupby, stable sorts, `America/Los_Angeles` month bucketing

## Parity gate — FULL PARITY

`parity/capture_fixture.py` runs the **production Python code** against Railway Postgres (pinned to the D1 snapshot eval-id and a captured clock); `parity/run_parity.mjs` runs the **worker's own compiled modules** against the real D1 via a db shim. Result: **2,505 frame rows, every stats payload (days=90 & days=0), evals drill-downs, both teams — zero diffs.**

## Findings for the record

1. **The Python oracle is row-order-nondeterministic** in the archived-rubric alias map: sales_v1 `value_uplift`@6 aliases into v2's `landing_guarantee` column while v1's own `landing_guarantee` row also writes it. 39/41 collision rows resolve direct-wins by heap order; 2 post-edit rows resolve the other way. Port + fixture pin **direct-beats-aliased** explicitly — those 2 historic Sales cells intentionally differ from Railway. Recommend the same determinism fix in Python post-freeze.
2. SSE is live end-to-end: `/api/{team}/events/stream` tails `qa_events` (bounded ~50s streams, `Last-Event-ID` resume). It will emit real toasts once the scoring write-path (or the Railway double-write) starts inserting events — the transport was already verified green on `/sse-test`.
3. Datapoint links land on an interim page linking to Railway — the honest strangler seam; that page is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)