### PR TITLE
feat(sandy-qa): greeting page + qa-scoring-pipeline workflow (scoring engine, part 1)

### DIFF
--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -30,6 +30,68 @@ import headerJs from "../../pages/static/header.js?raw";
 const RAILWAY_BASE = "https://hellolanding-qa.up.railway.app";
 const KNOWN_TEAMS = new Set(["member_support", "sales"]);
 
+const GREETING_PAGE = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QA Scoring — Landing</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&display=swap" rel="stylesheet">
+<style>
+:root{--navy:#15192D;--accent:#1A61D9;--bg:#E7EFFB;--surface:#fff;--border:#c9d5e8;--text:#15192D;--muted:#5a6478;--green:#28A745}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'DM Mono',monospace;background:var(--bg);color:var(--text);min-height:100vh}
+h1,h2,h3{font-family:'Fraunces',serif}
+.header{background:var(--navy);color:#fff;padding:20px 24px}
+.header h1{font-size:1.35rem;font-weight:700}
+.header .sub{font-size:.78rem;color:rgba(255,255,255,.65);margin-top:4px}
+.container{max-width:960px;margin:0 auto;padding:28px 24px;display:flex;flex-direction:column;gap:22px}
+.teams{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
+.team-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:22px;
+  text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:8px;transition:border-color .15s,transform .15s}
+.team-card:hover{border-color:var(--accent);transform:translateY(-2px)}
+.team-card h2{font-size:1.15rem}
+.team-card .go{color:var(--accent);font-size:.8rem;margin-top:6px}
+.team-card.soon{opacity:.65;cursor:default}
+.team-card.soon:hover{border-color:var(--border);transform:none}
+.badge{display:inline-block;padding:2px 10px;border-radius:9999px;font-size:.65rem;font-weight:500;
+  text-transform:uppercase;letter-spacing:.05em;background:#dbeafe;color:#1e40af;width:fit-content}
+.badge.soon-b{background:#fef3c7;color:#92400e}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:22px}
+.card h3{font-size:1rem;margin-bottom:10px}
+.how li{margin:8px 0 8px 18px;font-size:.82rem;line-height:1.5}
+.how b{font-weight:600}
+.how .path{color:var(--accent)}
+.note{font-size:.72rem;color:var(--muted);line-height:1.5}
+</style></head><body>
+<div class="header"><h1>QA Scoring</h1>
+<div class="sub">Landing call-quality platform — two-stage AI scoring, analyst review, team analytics</div></div>
+<div class="container">
+  <div class="teams">
+    <a class="team-card" href="/dashboard/member_support">
+      <span class="badge">Live</span><h2>Member Support</h2>
+      <span class="note">Team dashboard, agent analytics, month drill-downs</span>
+      <span class="go">Open dashboard &rsaquo;</span></a>
+    <a class="team-card" href="/dashboard/sales">
+      <span class="badge">Live</span><h2>Sales</h2>
+      <span class="note">Team dashboard, agent analytics, month drill-downs</span>
+      <span class="go">Open dashboard &rsaquo;</span></a>
+    <div class="team-card soon">
+      <span class="badge soon-b">Coming soon</span><h2>Sofia AI</h2>
+      <span class="note">QA for our voice AI agent — calls on Retell.ai</span></div>
+  </div>
+  <div class="card"><h3>Finding your way around</h3><ul class="how">
+    <li><b>Team dashboard</b> — <span class="path">/dashboard/&lt;team&gt;</span>: live KPIs, SPC + score
+      distribution, EWMA by agent (click any bar to drill down). Updates push live — no refresh needed.</li>
+    <li><b>Month drill-down</b> — click the Last/Current Month chiclets for every evaluation in that month.</li>
+    <li><b>Agent view</b> — click any agent name for their history and section trends.</li>
+    <li><b>Datapoint</b> — every score links to the full scorecard: section scores, confidence, reasoning.</li>
+    <li><b>Call lookup</b> — <span class="path">/lookup/&lt;team&gt;</span>: Dialpad call history + recordings.
+      <b>Restricted</b> to authorized QA staff.</li>
+  </ul></div>
+  <div class="note">Scoring &amp; review actions run on the current production system during the
+  migration shadow period; this app mirrors all evaluation data live and takes over scoring next.</div>
+</div></body></html>`;
+
 const html = (body: string) =>
   new Response(body, { headers: { "Content-Type": "text/html; charset=utf-8" } });
 const json = (data: unknown, status = 200) =>
@@ -90,6 +152,9 @@ export async function handleTeamRoutes(
   lookupAllow?: string
 ): Promise<Response | null> {
   const path = url.pathname;
+
+  // ── greeting page (platform default URL) ─────────────────────────────────
+  if (path === "/") return html(GREETING_PAGE);
 
   // ── static assets shared by the ported pages ──────────────────────────────
   if (path === "/static/header.css")

--- a/sandy-qa/workflows/qa-scoring-pipeline.js
+++ b/sandy-qa/workflows/qa-scoring-pipeline.js
@@ -1,0 +1,358 @@
+/**
+ * qa-scoring-pipeline — the QA scoring engine's AI legs (PortManifest §6).
+ *
+ * Design split: the qa-scoring APP builds every prompt (rubric from D1,
+ * SOP block, CC disposition grounding, long-call notes) and passes them in
+ * the trigger payload; this workflow is a GENERIC durable executor:
+ *
+ *   audio-leg   Dialpad meta → recording download (in-memory) → Gemini
+ *               Files upload → ACTIVE poll → Stage-A annotate (constrained
+ *               schema, bounded thinking, 0→0.2 temp-bump retry)
+ *   judge-leg   Stage-B judge from the annotation — Claude via the AI
+ *               Gateway anthropic passthrough (pinned model) or Gemini
+ *               direct, payload-driven
+ *   plan-b      single-stage Gemini audio scoring when annotate or judge
+ *               fails (payload carries the full single-stage prompt)
+ *   callback    scorecard JSON + provenance + timings back to the app,
+ *               which validates, computes the overall score, and persists
+ *
+ * Spike-proven constraints honored: whole audio leg in ONE step (step
+ * returns are checkpointed + size-capped); thinkingConfig.thinkingBudget
+ * carried (thinking eats maxOutputTokens on gemini-2.5); judge model is
+ * PINNED, never dynamic/sandy-workflows.
+ *
+ * Secrets (per-workflow): DIALPAD_API_KEY, GEMINI_API_KEY. Org: AI_GATEWAY_TOKEN.
+ *
+ * Payload:
+ * {
+ *   call_id, team_id,
+ *   pipeline: "two_stage" | "single",
+ *   annotator: { model, system, prompt, response_schema, thinking_budget,
+ *                max_output_tokens },
+ *   judge: { provider: "anthropic"|"gemini", model, system,
+ *            prompt_template,           // "{{ANNOTATION_JSON}}" placeholder
+ *            max_tokens },
+ *   single_stage: { model, system, prompt, temperature, max_output_tokens },
+ *   callback_url, callback_token
+ * }
+ */
+
+import { WorkflowEntrypoint } from "cloudflare:workers";
+
+const GEMINI = "https://generativelanguage.googleapis.com";
+const AIG_ANTHROPIC =
+  "https://gateway.ai.cloudflare.com/v1/d094105625bec434114c0b80ecfa7238/sandy-workflows/anthropic/v1/messages";
+
+const RETRY = { retries: { limit: 1, delay: "10 seconds", backoff: "linear" } };
+
+async function sendCallback(callbackUrl, payload, sandySecrets) {
+  const secret = sandySecrets?._sandyCallbackSecret;
+  const bodyText = JSON.stringify(payload);
+  const headers = { "Content-Type": "application/json" };
+  if (secret) {
+    const pathname = new URL(callbackUrl).pathname;
+    const key = await crypto.subtle.importKey(
+      "raw", new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+    const mac = await crypto.subtle.sign(
+      "HMAC", key, new TextEncoder().encode(`POST|${pathname}|${bodyText}`));
+    headers["X-Sandy-Workflow-Callback"] = Array.from(new Uint8Array(mac))
+      .map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  const res = await fetch(callbackUrl, {
+    method: "POST", headers, body: bodyText,
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!res.ok) throw new Error(`Callback failed: HTTP ${res.status}`);
+}
+
+function stripFences(text) {
+  return String(text)
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+}
+
+// Extract the first complete JSON object from model text (fence-tolerant).
+function extractJson(text) {
+  const t = stripFences(text);
+  const start = t.indexOf("{");
+  const end = t.lastIndexOf("}") + 1;
+  if (start === -1 || end === 0) throw new Error("no JSON object in response");
+  let body = t.slice(start, end).replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+  try {
+    return JSON.parse(body);
+  } catch (first) {
+    // trailing-comma salvage (observed live on a judge output, eval 2444)
+    const fixed = body.replace(/,(\s*[}\]])/g, "$1");
+    try {
+      return JSON.parse(fixed);
+    } catch {
+      throw new Error(`JSON parse failed: ${String(first).slice(0, 120)}`);
+    }
+  }
+}
+
+function finishDiag(genJson) {
+  const cand = (genJson.candidates ?? [])[0] ?? {};
+  const usage = genJson.usageMetadata ?? {};
+  return {
+    finish_reason: cand.finishReason ?? null,
+    prompt_tokens: usage.promptTokenCount ?? null,
+    output_tokens: usage.candidatesTokenCount ?? null,
+    thoughts_tokens: usage.thoughtsTokenCount ?? null,
+  };
+}
+
+async function geminiGenerate(gmKey, model, parts, genConfig, system) {
+  const res = await fetch(`${GEMINI}/v1beta/models/${model}:generateContent`, {
+    method: "POST",
+    headers: { "x-goog-api-key": gmKey, "content-type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts }],
+      systemInstruction: system
+        ? { parts: [{ text: system }] }
+        : undefined,
+      generationConfig: genConfig,
+    }),
+    signal: AbortSignal.timeout(480000),
+  });
+  if (!res.ok)
+    throw new Error(`gemini ${model} HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const json = await res.json();
+  const text = ((json.candidates?.[0]?.content ?? {}).parts ?? [])
+    .map((p) => p.text ?? "")
+    .join("");
+  return { json, text, diag: finishDiag(json) };
+}
+
+export class TenantWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const p = event.payload;
+    const dpKey = p._sandySecrets?.DIALPAD_API_KEY;
+    const gmKey = p._sandySecrets?.GEMINI_API_KEY;
+    const aigKey = p._sandySecrets?.AI_GATEWAY_TOKEN;
+
+    const result = {
+      call_id: p.call_id,
+      team_id: p.team_id,
+      status: "error",
+      pipeline_requested: p.pipeline,
+      scorer_provider: null,
+      scorer_model: null,
+      pipeline_fallback_reason: null,
+      annotation: null,
+      annotator_model: null,
+      annotate_diag: null,
+      scorecard_raw: null,
+      timings_ms: {},
+      error: null,
+    };
+
+    let audioLeg = null;
+    try {
+      if (!p.call_id || !dpKey || !gmKey)
+        throw new Error("missing call_id or DIALPAD/GEMINI secrets");
+
+      // ── audio leg: download + upload + Stage-A annotate (ONE step) ────────
+      audioLeg = await step.do("audio-leg", RETRY, async () => {
+        const out = { timings: {} };
+        let t = Date.now();
+        const metaRes = await fetch(
+          `https://dialpad.com/api/v2/call/${encodeURIComponent(p.call_id)}`,
+          { headers: { authorization: `Bearer ${dpKey}` } });
+        if (!metaRes.ok)
+          throw new Error(`dialpad-meta HTTP ${metaRes.status}`);
+        const meta = await metaRes.json();
+        const rec = (meta.recording_details ?? [])[0] ?? {};
+        if (!rec.url) throw new Error("no recording_details url");
+        const recUrl = new URL(rec.url);
+        recUrl.searchParams.set("apikey", dpKey);
+        const audioRes = await fetch(recUrl.toString(), { redirect: "follow" });
+        if (!audioRes.ok) throw new Error(`dialpad-audio HTTP ${audioRes.status}`);
+        const audioBuf = await audioRes.arrayBuffer();
+        const mime = (audioRes.headers.get("content-type") ?? "audio/mp3").split(";")[0].trim();
+        out.audio_bytes = audioBuf.byteLength;
+        out.timings.download = Date.now() - t;
+
+        // Gemini Files resumable upload
+        t = Date.now();
+        const startRes = await fetch(`${GEMINI}/upload/v1beta/files`, {
+          method: "POST",
+          headers: {
+            "x-goog-api-key": gmKey,
+            "X-Goog-Upload-Protocol": "resumable",
+            "X-Goog-Upload-Command": "start",
+            "X-Goog-Upload-Header-Content-Length": String(audioBuf.byteLength),
+            "X-Goog-Upload-Header-Content-Type": mime,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ file: { display_name: `score-${p.call_id}` } }),
+        });
+        const uploadUrl = startRes.headers.get("x-goog-upload-url");
+        if (!startRes.ok || !uploadUrl)
+          throw new Error(`gemini-upload-start HTTP ${startRes.status}`);
+        const upRes = await fetch(uploadUrl, {
+          method: "POST",
+          headers: {
+            "X-Goog-Upload-Offset": "0",
+            "X-Goog-Upload-Command": "upload, finalize",
+            "content-type": mime,
+          },
+          body: audioBuf,
+        });
+        if (!upRes.ok) throw new Error(`gemini-upload HTTP ${upRes.status}`);
+        const file = ((await upRes.json()).file ?? {});
+        let state = file.state ?? "PROCESSING";
+        for (let i = 0; state !== "ACTIVE" && i < 30; i++) {
+          await new Promise((r) => setTimeout(r, 2000));
+          const pr = await fetch(`${GEMINI}/v1beta/${file.name}`, {
+            headers: { "x-goog-api-key": gmKey } });
+          state = (await pr.json()).state;
+          if (state === "FAILED") throw new Error("gemini file FAILED");
+        }
+        if (state !== "ACTIVE") throw new Error("gemini file never ACTIVE");
+        out.gemini_file = { name: file.name, uri: file.uri, mime };
+        out.timings.upload = Date.now() - t;
+
+        // Stage-A annotation with temp-bump retry (0 → 0.2); constrained
+        // decoding via payload schema; bounded thinking.
+        if (p.pipeline !== "single" && p.annotator) {
+          t = Date.now();
+          const filePart = { fileData: { fileUri: file.uri, mimeType: mime } };
+          let lastErr = null;
+          for (const temperature of [0.0, 0.2]) {
+            try {
+              const { json, text, diag } = await geminiGenerate(
+                gmKey, p.annotator.model,
+                [filePart, { text: p.annotator.prompt }],
+                {
+                  temperature,
+                  maxOutputTokens: p.annotator.max_output_tokens ?? 65536,
+                  thinkingConfig: { thinkingBudget: p.annotator.thinking_budget ?? 4096 },
+                  responseMimeType: "application/json",
+                  responseSchema: p.annotator.response_schema,
+                },
+                p.annotator.system
+              );
+              out.annotate_diag = diag;
+              if ((diag.finish_reason ?? "").includes("MAX_TOKENS"))
+                throw new Error(`annotation truncated [${JSON.stringify(diag)}]`);
+              out.annotation = JSON.parse(text); // schema-forced → parseable
+              break;
+            } catch (e) {
+              lastErr = e;
+            }
+          }
+          if (!out.annotation) out.annotate_error = String(lastErr).slice(0, 300);
+          out.timings.annotate = Date.now() - t;
+        }
+        return out;
+      });
+      result.timings_ms = audioLeg.timings;
+      result.annotation = audioLeg.annotation ?? null;
+      result.annotator_model = audioLeg.annotation ? p.annotator?.model : null;
+      result.annotate_diag = audioLeg.annotate_diag ?? null;
+
+      // ── judge leg (two_stage) ─────────────────────────────────────────────
+      if (p.pipeline === "two_stage" && result.annotation && p.judge) {
+        try {
+          const judged = await step.do("judge-leg", RETRY, async () => {
+            const t = Date.now();
+            const prompt = p.judge.prompt_template.replace(
+              "{{ANNOTATION_JSON}}", JSON.stringify(result.annotation));
+            let text;
+            if (p.judge.provider === "anthropic") {
+              if (!aigKey) throw new Error("AI_GATEWAY_TOKEN missing");
+              const res = await fetch(AIG_ANTHROPIC, {
+                method: "POST",
+                headers: {
+                  "cf-aig-authorization": aigKey,
+                  "anthropic-version": "2023-06-01",
+                  "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                  model: p.judge.model, // pinned — never dynamic/
+                  max_tokens: p.judge.max_tokens ?? 16384,
+                  system: p.judge.system,
+                  messages: [{ role: "user", content: prompt }],
+                }),
+                signal: AbortSignal.timeout(480000),
+              });
+              if (!res.ok)
+                throw new Error(`gateway ${res.status}: ${(await res.text()).slice(0, 200)}`);
+              text = ((await res.json()).content ?? [])
+                .map((b) => b.text ?? "").join("");
+            } else {
+              const g = await geminiGenerate(
+                gmKey, p.judge.model, [{ text: prompt }],
+                { temperature: 0.2, maxOutputTokens: p.judge.max_tokens ?? 16384 },
+                p.judge.system);
+              text = g.text;
+            }
+            return { scorecard: extractJson(text), ms: Date.now() - t };
+          });
+          result.scorecard_raw = judged.scorecard;
+          result.scorer_provider = p.judge.provider;
+          result.scorer_model = p.judge.model;
+          result.timings_ms.judge = judged.ms;
+        } catch (e) {
+          result.pipeline_fallback_reason = "text_scorer_failed";
+        }
+      } else if (p.pipeline === "two_stage" && !result.annotation) {
+        result.pipeline_fallback_reason = "annotate_failed";
+      }
+
+      // ── Plan B: single-stage audio scoring ────────────────────────────────
+      if (!result.scorecard_raw && p.single_stage) {
+        const single = await step.do("single-stage", RETRY, async () => {
+          const t = Date.now();
+          const g = await geminiGenerate(
+            gmKey, p.single_stage.model,
+            [
+              { fileData: { fileUri: audioLeg.gemini_file.uri, mimeType: audioLeg.gemini_file.mime } },
+              { text: p.single_stage.prompt },
+            ],
+            {
+              temperature: p.single_stage.temperature ?? 0.2,
+              maxOutputTokens: p.single_stage.max_output_tokens ?? 65536,
+            },
+            p.single_stage.system);
+          return { scorecard: extractJson(g.text), diag: g.diag, ms: Date.now() - t };
+        });
+        result.scorecard_raw = single.scorecard;
+        result.scorer_provider = "gemini";
+        result.scorer_model = p.single_stage.model;
+        result.timings_ms.single_stage = single.ms;
+      }
+
+      if (!result.scorecard_raw) throw new Error("no scorecard produced by any path");
+      result.status = "complete";
+    } catch (err) {
+      result.error = String(err && err.message ? err.message : err).slice(0, 500);
+    }
+
+    // ── cleanup + callback ──────────────────────────────────────────────────
+    await step.do("finish", async () => {
+      if (audioLeg?.gemini_file?.name) {
+        try {
+          await fetch(`${GEMINI}/v1beta/${audioLeg.gemini_file.name}`, {
+            method: "DELETE",
+            headers: { "x-goog-api-key": gmKey },
+          });
+        } catch {}
+      }
+      if (p.callback_url) {
+        await sendCallback(
+          p.callback_url,
+          { run_id: event.instanceId, callback_token: p.callback_token, ...result },
+          p._sandySecrets
+        );
+      }
+      return { delivered: !!p.callback_url, status: result.status };
+    });
+
+    if (result.status !== "complete") throw new Error(result.error ?? "pipeline failed");
+    return { status: result.status, call_id: p.call_id };
+  }
+}


