### PR TITLE
feat(sandy-qa): datapoint + per-agent dashboard + lookup pages (evaluator journey complete, read-side)

### DIFF
--- a/sandy-qa/pages/dashboard.html
+++ b/sandy-qa/pages/dashboard.html
@@ -1,0 +1,729 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agent Progression Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/header.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <style>
+    :root {
+      --navy: #15192D;
+      --accent: #1A61D9;
+      --bg: #E7EFFB;
+      --surface: #ffffff;
+      --border: #c9d5e8;
+      --text: #15192D;
+      --muted: #5a6478;
+      --green: #28A745;
+      --amber: #E8A317;
+      --red: #D9534F;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'DM Mono', monospace;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    /* Header CSS lives in /static/header.css (shared with team_dashboard.html). */
+
+    /* Layout */
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    /* Cards */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+    }
+    .card h2 {
+      font-size: 1.1rem;
+      margin-bottom: 16px;
+      color: var(--navy);
+    }
+    .hidden { display: none; }
+
+    /* Placeholder */
+    .placeholder {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    /* Stats row */
+    .stats-row {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+    }
+    .stat-box {
+      text-align: center;
+      padding: 16px 8px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg);
+    }
+    .stat-box .stat-value {
+      font-family: 'Fraunces', serif;
+      font-size: 1.8rem;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+    .stat-box .stat-label {
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+
+    /* Charts */
+    .chart-wrapper {
+      position: relative;
+      height: 320px;
+      cursor: pointer;
+    }
+
+    /* Assessment */
+    .assessment-overall {
+      background: var(--bg);
+      border-radius: 10px;
+      padding: 16px;
+      margin-bottom: 20px;
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+    .section-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+    .section-card {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 16px;
+      background: var(--bg);
+    }
+    .section-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+    .section-card-header .section-name {
+      font-weight: 700;
+      text-transform: capitalize;
+      font-size: 0.9rem;
+    }
+    .trend-badge {
+      font-size: 0.7rem;
+      font-weight: 500;
+      padding: 2px 10px;
+      border-radius: 999px;
+      color: #fff;
+    }
+    .trend-badge.improving { background: var(--green); }
+    .trend-badge.stable { background: #6ba87b; }
+    .trend-badge.declining { background: var(--red); }
+    .trend-badge.fluctuating { background: var(--amber); }
+    .section-card .summary {
+      font-size: 0.82rem;
+      color: var(--muted);
+      line-height: 1.5;
+      margin-bottom: 8px;
+    }
+    .coaching-toggle {
+      font-size: 0.8rem;
+      color: var(--accent);
+      cursor: pointer;
+      font-weight: 500;
+      user-select: none;
+    }
+    .coaching-tip {
+      display: none;
+      margin-top: 8px;
+      font-size: 0.82rem;
+      line-height: 1.5;
+      padding: 10px;
+      background: var(--surface);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+    }
+    .coaching-tip.visible { display: block; }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 16px;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+
+    /* Score colors */
+    .score-green { color: var(--green); }
+    .score-amber { color: var(--amber); }
+    .score-red { color: var(--red); }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      .stats-row { grid-template-columns: repeat(2, 1fr); }
+      .section-grid { grid-template-columns: 1fr; }
+      .chart-wrapper { height: 240px; }
+    }
+  </style>
+</head>
+<body>
+  <div id="appHeader"></div>
+
+  <div class="container">
+    <div id="placeholder" class="placeholder">Select an agent to view their progression.</div>
+
+    <div id="statsCard" class="card hidden">
+      <h2>Summary</h2>
+      <div class="stats-row">
+        <div class="stat-box">
+          <div class="stat-value" id="statCount">--</div>
+          <div class="stat-label">Evaluations</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-value" id="statAvg">--</div>
+          <div class="stat-label">Average Score</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-value" id="statLatest">--</div>
+          <div class="stat-label">Latest Score</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-value" id="statHighest">--</div>
+          <div class="stat-label">Highest Score</div>
+        </div>
+      </div>
+    </div>
+
+    <div id="trendCard" class="card hidden">
+      <h2>Overall Score Trend</h2>
+      <div class="chart-wrapper">
+        <canvas id="trendChart"></canvas>
+      </div>
+    </div>
+
+    <div id="sectionCard" class="card hidden">
+      <h2>Per-Section Averages</h2>
+      <div class="chart-wrapper">
+        <canvas id="sectionChart"></canvas>
+      </div>
+    </div>
+
+    <div id="onepagerCard" class="card hidden">
+      <h2>Monthly One-Pager</h2>
+      <p style="font-size:0.85rem;color:var(--muted);margin:0 0 10px;">
+        Print-ready QA summary for <strong id="onepagerMonth">the last closed month</strong> —
+        evaluation count and score stats, the score-progression sparkline, per-section
+        performance with trends, and the monthly AI assessment. Refreshes automatically on
+        the 1st of each month, in step with the monthly workbook export.
+      </p>
+      <a id="onepagerLink" href="#" target="_blank" rel="noopener"
+         style="font-family:'DM Mono',monospace;font-size:0.85rem;display:inline-block;padding:8px 18px;background:var(--accent);color:#fff;border-radius:6px;text-decoration:none;">
+        Open one-pager →
+      </a>
+    </div>
+
+    <div id="assessmentCard" class="card">
+      <h2>AI Progression Assessment</h2>
+      <div id="assessmentPlaceholder" style="text-align:center;padding:20px;">
+        <button id="aiBtn" onclick="loadAIAssessment()" style="font-family:'DM Mono',monospace;font-size:0.85rem;padding:10px 24px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;">Get AI Assessment</button>
+        <p style="font-size:0.75rem;color:var(--muted);margin-top:8px;">Generates a Gemini coaching assessment (~$0.15 per API call)</p>
+      </div>
+      <div id="assessmentContent" class="hidden">
+        <div id="assessmentOverall" class="assessment-overall"></div>
+        <div id="sectionGrid" class="section-grid"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="footer" class="footer"></div>
+
+  <script src="/static/header.js"></script>
+  <script>
+    // --- Auth (Sandy port): Google SSO authenticates every request; the
+    // legacy API-key plumbing is vestigial. Function shapes preserved.
+    function getApiKey() { return 'sso'; }
+    function authHeaders() { return {}; }
+    const TEAM_ID = (location.pathname.match(/^\/dashboard\/([^\/]+)\/agent\//) || [, 'member_support'])[1];
+    const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+
+    // Filter state mirrored from QAHeader (header.js). `selectedDays` is
+    // null when a custom range is active — in that case `dateFrom`/`dateTo`
+    // are used. The AI Assessment endpoint is days-only, so we hide that
+    // card while a custom range is active (see loadDashboard).
+    let selectedDays = 30;
+    let dateFrom = null;
+    let dateTo = null;
+    let qaHeader = null;
+    let trendChartInstance = null;
+    let sectionChartInstance = null;
+
+    // Team section metadata (populated by loadTeamSections before any render).
+    // `_numericSectionKeys` drives the bar chart; `_sectionLabels` titles cards.
+    let _teamSections = [];
+    let _sectionLabels = {};
+    let _numericSectionKeys = [];
+
+    async function loadTeamSections() {
+      try {
+        const res = await fetch(`${API_BASE}/team/sections`, { headers: authHeaders() });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        _teamSections = await res.json();
+        _sectionLabels = Object.fromEntries(
+          _teamSections.map(s => [s.history_id || s.id, s.name])
+        );
+        _numericSectionKeys = _teamSections
+          .filter(s => (s.score_type === 'numeric' || s.score_type === 'manual') && !s.auto_value)
+          .map(s => s.history_id || s.id);
+      } catch (e) {
+        console.error('Failed to load team sections:', e);
+      }
+    }
+
+    // Overall score is 0-100 scale
+    function overallColor(score) {
+      if (score >= 85) return '#28A745';
+      if (score >= 70) return '#E8A317';
+      return '#D9534F';
+    }
+    function overallClass(score) {
+      if (score >= 85) return 'score-green';
+      if (score >= 70) return 'score-amber';
+      return 'score-red';
+    }
+    // Section scores are 1-5 scale
+    function sectionColor(score) {
+      if (score >= 4.25) return '#28A745';
+      if (score >= 3.5) return '#E8A317';
+      return '#D9534F';
+    }
+
+    // Extract a numeric score from a section object (handles string "4", "Yes", etc.)
+    function parseSectionScore(section) {
+      if (!section) return null;
+      const val = section.score != null ? section.score : section;
+      const num = parseFloat(val);
+      return isNaN(num) ? null : num;
+    }
+
+    async function fetchJSON(url) {
+      try {
+        const res = await fetch(url, { headers: authHeaders() });
+        if (res.status === 401) {
+          sessionStorage.removeItem('qa_api_key');
+          alert('Invalid API key. Please reload and try again.');
+          return null;
+        }
+        if (res.status === 404) return null;
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } catch (e) {
+        console.error('Fetch error:', e);
+        return null;
+      }
+    }
+
+    // Extract agent name from URL: /dashboard/{team_id}/agent/{name}
+    function getAgentFromURL() {
+      const m = window.location.pathname.match(/^\/dashboard\/[^\/]+\/agent\/(.+)$/);
+      return m ? decodeURIComponent(m[1]) : null;
+    }
+
+    const currentAgent = getAgentFromURL();
+
+    // --- Monthly one-pager card ---
+    // "Last closed month" in the project bucket TZ (America/Los_Angeles),
+    // mirroring the backend's last_closed_month(): the label and link roll
+    // forward automatically on the 1st, in step with the workbook export.
+    const MONTH_NAMES = ['January','February','March','April','May','June',
+                         'July','August','September','October','November','December'];
+    function lastClosedMonthLA() {
+      const parts = new Intl.DateTimeFormat('en-US',
+        { timeZone: 'America/Los_Angeles', year: 'numeric', month: 'numeric' }
+      ).formatToParts(new Date());
+      let y = +parts.find(p => p.type === 'year').value;
+      let m = +parts.find(p => p.type === 'month').value - 1;
+      if (m === 0) { m = 12; y -= 1; }
+      return { label: `${MONTH_NAMES[m - 1]} ${y}`, y, m };
+    }
+
+    function renderOnepagerCard(agentName) {
+      const { label } = lastClosedMonthLA();
+      document.getElementById('onepagerMonth').textContent = label;
+      const link = document.getElementById('onepagerLink');
+      link.textContent = `Open the ${label} one-pager →`;
+      link.href = `/dashboard/${TEAM_ID}/onepager/${encodeURIComponent(agentName)}`;
+      // sessionStorage is per-tab, so the viewer shell in the new tab
+      // can't see this tab's key and would re-prompt. Hand it over in the
+      // URL fragment: never sent to the server, stripped by the shell on
+      // arrival, and the copyable href above stays key-free (a shared
+      // link should still prompt). Assignment (not addEventListener) so
+      // re-renders never stack handlers.
+      link.onclick = function (e) {
+        const key = sessionStorage.getItem('qa_api_key');
+        if (!key) return; // plain navigation; the shell will prompt
+        e.preventDefault();
+        window.open(this.href + '#k=' + encodeURIComponent(key), '_blank', 'noopener');
+      };
+      document.getElementById('onepagerCard').classList.remove('hidden');
+    }
+
+    async function loadDashboard(agentName) {
+      if (!agentName) return;
+
+      document.getElementById('placeholder').textContent = 'Loading...';
+      document.getElementById('placeholder').classList.remove('hidden');
+      ['statsCard', 'trendCard', 'sectionCard', 'onepagerCard'].forEach(id =>
+        document.getElementById(id).classList.add('hidden')
+      );
+      // Reset AI assessment
+      _resetAIButton();
+      document.getElementById('assessmentPlaceholder').classList.remove('hidden');
+      document.getElementById('assessmentContent').classList.add('hidden');
+      // Backend progression endpoint is days-only; hide the AI card while
+      // a custom range is active so the button can't generate a window
+      // mismatch ("last 30 days" assessment shown next to a bonus-range
+      // chart). Falls back to whatever the last preset would have shown.
+      const customActive = !!(dateFrom && dateTo);
+      document.getElementById('assessmentCard').classList.toggle('hidden', customActive);
+      document.getElementById('footer').textContent = '';
+
+      const params = new URLSearchParams();
+      if (customActive) {
+        params.set('date_from', dateFrom);
+        params.set('date_to', dateTo);
+      } else {
+        params.set('days', selectedDays);
+      }
+      const history = await fetchJSON(
+        `${API_BASE}/agents/${encodeURIComponent(agentName)}/history?${params}`
+      );
+
+      if (!history) {
+        const windowLabel = customActive ? `${dateFrom} – ${dateTo}` : `the last ${selectedDays} days`;
+        document.getElementById('placeholder').textContent =
+          `No evaluations found for "${agentName}" in ${windowLabel}.`;
+        return;
+      }
+
+      document.getElementById('placeholder').classList.add('hidden');
+      renderStats(history);
+      renderTrendChart(history);
+      renderSectionChart(history);
+      renderOnepagerCard(agentName);
+
+      const windowLabel = customActive ? `${dateFrom} – ${dateTo}` : `Last ${selectedDays} days`;
+      document.getElementById('footer').textContent =
+        `Data source: Google Sheets | ${history.length} evaluations | ${windowLabel}`;
+
+      // Restore cached AI assessment if available (preset-windows only).
+      if (!customActive) {
+        const cachedAssessment = _getCachedAssessment();
+        if (cachedAssessment) {
+          _showAssessment(cachedAssessment);
+        }
+      }
+    }
+
+    function _assessmentCacheKey() {
+      return `qa_assessment_${currentAgent}_${selectedDays}`;
+    }
+
+    function _cacheAssessment(progression) {
+      try {
+        const entry = { data: progression, cachedAt: Date.now() };
+        sessionStorage.setItem(_assessmentCacheKey(), JSON.stringify(entry));
+      } catch (e) { /* sessionStorage full or unavailable — ignore */ }
+    }
+
+    function _getCachedAssessment() {
+      try {
+        const raw = sessionStorage.getItem(_assessmentCacheKey());
+        if (!raw) return null;
+        const entry = JSON.parse(raw);
+        // 1-hour TTL (matches backend cache)
+        if (Date.now() - entry.cachedAt > 3600000) {
+          sessionStorage.removeItem(_assessmentCacheKey());
+          return null;
+        }
+        return entry.data;
+      } catch (e) { return null; }
+    }
+
+    function _resetAIButton() {
+      const btn = document.getElementById('aiBtn');
+      btn.textContent = 'Get AI Assessment';
+      btn.disabled = false;
+    }
+
+    function _showAssessment(progression) {
+      renderAssessment(progression);
+      document.getElementById('assessmentPlaceholder').classList.add('hidden');
+      document.getElementById('assessmentContent').classList.remove('hidden');
+    }
+
+    async function loadAIAssessment() {
+      if (!currentAgent) return;
+      const btn = document.getElementById('aiBtn');
+      btn.disabled = true;
+      btn.textContent = 'Generating...';
+
+      const progression = await fetchJSON(
+        `${API_BASE}/agents/${encodeURIComponent(currentAgent)}/progression?days=${selectedDays}`
+      );
+
+      if (progression) {
+        _showAssessment(progression);
+        _cacheAssessment(progression);
+        _resetAIButton();
+      } else {
+        btn.textContent = 'Failed — retry';
+        btn.disabled = false;
+      }
+    }
+
+    function renderStats(history) {
+      const scores = history.map(r => r.overall_score).filter(s => s != null);
+      const count = history.length;
+      const avg = scores.length ? (scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
+      const latest = scores.length ? scores[scores.length - 1] : 0;
+      const highest = scores.length ? Math.max(...scores) : 0;
+
+      document.getElementById('statCount').textContent = count;
+      document.getElementById('statCount').className = 'stat-value';
+
+      document.getElementById('statAvg').textContent = avg.toFixed(1);
+      document.getElementById('statAvg').className = 'stat-value ' + overallClass(avg);
+
+      document.getElementById('statLatest').textContent = latest.toFixed(1);
+      document.getElementById('statLatest').className = 'stat-value ' + overallClass(latest);
+
+      document.getElementById('statHighest').textContent = highest.toFixed(1);
+      document.getElementById('statHighest').className = 'stat-value ' + overallClass(highest);
+
+      document.getElementById('statsCard').classList.remove('hidden');
+    }
+
+    function renderTrendChart(history) {
+      const ctx = document.getElementById('trendChart').getContext('2d');
+      if (trendChartInstance) { trendChartInstance.destroy(); trendChartInstance = null; }
+
+      const labels = history.map(r => {
+        const d = new Date(r.timestamp);
+        return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      });
+      const data = history.map(r => r.overall_score);
+      const pointColors = data.map(s => overallColor(s));
+
+      trendChartInstance = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [{
+            label: 'Overall Score',
+            data,
+            borderColor: '#1A61D9',
+            backgroundColor: 'rgba(26, 97, 217, 0.1)',
+            fill: true,
+            tension: 0.3,
+            pointBackgroundColor: pointColors,
+            pointBorderColor: pointColors,
+            pointRadius: 5,
+            pointHoverRadius: 7
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          onClick: (event, activeElements) => {
+            if (activeElements.length) {
+              const idx = activeElements[0].index;
+              const rec = history[idx];
+              if (rec.eval_id) window.location.href = `/datapoint/${TEAM_ID}/${rec.eval_id}`;
+            }
+          },
+          scales: {
+            y: { min: 0, max: 100, ticks: { stepSize: 10 } }
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                afterBody(items) {
+                  const idx = items[0].dataIndex;
+                  const rec = history[idx];
+                  let lines = [];
+                  if (rec.key_strengths) {
+                    const str = typeof rec.key_strengths === 'string' ? rec.key_strengths : '';
+                    lines.push('Strengths: ' + str.substring(0, 80) + (str.length > 80 ? '...' : ''));
+                  }
+                  if (rec.improvements) {
+                    const imp = typeof rec.improvements === 'string' ? rec.improvements : '';
+                    lines.push('Improve: ' + imp.substring(0, 80) + (imp.length > 80 ? '...' : ''));
+                  }
+                  return lines;
+                }
+              }
+            }
+          }
+        },
+        plugins: [{
+          id: 'goalLine',
+          afterDraw(chart) {
+            const yScale = chart.scales.y;
+            const goalY = yScale.getPixelForValue(85);
+            const ctx2 = chart.ctx;
+            ctx2.save();
+            ctx2.setLineDash([6, 4]);
+            ctx2.strokeStyle = '#28A745';
+            ctx2.lineWidth = 1.5;
+            ctx2.beginPath();
+            ctx2.moveTo(chart.chartArea.left, goalY);
+            ctx2.lineTo(chart.chartArea.right, goalY);
+            ctx2.stroke();
+            ctx2.setLineDash([]);
+            ctx2.fillStyle = '#28A745';
+            ctx2.font = '11px DM Mono';
+            ctx2.fillText('Goal: 85', chart.chartArea.right - 60, goalY - 6);
+            ctx2.restore();
+          }
+        }]
+      });
+
+      document.getElementById('trendCard').classList.remove('hidden');
+    }
+
+    function renderSectionChart(history) {
+      const ctx = document.getElementById('sectionChart').getContext('2d');
+      if (sectionChartInstance) { sectionChartInstance.destroy(); sectionChartInstance = null; }
+
+      // Extract numeric scores from sections dict: r.sections[key].score
+      const avgs = _numericSectionKeys.map(key => {
+        const vals = history
+          .map(r => r.sections ? parseSectionScore(r.sections[key]) : null)
+          .filter(v => v != null);
+        return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
+      });
+
+      const bgColors = avgs.map(s => {
+        if (s >= 4.25) return 'rgba(40, 167, 69, 0.2)';
+        if (s >= 3.5) return 'rgba(232, 163, 23, 0.2)';
+        return 'rgba(217, 83, 79, 0.2)';
+      });
+      const borderColors = avgs.map(s => {
+        if (s >= 4.25) return '#28A745';
+        if (s >= 3.5) return '#E8A317';
+        return '#D9534F';
+      });
+
+      sectionChartInstance = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: _numericSectionKeys.map(k => _sectionLabels[k] || k),
+          datasets: [{
+            label: 'Average Score',
+            data: avgs,
+            backgroundColor: bgColors,
+            borderColor: borderColors,
+            borderWidth: 2,
+            borderRadius: 4
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            y: { min: 0, max: 5, ticks: { stepSize: 1 } }
+          },
+          plugins: {
+            legend: { display: false }
+          }
+        }
+      });
+
+      document.getElementById('sectionCard').classList.remove('hidden');
+    }
+
+    function renderAssessment(progression) {
+      const overall = document.getElementById('assessmentOverall');
+      overall.textContent = progression.overall_assessment || 'No overall assessment available.';
+
+      const grid = document.getElementById('sectionGrid');
+      grid.innerHTML = '';
+
+      // section_assessments is a dict: { "greeting": { trend, summary, coaching_tip }, ... }
+      const assessments = progression.section_assessments || {};
+      Object.entries(assessments).forEach(([key, sec]) => {
+        const card = document.createElement('div');
+        card.className = 'section-card';
+
+        const trendClass = (sec.trend || 'stable').toLowerCase();
+        const trendLabel = trendClass.charAt(0).toUpperCase() + trendClass.slice(1);
+
+        card.innerHTML = `
+          <div class="section-card-header">
+            <span class="section-name">${_sectionLabels[key] || key}</span>
+            <span class="trend-badge ${trendClass}">${trendLabel}</span>
+          </div>
+          <div class="summary">${sec.summary || ''}</div>
+          <div class="coaching-toggle" onclick="this.nextElementSibling.classList.toggle('visible')">
+            Coaching Tip
+          </div>
+          <div class="coaching-tip">${sec.coaching_tip || 'No tip available.'}</div>
+        `;
+        grid.appendChild(card);
+      });
+
+    }
+
+    // QAHeader (header.js) owns the time-window chiclets / custom-range
+    // popover. Active Only / Supervisor are rendered disabled on this page
+    // (they don't apply to a single agent) — see header.js init for the
+    // page='agent' branch.
+    qaHeader = window.QAHeader.init({
+      page: 'agent',
+      team: TEAM_ID,
+      agent: currentAgent,
+      title: currentAgent || 'Agent Dashboard',
+      onChange: ({ days, dateFrom: f, dateTo: t }) => {
+        selectedDays = days;
+        dateFrom = f;
+        dateTo = t;
+        if (currentAgent) loadDashboard(currentAgent);
+      },
+    });
+
+    // Init — load team sections first, then dashboard. QAHeader's first
+    // onChange already triggered loadDashboard, but it ran before sections
+    // were ready; we re-run after to make sure section labels are populated.
+    (async () => {
+      await loadTeamSections();
+      if (currentAgent) {
+        loadDashboard(currentAgent);
+      } else {
+        document.getElementById('placeholder').textContent = 'No agent specified in URL.';
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/sandy-qa/pages/datapoint.html
+++ b/sandy-qa/pages/datapoint.html
@@ -1,0 +1,692 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Evaluation Detail — DataPoint</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --navy: #15192D;
+      --accent: #1A61D9;
+      --bg: #E7EFFB;
+      --surface: #ffffff;
+      --border: #c9d5e8;
+      --text: #15192D;
+      --muted: #5a6478;
+      --green: #28A745;
+      --amber: #E8A317;
+      --red: #D9534F;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'DM Mono', monospace;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    .header {
+      background: var(--navy);
+      color: #fff;
+      padding: 16px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .header h1 { font-size: 1.15rem; font-weight: 600; }
+    .header-meta { font-size: 0.75rem; color: rgba(255,255,255,0.6); margin-top: 4px; }
+    .nav-links { display: flex; gap: 8px; }
+    .nav-links a {
+      color: rgba(255,255,255,0.7);
+      text-decoration: none;
+      font-size: 0.8rem;
+      border: 1px solid rgba(255,255,255,0.3);
+      padding: 4px 12px;
+      border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .nav-links a:hover { background: rgba(255,255,255,0.1); }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+    }
+    .card h2 { font-size: 1rem; margin-bottom: 12px; color: var(--navy); }
+
+    .placeholder {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    /* Call Metadata — grouped grid */
+    .meta-groups {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 16px;
+    }
+    .meta-group {
+      background: var(--bg);
+      border-radius: 10px;
+      padding: 12px 14px;
+    }
+    .meta-group-title {
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+    .info-item { color: var(--muted); font-size: 0.78rem; padding: 2px 0; overflow-wrap: anywhere; }
+    .info-item strong { color: var(--text); }
+    .csat-badge {
+      display: inline-block; font-size: 0.72rem; padding: 2px 8px;
+      background: #d0ddf0; border-radius: 12px; color: var(--text);
+    }
+
+    /* SOP reference footnotes */
+    .reference-item {
+      display: grid; grid-template-columns: 56px 1fr; gap: 8px;
+      padding: 6px 0; font-size: 0.78rem; line-height: 1.5;
+      border-bottom: 1px solid var(--border);
+    }
+    .reference-item:last-child { border-bottom: none; }
+    .reference-num { color: var(--muted); font-variant-numeric: tabular-nums; }
+    .reference-meta { color: var(--muted); font-size: 0.68rem; }
+    .reference-flag { color: var(--amber); font-size: 0.68rem; }
+
+    /* Call summary */
+    .call-summary {
+      background: var(--bg);
+      border-radius: 10px;
+      padding: 16px;
+      font-size: 0.85rem;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+
+    /* Score breakdown */
+    .section-row {
+      display: grid;
+      grid-template-columns: 1fr 60px 80px;
+      align-items: start;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .section-row:last-child { border-bottom: none; }
+    .section-name { font-weight: 500; font-size: 0.85rem; }
+    .section-reasoning { font-size: 0.75rem; color: var(--muted); margin-top: 4px; line-height: 1.4; }
+    .score-val { text-align: center; font-weight: 500; font-size: 0.85rem; }
+    .conf-badge {
+      font-size: 0.65rem;
+      padding: 2px 8px;
+      border-radius: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      text-align: center;
+      display: inline-block;
+    }
+    .conf-high { background: #d1fae5; color: #2d6a4f; }
+    .conf-medium { background: #fef3c7; color: #b45309; }
+    .conf-low { background: #fee2e2; color: #991b1b; }
+
+    /* Overall score */
+    .overall-score {
+      font-family: 'Fraunces', serif;
+      font-size: 2rem;
+      font-weight: 700;
+      text-align: center;
+      padding: 12px;
+    }
+
+    /* Feedback cards */
+    .feedback-card {
+      border-radius: 10px;
+      padding: 16px;
+      font-size: 0.82rem;
+      line-height: 1.6;
+    }
+    .feedback-strengths {
+      background: #eff6ff;
+      border-left: 4px solid var(--accent);
+    }
+    .feedback-improvements {
+      background: var(--surface);
+      border-left: 4px solid var(--navy);
+    }
+    .feedback-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      margin-bottom: 8px;
+      font-weight: 500;
+    }
+
+    /* Dialpad button */
+    .dialpad-btn {
+      display: inline-block;
+      font-family: 'DM Mono', monospace;
+      font-size: 0.82rem;
+      padding: 10px 20px;
+      background: var(--navy);
+      color: #fff;
+      text-decoration: none;
+      border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .dialpad-btn:hover { background: #1e2340; }
+
+    /* Mini history table */
+    .history-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.78rem;
+    }
+    .history-table th {
+      text-align: left;
+      padding: 8px;
+      border-bottom: 2px solid var(--border);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+    }
+    .history-table td {
+      padding: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .history-table tr.current { background: #eff6ff; }
+
+    .score-green { color: var(--green); }
+    .score-amber { color: var(--amber); }
+    .score-red { color: var(--red); }
+
+    .footer {
+      text-align: center;
+      padding: 16px;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+
+    @media (max-width: 640px) {
+      .info-grid { grid-template-columns: 1fr; }
+      .section-row { grid-template-columns: 1fr 50px 70px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1 id="headerTitle">DataPoint</h1>
+      <div class="header-meta" id="headerMeta"></div>
+    </div>
+    <div class="nav-links">
+      <a id="teamLink" href="/dashboard/member_support">Team View</a>
+      <a href="#" id="agentLink">Agent View</a>
+    </div>
+  </div>
+
+  <div class="container">
+    <div id="placeholder" class="placeholder">Loading evaluation...</div>
+
+    <div id="infoCard" class="card" style="display:none;">
+      <h2>Call Metadata</h2>
+      <div class="meta-groups" id="metaGroups"></div>
+    </div>
+
+    <div id="summaryCard" class="card" style="display:none;">
+      <h2>Call Summary</h2>
+      <div class="call-summary" id="callSummary"></div>
+    </div>
+
+    <div id="scoresCard" class="card" style="display:none;">
+      <h2>Score Breakdown</h2>
+      <div class="overall-score" id="overallScore"></div>
+      <div id="sectionRows"></div>
+    </div>
+
+    <div id="feedbackCard" style="display:none;">
+      <div class="feedback-card feedback-strengths" style="margin-bottom:12px;">
+        <div class="feedback-label">Key Strengths</div>
+        <div id="strengths"></div>
+      </div>
+      <div class="feedback-card feedback-improvements">
+        <div class="feedback-label">Opportunities for Improvement</div>
+        <div id="improvements"></div>
+      </div>
+    </div>
+
+    <div id="referencesCard" class="card" style="display:none;">
+      <h2>References</h2>
+      <div style="font-size:0.7rem; color:var(--muted); margin-bottom:8px;">
+        Internal SOPs the AI evaluator consulted when scoring this call —
+        numbering matches the [SOP n] citations in the reasoning above.
+      </div>
+      <div id="referencesList"></div>
+    </div>
+
+    <div id="dialpadCard" style="display:none; text-align:center; padding:8px 0;">
+      <a class="dialpad-btn" id="dialpadLink" href="#" target="_blank">Review Call Recording</a>
+    </div>
+
+    <!-- ScorecardActions S7 (§4.1/§4.4): lifecycle actions. This surface
+         deliberately has NO override control — overriding is an
+         approval-flow action, scorecard page only (§4.3). -->
+    <div id="actionsCard" class="card" style="display:none;">
+      <h2>Actions</h2>
+      <div style="font-size:0.7rem; color:var(--muted); margin-bottom:8px;">
+        Every action below is audited. Editing or re-scoring a finalized
+        evaluation notifies the agent by default.
+      </div>
+      <div style="display:flex; gap:8px; flex-wrap:wrap;">
+        <a class="dialpad-btn" id="editInEditorLink" href="#">Edit in Scorecard Editor</a>
+        <a class="dialpad-btn" id="rescoreBtn" href="#" onclick="rescoreEval(); return false;">Re-score (fresh AI pass)</a>
+        <a class="dialpad-btn" id="deleteBtn" href="#" style="display:none; background:#7f1d1d;"
+           onclick="deleteEval(); return false;">Delete Evaluation…</a>
+      </div>
+      <div id="actionStatus" style="font-size:0.75rem; margin-top:8px; color:var(--muted);"></div>
+    </div>
+
+    <div id="historyCard" class="card" style="display:none;">
+      <h2>QA Progression</h2>
+      <table class="history-table">
+        <thead>
+          <tr><th>Date</th><th>Score</th><th>Trend</th></tr>
+        </thead>
+        <tbody id="historyBody"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div id="footer" class="footer"></div>
+
+  <script>
+    // --- Auth (Sandy port): Google SSO authenticates every request; the
+    // legacy API-key plumbing is vestigial. Function shapes preserved.
+    function getApiKey() { return 'sso'; }
+    function authHeaders() { return {}; }
+
+    async function fetchJSON(url) {
+      try {
+        const res = await fetch(url, { headers: authHeaders() });
+        if (res.status === 401) {
+          sessionStorage.removeItem('qa_api_key');
+          alert('Invalid API key. Please reload and try again.');
+          return null;
+        }
+        if (res.status === 404) return null;
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } catch (e) {
+        console.error('Fetch error:', e);
+        return null;
+      }
+    }
+
+    function scoreColor(score) {
+      if (score >= 85) return 'score-green';
+      if (score >= 70) return 'score-amber';
+      return 'score-red';
+    }
+
+    // Extract team_id and call_id from URL: /datapoint/{team_id}/{call_id}
+    function parseURL() {
+      const m = window.location.pathname.match(/^\/datapoint\/([^\/]+)\/(.+)$/);
+      if (m) return { teamId: m[1], callId: decodeURIComponent(m[2]) };
+      return { teamId: 'member_support', callId: null };
+    }
+
+    const { teamId: TEAM_ID, callId } = parseURL();
+    const API_BASE = `${window.location.origin}/api/${TEAM_ID}`;
+    document.addEventListener('DOMContentLoaded', () => {
+      const teamLink = document.getElementById('teamLink');
+      if (teamLink) teamLink.href = `/dashboard/${TEAM_ID}`;
+    });
+
+    // Team section metadata. _sectionOrder is canonical (sorted by
+    // section_number from the endpoint); _teamSectionsByKey gives O(1)
+    // score_type / auto_value lookup for the confidence badge.
+    let _teamSections = [];
+    let _sectionOrder = [];
+    let _sectionLabels = {};
+    let _teamSectionsByKey = {};
+
+    async function loadTeamSections() {
+      try {
+        const res = await fetch(`${API_BASE}/team/sections`, { headers: authHeaders() });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        _teamSections = await res.json();
+        _sectionOrder = _teamSections.map(s => s.history_id || s.id);
+        _sectionLabels = Object.fromEntries(
+          _teamSections.map(s => [s.history_id || s.id, s.name])
+        );
+        _teamSectionsByKey = Object.fromEntries(
+          _teamSections.map(s => [s.history_id || s.id, s])
+        );
+      } catch (e) {
+        console.error('Failed to load team sections:', e);
+      }
+    }
+
+    function escHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str == null ? '' : String(str);
+      return div.innerHTML;
+    }
+
+    function formatDuration(ms) {
+      if (!ms || ms <= 0) return null;
+      const totalSec = Math.round(ms / 1000);
+      const m = Math.floor(totalSec / 60);
+      const s = totalSec % 60;
+      return `${m}:${String(s).padStart(2, '0')} min`;
+    }
+
+    function metaGroup(title, items) {
+      const rows = items
+        .filter(i => i.html || (i.value !== null && i.value !== undefined && i.value !== ''))
+        .map(i => `<div class="info-item"><strong>${escHtml(i.label)}:</strong> ${i.html || escHtml(i.value)}</div>`)
+        .join('');
+      if (!rows) return '';
+      return `<div class="meta-group"><div class="meta-group-title">${escHtml(title)}</div>${rows}</div>`;
+    }
+
+    function renderCallMetadata(eval_) {
+      const disposition = eval_.dialpad_disposition_category
+        ? (eval_.dialpad_disposition
+            ? `${eval_.dialpad_disposition_category} — ${eval_.dialpad_disposition}`
+            : eval_.dialpad_disposition_category)
+        : null;
+      const csatHtml = (eval_.ai_csat !== null && eval_.ai_csat !== undefined)
+        ? `<span class="csat-badge" title="Dialpad Ai CSAT — model estimate, not a member survey">${escHtml(eval_.ai_csat)}/5 Ai (estimate)</span>`
+        : null;
+
+      const groups = [
+        metaGroup('Call', [
+          { label: 'Date', value: new Date(eval_.timestamp).toLocaleString() },
+          { label: 'Duration', value: formatDuration(eval_.call_duration_ms) },
+          { label: 'Entry-point ID', value: eval_.dialpad_entry_point_call_id },
+          { label: 'Call ID', value: eval_.dialpad_call_id },
+          { label: 'Master ID',
+            value: eval_.dialpad_master_call_id !== eval_.dialpad_call_id
+              ? eval_.dialpad_master_call_id : null },
+        ]),
+        metaGroup('Outcome', [
+          { label: 'Disposition', value: disposition },
+          { label: 'Ai CSAT', html: csatHtml },
+          { label: 'SOP grounding',
+            value: (eval_.pulpo_docs && eval_.pulpo_docs.length)
+              ? `${eval_.pulpo_docs.length} SOP${eval_.pulpo_docs.length > 1 ? 's' : ''} (see References)`
+              : (eval_.sop_used || null) },
+        ]),
+        metaGroup('Member', [
+          { label: 'Caller', value: eval_.caller_name },
+          { label: 'Phone', value: eval_.caller_phone },
+        ]),
+        metaGroup('Evaluation', [
+          { label: 'Agent', value: eval_.agent_name },
+          { label: 'Evaluator', value: eval_.manager_email },
+          { label: 'Source', value: eval_.source },
+        ]),
+      ].join('');
+
+      document.getElementById('metaGroups').innerHTML = groups;
+      document.getElementById('infoCard').style.display = '';
+    }
+
+    function renderReferences(eval_) {
+      const docs = Array.isArray(eval_.pulpo_docs) ? eval_.pulpo_docs : [];
+      let items = '';
+      if (docs.length > 0) {
+        items = docs.map((d, i) => {
+          const metaBits = [];
+          if (d.score != null) metaBits.push(`match ${Number(d.score).toFixed(2)}`);
+          if (d.updated_at) metaBits.push(`updated ${String(d.updated_at).slice(0, 10)}`);
+          const meta = metaBits.length ? `<span class="reference-meta"> — ${metaBits.join(', ')}</span>` : '';
+          const flagNote = d.open_flags > 0
+            ? `<div class="reference-flag">⚑ ${d.open_flags} open flag${d.open_flags > 1 ? 's' : ''} — passages under review; verify before treating as current policy.</div>`
+            : '';
+          return `
+            <div class="reference-item">
+              <div class="reference-num">[SOP ${i + 1}]</div>
+              <div>${escHtml(d.title || d.id || '')}${meta}${flagNote}</div>
+            </div>`;
+        }).join('');
+      } else if (eval_.sop_used) {
+        // Evals scored before provenance existed carry only the title.
+        items = `
+          <div class="reference-item">
+            <div class="reference-num">[SOP 1]</div>
+            <div>${escHtml(eval_.sop_used)}</div>
+          </div>`;
+      }
+      if (!items) return;
+      document.getElementById('referencesList').innerHTML = items;
+      document.getElementById('referencesCard').style.display = '';
+    }
+
+    async function loadDataPoint() {
+      if (!callId) {
+        document.getElementById('placeholder').textContent = 'No call ID in URL.';
+        return;
+      }
+
+      const eval_ = await fetchJSON(`${API_BASE}/datapoints/${callId}`);
+
+      if (!eval_) {
+        document.getElementById('placeholder').textContent = `No evaluation found for call ${callId}.`;
+        return;
+      }
+
+      document.getElementById('placeholder').style.display = 'none';
+
+      // Header
+      document.getElementById('headerTitle').textContent = eval_.agent_name;
+      document.getElementById('headerMeta').textContent =
+        `Call ${callId}  |  ${new Date(eval_.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}  |  Evaluator: ${eval_.manager_email}`;
+      document.getElementById('agentLink').href = `/dashboard/${TEAM_ID}/agent/${encodeURIComponent(eval_.agent_name)}`;
+
+      // Call Metadata — everything the pipeline captured for this call,
+      // grouped: verified Dialpad facts (DispositionDesign §5), member
+      // info, call clocks/ids, and the evaluation trail.
+      renderCallMetadata(eval_);
+
+      // SOP reference footnotes (PulpoConnection §4.2 provenance).
+      renderReferences(eval_);
+
+      // Call summary
+      if (eval_.call_summary) {
+        document.getElementById('callSummary').textContent = eval_.call_summary;
+        document.getElementById('summaryCard').style.display = '';
+      }
+
+      // Overall score
+      const overallEl = document.getElementById('overallScore');
+      overallEl.textContent = eval_.overall_score.toFixed(1);
+      overallEl.className = 'overall-score ' + scoreColor(eval_.overall_score);
+
+      // Section rows — order, labels, and MANUAL/AUTO badge derived from
+      // /api/{team_id}/team/sections so MS and Sales render correctly without
+      // any hardcoded section ids.
+      let rowsHtml = '';
+      for (const key of _sectionOrder) {
+        const sec = eval_.sections[key];
+        if (!sec) continue;
+        const sd = _teamSectionsByKey[key];
+        const confClass = sec.confidence ? `conf-${sec.confidence}` : '';
+        let confLabel = sec.confidence;
+        if (!confLabel && sd) {
+          if (sd.score_type === 'manual' || sd.score_type === 'manual_yn') confLabel = 'MANUAL';
+          else if (sd.auto_value) confLabel = 'AUTO';
+        }
+        confLabel = confLabel || '';
+        rowsHtml += `
+          <div class="section-row">
+            <div>
+              <div class="section-name">${_sectionLabels[key] || key}</div>
+              ${sec.reasoning ? `<div class="section-reasoning">${sec.reasoning}</div>` : ''}
+            </div>
+            <div class="score-val">${sec.score || '—'}</div>
+            <div><span class="conf-badge ${confClass}">${confLabel}</span></div>
+          </div>
+        `;
+      }
+      document.getElementById('sectionRows').innerHTML = rowsHtml;
+      document.getElementById('scoresCard').style.display = '';
+
+      // ScorecardActions S7 — lifecycle action bar (no override here).
+      setupActions(eval_);
+
+      // Feedback
+      document.getElementById('strengths').textContent = eval_.key_strengths || 'No strengths recorded.';
+      document.getElementById('improvements').textContent = eval_.improvements || 'No improvements recorded.';
+      document.getElementById('feedbackCard').style.display = '';
+
+      // Dialpad link
+      if (eval_.dialpad_link) {
+        const link = document.getElementById('dialpadLink');
+        link.href = eval_.dialpad_link.split('[')[0].trim();
+        document.getElementById('dialpadCard').style.display = '';
+      }
+
+      // Mini progression history
+      const history = await fetchJSON(`${API_BASE}/agents/${encodeURIComponent(eval_.agent_name)}/history?days=90`);
+      if (history && history.length > 0) {
+        const last5 = history.slice(-5);
+        let tbody = '';
+        for (let i = 0; i < last5.length; i++) {
+          const h = last5[i];
+          const isCurrent = h.eval_id === callId;
+          const date = new Date(h.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+          const trend = i > 0 ? (h.overall_score > last5[i-1].overall_score ? '<span style="color:var(--green);">&#9650;</span>' : h.overall_score < last5[i-1].overall_score ? '<span style="color:var(--red);">&#9660;</span>' : '<span style="color:var(--amber);">&#9679;</span>') : '';
+          tbody += `
+            <tr class="${isCurrent ? 'current' : ''}">
+              <td>${date}</td>
+              <td class="${scoreColor(h.overall_score)}">${h.overall_score.toFixed(1)}</td>
+              <td>${trend}</td>
+            </tr>
+          `;
+        }
+        document.getElementById('historyBody').innerHTML = tbody;
+        document.getElementById('historyCard').style.display = '';
+      }
+
+      document.getElementById('footer').textContent = `DataPoint ${callId} | ${eval_.source} evaluation`;
+    }
+
+    // ── ScorecardActions S7 — lifecycle actions (§4.1 edit, §4.2
+    // rescore, §4.4 delete). NO override on this surface (§4.3).
+    let _evalMeta = null;
+
+    async function setupActions(eval_) {
+      _evalMeta = eval_;
+      document.getElementById('editInEditorLink').href =
+        `/scorecard/${TEAM_ID}/${encodeURIComponent(callId)}`;
+      document.getElementById('actionsCard').style.display = '';
+      // Role-gated rendering (S7): Delete is privileged-only. Rendering
+      // is UX — the route still 403s + audits a denied row.
+      const who = await fetchJSON(`${API_BASE}/whoami`);
+      if (who && who.role === 'privileged') {
+        document.getElementById('deleteBtn').style.display = '';
+      }
+    }
+
+    function evaluatorEmail() {
+      let e = localStorage.getItem('qa_evaluator_email') || '';
+      if (!e) {
+        e = (prompt('Your email (recorded in the audit trail):') || '').trim();
+        if (e) localStorage.setItem('qa_evaluator_email', e);
+      }
+      return e;
+    }
+
+    async function rescoreEval() {
+      const email = evaluatorEmail();
+      if (!email) return;
+      const suppress = !window.confirm(
+        'Re-send the evaluation email (with the re-score disclaimer) when '
+        + 'the fresh pass finalizes?\n\nOK = send (default) · Cancel = suppress');
+      const st = document.getElementById('actionStatus');
+      st.textContent = 'Scheduling fresh AI pass…';
+      try {
+        const res = await fetch(
+          `${API_BASE}/score/${encodeURIComponent(callId)}/rescore`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+            body: JSON.stringify({ evaluator_email: email, suppress_email: suppress }),
+          });
+        const data = await res.json();
+        if (!res.ok) throw new Error(
+          typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+        st.textContent = `Re-score scheduled (superseding ${data.superseded_score}). `
+          + 'The fresh pass replaces this evaluation on the same row — follow it in the Scorecard Editor.';
+      } catch (err) {
+        st.textContent = `Re-score error: ${err.message}`;
+      }
+    }
+
+    async function deleteEval() {
+      // §4.4 UI: type-the-agent-name confirm.
+      const typed = prompt(
+        `PERMANENT DELETE — this removes the evaluation, its sections, and `
+        + `its stat point, and blanks the Sheets row.\n\nType the agent name `
+        + `("${_evalMeta.agent_name}") to confirm:`);
+      if (typed === null) return;
+      if (typed.trim() !== _evalMeta.agent_name) {
+        alert('Name did not match — delete cancelled.');
+        return;
+      }
+      const st = document.getElementById('actionStatus');
+      st.textContent = 'Deleting…';
+      try {
+        const res = await fetch(`${API_BASE}/score/${encodeURIComponent(callId)}`, {
+          method: 'DELETE', headers: authHeaders(),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(
+          typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+        // §4.4.1 — the response snapshot is the caller's backup; save it.
+        const blob = new Blob([JSON.stringify(data.snapshot, null, 2)],
+                              { type: 'application/json' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `eval_${data.evaluation_id}_backup.json`;
+        a.click();
+        st.textContent = `Deleted evaluation ${data.evaluation_id}. Backup downloaded`
+          + (data.tombstoned_history_row
+             ? `; Sheets row ${data.tombstoned_history_row} blanked.` : '.');
+      } catch (err) {
+        st.textContent = `Delete error: ${err.message}`;
+      }
+    }
+
+    (async () => {
+      await loadTeamSections();
+      loadDataPoint();
+    })();
+  </script>
+</body>
+</html>

--- a/sandy-qa/pages/lookup.html
+++ b/sandy-qa/pages/lookup.html
@@ -1,0 +1,765 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dialpad User Lookup</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --navy: #15192D; --accent: #1A61D9; --bg: #E7EFFB; --surface: #ffffff;
+      --border: #c9d5e8; --text: #15192D; --muted: #5a6478;
+      --green: #28A745; --amber: #E8A317; --red: #D9534F;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    h1, h2, h3 { font-family: 'Fraunces', serif; }
+
+    /* Header */
+    .header {
+      background: var(--navy); color: #fff; padding: 16px 24px;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    .header h1 { font-size: 1.25rem; font-weight: 600; }
+    .nav-links { display: flex; gap: 8px; }
+    .nav-links a {
+      color: rgba(255,255,255,0.7); text-decoration: none; font-size: 0.8rem;
+      border: 1px solid rgba(255,255,255,0.3); padding: 4px 12px; border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .nav-links a:hover { background: rgba(255,255,255,0.1); }
+
+    /* Layout */
+    .container { max-width: 800px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+
+    /* Search bar */
+    .search-bar {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+      padding: 20px; display: flex; gap: 12px; align-items: end;
+    }
+    .search-bar .field { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+    .search-bar label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .search-bar input {
+      font-family: 'DM Mono', monospace; font-size: 0.9rem; padding: 8px 12px;
+      border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+    }
+    .search-bar input:focus { outline: none; border-color: var(--accent); }
+    .search-bar button {
+      font-family: 'DM Mono', monospace; font-size: 0.85rem; padding: 8px 20px;
+      background: var(--accent); color: #fff; border: none; border-radius: 6px;
+      cursor: pointer; white-space: nowrap; transition: opacity 0.2s;
+    }
+    .search-bar button:hover { opacity: 0.9; }
+    .search-bar button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* Result card */
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px; }
+    .card h2 { font-size: 1.1rem; margin-bottom: 16px; }
+
+    /* Profile header */
+    .profile-header { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
+    .profile-avatar {
+      width: 56px; height: 56px; border-radius: 50%; background: var(--accent);
+      color: #fff; display: flex; align-items: center; justify-content: center;
+      font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 700; flex-shrink: 0;
+    }
+    .profile-name { font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 600; }
+    .profile-title { font-size: 0.8rem; color: var(--muted); margin-top: 2px; }
+
+    /* Status badges */
+    .badges { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .badge {
+      font-size: 0.7rem; padding: 3px 10px; border-radius: 20px; font-weight: 500;
+      text-transform: uppercase; letter-spacing: 0.03em;
+    }
+    .badge.green { background: #e6f4ea; color: #137333; }
+    .badge.amber { background: #fef7e0; color: #9a6700; }
+    .badge.red { background: #fce8e6; color: #c5221f; }
+    .badge.blue { background: #e8f0fe; color: #1a61d9; }
+    .badge.gray { background: #f1f3f5; color: #5a6478; }
+
+    /* Info grid */
+    .info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; }
+    .info-item label { display: block; font-size: 0.65rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px; }
+    .info-item .val { font-size: 0.85rem; word-break: break-all; }
+
+    /* Groups table */
+    .groups-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 8px; }
+    .groups-table th, .groups-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    .groups-table th { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+
+    /* Calls section */
+    .calls-controls {
+      display: flex; gap: 12px; align-items: end; flex-wrap: wrap; margin-bottom: 16px;
+    }
+    .calls-controls .field { display: flex; flex-direction: column; gap: 4px; }
+    .calls-controls label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .calls-controls input[type="datetime-local"] {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 10px;
+      border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+    }
+    .calls-controls input:focus { outline: none; border-color: var(--accent); }
+    .calls-controls button {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 16px;
+      background: var(--accent); color: #fff; border: none; border-radius: 6px;
+      cursor: pointer; transition: opacity 0.2s;
+    }
+    .calls-controls button:hover { opacity: 0.9; }
+    .calls-controls button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .calls-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+    .calls-table th, .calls-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    .calls-table th {
+      font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+      position: sticky; top: 0; background: var(--surface);
+    }
+    .calls-table tr.flagged { background: #fef7e0; }
+    .calls-table a { color: var(--accent); text-decoration: none; }
+    .calls-table a:hover { text-decoration: underline; }
+    .calls-count { font-size: 0.75rem; color: var(--muted); margin-bottom: 8px; }
+    .direction-badge {
+      font-size: 0.65rem; padding: 2px 8px; border-radius: 10px; font-weight: 500;
+    }
+    .direction-badge.inbound { background: #e8f0fe; color: #1a61d9; }
+    .direction-badge.outbound { background: #e6f4ea; color: #137333; }
+
+    /* Error / empty states */
+    .msg { padding: 16px; border-radius: 8px; font-size: 0.85rem; text-align: center; }
+    .msg.error { background: #fce8e6; color: #c5221f; }
+    .msg.empty { background: var(--surface); color: var(--muted); border: 1px solid var(--border); }
+
+    .hidden { display: none; }
+
+    /* Action buttons in calls table */
+    .row-action {
+      display: inline-block; font-family: 'DM Mono', monospace; font-size: 0.7rem;
+      padding: 3px 10px; border-radius: 4px; border: 1px solid var(--accent);
+      color: var(--accent); background: transparent; cursor: pointer; margin-right: 4px;
+      white-space: nowrap;
+    }
+    .row-action:hover:not(:disabled) { background: var(--accent); color: #fff; }
+    .row-action:disabled,
+    .row-action.disabled {
+      opacity: 0.4; cursor: not-allowed; border-color: var(--muted); color: var(--muted);
+    }
+    .row-action.score { border-color: var(--green); color: #137333; }
+    .row-action.score:hover:not(:disabled):not(.disabled) { background: var(--green); color: #fff; }
+    .score-status {
+      font-size: 0.7rem; color: var(--muted); display: inline-block; margin-left: 6px;
+    }
+    .score-status.complete { color: #137333; }
+    .score-status.flagged { color: #c5221f; font-weight: 600; }
+    .score-status.flagged a.editor-flagged { color: #c5221f; text-decoration: underline; }
+    .score-status.error { color: var(--red); }
+
+    /* Team-pick modal */
+    .modal-backdrop {
+      position: fixed; inset: 0; background: rgba(21,25,45,0.5);
+      display: flex; align-items: center; justify-content: center; z-index: 100;
+    }
+    /* Specificity bump — .hidden alone loses to .modal-backdrop's display:flex
+       because .modal-backdrop is declared later in this stylesheet. */
+    .modal-backdrop.hidden { display: none; }
+    .modal {
+      background: var(--surface); border-radius: 12px; padding: 24px; max-width: 360px;
+      width: calc(100% - 32px); box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+    }
+    .modal h3 { font-size: 1rem; margin-bottom: 8px; }
+    .modal p { font-size: 0.8rem; color: var(--muted); margin-bottom: 16px; }
+    .modal .options { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
+    .modal .option {
+      display: flex; align-items: center; gap: 8px; padding: 10px 12px;
+      border: 1px solid var(--border); border-radius: 6px; cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .modal .option:hover { background: var(--bg); }
+    .modal .option input { cursor: pointer; }
+    .modal .actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .modal .actions button {
+      font-family: 'DM Mono', monospace; font-size: 0.8rem; padding: 6px 16px;
+      border-radius: 6px; cursor: pointer; border: 1px solid var(--border);
+    }
+    .modal .actions .primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .modal .actions .primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .modal .actions .secondary { background: transparent; color: var(--text); }
+
+    @media (max-width: 600px) {
+      .info-grid { grid-template-columns: 1fr; }
+      .search-bar { flex-direction: column; align-items: stretch; }
+      .calls-controls { flex-direction: column; align-items: stretch; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Dialpad User Lookup</h1>
+    <div class="nav-links">
+      <a href="/">Scoring</a>
+      <a href="/dashboard">Dashboard</a>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="search-bar">
+      <div class="field">
+        <label for="email">Email address</label>
+        <input type="email" id="email" placeholder="agent@hellolanding.com" />
+      </div>
+      <button id="searchBtn" onclick="doSearch()">Look up</button>
+    </div>
+
+    <div id="errorMsg" class="msg error hidden"></div>
+    <div id="emptyMsg" class="msg empty hidden">No user found for that email.</div>
+
+    <div id="resultCard" class="card hidden">
+      <div class="profile-header">
+        <div class="profile-avatar" id="avatar"></div>
+        <div>
+          <div class="profile-name" id="displayName"></div>
+          <div class="profile-title" id="jobTitle"></div>
+        </div>
+      </div>
+
+      <div class="badges" id="badges"></div>
+
+      <h3 style="font-size:0.85rem; margin-bottom:12px;">Details</h3>
+      <div class="info-grid" id="infoGrid"></div>
+
+      <div id="groupsSection" class="hidden" style="margin-top:20px;">
+        <h3 style="font-size:0.85rem; margin-bottom:8px;">Groups</h3>
+        <table class="groups-table">
+          <thead><tr><th>Group ID</th><th>Type</th><th>Role</th></tr></thead>
+          <tbody id="groupsBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Calls section — appears after successful user lookup -->
+    <div id="callsCard" class="card hidden">
+      <h3 style="font-size:0.95rem; margin-bottom:16px;">Call History</h3>
+      <div class="calls-controls">
+        <div class="field">
+          <label for="dateStart">From</label>
+          <input type="datetime-local" id="dateStart" />
+        </div>
+        <div class="field">
+          <label for="dateEnd">To</label>
+          <input type="datetime-local" id="dateEnd" />
+        </div>
+        <button id="fetchCallsBtn" onclick="fetchCalls()">Fetch calls</button>
+      </div>
+      <div id="callsError" class="msg error hidden"></div>
+      <div id="callsEmpty" class="msg empty hidden">No calls found in this range.</div>
+      <div id="callsCount" class="calls-count hidden"></div>
+      <div style="overflow-x:auto;">
+        <table class="calls-table hidden" id="callsTable">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Direction</th>
+              <th>Contact</th>
+              <th>Duration</th>
+              <th>Recorded</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody id="callsBody"></tbody>
+        </table>
+      </div>
+      <button id="loadMoreBtn" class="hidden" onclick="loadMore()" style="
+        font-family:'DM Mono',monospace; font-size:0.8rem; padding:8px 20px; margin-top:12px;
+        background:transparent; color:var(--accent); border:1px solid var(--accent); border-radius:6px;
+        cursor:pointer; align-self:center; transition:background 0.2s, color 0.2s;
+      ">Load next 10</button>
+    </div>
+  </div>
+
+  <!-- Team-pick modal (privileged + unrostered agent) -->
+  <div id="teamPickModal" class="modal-backdrop hidden">
+    <div class="modal">
+      <h3>Choose target team</h3>
+      <p>This agent isn't in any team's roster. Pick which team's scoring pipeline should evaluate this call.</p>
+      <div class="options" id="teamPickOptions"></div>
+      <div class="actions">
+        <button class="secondary" onclick="closeTeamPick()">Cancel</button>
+        <button class="primary" id="teamPickConfirm" onclick="confirmTeamPick()" disabled>Score</button>
+      </div>
+    </div>
+  </div>
+
+<script>
+const TEAM_ID = (location.pathname.match(/^\/lookup\/([^\/]+)/) || [, 'member_support'])[1];
+const API_BASE = `/api/${TEAM_ID}`;
+
+const $ = id => document.getElementById(id);
+
+// localStorage (not sessionStorage) so the new tab opened by "Open editor"
+// inherits the API key + manager email without re-prompting. Same browser,
+// same origin, but a new tab has its own sessionStorage.
+function getApiKey() { return 'sso'; } // Sandy: Google SSO owns auth
+function authHeaders() { return {}; }
+
+function getManagerEmail() {
+  let email = localStorage.getItem('qa_manager_email');
+  if (!email) {
+    email = prompt('Enter your evaluator email (you, the manager scoring this call):');
+    if (email) localStorage.setItem('qa_manager_email', email.trim());
+  }
+  return email;
+}
+
+let currentUserId = null;
+let currentSearchEmail = null;
+let currentScoringPermission = null;
+let nextCursor = null;
+let totalLoaded = 0;
+
+// Configured team list — keep in sync with backend/config/teams/*.json.
+// Drives the team-pick modal options for privileged + unrostered cases.
+const TEAMS = ['member_support', 'sales'];
+
+// Default date range: past 7 days
+function initDateDefaults() {
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  $('dateEnd').value = toLocalISO(now);
+  $('dateStart').value = toLocalISO(weekAgo);
+}
+function toLocalISO(d) {
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+initDateDefaults();
+
+// Allow Enter key to trigger search
+$('email').addEventListener('keydown', e => { if (e.key === 'Enter') doSearch(); });
+
+async function doSearch() {
+  const email = $('email').value.trim();
+  if (!email) return;
+
+  const btn = $('searchBtn');
+  btn.disabled = true;
+  btn.textContent = 'Searching...';
+  $('resultCard').classList.add('hidden');
+  $('callsCard').classList.add('hidden');
+  $('errorMsg').classList.add('hidden');
+  $('emptyMsg').classList.add('hidden');
+  currentUserId = null;
+
+  try {
+    const resp = await fetch(`${API_BASE}/lookup?email=${encodeURIComponent(email)}`, { headers: authHeaders() });
+    if (resp.status === 404) {
+      $('emptyMsg').classList.remove('hidden');
+      return;
+    }
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const user = await resp.json();
+    currentUserId = user.id;
+    currentSearchEmail = email;
+    renderUser(user);
+    // Fetch scoring permission once per agent (same for every row) so
+    // renderCalls can decide Score Call button state without a per-row probe.
+    currentScoringPermission = await fetchScoringPermission(email);
+    // Show calls section and auto-fetch
+    $('callsCard').classList.remove('hidden');
+    fetchCalls();
+  } catch (e) {
+    $('errorMsg').textContent = e.message;
+    $('errorMsg').classList.remove('hidden');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Look up';
+  }
+}
+
+async function fetchCalls(append = false) {
+  if (!currentUserId) return;
+
+  const btn = append ? $('loadMoreBtn') : $('fetchCallsBtn');
+  btn.disabled = true;
+  btn.textContent = 'Loading...';
+
+  if (!append) {
+    $('callsTable').classList.add('hidden');
+    $('callsCount').classList.add('hidden');
+    $('callsError').classList.add('hidden');
+    $('callsEmpty').classList.add('hidden');
+    $('loadMoreBtn').classList.add('hidden');
+    $('callsBody').innerHTML = '';
+    nextCursor = null;
+    totalLoaded = 0;
+  }
+
+  const params = new URLSearchParams({ user_id: currentUserId, limit: '10' });
+  const ds = $('dateStart').value;
+  const de = $('dateEnd').value;
+  if (ds) params.set('date_start', ds);
+  if (de) params.set('date_end', de);
+  if (append && nextCursor) params.set('cursor', nextCursor);
+
+  try {
+    const resp = await fetch(`${API_BASE}/lookup/calls?${params}`, { headers: authHeaders() });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const data = await resp.json();
+    nextCursor = data.cursor || null;
+    renderCalls(data.calls, append);
+  } catch (e) {
+    $('callsError').textContent = e.message;
+    $('callsError').classList.remove('hidden');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = append ? 'Load next 10' : 'Fetch calls';
+  }
+}
+
+function loadMore() {
+  fetchCalls(true);
+}
+
+async function generateLink(e, el) {
+  e.preventDefault();
+  const rid = el.dataset.rid;
+  const rtype = el.dataset.rtype || 'admincallrecording';
+  el.textContent = '...';
+  el.style.pointerEvents = 'none';
+  try {
+    const resp = await fetch(
+      `${API_BASE}/lookup/recording-link?recording_id=${encodeURIComponent(rid)}&recording_type=${encodeURIComponent(rtype)}`,
+      { method: 'POST', headers: authHeaders() }
+    );
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      throw new Error(err.detail || `HTTP ${resp.status}`);
+    }
+    const data = await resp.json();
+    el.href = data.link;
+    el.target = '_blank';
+    el.textContent = 'Link';
+    el.style.pointerEvents = '';
+    el.onclick = null;
+  } catch (err) {
+    el.textContent = 'Failed';
+    el.style.color = 'var(--red)';
+    el.title = err.message;
+    el.style.pointerEvents = '';
+  }
+}
+
+function renderCalls(calls, append) {
+  if (!calls.length && !append) {
+    $('callsEmpty').classList.remove('hidden');
+    return;
+  }
+
+  totalLoaded += calls.length;
+  $('callsCount').textContent = `${totalLoaded} call${totalLoaded !== 1 ? 's' : ''} loaded`;
+  $('callsCount').classList.remove('hidden');
+
+  const perm = currentScoringPermission;
+  const canScore = !!(perm && perm.can_score);
+  // Tooltip explaining why Score Call is disabled. Same reason for every
+  // row when the calling key has no scoring access for this agent.
+  let disabledReason = '';
+  if (!perm) disabledReason = 'Could not check scoring permission';
+  else if (!perm.can_score) disabledReason = 'API key not authorized to score this agent';
+
+  const rows = calls.map(c => {
+    const dir = c.direction || 'unknown';
+    const dirCls = dir === 'inbound' ? 'inbound' : 'outbound';
+    const flagCls = c._flagged_long_call ? ' flagged' : '';
+    const dur = fmtDuration(c.duration);
+    const contact = c.contact_name || c.external_number || c.contact_phone || '-';
+    const dateStr = fmtDateTime(c.date_started || c.date_connected);
+    const rec = c.was_recorded ? 'Yes' : 'No';
+
+    // Share Link (renamed Generate)
+    let shareCell = '';
+    if (c.recording_id) {
+      shareCell = `<a href="#" class="row-action gen-link" data-rid="${esc(c.recording_id)}" data-rtype="${esc(c.recording_type)}" onclick="generateLink(event, this)">Share Link</a>`;
+    }
+
+    // Score Call — needs call_id + recording + permission
+    let scoreCell = '';
+    const hasCall = !!c.call_id;
+    const recOk = !!c.was_recorded;
+    if (hasCall) {
+      const blocked = !recOk || !canScore;
+      const reason = !recOk ? 'No recording on this call' : disabledReason;
+      const cls = blocked ? 'row-action score disabled' : 'row-action score';
+      const onclick = blocked ? '' : `onclick="scoreCall(this, '${esc(c.call_id)}')"`;
+      const titleAttr = blocked ? ` title="${esc(reason)}"` : '';
+      const disabledAttr = blocked ? ' disabled' : '';
+      scoreCell = `<button class="${cls}" data-call-id="${esc(c.call_id)}"${onclick}${titleAttr}${disabledAttr}>Score Call</button><span class="score-status" data-status></span>`;
+    }
+
+    const actionsCell = (shareCell || scoreCell) ? `${shareCell}${scoreCell}` : '-';
+
+    return `<tr class="${flagCls}">
+      <td>${esc(dateStr)}</td>
+      <td><span class="direction-badge ${dirCls}">${esc(dir)}</span></td>
+      <td>${esc(contact)}</td>
+      <td>${esc(dur)}</td>
+      <td>${rec}</td>
+      <td>${actionsCell}</td>
+    </tr>`;
+  }).join('');
+
+  $('callsBody').insertAdjacentHTML('beforeend', rows);
+  $('callsTable').classList.remove('hidden');
+
+  // Show/hide Load More based on cursor
+  if (nextCursor) $('loadMoreBtn').classList.remove('hidden');
+  else $('loadMoreBtn').classList.add('hidden');
+}
+
+function renderUser(u) {
+  // Avatar initials
+  const initials = (u.first_name?.[0] || '') + (u.last_name?.[0] || '');
+  $('avatar').textContent = initials.toUpperCase();
+
+  $('displayName').textContent = u.display_name;
+  $('jobTitle').textContent = u.job_title || 'No title';
+
+  // Badges
+  const badges = [];
+  badges.push({ text: u.state, cls: u.state === 'active' ? 'green' : 'red' });
+  if (u.is_online) badges.push({ text: 'Online', cls: 'green' });
+  else badges.push({ text: 'Offline', cls: 'gray' });
+  if (u.is_on_duty) badges.push({ text: 'On duty', cls: 'blue' });
+  else if (u.is_available) badges.push({ text: 'Available', cls: 'green' });
+  else badges.push({ text: u.on_duty_status || 'Off duty', cls: 'gray' });
+  if (u.is_admin) badges.push({ text: 'Admin', cls: 'amber' });
+  badges.push({ text: u.license, cls: 'blue' });
+
+  $('badges').innerHTML = badges
+    .map(b => `<span class="badge ${b.cls}">${esc(b.text)}</span>`)
+    .join('');
+
+  // Info grid
+  const fields = [
+    ['User ID', u.id],
+    ['Email', (u.emails || []).join(', ')],
+    ['Extension', u.extension],
+    ['Phone', (u.phone_numbers || []).join(', ')],
+    ['Timezone', u.timezone],
+    ['Office ID', u.office_id],
+    ['Date Added', fmtDate(u.date_added)],
+    ['Last Active', fmtDate(u.duty_status_started)],
+  ];
+  $('infoGrid').innerHTML = fields
+    .map(([label, val]) => `<div class="info-item"><label>${esc(label)}</label><div class="val">${esc(val || '-')}</div></div>`)
+    .join('');
+
+  // Groups
+  const groups = u.groups || [];
+  if (groups.length) {
+    $('groupsBody').innerHTML = groups
+      .map(g => `<tr><td>${esc(g.group_id)}</td><td>${esc(g.group_type)}</td><td>${esc(g.role)}</td></tr>`)
+      .join('');
+    $('groupsSection').classList.remove('hidden');
+  } else {
+    $('groupsSection').classList.add('hidden');
+  }
+
+  $('resultCard').classList.remove('hidden');
+}
+
+function fmtDate(iso) {
+  if (!iso) return '-';
+  try { return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }); }
+  catch { return iso; }
+}
+
+function fmtDateTime(iso) {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true
+    });
+  } catch { return iso; }
+}
+
+function fmtDuration(ms) {
+  if (!ms) return '-';
+  const totalSec = Math.round(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+// ---------------------------------------------------------------------
+// Scoring-permission probe + Score Call flow (LookupToScore.md PR 5)
+// ---------------------------------------------------------------------
+
+async function fetchScoringPermission(email) {
+  try {
+    const resp = await fetch(
+      `${API_BASE}/lookup/scoring-permission?email=${encodeURIComponent(email)}`,
+      { headers: authHeaders() }
+    );
+    if (!resp.ok) {
+      console.warn(`scoring-permission ${resp.status}`);
+      return { agent_email: email, resolved_team: null, can_score: false, needs_team_pick: false };
+    }
+    return await resp.json();
+  } catch (e) {
+    console.warn('scoring-permission failed', e);
+    return { agent_email: email, resolved_team: null, can_score: false, needs_team_pick: false };
+  }
+}
+
+let _pendingTeamPick = null;  // { btn, callId, resolve }
+
+function openTeamPick(callId, btn) {
+  const opts = TEAMS.map(t => `
+    <label class="option">
+      <input type="radio" name="targetTeam" value="${esc(t)}" onchange="$('teamPickConfirm').disabled = false;">
+      <span>${esc(t)}</span>
+    </label>`).join('');
+  $('teamPickOptions').innerHTML = opts;
+  $('teamPickConfirm').disabled = true;
+  $('teamPickModal').classList.remove('hidden');
+  return new Promise(resolve => {
+    _pendingTeamPick = { btn, callId, resolve };
+  });
+}
+
+function closeTeamPick() {
+  $('teamPickModal').classList.add('hidden');
+  if (_pendingTeamPick) {
+    _pendingTeamPick.resolve(null);
+    _pendingTeamPick = null;
+  }
+}
+
+function confirmTeamPick() {
+  const picked = document.querySelector('input[name="targetTeam"]:checked');
+  if (!picked) return;
+  const team = picked.value;
+  $('teamPickModal').classList.add('hidden');
+  if (_pendingTeamPick) {
+    _pendingTeamPick.resolve(team);
+    _pendingTeamPick = null;
+  }
+}
+
+async function scoreCall(btn, callId) {
+  if (!currentSearchEmail || !currentScoringPermission) {
+    alert('Refresh: missing agent context.');
+    return;
+  }
+  const managerEmail = getManagerEmail();
+  if (!managerEmail) {
+    alert('Manager email is required to score a call.');
+    return;
+  }
+
+  // Resolve target team: needs_team_pick (privileged + unrostered) → modal.
+  // Otherwise use the resolved team (if present) or the path team for team keys.
+  let targetTeam;
+  if (currentScoringPermission.needs_team_pick) {
+    targetTeam = await openTeamPick(callId, btn);
+    if (!targetTeam) return;  // cancelled
+  } else {
+    targetTeam = currentScoringPermission.resolved_team || TEAM_ID;
+  }
+
+  const statusEl = btn.parentElement.querySelector('[data-status]');
+  btn.disabled = true;
+  btn.classList.add('disabled');
+  statusEl.textContent = 'Submitting...';
+  statusEl.className = 'score-status';
+
+  const form = new FormData();
+  form.append('call_id', callId);
+  form.append('agent_email', currentSearchEmail);
+  form.append('manager_email', managerEmail);
+
+  let jobId;
+  try {
+    const resp = await fetch(`/api/${targetTeam}/score`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: form,
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(data.detail || `HTTP ${resp.status}`);
+    }
+    jobId = data.job_id;
+    statusEl.textContent = `${data.status || 'pending'}...`;
+  } catch (e) {
+    statusEl.textContent = 'Failed';
+    statusEl.className = 'score-status error';
+    statusEl.title = e.message;
+    btn.disabled = false;
+    btn.classList.remove('disabled');
+    return;
+  }
+
+  // Poll until terminal.
+  pollScoreJob(targetTeam, jobId, statusEl, btn);
+}
+
+function openFlaggedEditor(url) {
+  // CutoverDesign §5: warn the operator before entering the editor.
+  alert('This call cannot be automatically scored until you review it.\n\n' +
+        'A section score triggered the human-review gate. Review the call, ' +
+        'score the Human Review section, and approve to finalize.');
+  window.open(url, '_blank');
+}
+
+function pollScoreJob(targetTeam, jobId, statusEl, btn) {
+  const interval = setInterval(async () => {
+    try {
+      const r = await fetch(`/api/${targetTeam}/score/${jobId}`, { headers: authHeaders() });
+      const data = await r.json();
+      const status = data.status || '?';
+      statusEl.textContent = status;
+      if (['complete', 'approved'].includes(status)) {
+        const url = `/scorecard/${esc(targetTeam)}/${esc(jobId)}`;
+        if (data.scoring_status === 'flagged_human_review') {
+          // Post-cutover (CutoverDesign §5): the §3.14 trigger fired — the
+          // call cannot auto-finalize until a human reviews it.
+          statusEl.className = 'score-status flagged';
+          statusEl.innerHTML = `flagged · <a class="editor-flagged" href="#" onclick="openFlaggedEditor('${url}'); return false;">Open Editor</a>`;
+        } else if (data.state === 'finalized') {
+          // Engine-scored and finalized — the scorecard opens read-only.
+          statusEl.className = 'score-status complete';
+          statusEl.innerHTML = `scored ${data.overall_score ?? ''} · <a href="${url}" target="_blank">Open Editor</a>`;
+        } else {
+          statusEl.className = 'score-status complete';
+          statusEl.innerHTML = `complete · <a href="${url}" target="_blank">Open editor</a>`;
+        }
+        clearInterval(interval);
+      } else if (status === 'error') {
+        statusEl.className = 'score-status error';
+        statusEl.title = data.error || '';
+        btn.disabled = false;
+        btn.classList.remove('disabled');
+        clearInterval(interval);
+      }
+    } catch (e) {
+      // Transient — keep polling. A long outage will be visible as "pending..." stalling.
+    }
+  }, 3000);
+}
+</script>
+</body>
+</html>

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -15,6 +15,9 @@ import { handleTeamRoutes } from "./routes/teamApi.js";
 
 export interface Env {
   DB: D1Database;
+  // Dashboard-set app secret (Sandy UI → Edit Secrets) — enables /lookup's
+  // live Dialpad calls. Absent → lookup APIs return 503 with instructions.
+  DIALPAD_API_KEY?: string;
   // Optional: pre-select a specific workflow. Leave unset to list all available.
   WORKFLOW_ID?: string;
   // Provisioned automatically by Sandy at publish time for apps with cron schedules.
@@ -37,7 +40,7 @@ export default {
     }
 
     // ── Ported QA pages + team analytics APIs (PortManifest §3/§4/§6.1) ──
-    const teamRes = await handleTeamRoutes(request, env.DB, url);
+    const teamRes = await handleTeamRoutes(request, env.DB, url, env.DIALPAD_API_KEY);
     if (teamRes) return teamRes;
 
     // ── SSE transport spike (PortManifest §"SSE on Sandy") ───────────────

--- a/sandy-qa/src/lib/records.ts
+++ b/sandy-qa/src/lib/records.ts
@@ -1,0 +1,195 @@
+// EvaluationRecord read path — worker-side port of backend/services/
+// db_provider.py (PostgresProvider). Serves the datapoint page, the
+// per-agent dashboard, and the drill-downs with SECTION content, shaped
+// exactly like the Railway provider (sections keyed by history_id,
+// manager_email/improvements naming bridges, YN_DISPLAY strings).
+
+import type { TeamConfig } from "./teamConfig.js";
+
+const YN_DISPLAY: Record<string, string> = {
+  Y: "Yes",
+  N: "No",
+  NA: "Not Applicable",
+};
+
+const EVAL_COLUMNS = `id, agent_name_raw, agent_email, evaluator_email,
+  COALESCE(call_connected_at, created_at) AS ts,
+  overall_score, dialpad_link, key_strengths, opportunities,
+  call_summary, caller_name, caller_phone, source,
+  dialpad_disposition_category, dialpad_disposition, ai_csat,
+  call_duration_ms, dialpad_call_id, dialpad_entry_point_call_id,
+  dialpad_master_call_id, dialpad_call_metadata`;
+
+export function extractEvalId(link: string): string {
+  if (!link) return "";
+  const clean = link.split("[")[0].trim().split("?")[0].trim();
+  return clean.replace(/\/+$/, "").split("/").pop() ?? "";
+}
+
+function isoZ(ts: string): string {
+  const t = Date.parse(ts.includes("T") ? ts : ts.replace(" ", "T") + "Z");
+  return new Date(t).toISOString();
+}
+
+function displayScore(row: any | undefined): string {
+  if (!row) return "";
+  if (row.numeric_score !== null && row.numeric_score !== undefined)
+    return String(row.numeric_score);
+  if (row.binary_value !== null && row.binary_value !== undefined)
+    return YN_DISPLAY[row.binary_value] ?? "Not Applicable";
+  return "";
+}
+
+function recordFromRows(config: TeamConfig, ev: any, sectionRows: any[]): any {
+  const bySectionId = new Map(sectionRows.map((s) => [s.section_id, s]));
+  const sections: Record<string, any> = {};
+  for (const sec of config.sections_by_number) {
+    const row = bySectionId.get(sec.id);
+    sections[sec.history_id] = {
+      score: displayScore(row),
+      confidence: row?.confidence ?? null,
+      reasoning: row?.reasoning ?? null,
+    };
+  }
+  let metadata: any = {};
+  if (ev.dialpad_call_metadata) {
+    try {
+      metadata = JSON.parse(ev.dialpad_call_metadata);
+    } catch {}
+  }
+  if (typeof metadata !== "object" || metadata === null) metadata = {};
+  const link = ev.dialpad_link || null;
+  return {
+    timestamp: isoZ(ev.ts),
+    agent_name: ev.agent_name_raw,
+    agent_email: ev.agent_email ?? "",
+    manager_email: ev.evaluator_email ?? "",
+    overall_score: ev.overall_score !== null ? Number(ev.overall_score) : 0.0,
+    sections,
+    eval_id: extractEvalId(link ?? ""),
+    dialpad_link: link,
+    key_strengths: ev.key_strengths || null,
+    improvements: ev.opportunities || null,
+    call_summary: ev.call_summary || null,
+    caller_name: ev.caller_name || null,
+    caller_phone: ev.caller_phone || null,
+    source: ev.source || "manual",
+    dialpad_disposition_category: ev.dialpad_disposition_category || null,
+    dialpad_disposition: ev.dialpad_disposition || null,
+    ai_csat: ev.ai_csat !== null && ev.ai_csat !== undefined ? Number(ev.ai_csat) : null,
+    call_duration_ms: ev.call_duration_ms ?? null,
+    dialpad_call_id: ev.dialpad_call_id || null,
+    dialpad_entry_point_call_id: ev.dialpad_entry_point_call_id || null,
+    dialpad_master_call_id: ev.dialpad_master_call_id || null,
+    sop_used: metadata.sop_used || null,
+    pulpo_docs: Array.isArray(metadata.pulpo_docs) ? metadata.pulpo_docs : [],
+  };
+}
+
+async function attachSections(
+  db: D1Database,
+  config: TeamConfig,
+  evals: any[]
+): Promise<any[]> {
+  if (!evals.length) return [];
+  const ids = evals.map((e) => e.id);
+  // D1 has no array binds — chunk an IN list (evals per window are bounded).
+  const sectionRows: any[] = [];
+  for (let i = 0; i < ids.length; i += 80) {
+    const chunk = ids.slice(i, i + 80);
+    const res = await db
+      .prepare(
+        `SELECT evaluation_id, section_id, numeric_score, binary_value, confidence, reasoning
+         FROM qa_evaluation_sections WHERE evaluation_id IN (${chunk.map(() => "?").join(",")})`
+      )
+      .bind(...chunk)
+      .all<any>();
+    sectionRows.push(...res.results);
+  }
+  const byEval = new Map<number, any[]>();
+  for (const s of sectionRows) {
+    let g = byEval.get(s.evaluation_id);
+    if (!g) byEval.set(s.evaluation_id, (g = []));
+    g.push(s);
+  }
+  return evals.map((ev) => recordFromRows(config, ev, byEval.get(ev.id) ?? []));
+}
+
+export async function fetchRecords(
+  db: D1Database,
+  config: TeamConfig,
+  opts: { days?: number; agentRaw?: string; fromMs?: number; toMs?: number }
+): Promise<any[]> {
+  let where =
+    "WHERE team_id = ? AND state = 'finalized'";
+  const params: any[] = [config.team_id];
+  if (opts.fromMs !== undefined && opts.toMs !== undefined) {
+    where += " AND COALESCE(call_connected_at, created_at) >= ? AND COALESCE(call_connected_at, created_at) <= ?";
+    params.push(new Date(opts.fromMs).toISOString(), new Date(opts.toMs).toISOString());
+  } else if (opts.days !== undefined) {
+    const cutoff = new Date(Date.now() - opts.days * 86_400_000).toISOString();
+    where += " AND COALESCE(call_connected_at, created_at) >= ?";
+    params.push(cutoff);
+  }
+  if (opts.agentRaw !== undefined) {
+    where += " AND LOWER(agent_name_raw) = LOWER(?)";
+    params.push(opts.agentRaw.trim());
+  }
+  const evals = await db
+    .prepare(
+      `SELECT ${EVAL_COLUMNS} FROM qa_evaluations ${where}
+       ORDER BY COALESCE(call_connected_at, created_at)`
+    )
+    .bind(...params)
+    .all<any>();
+  return attachSections(db, config, evals.results);
+}
+
+export async function getByEvalId(
+  db: D1Database,
+  config: TeamConfig,
+  callId: string
+): Promise<any | null> {
+  if (!callId) return null;
+  const row = await db
+    .prepare(
+      `SELECT ${EVAL_COLUMNS} FROM qa_evaluations
+       WHERE team_id = ? AND state = 'finalized'
+       AND (dialpad_entry_point_call_id = ? OR dialpad_call_id = ?)
+       ORDER BY COALESCE(call_connected_at, created_at) LIMIT 1`
+    )
+    .bind(config.team_id, callId, callId)
+    .first<any>();
+  if (row) {
+    const [rec] = await attachSections(db, config, [row]);
+    if (rec.eval_id === callId) return rec;
+  }
+  // Fallback scan (junk-link rows) — mirrors the route's 365-day scan.
+  const all = await fetchRecords(db, config, { days: 365 });
+  return all.find((r) => r.eval_id === callId) ?? null;
+}
+
+export async function listAgents(db: D1Database, teamId: string): Promise<string[]> {
+  const rows = await db
+    .prepare(
+      `SELECT DISTINCT agent_name_raw FROM qa_evaluations
+       WHERE team_id = ? AND state = 'finalized' ORDER BY agent_name_raw`
+    )
+    .bind(teamId)
+    .all<{ agent_name_raw: string }>();
+  return rows.results.map((r) => r.agent_name_raw.trim()).filter(Boolean);
+}
+
+export async function resolveTeamForAgent(
+  db: D1Database,
+  email: string
+): Promise<string | null> {
+  const row = await db
+    .prepare(
+      `SELECT team_id FROM qa_agents WHERE active = 1 AND LOWER(email) = LOWER(?)
+       ORDER BY CASE team_id WHEN 'member_support' THEN 0 ELSE 1 END LIMIT 1`
+    )
+    .bind(email.trim())
+    .first<{ team_id: string }>();
+  return row?.team_id ?? null;
+}

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -6,10 +6,22 @@
 import { loadTeamConfig } from "../lib/teamConfig.js";
 import { fetchHistoryFrame } from "../lib/historyFrame.js";
 import { assembleTeamEvals, assembleTeamStats } from "../lib/teamStats.js";
+import {
+  fetchRecords,
+  getByEvalId,
+  listAgents,
+  resolveTeamForAgent,
+} from "../lib/records.js";
 // @ts-ignore vite ?raw
 import teamDashboardHtml from "../../pages/team_dashboard.html?raw";
 // @ts-ignore vite ?raw
 import teamEvalsHtml from "../../pages/team_evals.html?raw";
+// @ts-ignore vite ?raw
+import agentDashboardHtml from "../../pages/dashboard.html?raw";
+// @ts-ignore vite ?raw
+import datapointHtml from "../../pages/datapoint.html?raw";
+// @ts-ignore vite ?raw
+import lookupHtml from "../../pages/lookup.html?raw";
 // @ts-ignore vite ?raw
 import headerCss from "../../pages/static/header.css?raw";
 // @ts-ignore vite ?raw
@@ -29,7 +41,8 @@ const json = (data: unknown, status = 200) =>
 export async function handleTeamRoutes(
   request: Request,
   db: D1Database,
-  url: URL
+  url: URL,
+  dialpadKey?: string
 ): Promise<Response | null> {
   const path = url.pathname;
 
@@ -60,25 +73,62 @@ export async function handleTeamRoutes(
 <p><a href="javascript:history.back()" style="color:#5a6478">&larr; Back</a></p>
 </div></body></html>`
     );
+  // Real pages (Railway originals, SSO shim) — datapoint, per-agent
+  // dashboard, and lookup. The one-pager stays interim (renderer +
+  // EOM-export coupling ports in a later slice).
   m = path.match(/^\/datapoint\/([^/]+)\/([^/]+)$/);
-  if (m)
-    return interimPage(
-      "Datapoint drill-down",
-      `${RAILWAY_BASE}/datapoint/${m[1]}/${encodeURIComponent(m[2])}`
-    );
+  if (m && KNOWN_TEAMS.has(m[1])) return html(datapointHtml);
+  m = path.match(/^\/datapoint\/([^/]+)$/);
+  if (m) return html(datapointHtml); // legacy no-team route (defaults MS)
   m = path.match(/^\/dashboard\/([^/]+)\/agent\/(.+)$/);
-  if (m && KNOWN_TEAMS.has(m[1]))
-    return interimPage(
-      "Per-agent dashboard",
-      `${RAILWAY_BASE}/dashboard/${m[1]}/agent/${m[2]}`
-    );
+  if (m && KNOWN_TEAMS.has(m[1])) return html(agentDashboardHtml);
+  m = path.match(/^\/lookup\/([^/]+)$/);
+  if (m && KNOWN_TEAMS.has(m[1])) return html(lookupHtml);
 
-  // ── drill-down list APIs (dist histogram + EWMA bar expansions) ──────────
+  // ── drill-down + record APIs ─────────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/datapoints$/);
   if (m && KNOWN_TEAMS.has(m[1])) return datapointsList(db, m[1], url);
+  m = path.match(/^\/api\/([^/]+)\/datapoints\/([^/]+)$/);
+  if (m && KNOWN_TEAMS.has(m[1])) {
+    const config = await loadTeamConfig(db, m[1]);
+    const rec = await getByEvalId(db, config, decodeURIComponent(m[2]));
+    return rec
+      ? json(rec)
+      : json({ detail: `No evaluation found for call_id '${m[2]}'.` }, 404);
+  }
+  m = path.match(/^\/api\/([^/]+)\/agents$/);
+  if (m && KNOWN_TEAMS.has(m[1])) return json(await listAgents(db, m[1]));
   m = path.match(/^\/api\/([^/]+)\/agents\/([^/]+)\/history$/);
   if (m && KNOWN_TEAMS.has(m[1]))
     return agentHistory(db, m[1], decodeURIComponent(m[2]), url);
+  m = path.match(/^\/api\/([^/]+)\/agents\/([^/]+)\/onepager$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return html(
+      `<!DOCTYPE html><html><head><title>One-pager — porting</title></head>
+<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
+<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:520px">
+<h2 style="margin-top:0">Monthly one-pager: later port slice</h2>
+<p>The one-pager renderer is coupled to the EOM export workflow and ports with it. Until then it lives on Railway.</p>
+<p><a href="javascript:history.back()" style="color:#5a6478">&larr; Back</a></p>
+</div></body></html>`
+    );
+  m = path.match(/^\/api\/([^/]+)\/agents\/([^/]+)\/progression$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return json(
+      { detail: "Progression assessments port with the scoring-workflow slice (AI generation)." },
+      503
+    );
+  m = path.match(/^\/api\/([^/]+)\/whoami$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    // Read-only viewer identity behind SSO — team role hides the
+    // privileged-only controls (delete etc.); action routes don't exist
+    // here yet anyway.
+    return json({ role: "team", team_id: m[1] });
+
+  // ── lookup APIs (Dialpad-backed; needs the DIALPAD_API_KEY app secret) ───
+  m = path.match(/^\/api\/([^/]+)\/lookup(\/calls|\/recording-link|\/scoring-permission)?$/);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return lookupRoutes(db, m[1], m[2] ?? "", url, request, dialpadKey);
 
   // ── team APIs: /api/{team}/team/* ─────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/(team\/[a-z_]+|events\/stream)$/);
@@ -233,14 +283,195 @@ async function agentHistory(
   agent: string,
   url: URL
 ) {
+  // Mirrors backend/routes/dashboard.py::agent_history — provider-shaped
+  // records WITH section content (the per-agent dashboard renders section
+  // trends); raw-name match, 404 on empty, range overrides days.
   const config = await loadTeamConfig(db, teamId);
-  const a = agent.trim().toLowerCase();
-  let rows = (await fetchHistoryFrame(db, config)).filter(
-    (r) => r.agent.toLowerCase() === a
-  );
-  rows = windowFilter(rows, url, 90, 730);
-  if (!rows.length) return json({ detail: `No history for '${agent}'` }, 404);
-  return json(rows.map(recordFromFrameRow));
+  const p = url.searchParams;
+  const dateFrom = p.get("date_from");
+  const dateTo = p.get("date_to");
+  let records: any[];
+  if (dateFrom && dateTo) {
+    const fromMs = Date.parse(`${dateFrom}T00:00:00Z`);
+    const toMs = Date.parse(`${dateTo}T23:59:59.999Z`);
+    if (Number.isNaN(fromMs) || Number.isNaN(toMs))
+      return json({ detail: "date_from / date_to must be ISO YYYY-MM-DD" }, 422);
+    if (toMs < fromMs)
+      return json({ detail: "date_to must be on or after date_from" }, 422);
+    records = await fetchRecords(db, config, { agentRaw: agent, fromMs, toMs });
+    if (!records.length)
+      return json(
+        { detail: `No evaluations found for '${agent}' between ${dateFrom} and ${dateTo}` },
+        404
+      );
+    return json(records);
+  }
+  const days = Math.min(730, Math.max(1, parseInt(p.get("days") ?? "30", 10) || 30));
+  records = await fetchRecords(db, config, { agentRaw: agent, days });
+  if (!records.length)
+    return json(
+      { detail: `No evaluations found for '${agent}' in the last ${days} days` },
+      404
+    );
+  return json(records);
+}
+
+// ── lookup (Dialpad-backed) — port of backend/routes/lookup.py ──────────────
+
+async function lookupRoutes(
+  db: D1Database,
+  teamId: string,
+  sub: string,
+  url: URL,
+  request: Request,
+  dialpadKey?: string
+): Promise<Response> {
+  const p = url.searchParams;
+
+  if (sub === "/scoring-permission") {
+    // Sandy has no API-key roles: everyone behind SSO is a viewer for now
+    // (scoring actions port with the scoring-workflow slice), so the
+    // Score button stays inert while team resolution keeps row context.
+    const email = p.get("email") ?? "";
+    const resolved = email ? await resolveTeamForAgent(db, email) : null;
+    return json({
+      agent_email: email,
+      resolved_team: resolved,
+      can_score: false,
+      needs_team_pick: false,
+    });
+  }
+
+  if (!dialpadKey)
+    return json(
+      {
+        detail:
+          "DIALPAD_API_KEY app secret not configured — add it in the Sandy Dashboard (Edit Secrets) to enable /lookup.",
+      },
+      503
+    );
+  const auth = { authorization: `Bearer ${dialpadKey}` };
+  const DP = "https://dialpad.com/api/v2";
+  const epochIso = (v: any) =>
+    v ? new Date(Number(v)).toISOString() : null;
+
+  if (sub === "" ) {
+    const email = p.get("email");
+    if (!email) return json({ detail: "email query param required" }, 422);
+    const r = await fetch(`${DP}/users?email=${encodeURIComponent(email)}`, {
+      headers: auth,
+    });
+    if (!r.ok) return json({ detail: `Dialpad ${r.status}` }, 502);
+    const items = ((await r.json()) as any).items ?? [];
+    if (!items.length)
+      return json({ detail: `No Dialpad user found for '${email}'` }, 404);
+    const u = items[0];
+    return json({
+      id: String(u.id ?? ""),
+      display_name: u.display_name ?? "",
+      first_name: u.first_name ?? "",
+      last_name: u.last_name ?? "",
+      emails: u.emails ?? [],
+      extension: u.extension ?? "",
+      phone_numbers: u.phone_numbers ?? [],
+      job_title: u.job_title ?? "",
+      state: u.state ?? "",
+      license: u.license ?? "",
+      is_admin: u.is_admin ?? false,
+      is_online: u.is_online ?? false,
+      is_available: u.is_available ?? false,
+      is_on_duty: u.is_on_duty ?? false,
+      on_duty_status: u.on_duty_status ?? "",
+      timezone: u.timezone ?? "",
+      office_id: String(u.office_id ?? ""),
+      date_added: u.date_added ?? "",
+      duty_status_started: u.duty_status_started ?? "",
+      groups: (u.group_details ?? []).map((g: any) => ({
+        group_id: String(g.group_id ?? ""),
+        group_type: g.group_type ?? "",
+        role: g.role ?? "",
+      })),
+    });
+  }
+
+  if (sub === "/calls") {
+    const userId = p.get("user_id");
+    if (!userId) return json({ detail: "user_id query param required" }, 422);
+    const params = new URLSearchParams({
+      target_id: userId,
+      target_type: "user",
+      limit: String(Math.min(100, Math.max(1, parseInt(p.get("limit") ?? "10", 10) || 10))),
+    });
+    for (const [inKey, outKey] of [
+      ["date_start", "started_after"],
+      ["date_end", "started_before"],
+    ] as const) {
+      const v = p.get(inKey);
+      if (v) {
+        const t = Date.parse(v.includes("Z") || v.includes("+") ? v : v + "Z");
+        if (Number.isNaN(t))
+          return json({ detail: `${inKey} must be ISO format (YYYY-MM-DDTHH:MM)` }, 400);
+        params.set(outKey, String(t));
+      }
+    }
+    if (p.get("cursor")) params.set("cursor", p.get("cursor")!);
+    const r = await fetch(`${DP}/call?${params}`, { headers: auth });
+    if (!r.ok) return json({ user_id: userId, call_count: 0, calls: [], cursor: null });
+    const data = (await r.json()) as any;
+    const FLAG_MS = 25 * 60 * 1000;
+    const calls = (data.items ?? []).map((c: any) => {
+      const rec = c.recording_details?.[0] ?? null;
+      const duration = c.total_duration || c.duration || 0;
+      return {
+        call_id: String(c.call_id ?? ""),
+        date_started: epochIso(c.date_started),
+        date_connected: epochIso(c.date_connected),
+        date_ended: epochIso(c.date_ended),
+        duration,
+        direction: c.direction ?? "",
+        was_recorded: !!c.recording_details,
+        recording_id: rec ? String(rec.id ?? "") : "",
+        recording_url: rec ? rec.url ?? "" : "",
+        recording_duration: rec ? Math.trunc(Number(rec.duration ?? 0)) : 0,
+        recording_type: rec ? rec.recording_type ?? "" : "",
+        is_transferred: c.is_transferred ?? false,
+        external_number: c.external_number ?? "",
+        internal_number: c.internal_number ?? "",
+        contact_name: c.contact?.name ?? "",
+        contact_phone: c.contact?.phone ?? "",
+        mos_score: c.mos_score ?? null,
+        entry_point_call_id: String(c.entry_point_call_id ?? ""),
+        _flagged_long_call: duration > FLAG_MS,
+      };
+    });
+    return json({
+      user_id: userId,
+      call_count: calls.length,
+      calls,
+      cursor: data.cursor || null,
+    });
+  }
+
+  if (sub === "/recording-link" && request.method === "POST") {
+    const recordingId = p.get("recording_id");
+    if (!recordingId) return json({ detail: "recording_id required" }, 422);
+    const r = await fetch(`${DP}/recordingsharelink`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({
+        privacy: "company",
+        recording_type: p.get("recording_type") ?? "admincallrecording",
+        recording_id: recordingId,
+      }),
+    });
+    if (r.ok) {
+      const link = ((await r.json()) as any).access_link;
+      if (link) return json({ link });
+    }
+    return json({ detail: "Could not generate recording link" }, 404);
+  }
+
+  return json({ detail: "not found" }, 404);
 }
 
 // ── SSE: D1-tailed event stream (PortManifest §6.1) ─────────────────────────


### PR DESCRIPTION
## What this is

The three remaining evaluator-journey pages, ahead of enabling the shadow double-write:

- **`/datapoint/{team}/{call_id}`** (+ legacy no-team route) — full scorecard drill-down with real section content, confidence, reasoning
- **`/dashboard/{team}/agent/{name}`** — per-agent dashboard (history + section trends)
- **`/lookup/{team}`** — the Dialpad call lookup that anchors the evaluator journey

Same porting doctrine: Railway HTML served verbatim, SSO shim only (lookup's `localStorage` auth variant included). Deployed as v0.7.

## ⚠ One action needed to light up /lookup

Lookup's live Dialpad calls need the **`DIALPAD_API_KEY` app secret**, which is **Sandy-Dashboard-only** (CLI can't set app secrets): *Sandy Dashboard → qa-scoring → Edit Secrets → add `DIALPAD_API_KEY`* (same value as Railway). Until then, lookup APIs return a 503 explaining exactly this.

## API surface added

`src/lib/records.ts` ports `PostgresProvider` — EvaluationRecord with sections keyed by history_id, `YN_DISPLAY` strings, the `manager_email`/`improvements` naming bridges, indexed `get_by_eval_id` with link verification + 365-day scan fallback. Routes: `/api/{t}/datapoints/{call_id}`, `/api/{t}/agents`, provider-faithful `/agents/{name}/history` (now with real sections — the EWMA drill gets richer too), `/whoami` (read-only role → privileged-only controls hide), and the three Dialpad lookup routes.

## Still interim (by design)

- Monthly **one-pager** — coupled to the EOM export workflow; ports with it.
- **Progression assessment** panel — AI generation; ports with the scoring-workflow slice (returns 503; panel shows its error state).
- **Score Call** button on lookup — `can_score=false` until scoring actions port; evaluators keep scoring on Railway during shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)