### PR TITLE
feat(sandy-qa): drill-down APIs (dist histogram + EWMA) + nightly parity cron

### DIFF
--- a/sandy-qa/.gitignore
+++ b/sandy-qa/.gitignore
@@ -5,3 +5,4 @@ _release/
 .wrangler/
 parity/fixture.json
 parity/lib.mjs
+parity/parity.log

--- a/sandy-qa/parity/nightly.sh
+++ b/sandy-qa/parity/nightly.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Nightly golden-fixture parity: Railway Postgres oracle vs the Sandy D1 port.
+# Runs until Railway disconnect (SandyMigration Phase 5 exit checklist feeds
+# on this log). Installed via crontab — see PortManifest §11.3.
+#
+# Re-pins every run to D1's current max finalized eval id, recaptures the
+# Python fixture, reruns the worker's modules against D1, appends one verdict
+# line per run to parity.log, and raises a macOS notification on any failure.
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APP_DIR="$ROOT/qa-automation/AI-Scoring"
+PAR="$ROOT/sandy-qa/parity"
+LOG="$PAR/parity.log"
+PY3="/opt/homebrew/bin/python3"   # cron's PATH lacks homebrew; sandy.py needs 3.10+
+SANDY="$HOME/.claude/commands/scripts/sandy.py"
+APP_ID="a2cc5b5a-df29-4ae7-9dbb-e270052015e7"
+STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+
+notify() { /usr/bin/osascript -e "display notification \"$1\" with title \"QA Sandy parity\"" 2>/dev/null; }
+
+PIN=$("$PY3" "$SANDY" db query "$APP_ID" \
+  "SELECT COALESCE(max(id),0) AS m FROM qa_evaluations WHERE state='finalized'" \
+  2>>"$LOG" | "$PY3" -c "import json,sys; print(json.load(sys.stdin)['data'][0]['results'][0]['m'])" 2>>"$LOG")
+if [ -z "${PIN:-}" ]; then
+  echo "[$STAMP] FAIL: pin query — Sandy token expired? run: python3 $SANDY login --start" >>"$LOG"
+  notify "pin query failed — Sandy token expired?"
+  exit 1
+fi
+
+cd "$APP_DIR" || exit 1
+if ! .venv/bin/python "$PAR/capture_fixture.py" --max-eval-id "$PIN" --out "$PAR/fixture.json" >>"$LOG" 2>&1; then
+  echo "[$STAMP] FAIL: fixture capture (Railway PG reachable?)" >>"$LOG"
+  notify "fixture capture failed"
+  exit 1
+fi
+
+cd "$ROOT/sandy-qa" || exit 1
+node_modules/wrangler/node_modules/esbuild/bin/esbuild parity/entry.ts \
+  --bundle --format=esm --outfile=parity/lib.mjs --platform=neutral >/dev/null 2>&1
+if node parity/run_parity.mjs parity/fixture.json >>"$LOG" 2>&1; then
+  echo "[$STAMP] OK: FULL PARITY (pin=$PIN)" >>"$LOG"
+else
+  echo "[$STAMP] FAIL: PARITY MISMATCH (pin=$PIN) — diffs above" >>"$LOG"
+  notify "PARITY MISMATCH — check sandy-qa/parity/parity.log"
+  exit 2
+fi

