### PR TITLE
feat(sandy-qa): shadow double-write (interim pull) + lookup compliance lock

### DIFF
--- a/sandy-qa/.gitignore
+++ b/sandy-qa/.gitignore
@@ -6,3 +6,4 @@ _release/
 parity/fixture.json
 parity/lib.mjs
 parity/parity.log
+scripts/shadow_sync.log

--- a/sandy-qa/scripts/shadow_sync.py
+++ b/sandy-qa/scripts/shadow_sync.py
@@ -34,6 +34,8 @@ WIPE_ORDER = [
     "qa_evaluation_tags", "qa_assessment_sections", "qa_assessments",
     "qa_formula_compliance_sweeps", "qa_evaluation_sections",
     "qa_evaluations", "qa_agents",
+    # FK-free tables re-imported by RESYNC — wipe or their PKs collide.
+    "qa_tags", "qa_score_audit", "qa_score_audit_archive", "qa_api_audit_log",
 ]
 # Re-import: agents first, then everything from qa_evaluations onward in
 # pg_to_d1's FK-safe order (cc_* tables stay on their initial snapshot until

--- a/sandy-qa/scripts/shadow_sync.py
+++ b/sandy-qa/scripts/shadow_sync.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Shadow sync: Railway Postgres → Sandy D1 (interim pull-based double-write).
+
+The DESIGNED Phase-5 path is Railway pushing finalized evaluations to Sandy
+with an App Service Token — blocked on Engineering ask #3. Until then this
+script IS the shadow write: it re-syncs the qa_* tables (full fidelity —
+row UPDATEs included, which an id-watermark would miss) and publishes
+`eval_approved` rows into qa_events for evaluations that newly reached
+`finalized` since the last sync, so the floor-TV SSE toasts fire from Sandy.
+
+Runs from qa-automation/AI-Scoring (needs .env + .venv), on a cron:
+    .venv/bin/python ../../sandy-qa/scripts/shadow_sync.py
+"""
+
+import asyncio
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+_HERE = pathlib.Path(__file__).parent
+spec = importlib.util.spec_from_file_location("pg_to_d1", _HERE / "pg_to_d1.py")
+pg_to_d1 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pg_to_d1)
+
+APP_ID = pg_to_d1.APP_ID
+TABLES = pg_to_d1.TABLES
+
+# qa_* wipe order: children before parents (D1 enforces FKs), agents last.
+WIPE_ORDER = [
+    "qa_agent_stat_points", "qa_coaching_evaluations", "qa_coachings",
+    "qa_evaluation_tags", "qa_assessment_sections", "qa_assessments",
+    "qa_formula_compliance_sweeps", "qa_evaluation_sections",
+    "qa_evaluations", "qa_agents",
+]
+# Re-import: agents first, then everything from qa_evaluations onward in
+# pg_to_d1's FK-safe order (cc_* tables stay on their initial snapshot until
+# the CC slice; dispositions freshness is not shadow-gating).
+RESYNC = [("qa.agents", "qa_agents")] + [
+    t for t in TABLES if t[1] in (
+        "qa_evaluations", "qa_evaluation_sections", "qa_formula_compliance_sweeps",
+        "qa_agent_stat_points", "qa_tags", "qa_evaluation_tags", "qa_coachings",
+        "qa_coaching_evaluations", "qa_assessments", "qa_assessment_sections",
+        "qa_score_audit", "qa_score_audit_archive", "qa_api_audit_log",
+    )
+]
+
+
+def eval_id_from_link(link: str) -> str:
+    if not link:
+        return ""
+    clean = link.split("[")[0].strip().split("?")[0].strip()
+    return clean.rstrip("/").split("/")[-1]
+
+
+def d1_finalized_ids() -> set[int]:
+    r = subprocess.run(
+        [sys.executable, pg_to_d1.SANDY, "db", "query", APP_ID,
+         "SELECT id FROM qa_evaluations WHERE state='finalized'"],
+        capture_output=True, text=True, timeout=120)
+    if r.returncode != 0:
+        raise RuntimeError(f"d1 id snapshot failed: {(r.stdout + r.stderr)[:300]}")
+    return {row["id"] for row in json.loads(r.stdout)["data"][0]["results"]}
+
+
+def truncate(s, n=280):
+    s = s or ""
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+async def main():
+    import asyncpg
+    started = datetime.now(timezone.utc)
+    before_ids = d1_finalized_ids()
+
+    conn = await asyncpg.connect(pg_to_d1.env_value("DATABASE_URL", pathlib.Path(".env")), timeout=30)
+    try:
+        # 1. wipe + full re-import of the qa_* tree (row updates included)
+        pg_to_d1.apply_sql(
+            "PRAGMA defer_foreign_keys = true;\n"
+            + "\n".join(f"DELETE FROM {t};" for t in WIPE_ORDER)
+        )
+        for pg_name, d1_name in RESYNC:
+            await pg_to_d1.import_table(conn, pg_name, d1_name, wipe=False)
+
+        # 2. publish eval_approved for evals that newly reached finalized
+        after_ids = d1_finalized_ids()
+        new_ids = sorted(after_ids - before_ids)
+        published = 0
+        if new_ids:
+            rows = await conn.fetch(
+                "SELECT id, team_id, agent_name_raw, evaluator_email, overall_score, "
+                "call_summary, key_strengths, opportunities, dialpad_link, "
+                "dialpad_call_id, approved_at "
+                "FROM qa.evaluations WHERE id = ANY($1::bigint[])", new_ids)
+            stmts = []
+            for r in rows:
+                payload = {
+                    "call_id": r["dialpad_call_id"] or "",
+                    "eval_id": eval_id_from_link(r["dialpad_link"] or "") or (r["dialpad_call_id"] or ""),
+                    "history_row": None,
+                    "agent": r["agent_name_raw"] or "",
+                    "evaluator_email": r["evaluator_email"] or "",
+                    "overall_score": float(r["overall_score"]) if r["overall_score"] is not None else None,
+                    "summary": truncate(r["call_summary"]),
+                    "strengths": truncate(r["key_strengths"]),
+                    "opportunities": truncate(r["opportunities"]),
+                    "dialpad_link": r["dialpad_link"] or "",
+                    "timestamp": (r["approved_at"] or started).isoformat(),
+                }
+                stmts.append(
+                    "INSERT INTO qa_events (team_id, type, payload) VALUES ("
+                    + pg_to_d1.lit(r["team_id"]) + ", 'eval_approved', "
+                    + pg_to_d1.lit(json.dumps(payload)) + ");")
+            pg_to_d1.apply_sql("\n".join(stmts))
+            published = len(stmts)
+
+        # 3. spot reconciliation on the two load-bearing tables
+        ok = True
+        for pg_name, d1_name in (("qa.evaluations", "qa_evaluations"),
+                                 ("qa.evaluation_sections", "qa_evaluation_sections")):
+            pg_row = await conn.fetchrow(
+                f"SELECT count(*) c, COALESCE(sum(id),0)::bigint s FROM {pg_name}")
+            d1_row = pg_to_d1.d1_query(
+                f"SELECT count(*) c, COALESCE(sum(id),0) s FROM {d1_name}")[0]
+            ok &= (pg_row["c"], pg_row["s"]) == (d1_row["c"], d1_row["s"])
+        secs = (datetime.now(timezone.utc) - started).total_seconds()
+        print(f"SHADOW SYNC {'OK' if ok else 'RECONCILE MISMATCH'}: "
+              f"{len(after_ids)} finalized evals, +{published} events published, {secs:.0f}s")
+        sys.exit(0 if ok else 2)
+    finally:
+        await conn.close()
+
+
+asyncio.run(main())

--- a/sandy-qa/scripts/shadow_sync.sh
+++ b/sandy-qa/scripts/shadow_sync.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Cron wrapper for shadow_sync.py (interim pull-based shadow double-write).
+# Every 30 min: full qa_* re-sync + qa_events publication. Replaced by the
+# Railway push once Engineering provisions the App Service Token.
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LOG="$ROOT/sandy-qa/scripts/shadow_sync.log"
+STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+cd "$ROOT/qa-automation/AI-Scoring" || exit 1
+if OUT=$(.venv/bin/python "$ROOT/sandy-qa/scripts/shadow_sync.py" 2>&1); then
+  echo "[$STAMP] $(echo "$OUT" | tail -1)" >>"$LOG"
+else
+  echo "[$STAMP] FAIL:" >>"$LOG"
+  echo "$OUT" | tail -5 >>"$LOG"
+  /usr/bin/osascript -e 'display notification "shadow sync failed — see shadow_sync.log" with title "QA Sandy shadow"' 2>/dev/null
+  exit 1
+fi

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -18,6 +18,9 @@ export interface Env {
   // Dashboard-set app secret (Sandy UI → Edit Secrets) — enables /lookup's
   // live Dialpad calls. Absent → lookup APIs return 503 with instructions.
   DIALPAD_API_KEY?: string;
+  // Dashboard-set app secret: comma-separated emails allowed on /lookup
+  // (interim deny-by-default compliance lock until per-team RBAC lands).
+  LOOKUP_ALLOW?: string;
   // Optional: pre-select a specific workflow. Leave unset to list all available.
   WORKFLOW_ID?: string;
   // Provisioned automatically by Sandy at publish time for apps with cron schedules.
@@ -40,7 +43,9 @@ export default {
     }
 
     // ── Ported QA pages + team analytics APIs (PortManifest §3/§4/§6.1) ──
-    const teamRes = await handleTeamRoutes(request, env.DB, url, env.DIALPAD_API_KEY);
+    const teamRes = await handleTeamRoutes(
+      request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW
+    );
     if (teamRes) return teamRes;
 
     // ── SSE transport spike (PortManifest §"SSE on Sandy") ───────────────

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -38,11 +38,56 @@ const json = (data: unknown, status = 200) =>
     headers: { "Content-Type": "application/json" },
   });
 
+// SSO identity: Sandy's edge injects the platform-verified CF Access JWT.
+// We read the email claim for app-level authorization (signature validation
+// happens at the Access edge before the request reaches the worker; worth an
+// Engineering confirmation that tenant workers can rely on this header).
+function accessEmail(request: Request): string {
+  const jwt =
+    request.headers.get("Cf-Access-Jwt-Assertion") ??
+    request.headers.get("cf-access-jwt-assertion") ??
+    "";
+  const parts = jwt.split(".");
+  if (parts.length < 2) return "";
+  try {
+    const payload = JSON.parse(
+      atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))
+    );
+    return (payload.email ?? "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+// Interim lookup lock (compliance): /lookup exposes every agent's calls +
+// recordings, so it is DENY-BY-DEFAULT until per-team/role RBAC lands.
+// LOOKUP_ALLOW (Dashboard app secret) = comma-separated allowed emails.
+function lookupAllowed(request: Request, lookupAllow?: string): boolean {
+  if (!lookupAllow) return false;
+  const email = accessEmail(request);
+  if (!email) return false;
+  return lookupAllow
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(email);
+}
+
+const LOOKUP_DENIED_PAGE = `<!DOCTYPE html><html><head><title>Lookup — restricted</title></head>
+<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
+<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:540px">
+<h2 style="margin-top:0">Call lookup is restricted</h2>
+<p>This page surfaces call recordings across the company, so access is
+limited to authorized QA staff while per-team role-based access is built.</p>
+<p style="color:#5a6478">If you need access, contact the QA team.</p>
+</div></body></html>`;
+
 export async function handleTeamRoutes(
   request: Request,
   db: D1Database,
   url: URL,
-  dialpadKey?: string
+  dialpadKey?: string,
+  lookupAllow?: string
 ): Promise<Response | null> {
   const path = url.pathname;
 
@@ -83,7 +128,13 @@ export async function handleTeamRoutes(
   m = path.match(/^\/dashboard\/([^/]+)\/agent\/(.+)$/);
   if (m && KNOWN_TEAMS.has(m[1])) return html(agentDashboardHtml);
   m = path.match(/^\/lookup\/([^/]+)$/);
-  if (m && KNOWN_TEAMS.has(m[1])) return html(lookupHtml);
+  if (m && KNOWN_TEAMS.has(m[1]))
+    return lookupAllowed(request, lookupAllow)
+      ? html(lookupHtml)
+      : new Response(LOOKUP_DENIED_PAGE, {
+          status: 403,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
 
   // ── drill-down + record APIs ─────────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/datapoints$/);
@@ -127,8 +178,11 @@ export async function handleTeamRoutes(
 
   // ── lookup APIs (Dialpad-backed; needs the DIALPAD_API_KEY app secret) ───
   m = path.match(/^\/api\/([^/]+)\/lookup(\/calls|\/recording-link|\/scoring-permission)?$/);
-  if (m && KNOWN_TEAMS.has(m[1]))
+  if (m && KNOWN_TEAMS.has(m[1])) {
+    if (!lookupAllowed(request, lookupAllow))
+      return json({ detail: "Lookup access restricted pending role-based access." }, 403);
     return lookupRoutes(db, m[1], m[2] ?? "", url, request, dialpadKey);
+  }
 
   // ── team APIs: /api/{team}/team/* ─────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/(team\/[a-z_]+|events\/stream)$/);


### PR DESCRIPTION
## Shadow writes — enabled (interim pull-based)

The designed Phase-5 path (Railway pushes finalized evals with an App Service Token) is blocked on Engineering ask #3 — machine callers can't pass the SSO wall without a `sast_` token. Until the sit-down lands it, `scripts/shadow_sync.py` **is** the shadow write, on a 30-minute crontab (`qa-sandy-shadow`):

1. Wipes + re-imports the full `qa_*` tree from Railway Postgres — **full fidelity**, including row UPDATEs that an id-watermark sync would miss (rescores, edits, coaching links).
2. Publishes `eval_approved` rows into `qa_events` for evaluations that newly reached `finalized` — the exact payload shape `scoring.py` publishes — so the **floor-TV toasts + Recent Evals chiclet now fire from Sandy** within ≤30 min + ≤3 s SSE latency.
3. Spot-reconciles evaluations + sections every run; macOS notification on failure.

`cc_*` tables stay on their initial snapshot until the CC slice (dispositions freshness isn't shadow-gating). Once the service token exists, Railway pushes live and this cron retires.

## Lookup compliance lock (v0.8, deployed)

`/lookup` pages **and** APIs are now **deny-by-default** — the page surfaces cross-company call recordings. App-level authorization reads the SSO email from the platform-verified `Cf-Access-Jwt-Assertion` header; the `LOOKUP_ALLOW` app secret (Dashboard-set, comma-separated emails) grants interim access. Unauthorized users get a clean "restricted" page, not an error.

**To use lookup yourself:** Sandy Dashboard → qa-scoring → Edit Secrets → add `LOOKUP_ALLOW` = `maximiliano.perez@hellolanding.com` (add teammates comma-separated).

## Pinned (later this session / sit-down)

- **Full per-team/per-role RBAC** — D1 roles table keyed on the Access email (manager-editable), replacing the allow-list. No Engineering RBAC needed; app-level enforcement.
- Sit-down: confirm the platform guarantee on `Cf-Access-Jwt-Assertion` reaching tenant workers pre-verified; App Service Token to replace this pull sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)