### PR DESCRIPTION
## Greeting page (v0.9, live)

https://qa-scoring.sandy.hellolanding.tech/ now serves a proper landing: team picker (Member Support / Sales, **Sofia AI teased as coming soon**), capabilities how-to, and the shadow-period note — in the QA app's visual language.

## Scoring engine, part 1: the workflow

`qa-scoring-pipeline` (id `25dec973`, v0.1, published, enabled for the qa-scoring app). **Architecture decision:** prompts are built **app-side** — rubric from D1, SOP block, and the **CC disposition grounding block** (`cc_context` port — the part that matters most) — and ride the trigger payload. The workflow is a *generic durable executor*:

- **audio-leg** (one step, spike-proven shape): Dialpad download → Gemini Files upload → Stage-A annotate with constrained schema, `thinkingBudget`, 0→0.2 temp-bump retry, MAX_TOKENS diagnostics
- **judge-leg**: Stage-B judge from the annotation — Claude via the AI Gateway **anthropic passthrough with a pinned model** (never `dynamic/`), or Gemini direct, payload-selected
- **Plan B**: single-stage Gemini audio scoring when annotate/judge fails (`pipeline_fallback_reason` recorded, matching Railway's fallback doctrine)
- **callback**: HMAC-signed scorecard + provenance + timings back to the app

## ⚠ User action (same as the spike workflow)

The new workflow needs its per-workflow secrets — run in-session:
```
! cd ~/Dev/Landing-scripts/qa-automation/AI-Scoring && set -a && source .env && set +a && python3 "$HOME/.claude/commands/scripts/sandy.py" workflows secrets-set 25dec973-c4ab-4122-b2ce-9d3a03c802d8 DIALPAD_API_KEY "$DIALPAD_API_KEY" > /dev/null && python3 "$HOME/.claude/commands/scripts/sandy.py" workflows secrets-set 25dec973-c4ab-4122-b2ce-9d3a03c802d8 GEMINI_API_KEY "$GEMINI_API_KEY" > /dev/null && echo "scoring workflow secrets set"
```

## Next slices (scoring engine, part 2)

Worker-side: prompt builders (annotator/judge/single-stage from rubric_json), `score_compute` formula port, `POST /score` trigger + callback persist (draft eval → human-review gate → finalize + `qa_events`), and `cc_*` incremental shadow sync so disposition grounding stays fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)