--- a/sandy-qa/src/lib/historyFrame.ts
+++ b/sandy-qa/src/lib/historyFrame.ts
@@ -16,6 +16,10 @@ export interface FrameRow {
   eval_id: string;
   num: Record<string, number | null>;
   yn: Record<string, string>;
+  // Extras for the drill-down list endpoints (not part of the stats frame
+  // contract — excluded from parity's serializeTsFrame on purpose).
+  caller_name: string;
+  agent_email: string;
 }
 
 export function stripAccents(s: string): string {
@@ -64,6 +68,7 @@ export async function fetchHistoryFrame(
     db
       .prepare(
         `SELECT e.id, e.agent_id, e.agent_name_raw, e.evaluator_email, e.overall_score,
+                e.caller_name, e.agent_email,
                 e.dialpad_link, e.dialpad_entry_point_call_id, e.dialpad_call_metadata,
                 COALESCE(e.call_connected_at, e.approved_at) AS ts, e.approved_at,
                 COALESCE(a.canonical_name, a.name, e.agent_name_raw) AS agent_display,
@@ -188,6 +193,8 @@ export async function fetchHistoryFrame(
       eval_id: evalId,
       num,
       yn,
+      caller_name: ev.caller_name ?? "",
+      agent_email: ev.agent_email ?? "",
     });
   }
   return rows;

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -47,22 +47,38 @@ export async function handleTeamRoutes(
   m = path.match(/^\/dashboard\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1])) return html(teamDashboardHtml);
 
-  // Interim: datapoint drill-down ports in the next slice. Keep the link
-  // graph honest — page exists, explains itself, links to Railway.
-  m = path.match(/^\/datapoint\/([^/]+)\/([^/]+)$/);
-  if (m) {
-    const target = `${RAILWAY_BASE}/datapoint/${m[1]}/${encodeURIComponent(m[2])}`;
-    return html(
-      `<!DOCTYPE html><html><head><title>Datapoint — porting</title></head>
+  // Interim: datapoint + per-agent dashboard port in the next slice. Keep
+  // the link graph honest — pages exist, explain themselves, link to Railway.
+  const interimPage = (title: string, target: string) =>
+    html(
+      `<!DOCTYPE html><html><head><title>${title} — porting</title></head>
 <body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
 <div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:520px">
-<h2 style="margin-top:0">Datapoint drill-down: next port slice</h2>
-<p>This page hasn't moved to Sandy yet (strangler order: dashboards → stats → datapoint).</p>
-<p><a href="${target}" style="color:#1A61D9">Open this datapoint on Railway &rsaquo;</a></p>
+<h2 style="margin-top:0">${title}: next port slice</h2>
+<p>This page hasn't moved to Sandy yet (strangler order: dashboards → stats → drill-downs).</p>
+<p><a href="${target}" style="color:#1A61D9">Open on Railway &rsaquo;</a></p>
 <p><a href="javascript:history.back()" style="color:#5a6478">&larr; Back</a></p>
 </div></body></html>`
     );
-  }
+  m = path.match(/^\/datapoint\/([^/]+)\/([^/]+)$/);
+  if (m)
+    return interimPage(
+      "Datapoint drill-down",
+      `${RAILWAY_BASE}/datapoint/${m[1]}/${encodeURIComponent(m[2])}`
+    );
+  m = path.match(/^\/dashboard\/([^/]+)\/agent\/(.+)$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return interimPage(
+      "Per-agent dashboard",
+      `${RAILWAY_BASE}/dashboard/${m[1]}/agent/${m[2]}`
+    );
+
+  // ── drill-down list APIs (dist histogram + EWMA bar expansions) ──────────
+  m = path.match(/^\/api\/([^/]+)\/datapoints$/);
+  if (m && KNOWN_TEAMS.has(m[1])) return datapointsList(db, m[1], url);
+  m = path.match(/^\/api\/([^/]+)\/agents\/([^/]+)\/history$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return agentHistory(db, m[1], decodeURIComponent(m[2]), url);
 
   // ── team APIs: /api/{team}/team/* ─────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/(team\/[a-z_]+|events\/stream)$/);
@@ -139,6 +155,92 @@ export async function handleTeamRoutes(
   }
 
   return null;
+}
+
+// ── drill-down list endpoints ───────────────────────────────────────────────
+// EvaluationRecord-shaped rows (the fields the dashboard drill-downs render:
+// agent_name / timestamp / overall_score / eval_id / caller_name, plus the
+// cheap extras). Built from the same canonicalized frame the stats use.
+
+function recordFromFrameRow(r: import("../lib/historyFrame.js").FrameRow) {
+  return {
+    timestamp: new Date(r.ts).toISOString(),
+    agent_name: r.agent,
+    agent_email: r.agent_email,
+    manager_email: r.manager_email,
+    overall_score: r.overall_score,
+    sections: {},
+    eval_id: r.eval_id || null,
+    dialpad_link: r.eval_id
+      ? `https://dialpad.com/callhistory/callreview/${r.eval_id}`
+      : null,
+    caller_name: r.caller_name || null,
+    source: "ai",
+  };
+}
+
+function windowFilter(
+  rows: import("../lib/historyFrame.js").FrameRow[],
+  url: URL,
+  defaultDays: number,
+  maxDays: number
+) {
+  const p = url.searchParams;
+  const dateFrom = p.get("date_from");
+  const dateTo = p.get("date_to");
+  if (dateFrom && dateTo) {
+    const from = Date.parse(`${dateFrom}T00:00:00Z`);
+    const to = Date.parse(`${dateTo}T23:59:59.999Z`);
+    return rows.filter((r) => r.ts >= from && r.ts <= to);
+  }
+  const days = Math.min(
+    maxDays,
+    Math.max(1, parseInt(p.get("days") ?? String(defaultDays), 10) || defaultDays)
+  );
+  const cutoff = Date.now() - days * 86_400_000;
+  return rows.filter((r) => r.ts >= cutoff);
+}
+
+async function datapointsList(db: D1Database, teamId: string, url: URL) {
+  const p = url.searchParams;
+  const bin = p.get("bin");
+  const agent = p.get("agent");
+  if (!bin && !agent)
+    return json({ detail: "Provide 'bin' (e.g. '81-90') or 'agent' query parameter" }, 400);
+  const config = await loadTeamConfig(db, teamId);
+  let rows = await fetchHistoryFrame(db, config);
+  if (agent) {
+    const a = agent.trim().toLowerCase();
+    rows = rows.filter((r) => r.agent.toLowerCase() === a);
+  }
+  rows = windowFilter(rows, url, 90, 365);
+  if (p.get("active_only") !== "false" && !agent)
+    rows = rows.filter((r) => r.is_active);
+  if (bin) {
+    const parts = bin.split("-");
+    const lo = Number(parts[0]);
+    const hi = Number(parts[1]);
+    if (!Number.isFinite(lo) || !Number.isFinite(hi))
+      return json({ detail: `Invalid bin format '${bin}', expected 'lo-hi'` }, 400);
+    rows = rows.filter((r) => r.overall_score >= lo && r.overall_score <= hi);
+  }
+  return json(rows.map(recordFromFrameRow));
+}
+
+async function agentHistory(
+  db: D1Database,
+  teamId: string,
+  agent: string,
+  url: URL
+) {
+  const config = await loadTeamConfig(db, teamId);
+  const a = agent.trim().toLowerCase();
+  let rows = (await fetchHistoryFrame(db, config)).filter(
+    (r) => r.agent.toLowerCase() === a
+  );
+  rows = windowFilter(rows, url, 90, 730);
+  if (!rows.length) return json({ detail: `No history for '${agent}'` }, 404);
+  return json(rows.map(recordFromFrameRow));
 }
 
 // ── SSE: D1-tailed event stream (PortManifest §6.1) ─────────────────────────


### PR DESCRIPTION
## What this fixes

The two dashboard gaps spotted after PR #166:
- **Score Distribution drill-down** (clicking histogram bars) → `GET /api/{team}/datapoints?bin=lo-hi&days=&active_only=` now implemented
- **EWMA detail view** (clicking an agent bar) → `GET /api/{team}/agents/{name}/history?days=|date_from&date_to` now implemented

Both serve EvaluationRecord-shaped rows from the same canonicalized frame the stats engine uses, so agent identity/active semantics stay consistent. Per-agent dashboard links (`/dashboard/{team}/agent/{name}`) get the same interim-page treatment as datapoints. Deployed as v0.6.

## Nightly parity until Railway disconnect

`parity/nightly.sh` + crontab (9:30 daily, marker `qa-sandy-parity`): re-pins to D1's max finalized eval id, recaptures the Python oracle fixture from Railway PG, reruns the worker's own modules against D1, logs one verdict line per run to `parity/parity.log`, and raises a **macOS notification on any failure** — including Sandy token expiry (first bites ~Aug 8; the log line says exactly what to run).

Proof run: `OK: FULL PARITY (pin=2525)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)