### PR TITLE
feat(sandy-qa): scoring engine part 2 — full pipeline wired (trigger → AI → persist → finalize)

### DIFF
--- a/sandy-qa/scripts/shadow_sync.py
+++ b/sandy-qa/scripts/shadow_sync.py
@@ -72,6 +72,82 @@ def truncate(s, n=280):
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+CC_CALLS_COLS = [
+    "id", "team_id", "dialpad_call_id", "dialpad_master_call_id",
+    "dialpad_entry_point_call_id", "started_at", "rang_at", "connected_at",
+    "ended_at", "total_duration_ms", "direction", "external_number",
+    "internal_number", "group_id", "dialpad_agent_id", "agent_name",
+    "caller_name", "caller_phone_e164", "caller_email", "target_name",
+    "target_type", "target_phone", "mos_score", "was_recorded",
+    "is_transferred", "recording_urls", "last_state", "last_state_at",
+    "total_hold_seconds", "raw_call_details", "scored", "scored_at",
+    "evaluation_orphaned", "evaluation_orphaned_at", "seen_via",
+    "first_seen_at", "last_updated_at", "disposition_category",
+    "disposition", "ai_csat", "disposition_source",
+]
+
+
+def _d1_scalar(sql: str):
+    return pg_to_d1.d1_query(sql)[0]["v"]
+
+
+async def sync_cc_incremental(conn) -> str:
+    # cc_calls upsert by last_updated_at watermark
+    wm = _d1_scalar("SELECT COALESCE(max(last_updated_at), '1970-01-01') AS v FROM cc_calls")
+    rows = await conn.fetch(
+        f"SELECT {', '.join(CC_CALLS_COLS)} FROM command_center.calls "
+        "WHERE last_updated_at > $1 ORDER BY last_updated_at LIMIT 5000",
+        # D1 stores ISO text; PG compares timestamptz — parse the watermark
+        datetime.fromisoformat(wm.replace("Z", "+00:00")),
+    )
+    if rows:
+        col_list = ", ".join(CC_CALLS_COLS)
+        updates = ", ".join(f"{c}=excluded.{c}" for c in CC_CALLS_COLS if c != "id")
+        stmts = ["PRAGMA defer_foreign_keys = true;"]
+        for r in rows:
+            vals = ", ".join(pg_to_d1.lit(r[c]) for c in CC_CALLS_COLS)
+            stmts.append(
+                f"INSERT INTO cc_calls ({col_list}) VALUES ({vals}) "
+                f"ON CONFLICT(id) DO UPDATE SET {updates};"
+            )
+            if sum(len(s) for s in stmts) > 300_000:
+                pg_to_d1.apply_sql("\n".join(stmts))
+                stmts = ["PRAGMA defer_foreign_keys = true;"]
+        if len(stmts) > 1:
+            pg_to_d1.apply_sql("\n".join(stmts))
+
+    # append-only tails by id watermark
+    appended = {}
+    for pg_name, d1_name, cols in (
+        ("command_center.hold_intervals", "cc_hold_intervals",
+         ["id", "team_id", "dialpad_call_id", "call_id", "started_at",
+          "ended_at", "seconds", "ended_by"]),
+        ("command_center.webhook_events", "cc_webhook_events",
+         ["id", "received_at", "team_id", "event_kind", "dialpad_call_id",
+          "dialpad_master_call_id", "dialpad_agent_id", "state",
+          "event_timestamp", "raw_payload", "processed_at"]),
+    ):
+        max_id = _d1_scalar(f"SELECT COALESCE(max(id), 0) AS v FROM {d1_name}")
+        tail = await conn.fetch(
+            f"SELECT {', '.join(cols)} FROM {pg_name} WHERE id > $1 ORDER BY id LIMIT 5000",
+            max_id)
+        if tail:
+            col_list = ", ".join(cols)
+            stmts = ["PRAGMA defer_foreign_keys = true;"]
+            for r in tail:
+                stmts.append(
+                    f"INSERT OR IGNORE INTO {d1_name} ({col_list}) VALUES "
+                    f"({', '.join(pg_to_d1.lit(r[c]) for c in cols)});")
+                if sum(len(s) for s in stmts) > 300_000:
+                    pg_to_d1.apply_sql("\n".join(stmts))
+                    stmts = ["PRAGMA defer_foreign_keys = true;"]
+            if len(stmts) > 1:
+                pg_to_d1.apply_sql("\n".join(stmts))
+        appended[d1_name] = len(tail)
+    return (f"calls+{len(rows)} holds+{appended['cc_hold_intervals']} "
+            f"webhooks+{appended['cc_webhook_events']}")
+
+
 async def main():
     import asyncpg
     started = datetime.now(timezone.utc)
@@ -119,6 +195,14 @@ async def main():
             pg_to_d1.apply_sql("\n".join(stmts))
             published = len(stmts)
 
+        # 2.5 cc_* incremental — disposition grounding must be FRESH
+        # (the scoring workflow's cc_context match reads cc_calls).
+        # cc_calls: upsert rows whose last_updated_at moved past the D1
+        # watermark (ON CONFLICT DO UPDATE — never INSERT OR REPLACE,
+        # which would cascade-delete cc_hold_intervals). hold_intervals /
+        # webhook_events are append-only: insert by id watermark.
+        cc_synced = await sync_cc_incremental(conn)
+
         # 3. spot reconciliation on the two load-bearing tables
         ok = True
         for pg_name, d1_name in (("qa.evaluations", "qa_evaluations"),
@@ -130,7 +214,8 @@ async def main():
             ok &= (pg_row["c"], pg_row["s"]) == (d1_row["c"], d1_row["s"])
         secs = (datetime.now(timezone.utc) - started).total_seconds()
         print(f"SHADOW SYNC {'OK' if ok else 'RECONCILE MISMATCH'}: "
-              f"{len(after_ids)} finalized evals, +{published} events published, {secs:.0f}s")
+              f"{len(after_ids)} finalized evals, +{published} events published, "
+              f"cc {cc_synced}, {secs:.0f}s")
         sys.exit(0 if ok else 2)
     finally:
         await conn.close()

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -189,6 +189,28 @@ es.onerror = () => { if (v.className === 'wait') { v.textContent = 'CONNECTION E
         .set({ status: body.status ?? "error", result: JSON.stringify(body) })
         .where(eq(workflowRuns.run_id, body.run_id));
       console.log(`[callback] workflow=${workflowName} run_id=${body.run_id} status=${body.status}`);
+      // qa-scoring-pipeline: persist the evaluation (draft/finalize + toast)
+      if (workflowName === "qa-scoring-pipeline") {
+        const { scoringCallback } = await import("./routes/scoring.js");
+        try {
+          const outcome = await scoringCallback(body, env.DB);
+          const jobId = (body as any).persist
+            ? `score-${(body as any).team_id}-${(body as any).call_id}-${String((body as any).persist.agent_name ?? "")
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, "-")}`
+            : null;
+          if (jobId) {
+            await env.DB.prepare(
+              "UPDATE workflow_runs SET status = ?, result = ? WHERE run_id = ?"
+            )
+              .bind(outcome.ok ? "complete" : "error", JSON.stringify(outcome), jobId)
+              .run();
+          }
+          console.log(`[scoring] ${outcome.ok ? "OK" : "FAIL"}: ${outcome.note}`);
+        } catch (err) {
+          console.log(`[scoring] persist threw: ${String(err).slice(0, 300)}`);
+        }
+      }
       return Response.json({ ok: true });
     }
 

--- a/sandy-qa/src/lib/ccContext.ts
+++ b/sandy-qa/src/lib/ccContext.ts
@@ -1,0 +1,168 @@
+// CC call-context grounding — port of backend/services/cc_context.py
+// (DispositionDesign §5). Triple-key match against cc_calls, hold cycles
+// from cc_hold_intervals, and the EMPHASIZED "CALL CONTEXT (VERIFIED
+// SYSTEM DATA)" block that rides AHEAD of the transcript / annotated
+// record in the scoring prompt. Non-fatal by doctrine: any failure
+// returns null and scoring proceeds ungrounded.
+//
+// Freshness note: cc_calls is fed by the shadow sync (and the hourly
+// Railway stats pull upstream of it) — a just-ended call may not be
+// matched yet; the absence path words that case safely.
+
+export interface CallContext {
+  cc_call_id: number;
+  matched_by: string;
+  disposition_category: string | null;
+  disposition: string | null;
+  ai_csat: number | null;
+  total_hold_seconds: number;
+  connected_at: string | null;
+  started_at: string | null;
+  holds: { started_at: string; ended_at: string; seconds: number }[];
+  has_hold_truth: boolean;
+}
+
+const MATCH_ORDER = ["entry_point", "call_id", "master"] as const;
+
+const MATCH_SQL = `
+SELECT id, disposition_category, disposition, ai_csat,
+       total_hold_seconds, connected_at, started_at, seen_via
+FROM cc_calls
+WHERE team_id = ?
+  AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ? OR dialpad_master_call_id = ?)
+LIMIT 1`;
+
+export async function fetchCallContext(
+  db: D1Database,
+  teamId: string,
+  ids: { entry_point?: string; call_id?: string; master?: string }
+): Promise<CallContext | null> {
+  try {
+    let row: any = null;
+    let matchedBy = "";
+    for (const key of MATCH_ORDER) {
+      const id = (ids[key] ?? "").trim();
+      if (!id) continue;
+      row = await db.prepare(MATCH_SQL).bind(teamId, id, id, id).first<any>();
+      if (row) {
+        matchedBy = key;
+        break;
+      }
+    }
+    if (!row) return null;
+    const holds = await db
+      .prepare(
+        "SELECT started_at, ended_at, seconds FROM cc_hold_intervals WHERE call_id = ? ORDER BY started_at"
+      )
+      .bind(row.id)
+      .all<any>();
+    return {
+      cc_call_id: row.id,
+      matched_by: matchedBy,
+      disposition_category: row.disposition_category ?? null,
+      disposition: row.disposition ?? null,
+      ai_csat: row.ai_csat !== null && row.ai_csat !== undefined ? Number(row.ai_csat) : null,
+      total_hold_seconds: row.total_hold_seconds ?? 0,
+      connected_at: row.connected_at ?? null,
+      started_at: row.started_at ?? null,
+      holds: holds.results,
+      has_hold_truth: row.seen_via === "webhook",
+    };
+  } catch {
+    return null; // grounding is an enhancement, never a scoring blocker
+  }
+}
+
+function mmss(totalSeconds: number): string {
+  const t = Math.max(0, Math.trunc(totalSeconds));
+  return `${Math.trunc(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+}
+
+function absenceSentence(language: string | null): string {
+  if (language === "es")
+    return (
+      "No disposition was captured for this call (back-to-back handling) — " +
+      "score on the AUDIO content: for Spanish calls the audio is the source " +
+      "of truth and the transcript is unreliable."
+    );
+  if (language === "en")
+    return (
+      "No disposition was captured for this call (back-to-back handling) — " +
+      "score on transcript evidence alone."
+    );
+  return (
+    "No disposition was captured for this call (back-to-back handling) — " +
+    "score on transcript evidence alone, OR on the audio content if the call " +
+    "is in Spanish (for Spanish calls the audio is the source of truth)."
+  );
+}
+
+export function buildCallContextBlock(
+  ctx: CallContext | null,
+  language: string | null = null
+): string {
+  if (ctx === null) return "";
+  const lines = [
+    "",
+    "=== CALL CONTEXT (VERIFIED SYSTEM DATA) ===",
+    "IMPORTANT: the facts below are verified Dialpad system records for " +
+      "THIS call. They are ground truth — do not second-guess them from " +
+      "the transcript or audio.",
+    "",
+  ];
+
+  if (ctx.disposition_category) {
+    const label =
+      ctx.disposition_category + (ctx.disposition ? ` — ${ctx.disposition}` : "");
+    lines.push(
+      `- The agent classified this call as: ${label}. Score the call ` +
+        "within reason FOR that disposition — the expectations of each " +
+        "section apply as they pertain to this call type."
+    );
+  } else {
+    lines.push(`- ${absenceSentence(language)}`);
+  }
+
+  const anchor = ctx.connected_at ?? ctx.started_at;
+  if (!ctx.has_hold_truth) {
+    lines.push(
+      "- No verified hold record is available for this call. Do NOT " +
+        "state specific hold counts or durations as verified fact."
+    );
+  } else if (ctx.holds.length) {
+    const described = ctx.holds.map((h) => {
+      const duration = mmss(h.seconds);
+      if (anchor !== null) {
+        const offset = mmss((Date.parse(h.started_at) - Date.parse(anchor)) / 1000);
+        return `${duration} at ${offset}`;
+      }
+      return duration;
+    });
+    const n = ctx.holds.length;
+    lines.push(
+      `- Verified hold record: ${n} hold${n !== 1 ? "s" : ""} ` +
+        `(${described.join(", ")}). Do NOT infer or report holds beyond this record.`
+    );
+  } else if (ctx.total_hold_seconds > 0) {
+    lines.push(
+      `- Verified total hold time: ${mmss(ctx.total_hold_seconds)}. ` +
+        "Do NOT infer additional holds beyond this total."
+    );
+  } else {
+    lines.push(
+      "- Verified: no holds occurred on this call. Do NOT report or " +
+        "penalize hold time."
+    );
+  }
+
+  if (ctx.ai_csat !== null) {
+    const csat = String(ctx.ai_csat).replace(/\.0$/, "");
+    lines.push(
+      `- Dialpad Ai CSAT estimate for this call: ${csat}/5 ` +
+        "(context only — do not let it anchor your section scores)."
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/sandy-qa/src/lib/ruleEngine.ts
+++ b/sandy-qa/src/lib/ruleEngine.ts
@@ -1,0 +1,341 @@
+// Pure formula rule engine — port of backend/services/rule_engine.py.
+// Table-driven scorer for the Ops-signed formula shape; one engine, both
+// teams. NO DB, NO clock. Semantics preserved line-for-line:
+//   - normalization: rating linear curve; binary Y/N map (per-section
+//     binary_map overrides formula-level); NA per normalization.na
+//     (full_credit → frac 1.0 | redistribute_per_rules → inactive, weight
+//     must be moved off or UnhandledNaWeightError)
+//   - evaluation_order tokens run exactly as listed; static misconfig
+//     throws before any data is read
+//   - when: equals compares String(answer); frac_lte/gte compare the
+//     normalized PRE-redistribution frac; inactive section → numeric
+//     conditions false, only equals:"NA" matches; signals default false
+//   - score_override: final IS set_score; evaluation continues for trace;
+//     later score_scale skipped
+//   - answers strict: unknown/missing keys throw; NA only where allowed
+// Final score clamped to formula.scale [min, max].
+
+export type SectionAnswer = number | string;
+
+const EPS = 1e-9;
+const WEIGHTED_SUM = "weighted_sum";
+
+const SCORE_TYPE_TRAITS: Record<string, [kind: string, naAllowed: boolean]> = {
+  rating_1_5: ["rating", false],
+  rating_1_5_na: ["rating", true],
+  binary_yn: ["binary", false],
+  binary_yn_na: ["binary", true],
+  manual_yn: ["binary", true],
+  auto_value: ["binary", false],
+};
+
+export class RuleEngineError extends Error {}
+
+export interface ScoreResult {
+  formula_id: string;
+  rubric_version: string;
+  final_score: number;
+  raw_score: number;
+  overridden: boolean;
+  effective_weights: Record<string, number>;
+  fracs: Record<string, number | null>;
+  contributions: Record<string, number>;
+  na_sections: string[];
+  events: { rule_id: string; event: string; route: string | null }[];
+  trace: { rule_id: string; rule_type: string; fired: boolean; note: string | null }[];
+}
+
+const PRE_SUM_ONLY = new Set(["weight_transfer", "weight_redistribution", "na_redistribution"]);
+const POST_SUM_ONLY = new Set(["score_scale"]);
+
+function checkStaticOrder(formula: any): void {
+  const order: string[] = formula.evaluation_order;
+  if (order.filter((t) => t === WEIGHTED_SUM).length !== 1)
+    throw new RuleEngineError(
+      `formula '${formula.formula_id}': evaluation_order must contain exactly one '${WEIGHTED_SUM}' token`
+    );
+  const sumAt = order.indexOf(WEIGHTED_SUM);
+  const rulesById = new Map<string, any>(formula.rules.map((r: any) => [r.id, r]));
+  order.forEach((token, pos) => {
+    if (token === WEIGHTED_SUM) return;
+    const rule = rulesById.get(token);
+    if (!rule) throw new RuleEngineError(`evaluation_order token '${token}' has no rule`);
+    if (PRE_SUM_ONLY.has(rule.type) && pos > sumAt)
+      throw new RuleEngineError(
+        `formula '${formula.formula_id}': ${rule.type} rule '${token}' after ${WEIGHTED_SUM}`
+      );
+    if (POST_SUM_ONLY.has(rule.type) && pos < sumAt)
+      throw new RuleEngineError(
+        `formula '${formula.formula_id}': ${rule.type} rule '${token}' before ${WEIGHTED_SUM}`
+      );
+  });
+}
+
+function ratingFrac(formula: any, section: any, answer: SectionAnswer): number {
+  const curve = formula.normalization.rating_1_5;
+  if (
+    typeof answer !== "number" ||
+    !Number.isInteger(answer) ||
+    answer < curve.input_min ||
+    answer > curve.input_max
+  )
+    throw new RuleEngineError(
+      `section '${section.key}': expected int rating ${curve.input_min}-${curve.input_max}, got ${JSON.stringify(answer)}`
+    );
+  const [outLo, outHi] = curve.output;
+  const span = curve.input_max - curve.input_min;
+  return outLo + ((answer - curve.input_min) / span) * (outHi - outLo);
+}
+
+function binaryFrac(formula: any, section: any, answer: SectionAnswer): number {
+  const map = section.binary_map ?? formula.normalization.binary_yn;
+  if (answer === "Y") return map.Y;
+  if (answer === "N") return map.N;
+  throw new RuleEngineError(
+    `section '${section.key}': expected 'Y'/'N', got ${JSON.stringify(answer)}`
+  );
+}
+
+function normalizeAnswers(
+  formula: any,
+  answers: Record<string, SectionAnswer>
+): [Record<string, number | null>, string[]] {
+  const sectionKeys = new Set<string>(formula.sections.map((s: any) => s.key));
+  const unknown = Object.keys(answers).filter((k) => !sectionKeys.has(k)).sort();
+  if (unknown.length)
+    throw new RuleEngineError(
+      `formula '${formula.formula_id}': answers for unknown sections ${JSON.stringify(unknown)}`
+    );
+  const missing = [...sectionKeys].filter((k) => !(k in answers)).sort();
+  if (missing.length)
+    throw new RuleEngineError(
+      `formula '${formula.formula_id}': missing answers for ${JSON.stringify(missing)}`
+    );
+
+  const fracs: Record<string, number | null> = {};
+  const naSections: string[] = [];
+  for (const section of formula.sections) {
+    const answer = answers[section.key];
+    const traits = SCORE_TYPE_TRAITS[section.score_type];
+    if (!traits)
+      throw new RuleEngineError(`section '${section.key}': unknown score_type '${section.score_type}'`);
+    const [kind, naAllowed] = traits;
+    if (answer === "NA") {
+      if (!naAllowed)
+        throw new RuleEngineError(
+          `section '${section.key}': NA not allowed for score_type='${section.score_type}'`
+        );
+      naSections.push(section.key);
+      fracs[section.key] = formula.normalization.na === "full_credit" ? 1.0 : null;
+      continue;
+    }
+    fracs[section.key] =
+      kind === "rating" ? ratingFrac(formula, section, answer) : binaryFrac(formula, section, answer);
+  }
+  return [fracs, naSections];
+}
+
+function whenMatches(
+  when: any,
+  answers: Record<string, SectionAnswer>,
+  fracs: Record<string, number | null>,
+  signals: Record<string, boolean>
+): boolean {
+  if (when.signal !== undefined) return signals[when.signal] ?? false;
+  if (when.any !== undefined) return when.any.some((c: any) => whenMatches(c, answers, fracs, signals));
+  if (when.all !== undefined) return when.all.every((c: any) => whenMatches(c, answers, fracs, signals));
+
+  const hasCondition =
+    when.equals !== undefined && when.equals !== null ||
+    when.frac_lte !== undefined && when.frac_lte !== null ||
+    when.frac_gte !== undefined && when.frac_gte !== null;
+  if (!hasCondition)
+    throw new RuleEngineError(`when-clause on section '${when.section}' has no condition`);
+  if (!(when.section in fracs))
+    throw new RuleEngineError(`when-clause references unknown section '${when.section}'`);
+  if (when.equals !== undefined && when.equals !== null && String(answers[when.section]) !== when.equals)
+    return false;
+  const frac = fracs[when.section];
+  if (when.frac_lte !== undefined && when.frac_lte !== null && (frac === null || frac > when.frac_lte))
+    return false;
+  if (when.frac_gte !== undefined && when.frac_gte !== null && (frac === null || frac < when.frac_gte))
+    return false;
+  return true;
+}
+
+function sectionsInWhen(when: any): Set<string> {
+  if (when.section !== undefined) return new Set([when.section]);
+  const clauses = when.any ?? when.all;
+  if (clauses)
+    return new Set(clauses.filter((c: any) => c.section !== undefined).map((c: any) => c.section));
+  return new Set();
+}
+
+function redistributionTargets(
+  selector: string | string[],
+  exclude: Set<string>,
+  weights: Record<string, number>,
+  fracs: Record<string, number | null>,
+  ruleId: string
+): string[] {
+  const pool =
+    typeof selector === "string"
+      ? Object.keys(weights).filter((k) => !exclude.has(k) && fracs[k] !== null && fracs[k] !== undefined)
+      : selector.filter((k) => !exclude.has(k) && fracs[k] !== null && fracs[k] !== undefined);
+  if (!pool.length)
+    throw new RuleEngineError(`rule '${ruleId}': no active target sections to redistribute to`);
+  return pool;
+}
+
+export function evaluateFormula(
+  formula: any,
+  answers: Record<string, SectionAnswer>,
+  signals: Record<string, boolean> = {}
+): ScoreResult {
+  checkStaticOrder(formula);
+  const [fracs, naSections] = normalizeAnswers(formula, answers);
+  const weights: Record<string, number> = {};
+  for (const s of formula.sections) weights[s.key] = s.weight;
+
+  const rulesById = new Map<string, any>(formula.rules.map((r: any) => [r.id, r]));
+  const trace: ScoreResult["trace"] = [];
+  const events: ScoreResult["events"] = [];
+  let overrideScore: number | null = null;
+  let rawScore: number | null = null;
+  let runningScore: number | null = null;
+
+  for (const token of formula.evaluation_order) {
+    if (token === WEIGHTED_SUM) {
+      const stranded = Object.entries(fracs)
+        .filter(([k, f]) => f === null && weights[k] > EPS)
+        .map(([k]) => k);
+      if (stranded.length)
+        throw new RuleEngineError(
+          `formula '${formula.formula_id}': NA sections still hold weight at weighted_sum time: ${JSON.stringify(stranded)}`
+        );
+      rawScore = Object.entries(fracs).reduce(
+        (acc, [k, f]) => (f !== null ? acc + weights[k] * f : acc),
+        0
+      );
+      runningScore = rawScore;
+      continue;
+    }
+
+    const rule = rulesById.get(token)!;
+    if (!rule.enabled) {
+      trace.push({ rule_id: rule.id, rule_type: rule.type, fired: false, note: "disabled" });
+      continue;
+    }
+    if (!whenMatches(rule.when, answers, fracs, signals)) {
+      trace.push({ rule_id: rule.id, rule_type: rule.type, fired: false, note: null });
+      continue;
+    }
+
+    let note: string | null = null;
+    if (rule.type === "score_override") {
+      overrideScore = rule.effect.set_score;
+      note = `final score overridden to ${overrideScore}`;
+    } else if (rule.type === "weight_transfer") {
+      const effect = rule.effect;
+      const source = effect.from;
+      const moved =
+        effect.amount === "all" ? weights[source] : weights[source] * (effect.fraction ?? 0);
+      weights[source] -= moved;
+      if (typeof effect.to === "string") {
+        weights[effect.to] += moved;
+        note = `moved ${moved} from '${source}' to '${effect.to}'`;
+      } else {
+        const shareSum = (Object.values(effect.to) as number[]).reduce((a, b) => a + b, 0);
+        if (Math.abs(shareSum - 1.0) > 1e-6)
+          throw new RuleEngineError(
+            `rule '${rule.id}': transfer target shares sum to ${shareSum}, expected 1.0`
+          );
+        for (const [target, share] of Object.entries(effect.to))
+          weights[target] += moved * (share as number);
+        note = `moved ${moved} from '${source}' split`;
+      }
+    } else if (rule.type === "weight_redistribution") {
+      const effect = rule.effect;
+      const poolWeight = weights[effect.from];
+      if (poolWeight <= EPS) {
+        note = `no-op: '${effect.from}' holds no weight`;
+      } else {
+        const targets = redistributionTargets(effect.to, new Set([effect.from]), weights, fracs, rule.id);
+        if (effect.method === "equal_additive") {
+          const per = poolWeight / targets.length;
+          for (const k of targets) weights[k] += per;
+        } else {
+          const base = targets.reduce((a, k) => a + weights[k], 0);
+          if (base <= EPS)
+            throw new RuleEngineError(`rule '${rule.id}': proportional redistribution but targets hold no weight`);
+          const snapshot = { ...weights };
+          for (const k of targets) weights[k] += poolWeight * snapshot[k] / base;
+        }
+        weights[effect.from] = 0.0;
+        note = `spread ${poolWeight} from '${effect.from}'`;
+      }
+    } else if (rule.type === "na_redistribution") {
+      const sources = [...sectionsInWhen(rule.when)]
+        .sort()
+        .filter((k) => (fracs[k] === null || fracs[k] === undefined) && (weights[k] ?? 0) > EPS);
+      if (!sources.length) {
+        note = "no-op: no NA sections with weight in when-clause";
+      } else {
+        const targets = redistributionTargets(rule.targets, new Set(sources), weights, fracs, rule.id);
+        const base = targets.reduce((a, k) => a + weights[k], 0);
+        if (base <= EPS)
+          throw new RuleEngineError(`rule '${rule.id}': proportional redistribution but targets hold no weight`);
+        const total = sources.reduce((a, k) => a + weights[k], 0);
+        const snapshot = { ...weights };
+        for (const k of targets) weights[k] += total * snapshot[k] / base;
+        for (const k of sources) weights[k] = 0.0;
+        note = `spread ${total} from NA sections`;
+      }
+    } else if (rule.type === "score_scale") {
+      if (overrideScore !== null) {
+        note = "skipped: score already overridden";
+      } else {
+        runningScore = (runningScore as number) * rule.effect.multiply;
+        note = `score × ${rule.effect.multiply}`;
+      }
+    } else if (rule.type === "flag") {
+      events.push({ rule_id: rule.id, event: rule.effect.emit_event, route: rule.effect.route ?? null });
+      note = `emitted '${rule.effect.emit_event}'`;
+    }
+    trace.push({ rule_id: rule.id, rule_type: rule.type, fired: true, note });
+  }
+
+  if (rawScore === null || runningScore === null)
+    throw new RuleEngineError("weighted_sum never ran");
+  let final = overrideScore !== null ? overrideScore : runningScore;
+  final = Math.min(Math.max(final, formula.scale.min), formula.scale.max);
+
+  return {
+    formula_id: formula.formula_id,
+    rubric_version: formula.rubric_version,
+    final_score: final,
+    raw_score: rawScore,
+    overridden: overrideScore !== null,
+    effective_weights: weights,
+    fracs,
+    contributions: Object.fromEntries(
+      Object.entries(fracs).map(([k, f]) => [k, f !== null ? weights[k] * f : 0.0])
+    ),
+    na_sections: naSections,
+    events,
+    trace,
+  };
+}
+
+// overall_score NUMERIC(5,1) projection — Python quantizes HALF-UP on the
+// decimal string (score_compute._quantize), NOT half-even.
+export function quantizeScore(score: number): number {
+  const s = Math.abs(score).toFixed(12);
+  const dot = s.indexOf(".");
+  const kept = s.slice(0, dot + 2);
+  const rest = s.slice(dot + 2);
+  let v = Math.round(parseFloat(kept) * 10);
+  if (rest >= "5".padEnd(rest.length, "0")) v += 1;
+  const out = v / 10;
+  return score < 0 ? -out : out;
+}

--- a/sandy-qa/src/lib/scoringPrompts.ts
+++ b/sandy-qa/src/lib/scoringPrompts.ts
@@ -1,0 +1,422 @@
+// Prompt builders — ports of backend/prompts/{annotator_prompt,
+// qa_scoring_prompt, judge_prompt}.py. Text preserved byte-for-byte where
+// Railway's prompts are byte-stable (rubric block, output schema, general
+// rules) so two-stage and single-stage judges score against identical
+// instructions on both stacks.
+//
+// Sections come from the CURRENT rubric_json (raw section objects — they
+// carry score_descriptions / na_applies_when / special_reasoning_
+// instructions that the SectionDef summary doesn't).
+
+const SCHEMA_VERSION = "gemini_annotate_v1";
+
+// Gemini response_schema for constrained decoding — hand-authored (the API's
+// OpenAPI subset rejects additionalProperties).
+export const ANNOTATOR_RESPONSE_SCHEMA = {
+  type: "object",
+  properties: {
+    schema_version: { type: "string" },
+    language_detected: { type: "string" },
+    turns: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          speaker: { type: "string", enum: ["agent", "caller", "system", "other"] },
+          text: { type: "string" },
+          emotion: { type: "string" },
+          paraphrase_intent: { type: "string" },
+          pace_marker: { type: "string" },
+          interruption: { type: "boolean" },
+          start_ms: { type: "integer" },
+          end_ms: { type: "integer" },
+        },
+        required: ["speaker", "text"],
+      },
+    },
+    holds: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          start_ms: { type: "integer" },
+          end_ms: { type: "integer" },
+          kind: { type: "string", enum: ["hold_music", "dead_air", "mute_suspected"] },
+          note: { type: "string" },
+        },
+        required: ["start_ms", "end_ms", "kind"],
+      },
+    },
+    call_observations: { type: "array", items: { type: "string" } },
+  },
+  required: ["schema_version", "turns"],
+};
+
+export const ANNOTATOR_SYSTEM =
+  "You are an audio-as-data interpreter for a QA pipeline at Landing, a " +
+  "flexible-living company. You listen to member support / sales calls and " +
+  "produce a structured ANNOTATED TRANSCRIPT. You never score, judge, or " +
+  "coach — a separate evaluator does that using ONLY your annotation. " +
+  "Anything you fail to capture from the audio is lost to the evaluator, " +
+  "so be faithful and complete.";
+
+const ANNOTATOR_INSTRUCTIONS = `=== YOUR TASK ===
+Listen to the attached call audio and produce ONE JSON object with this
+exact shape (schema_version "${SCHEMA_VERSION}"):
+
+{
+  "schema_version": "${SCHEMA_VERSION}",
+  "language_detected": "<primary spoken language, ISO 639-1, e.g. "en"/"es">",
+  "turns": [
+    {
+      "speaker": "agent" | "caller" | "system" | "other",
+      "text": "<what was actually said — from the AUDIO>",
+      "emotion": "<speaker's tone, e.g. neutral_friendly, frustrated, warm, flat, anxious>",
+      "paraphrase_intent": "<one short phrase: what this turn is doing, e.g. 'greeting + identity verification'>",
+      "pace_marker": "slow" | "normal" | "rushed",
+      "interruption": <true when this turn cuts the other speaker off>,
+      "start_ms": <int>, "end_ms": <int>
+    }, ...
+  ],
+  "holds": [
+    { "start_ms": <int>, "end_ms": <int>,
+       "kind": "hold_music" | "dead_air" | "mute_suspected",
+       "note": "<context, e.g. 'agent announced the hold before placing it'>" }
+  ],
+  "call_observations": [
+    "<call-level observations a per-turn field can't carry: background noise,
+     audio quality problems, overall tone arcs, long silences not worth a
+     hold entry, notable divergences from the reference transcript>"
+  ]
+}
+
+=== RULES ===
+- THE AUDIO IS THE SOURCE OF TRUTH. The reference transcript below is a
+  hint from an automatic transcriber; where it disagrees with what you
+  hear, trust your ears and note material divergences in
+  call_observations.
+- If the call is NOT in English: the reference transcript is unreliable.
+  Re-transcribe from the audio in the spoken language (do NOT translate
+  turns to English), and be extra thorough with emotion/pace annotations.
+- "turns.text" is verbatim speech. Do not summarize, censor, or clean it
+  up beyond removing filler stutters.
+- COLLAPSE filler and stutter runs: "uh uh uh...", "eh eh eh", repeated
+  false starts — transcribe AT MOST one or two instances, never the full
+  run. Prolonged stuttering or hesitation belongs in that turn's
+  pace_marker or in call_observations, not spelled out token by token.
+- "holds" are what you HEAR (music, dead air, suspected mute) — you are
+  an observer, not a system of record. Include an entry for any gap over
+  ~10 seconds. Do NOT record gaps shorter than 10 seconds — brief pauses
+  are normal conversation, not holds.
+- Timestamps are milliseconds from the start of the recording; best
+  effort, never omitted.
+- Mark "interruption": true only for genuine cut-offs, not backchannel
+  ("mm-hm", "right").
+- Output the JSON object ONLY — no markdown fences, no commentary.
+`;
+
+export function buildAnnotatorPrompt(
+  transcriptText: string,
+  momentsDisplay: any[] | null
+): string {
+  const parts = [ANNOTATOR_INSTRUCTIONS];
+  if (momentsDisplay && momentsDisplay.length) {
+    parts.push(
+      "=== DIALPAD SIGNAL MARKERS (hints, machine-detected) ===\n" +
+        JSON.stringify(momentsDisplay, null, 2)
+    );
+  }
+  if (transcriptText.trim()) {
+    parts.push(
+      "=== REFERENCE TRANSCRIPT (hint — the audio overrules it) ===\n" +
+        transcriptText.trim()
+    );
+  }
+  return parts.join("\n\n");
+}
+
+// ── scoring / judge shared blocks ───────────────────────────────────────────
+
+const LANDING_GENERAL_INSTRUCTIONS = `
+=== GENERAL LANDING RULES ===
+- Agent name in the greeting: an agent may introduce themselves with any
+  name they choose (some teams have multiple people with the same first
+  name, so reps may differentiate via a preferred or alternate name). Do
+  NOT penalize the agent for the specific name used in the greeting. Do
+  flag if the agent uses one name in the greeting and then switches to a
+  different name later in the same call — consistency within the call is
+  required. The agent's Dialpad-recorded name is internal and is NOT the
+  ground truth for what name they must use with the lead/member.
+- Source of truth: the audio is authoritative for scoring. If the call is
+  detected as non-English, score from the audio content and treat the
+  transcript as unreliable.`.replace(/\n$/, "");
+
+const JUDGE_GENERAL_INSTRUCTIONS = `
+=== GENERAL LANDING RULES ===
+- Agent name in the greeting: an agent may introduce themselves with any
+  name they choose (some teams have multiple people with the same first
+  name, so reps may differentiate via a preferred or alternate name). Do
+  NOT penalize the agent for the specific name used in the greeting. Do
+  flag if the agent uses one name in the greeting and then switches to a
+  different name later in the same call — consistency within the call is
+  required. The agent's Dialpad-recorded name is internal and is NOT the
+  ground truth for what name they must use with the lead/member.
+- Source of truth: the ANNOTATED CALL RECORD is the authoritative
+  account of the call. It was produced by an audio-native annotator
+  that listened to the full recording — including for non-English
+  calls, where the annotator re-transcribed from the audio. Score from
+  the record; there is no separate transcript to consult.`.replace(/\n$/, "");
+
+export interface PromptConfig {
+  company: string;
+  scoring_prompt: {
+    system_prompt_template: string;
+    confidence_levels_note: string;
+    sop_sections: (number | string)[];
+    long_call_focus_sections: string[];
+  };
+  sections: any[]; // raw rubric_json sections, sorted by section_number
+}
+
+function aiScoredSections(cfg: PromptConfig): any[] {
+  return cfg.sections.filter(
+    (s) => !["manual", "manual_yn"].includes(s.score_type) && !s.auto_value
+  );
+}
+
+function renderTemplate(template: string, company: string): string {
+  return template.replace(/\{company\}/g, company);
+}
+
+export function buildSystemPrompt(cfg: PromptConfig): string {
+  return `${renderTemplate(cfg.scoring_prompt.system_prompt_template, cfg.company)}\n\n${LANDING_GENERAL_INSTRUCTIONS}`;
+}
+
+export function buildJudgeSystemPrompt(cfg: PromptConfig): string {
+  return `${renderTemplate(cfg.scoring_prompt.system_prompt_template, cfg.company)}\n\n${JUDGE_GENERAL_INSTRUCTIONS}`;
+}
+
+export function buildScoringRubric(cfg: PromptConfig): string {
+  const lines: string[] = ["\n=== SCORING RUBRIC ===\n"];
+  for (const sec of cfg.sections) {
+    if (sec.score_type === "manual" || sec.score_type === "manual_yn") {
+      lines.push(
+        `SECTION ${sec.section_number} — ${sec.name} (SKIP — always manual, never scored by AI)\n`
+      );
+      continue;
+    }
+    let header: string;
+    if (sec.score_type === "yn") {
+      header = `SECTION ${sec.section_number} — ${sec.name} (yn_value: "Y", "N", or "NA")`;
+    } else {
+      header = `SECTION ${sec.section_number} — ${sec.name} (score: ${sec.score_range[0]}–${sec.score_range[1]})`;
+    }
+    if (sec.audio_dependent) header += " [AUDIO-DEPENDENT]";
+    lines.push(header);
+    if (sec.rubric_question) lines.push(sec.rubric_question);
+    if (sec.score_descriptions) {
+      for (const [key, desc] of Object.entries(sec.score_descriptions)) {
+        if (sec.score_type === "yn" && (key === "0" || key === "1")) {
+          lines.push(`${key === "1" ? "Y" : "N"} (${key}): ${desc}`);
+        } else {
+          lines.push(`${key}: ${desc}`);
+        }
+      }
+    }
+    if (sec.na_applicable && (sec.score_type === "yn" || sec.score_type === "numeric")) {
+      lines.push(
+        sec.na_applies_when
+          ? `NA policy: ${sec.na_applies_when}`
+          : "Mark NA if not applicable (e.g. internal call or no sensitive info discussed)."
+      );
+    }
+    lines.push("");
+  }
+  lines.push("=== CONFIDENCE LEVELS ===");
+  lines.push(cfg.scoring_prompt.confidence_levels_note);
+  lines.push("");
+  const capped = aiScoredSections(cfg).filter((s) => s.confidence_cap);
+  if (capped.length) {
+    const numbers = capped.map((s) => String(s.section_number)).join(" and ");
+    lines.push(
+      `For Sections ${numbers}: cap confidence at "${capped[0].confidence_cap}" ` +
+        "unless there is unambiguous audio evidence."
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildOutputSchema(cfg: PromptConfig): string {
+  const scored = aiScoredSections(cfg);
+  const lines: string[] = [
+    "\n=== REQUIRED OUTPUT FORMAT ===",
+    "Return exactly this JSON structure and nothing else:\n",
+    "{",
+    '  "sections": [',
+  ];
+  scored.forEach((sec, i) => {
+    const isLast = i === scored.length - 1;
+    let scoreVal: string, ynField: string, scoreTypeStr: string;
+    if (sec.score_type === "numeric") {
+      const [lo, hi] = sec.score_range;
+      scoreTypeStr = "numeric";
+      if (sec.na_applicable) {
+        scoreVal = `<${lo}-${hi} integer, or null if NA>`;
+        ynField = '"<null or NA>"';
+      } else {
+        scoreVal = `<${lo}-${hi} integer>`;
+        ynField = "null";
+      }
+    } else {
+      scoreVal = "null";
+      scoreTypeStr = "yn";
+      ynField = sec.na_applicable ? '"<Y or N or NA>"' : '"<Y or N>"';
+    }
+    let reasoning = "<one or two sentences>";
+    if (sec.special_reasoning_instructions)
+      reasoning = `<one or two sentences, ${sec.special_reasoning_instructions}>`;
+    lines.push("    {");
+    lines.push(`      "id": "${sec.id}",`);
+    lines.push(`      "name": "${sec.name}",`);
+    lines.push(`      "score": ${scoreVal},`);
+    lines.push(`      "score_type": "${scoreTypeStr}",`);
+    lines.push(`      "yn_value": ${ynField},`);
+    lines.push(`      "confidence": "<high or medium or low>",`);
+    lines.push(`      "reasoning": "${reasoning}",`);
+    lines.push(`      "audio_dependent": ${sec.audio_dependent ? "true" : "false"},`);
+    lines.push(`      "flags": []`);
+    lines.push(`    }${isLast ? "" : ","}`);
+  });
+  lines.push("  ],");
+  lines.push('  "call_summary": "<a concise summary of the call, in one or two sentences>",');
+  lines.push('  "key_strengths": "<2-3 specific strengths observed in this call, as a single string>",');
+  lines.push('  "opportunities": "<2-3 specific coaching opportunities from this call, as a single string>"');
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function sopSectionRefs(cfg: PromptConfig): string {
+  const byId = new Map(cfg.sections.map((s) => [s.id, s]));
+  const byNumber = new Map(cfg.sections.map((s) => [s.section_number, s]));
+  const refs = cfg.scoring_prompt.sop_sections
+    .map((sid) => (typeof sid === "number" ? byNumber.get(sid) : byId.get(sid)))
+    .filter(Boolean)
+    .map((s: any) => `Section ${s.section_number} (${s.name})`);
+  if (!refs.length) return "the SOP-relevant sections";
+  if (refs.length === 1) return refs[0];
+  return refs.slice(0, -1).join(", ") + " and " + refs[refs.length - 1];
+}
+
+function sopMissingNote(cfg: PromptConfig): string {
+  const refs = cfg.scoring_prompt.sop_sections.map(String).join(" and ");
+  return (
+    `\n[No SOP context loaded. Score Sections ${refs} ` +
+    "conservatively and add 'sop_context_missing' to their flags.]\n"
+  );
+}
+
+const ANNOTATION_CONTEXT_BLOCK = `
+=== ANNOTATED CALL RECORD (authoritative) ===
+You cannot hear the call. The record below is the authoritative account
+of it, produced by an audio-native annotator. How to read it:
+- Per-turn emotion / pace / [interrupts] tags are audio-derived
+  observations — use them as your evidence for tone, empathy, and
+  pacing judgments.
+- HOLD lines are labeled "observational — not system-verified": the
+  annotator HEARD them (music, dead air). Treat them as observations;
+  only the CALL CONTEXT block above (when present) contains verified
+  system data.
+- CALL-LEVEL OBSERVATIONS carry context per-turn fields can't (audio
+  quality, tone arcs, transcript divergences).
+- An "ANNOTATION TRUNCATED" observation means the record is partial:
+  score what the record shows, mark LOW confidence on any section the
+  missing tail could change, and say so in that section's reasoning.
+
+{{ANNOTATION_TEXT}}
+`;
+
+interface PromptExtras {
+  sopTitle?: string;
+  sopContent?: string;
+  agentName?: string;
+  extraNotes?: string;
+  callContextText?: string;
+}
+
+function sopBlock(cfg: PromptConfig, x: PromptExtras): string {
+  if (x.sopContent) {
+    return (
+      `\n=== SOP CONTEXT (${x.sopTitle ?? ""}) ===\n` +
+      `Use the following Standard Operating Procedure to evaluate ${sopSectionRefs(cfg)}.\n` +
+      "Score these sections against this policy, not general knowledge.\n\n" +
+      `${x.sopContent}\n`
+    );
+  }
+  return sopMissingNote(cfg);
+}
+
+// Single-stage user prompt (audio attached) — build_prompt port.
+export function buildScoringPrompt(
+  cfg: PromptConfig,
+  transcriptText: string,
+  x: PromptExtras = {}
+): string {
+  const parts = [buildScoringRubric(cfg), sopBlock(cfg, x)];
+  if (x.callContextText) parts.push(x.callContextText);
+  if (transcriptText)
+    parts.push(
+      "\n=== DIALPAD TRANSCRIPT ===\n" +
+        "Use this alongside the audio to improve accuracy. Speaker labels and content are from Dialpad.\n\n" +
+        `${transcriptText}\n`
+    );
+  if (x.agentName) parts.push(`\nAgent name: ${x.agentName}`);
+  if (x.extraNotes) parts.push(`Additional context: ${x.extraNotes}`);
+  parts.push(buildOutputSchema(cfg));
+  parts.push(
+    "\n[Audio attached — score the call based on what you hear; the " +
+      "transcript is secondary to the audio source. If the call is in " +
+      "SPANISH, ignore the transcript and base your scores solely on the " +
+      "audio. DO NOT mention a lack of SOP in your score reasoning if no " +
+      "SOP context was provided.]"
+  );
+  return parts.join("\n");
+}
+
+// Judge user prompt TEMPLATE — the workflow substitutes {{ANNOTATION_TEXT}}
+// with the rendered annotated record at judge time.
+export function buildJudgePromptTemplate(cfg: PromptConfig, x: PromptExtras = {}): string {
+  const parts = [buildScoringRubric(cfg), sopBlock(cfg, x)];
+  if (x.callContextText) parts.push(x.callContextText);
+  parts.push(ANNOTATION_CONTEXT_BLOCK);
+  if (x.agentName) parts.push(`\nAgent name: ${x.agentName}`);
+  if (x.extraNotes) parts.push(`Additional context: ${x.extraNotes}`);
+  parts.push(buildOutputSchema(cfg));
+  parts.push(
+    "\n[No audio is attached. Score exclusively from the ANNOTATED " +
+      "CALL RECORD and the context blocks above. DO NOT mention a lack " +
+      "of SOP in your score reasoning if no SOP context was provided.]"
+  );
+  return parts.join("\n");
+}
+
+// Long-call note — scoring_service.py extra_notes logic.
+export function buildLongCallNote(cfg: PromptConfig, durationMs: number): string {
+  const FLAG_MS = 25 * 60 * 1000;
+  if (!(durationMs > FLAG_MS)) return "";
+  const byId = new Map(cfg.sections.map((s) => [s.id, s]));
+  const focus = cfg.scoring_prompt.long_call_focus_sections
+    .map((sid) => byId.get(sid))
+    .filter(Boolean) as any[];
+  if (focus.length) {
+    const focusText = focus.map((s) => `${s.name} (Section ${s.section_number})`).join(", ");
+    return (
+      `NOTE: This call is over 25 minutes. Pay special attention to ${focusText}. ` +
+      "Flag any unnecessary hold time, delays, or pacing issues, including timestamps. "
+    );
+  }
+  return (
+    "NOTE: This call is over 25 minutes. Pay special attention to " +
+    "audio-dependent sections. Flag any unnecessary hold time, " +
+    "delays, or pacing issues, including timestamps. "
+  );
+}

--- a/sandy-qa/src/lib/teamConfig.ts
+++ b/sandy-qa/src/lib/teamConfig.ts
@@ -25,6 +25,15 @@ export interface StatsConfig {
 
 export interface TeamConfig {
   team_id: string;
+  company: string;
+  // PromptConfig for the scoring prompt builders — raw rubric sections
+  // (score_descriptions / na_applies_when / special_reasoning_instructions
+  // included) + the rubric's scoring_prompt block.
+  prompt_config: {
+    company: string;
+    scoring_prompt: any;
+    sections: any[];
+  };
   rubric_version: string;
   sections_by_number: SectionDef[];
   numeric_history_ids: string[];
@@ -48,9 +57,9 @@ function isNumeric(s: any): boolean {
 
 export async function loadTeamConfig(db: D1Database, teamId: string): Promise<TeamConfig> {
   const team = await db
-    .prepare("SELECT stats_config, excluded_test_agents FROM teams WHERE id = ?")
+    .prepare("SELECT stats_config, excluded_test_agents, company FROM teams WHERE id = ?")
     .bind(teamId)
-    .first<{ stats_config: string | null; excluded_test_agents: string }>();
+    .first<{ stats_config: string | null; excluded_test_agents: string; company: string | null }>();
   if (!team) throw new Error(`unknown team ${teamId}`);
 
   // Alias-map iteration order = insertion order (id ASC) — matches the
@@ -102,8 +111,17 @@ export async function loadTeamConfig(db: D1Database, teamId: string): Promise<Te
     ...(team.stats_config ? JSON.parse(team.stats_config) : {}),
   };
 
+  const rawSections = [...(current.sections as any[])].sort(
+    (a, b) => a.section_number - b.section_number
+  );
   return {
     team_id: teamId,
+    company: team.company ?? "Landing Living LLC",
+    prompt_config: {
+      company: team.company ?? "Landing Living LLC",
+      scoring_prompt: current.scoring_prompt ?? {},
+      sections: rawSections,
+    },
     rubric_version: current.rubric_version,
     sections_by_number: sections,
     numeric_history_ids: numeric.map((s) => s.history_id),

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -1,0 +1,515 @@
+// Scoring trigger + persist — port of the Railway path traced in
+// backend/services/scoring_service.py's docstring:
+//   POST /api/{team}/score        → prefetch transcript+details (app-side,
+//     avoids Dialpad bursts), CC grounding (mode=on — DispositionDesign §5),
+//     build all prompts, trigger the qa-scoring-pipeline workflow, persist a
+//     job row (idempotent on (team, call_id, agent)).
+//   POST /api/v1/callbacks/qa-scoring-pipeline → validate the scorecard
+//     against config, write the draft evaluation + sections, stamp active
+//     formula/rubric versions, evaluate the formula, quantize, run the
+//     §3.14 human-review gate → auto-finalize (+ qa_events eval_approved
+//     toast) or park flagged_human_review.
+//   GET /api/{team}/score/{job_id} → job status (D1-backed, not in-memory —
+//     an improvement over Railway's restart-forgetting _jobs store).
+
+import { loadTeamConfig, type TeamConfig } from "../lib/teamConfig.js";
+import { fetchCallContext, buildCallContextBlock } from "../lib/ccContext.js";
+import {
+  ANNOTATOR_RESPONSE_SCHEMA,
+  ANNOTATOR_SYSTEM,
+  buildAnnotatorPrompt,
+  buildJudgePromptTemplate,
+  buildJudgeSystemPrompt,
+  buildLongCallNote,
+  buildScoringPrompt,
+  buildSystemPrompt,
+} from "../lib/scoringPrompts.js";
+import { evaluateFormula, quantizeScore } from "../lib/ruleEngine.js";
+
+const WORKFLOW_NAME = "qa-scoring-pipeline";
+const DP = "https://dialpad.com/api/v2";
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+// ── Dialpad prefetch (ports of get_transcript / get_call_details) ───────────
+
+function mmssFrom(callStart: number | null, tsRaw: string): string {
+  if (!tsRaw || callStart === null) return "";
+  const t = Date.parse(tsRaw);
+  if (Number.isNaN(t)) return "";
+  const elapsed = Math.trunc((t - callStart) / 1000);
+  return `${Math.trunc(elapsed / 60)}:${String(elapsed % 60).padStart(2, "0")}`;
+}
+
+async function getTranscript(key: string, callId: string) {
+  const empty = { transcript_text: "", transcript_display: [] as any[], moments_display: [] as any[] };
+  try {
+    const r = await fetch(`${DP}/transcripts/${encodeURIComponent(callId)}`, {
+      headers: { authorization: `Bearer ${key}` },
+    });
+    if (!r.ok) return empty;
+    const data = (await r.json()) as any;
+    const transcriptLines: string[] = [];
+    const transcriptDisplay: any[] = [];
+    const momentsDisplay: any[] = [];
+    let callStart: number | null = null;
+    for (const line of data.lines ?? []) {
+      const tsRaw = line.time ?? "";
+      if (line.type === "transcript") {
+        const name = line.name ?? "Unknown";
+        const content = (line.content ?? "").trim();
+        if (!content) continue;
+        if (tsRaw && callStart === null) {
+          const t = Date.parse(tsRaw);
+          if (!Number.isNaN(t)) callStart = t;
+        }
+        transcriptLines.push(`${name}: ${content}`);
+        transcriptDisplay.push({
+          timestamp: mmssFrom(callStart, tsRaw),
+          speaker: name,
+          text: content,
+        });
+      } else if (["moment", "real_time_moment", "custom_moment"].includes(line.type)) {
+        const momentType = line.moment_type || (line.content ?? "").trim();
+        if (!momentType) continue;
+        momentsDisplay.push({
+          timestamp: mmssFrom(callStart, tsRaw),
+          time: tsRaw,
+          type: momentType,
+          agent: line.name ?? "",
+        });
+      }
+    }
+    return {
+      transcript_text: transcriptLines.join("\n"),
+      transcript_display: transcriptDisplay,
+      moments_display: momentsDisplay,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+async function getCallDetails(key: string, callId: string) {
+  try {
+    const r = await fetch(`${DP}/call/${encodeURIComponent(callId)}`, {
+      headers: { authorization: `Bearer ${key}` },
+    });
+    if (!r.ok) return {} as any;
+    const raw = (await r.json()) as any;
+    const contact = raw.contact ?? {};
+    return {
+      caller_name: contact.name ?? "",
+      caller_phone: contact.phone ?? "",
+      caller_email: contact.email ?? "",
+      date_connected: raw.date_connected ?? "",
+      date_ended: raw.date_ended ?? "",
+      total_duration: raw.total_duration ?? raw.duration ?? 0,
+      entry_point_call_id: String(raw.entry_point_call_id ?? ""),
+      master_call_id: String(raw.master_call_id ?? ""),
+      was_recorded: !!raw.recording_details,
+      raw,
+    } as any;
+  } catch {
+    return {} as any;
+  }
+}
+
+const epochToIso = (v: any): string | null => {
+  const n = Number(v);
+  return v && Number.isFinite(n) ? new Date(n).toISOString() : null;
+};
+
+// ── trigger ────────────────────────────────────────────────────────────────
+
+export async function scoreTrigger(
+  request: Request,
+  db: D1Database,
+  teamId: string,
+  env: { DIALPAD_API_KEY?: string; WORKFLOW_ID?: string }
+): Promise<Response> {
+  if (!env.DIALPAD_API_KEY)
+    return json({ detail: "DIALPAD_API_KEY app secret not configured" }, 503);
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return json({ detail: "multipart/form-data body required" }, 422);
+  }
+  const callId = (form.get("call_id") ?? "").toString().trim();
+  const agentEmail = (form.get("agent_email") ?? "").toString().trim().toLowerCase();
+  const managerEmail = (form.get("manager_email") ?? "").toString().trim().toLowerCase();
+  if (!callId || !agentEmail || !managerEmail)
+    return json({ detail: "call_id, agent_email, manager_email required" }, 422);
+
+  // identity: roster resolve (agent must be on THIS team's roster)
+  const agentRow = await db
+    .prepare(
+      "SELECT id, name, canonical_name, email FROM qa_agents WHERE team_id = ? AND active = 1 AND LOWER(email) = ? LIMIT 1"
+    )
+    .bind(teamId, agentEmail)
+    .first<any>();
+  if (!agentRow)
+    return json({ detail: `agent ${agentEmail} not on the ${teamId} roster` }, 403);
+  const agentName = (agentRow.canonical_name || agentRow.name).trim();
+
+  // idempotency: one active job per (team, call, agent)
+  const jobId = `score-${teamId}-${callId}-${agentName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  const existing = await db
+    .prepare("SELECT run_id, status FROM workflow_runs WHERE run_id = ?")
+    .bind(jobId)
+    .first<any>();
+  if (existing && ["pending", "running"].includes(existing.status))
+    return json({ job_id: jobId, status: existing.status, deduped: true });
+  const already = await db
+    .prepare(
+      "SELECT id FROM qa_evaluations WHERE team_id = ? AND dialpad_call_id = ? LIMIT 1"
+    )
+    .bind(teamId, callId)
+    .first<any>();
+  if (already)
+    return json({ detail: `call ${callId} already has evaluation ${already.id}` }, 409);
+
+  const config = await loadTeamConfig(db, teamId);
+  const [transcript, details] = await Promise.all([
+    getTranscript(env.DIALPAD_API_KEY, callId),
+    getCallDetails(env.DIALPAD_API_KEY, callId),
+  ]);
+
+  // CC grounding — mode 'on' for the Sandy pipeline (DispositionDesign §5)
+  const ccCtx = await fetchCallContext(db, teamId, {
+    entry_point: details.entry_point_call_id ?? "",
+    call_id: callId,
+    master: details.master_call_id ?? "",
+  });
+  const callContextText = buildCallContextBlock(ccCtx);
+
+  const durationMs = Number(details.total_duration ?? 0);
+  const extraNotes = buildLongCallNote(config.prompt_config, durationMs);
+  const promptExtras = {
+    sopTitle: "",
+    sopContent: "", // Pulpo SOP retrieval lands when PULPO_MCP secrets exist
+    agentName: agentName,
+    extraNotes,
+    callContextText,
+  };
+
+  const payload = {
+    call_id: callId,
+    team_id: teamId,
+    pipeline: "two_stage",
+    annotator: {
+      model: "gemini-2.5-flash",
+      system: ANNOTATOR_SYSTEM,
+      prompt: buildAnnotatorPrompt(transcript.transcript_text, transcript.moments_display),
+      response_schema: ANNOTATOR_RESPONSE_SCHEMA,
+      thinking_budget: 4096,
+      max_output_tokens: 65536,
+    },
+    judge: {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6", // pinned; SCORING_ANTHROPIC_MODEL parity to confirm
+      system: buildJudgeSystemPrompt(config.prompt_config),
+      prompt_template: buildJudgePromptTemplate(config.prompt_config, promptExtras),
+      max_tokens: 16384,
+    },
+    single_stage: {
+      model: "gemini-2.5-flash",
+      system: buildSystemPrompt(config.prompt_config),
+      prompt: buildScoringPrompt(config.prompt_config, transcript.transcript_text, promptExtras),
+      temperature: 0.2,
+      max_output_tokens: 65536,
+    },
+    // context the callback needs to persist the evaluation
+    persist: {
+      agent_id: agentRow.id,
+      agent_name: agentName,
+      agent_email: agentEmail,
+      manager_email: managerEmail,
+      caller_name: details.caller_name ?? "",
+      caller_phone: details.caller_phone ?? "",
+      call_connected_at: epochToIso(details.date_connected),
+      call_ended_at: epochToIso(details.date_ended),
+      call_duration_ms: durationMs || null,
+      dialpad_entry_point_call_id: details.entry_point_call_id || null,
+      dialpad_master_call_id: details.master_call_id || null,
+      cc_stamps: ccCtx
+        ? {
+            disposition_category: ccCtx.disposition_category,
+            disposition: ccCtx.disposition,
+            ai_csat: ccCtx.ai_csat,
+            cc_call_id: ccCtx.cc_call_id,
+          }
+        : null,
+      transcript_display: transcript.transcript_display,
+      moments_display: transcript.moments_display,
+      flagged_long_call: durationMs > 25 * 60 * 1000,
+    },
+  };
+
+  // trigger via the Sandy platform (template src/workflow.ts wiring)
+  const { listTriggerableWorkflows, triggerWorkflowWithCallback } = await import(
+    "../workflow.js"
+  );
+  const known = await listTriggerableWorkflows();
+  const wfId =
+    known.find((w: any) => w.name === WORKFLOW_NAME)?.id ??
+    "25dec973-c4ab-4122-b2ce-9d3a03c802d8";
+  const run = await triggerWorkflowWithCallback(wfId, WORKFLOW_NAME, request, payload);
+  // Two rows: the platform run id (the generic callback handler updates it)
+  // and the job id (idempotency + the status poll the console uses).
+  const stamp = JSON.stringify({ sandy_run_id: run?.id ?? null, call_id: callId, job_id: jobId });
+  for (const key of [run?.id, jobId]) {
+    if (!key) continue;
+    await db
+      .prepare(
+        "INSERT INTO workflow_runs (run_id, workflow_name, status, result, created_at) VALUES (?, ?, 'running', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now')) " +
+          "ON CONFLICT(run_id) DO UPDATE SET status='running', result=excluded.result"
+      )
+      .bind(key, WORKFLOW_NAME, stamp)
+      .run();
+  }
+  return json({ job_id: jobId, status: "pending", sandy_run_id: run?.id ?? null });
+}
+
+export async function scoreStatus(
+  db: D1Database,
+  jobId: string
+): Promise<Response> {
+  const row = await db
+    .prepare("SELECT run_id, status, result, created_at FROM workflow_runs WHERE run_id = ?")
+    .bind(jobId)
+    .first<any>();
+  if (!row) return json({ detail: `no job ${jobId}` }, 404);
+  let result: any = null;
+  try {
+    result = row.result ? JSON.parse(row.result) : null;
+  } catch {}
+  return json({ job_id: row.run_id, status: row.status, result, created_at: row.created_at });
+}
+
+// ── callback persist ───────────────────────────────────────────────────────
+
+function sectionRowsFromScorecard(config: TeamConfig, scorecard: any) {
+  // AI-scored sections from the model output; manual/auto sections filled
+  // with their designed defaults (manual_yn/manual → NA-state; auto_value →
+  // its hardcoded Y). Shapes mirror eval_store's Stage-1 write.
+  const bySecId = new Map<string, any>(
+    (scorecard.sections ?? []).map((s: any) => [s.id, s])
+  );
+  const rows: any[] = [];
+  for (const sec of config.prompt_config.sections) {
+    const dbScoreType =
+      sec.score_type === "numeric"
+        ? "numeric"
+        : sec.score_type === "yn"
+          ? "binary"
+          : sec.score_type === "manual"
+            ? "manual_numeric"
+            : sec.score_type === "manual_yn"
+              ? "manual_binary"
+              : "binary";
+    if (sec.auto_value) {
+      rows.push({
+        section_id: sec.id, section_number: sec.section_number,
+        score_type: "auto_value", numeric_score: null,
+        binary_value: sec.auto_value.toUpperCase().startsWith("Y") ? "Y" : "N",
+        score_source: "auto_value", ai_provider: null, model: null,
+        confidence: null, reasoning: null,
+      });
+      continue;
+    }
+    if (sec.score_type === "manual" || sec.score_type === "manual_yn") {
+      rows.push({
+        section_id: sec.id, section_number: sec.section_number,
+        score_type: dbScoreType,
+        numeric_score: null, binary_value: "NA",
+        score_source: "manual_default", ai_provider: null, model: null,
+        confidence: null, reasoning: null,
+      });
+      continue;
+    }
+    const out = bySecId.get(sec.id);
+    if (!out) throw new Error(`scorecard missing section '${sec.id}'`);
+    const ynValue = out.yn_value && out.yn_value !== "null" ? out.yn_value : null;
+    const numeric =
+      out.score !== null && out.score !== undefined && out.score !== "null"
+        ? Math.trunc(Number(out.score))
+        : null;
+    if (numeric === null && ynValue === null)
+      throw new Error(`section '${sec.id}': neither score nor yn_value`);
+    rows.push({
+      section_id: sec.id, section_number: sec.section_number,
+      score_type: dbScoreType,
+      numeric_score: dbScoreType === "numeric" && ynValue === "NA" ? null : numeric,
+      binary_value: dbScoreType === "numeric" && ynValue !== "NA" ? null : ynValue,
+      score_source: "ai",
+      // D1/PG CHECK admits gemini|landgpt only; true judge provenance rides
+      // models_used on the evaluation row (matches Railway's write).
+      ai_provider: "gemini",
+      model: null,
+      confidence: out.confidence ?? null,
+      reasoning: out.reasoning ?? null,
+    });
+  }
+  return rows;
+}
+
+function answersFromSectionRows(rows: any[]): Record<string, number | string> {
+  const answers: Record<string, number | string> = {};
+  for (const r of rows) {
+    if (r.binary_value !== null) answers[r.section_id] = r.binary_value;
+    else if (r.numeric_score !== null) answers[r.section_id] = r.numeric_score;
+  }
+  return answers;
+}
+
+export async function scoringCallback(
+  body: any,
+  db: D1Database
+): Promise<{ ok: boolean; note: string }> {
+  const jobStatus = body.status === "complete" ? "complete" : "error";
+  const p = body; // workflow result payload
+  const teamId = p.team_id;
+  const persist = p.persist ?? null;
+
+  if (jobStatus === "error" || !p.scorecard_raw || !persist) {
+    return { ok: false, note: p.error ?? "no scorecard in callback" };
+  }
+  const config = await loadTeamConfig(db, teamId);
+  const scorecard = p.scorecard_raw;
+
+  const sectionRows = sectionRowsFromScorecard(config, scorecard);
+  const answers = answersFromSectionRows(sectionRows);
+
+  // active version stamps (score_compute.get_active_versions port)
+  const fvRow = await db
+    .prepare(
+      "SELECT formula_version, formula_json FROM qa_formula_versions WHERE team_id = ? AND effective_until IS NULL ORDER BY effective_from DESC LIMIT 1"
+    )
+    .bind(teamId)
+    .first<any>();
+  if (!fvRow) return { ok: false, note: `no active formula for ${teamId}` };
+  const formula = JSON.parse(fvRow.formula_json);
+
+  const result = evaluateFormula(formula, answers);
+  const overallScore = quantizeScore(result.final_score);
+
+  // §3.14 human-review gate
+  let flagged = false;
+  for (const trig of formula.human_review_triggers ?? []) {
+    const a = answers[trig.section_id];
+    if (typeof a === "number" && a <= trig.max_score_to_trigger) {
+      flagged = true;
+      break;
+    }
+  }
+
+  const now = new Date().toISOString();
+  const modelsUsed = {
+    audio: p.annotator_model ? { provider: "gemini", model: p.annotator_model } : undefined,
+    text: { provider: p.scorer_provider, model: p.scorer_model },
+    ...(p.pipeline_fallback_reason ? { fallback: p.pipeline_fallback_reason } : {}),
+  };
+  const meta = {
+    moments: persist.moments_display ?? [],
+    transcript_display: persist.transcript_display ?? [],
+    sandy_pipeline: {
+      run_id: body.run_id,
+      timings_ms: p.timings_ms,
+      annotate_diag: p.annotate_diag,
+    },
+  };
+
+  const evalInsert = await db
+    .prepare(
+      `INSERT INTO qa_evaluations (
+        team_id, agent_id, agent_name_raw, agent_email, evaluator_email,
+        state, source, call_connected_at, call_ended_at, call_duration_ms,
+        language, dialpad_call_id, dialpad_entry_point_call_id,
+        dialpad_master_call_id, dialpad_link, caller_name, caller_phone,
+        call_summary, annotated_transcript, key_strengths, opportunities,
+        overall_score, formula_version, rubric_version, models_used,
+        ai_provider_primary, sampling_status, scoring_status,
+        created_at, approved_at, finalized_at,
+        dialpad_disposition_category, dialpad_disposition, ai_csat,
+        command_center_call_id, dialpad_call_metadata
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+    )
+    .bind(
+      teamId, persist.agent_id, persist.agent_name, persist.agent_email,
+      flagged ? null : persist.manager_email,
+      flagged ? "draft" : "finalized", "ai",
+      persist.call_connected_at, persist.call_ended_at, persist.call_duration_ms,
+      p.annotation?.language_detected ?? null,
+      p.call_id, persist.dialpad_entry_point_call_id, persist.dialpad_master_call_id,
+      `https://dialpad.com/callhistory/callreview/${persist.dialpad_entry_point_call_id || p.call_id}`,
+      persist.caller_name || null, persist.caller_phone || null,
+      scorecard.call_summary ?? null,
+      p.annotation ? JSON.stringify(p.annotation) : null,
+      scorecard.key_strengths ?? null, scorecard.opportunities ?? null,
+      flagged ? null : overallScore,
+      fvRow.formula_version, config.rubric_version,
+      JSON.stringify(modelsUsed), "gemini",
+      "not_sampled",
+      flagged ? "flagged_human_review" : "complete",
+      now, flagged ? null : now, flagged ? null : now,
+      persist.cc_stamps?.disposition_category ?? null,
+      persist.cc_stamps?.disposition ?? null,
+      persist.cc_stamps?.ai_csat ?? null,
+      persist.cc_stamps?.cc_call_id ?? null,
+      JSON.stringify(meta)
+    )
+    .run();
+  const evalId = evalInsert.meta.last_row_id;
+
+  for (const r of sectionRows) {
+    await db
+      .prepare(
+        `INSERT INTO qa_evaluation_sections (
+          evaluation_id, section_id, section_number, score_type,
+          numeric_score, binary_value, score_source, ai_provider, model,
+          confidence, reasoning
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?)`
+      )
+      .bind(
+        evalId, r.section_id, r.section_number, r.score_type,
+        r.numeric_score, r.binary_value, r.score_source, r.ai_provider,
+        r.model, r.confidence, r.reasoning
+      )
+      .run();
+  }
+
+  if (!flagged) {
+    await db
+      .prepare("INSERT INTO qa_events (team_id, type, payload) VALUES (?, 'eval_approved', ?)")
+      .bind(
+        teamId,
+        JSON.stringify({
+          call_id: p.call_id,
+          eval_id: persist.dialpad_entry_point_call_id || p.call_id,
+          history_row: null,
+          agent: persist.agent_name,
+          evaluator_email: persist.manager_email,
+          overall_score: overallScore,
+          summary: (scorecard.call_summary ?? "").slice(0, 280),
+          strengths: (scorecard.key_strengths ?? "").slice(0, 280),
+          opportunities: (scorecard.opportunities ?? "").slice(0, 280),
+          dialpad_link: `https://dialpad.com/callhistory/callreview/${persist.dialpad_entry_point_call_id || p.call_id}`,
+          timestamp: now,
+        })
+      )
+      .run();
+  }
+
+  return {
+    ok: true,
+    note: flagged
+      ? `evaluation ${evalId} parked for human review`
+      : `evaluation ${evalId} finalized at ${overallScore}`,
+  };
+}

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -201,6 +201,18 @@ export async function handleTeamRoutes(
           headers: { "Content-Type": "text/html; charset=utf-8" },
         });
 
+  // ── scoring trigger + status (scoring.ts) ────────────────────────────────
+  m = path.match(/^\/api\/([^/]+)\/score$/);
+  if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const { scoreTrigger } = await import("./scoring.js");
+    return scoreTrigger(request, db, m[1], { DIALPAD_API_KEY: dialpadKey });
+  }
+  m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)$/);
+  if (m && KNOWN_TEAMS.has(m[1]) && request.method === "GET") {
+    const { scoreStatus } = await import("./scoring.js");
+    return scoreStatus(db, decodeURIComponent(m[2]));
+  }
+
   // ── drill-down + record APIs ─────────────────────────────────────────────
   m = path.match(/^\/api\/([^/]+)\/datapoints$/);
   if (m && KNOWN_TEAMS.has(m[1])) return datapointsList(db, m[1], url);

--- a/sandy-qa/workflows/qa-scoring-pipeline.js
+++ b/sandy-qa/workflows/qa-scoring-pipeline.js
@@ -66,6 +66,45 @@ async function sendCallback(callbackUrl, payload, sandySecrets) {
   if (!res.ok) throw new Error(`Callback failed: HTTP ${res.status}`);
 }
 
+// AnnotatedTranscript → readable text — port of annotation_render.py.
+// Holds interleaved by start time (holds tie-break FIRST), always labeled
+// "observational — not system-verified"; call observations last.
+function mmssMs(ms) {
+  if (ms === null || ms === undefined) return "--:--";
+  const total = Math.trunc(Math.max(0, ms) / 1000);
+  return `${String(Math.trunc(total / 60)).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
+}
+function renderAnnotatedTranscript(a) {
+  const events = [];
+  for (const turn of a.turns ?? []) {
+    const traits = [turn.emotion, turn.pace_marker].filter(Boolean).join(", ");
+    const marks = turn.interruption ? " [interrupts]" : "";
+    const intent = turn.paraphrase_intent ? ` (${turn.paraphrase_intent})` : "";
+    let head = `[${mmssMs(turn.start_ms)} ${turn.speaker}`;
+    if (traits) head += ` | ${traits}`;
+    events.push([turn.start_ms ?? 0, 1, `${head}]${marks}${intent} "${turn.text}"`]);
+  }
+  for (const hold of a.holds ?? []) {
+    const seconds = Math.trunc(Math.max(0, hold.end_ms - hold.start_ms) / 1000);
+    const note = hold.note ? ` — ${hold.note}` : "";
+    events.push([
+      hold.start_ms, 0,
+      `[${mmssMs(hold.start_ms)}→${mmssMs(hold.end_ms)} HOLD ~${seconds}s (${hold.kind}, observational — not system-verified)]${note}`,
+    ]);
+  }
+  events.sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+  const lines = [
+    `Language detected: ${a.language_detected || "unknown"} (annotation schema ${a.schema_version})`,
+    "",
+    ...events.map((e) => e[2]),
+  ];
+  if ((a.call_observations ?? []).length) {
+    lines.push("", "CALL-LEVEL OBSERVATIONS:");
+    for (const obs of a.call_observations) lines.push(`- ${obs}`);
+  }
+  return lines.join("\n");
+}
+
 function stripFences(text) {
   return String(text)
     .replace(/^```(?:json)?\s*/i, "")
@@ -147,6 +186,8 @@ export class TenantWorkflow extends WorkflowEntrypoint {
       scorecard_raw: null,
       timings_ms: {},
       error: null,
+      // echoed through for the app's persist step
+      persist: p.persist ?? null,
     };
 
     let audioLeg = null;
@@ -260,7 +301,7 @@ export class TenantWorkflow extends WorkflowEntrypoint {
           const judged = await step.do("judge-leg", RETRY, async () => {
             const t = Date.now();
             const prompt = p.judge.prompt_template.replace(
-              "{{ANNOTATION_JSON}}", JSON.stringify(result.annotation));
+              "{{ANNOTATION_TEXT}}", renderAnnotatedTranscript(result.annotation));
             let text;
             if (p.judge.provider === "anthropic") {
               if (!aigKey) throw new Error("AI_GATEWAY_TOKEN missing");


### PR DESCRIPTION
## What this is

The scoring engine's second half: everything between "Score Call" and a finalized evaluation now exists on Sandy.

**Trigger** (`POST /api/{team}/score`): roster identity resolution, job idempotency, duplicate-eval 409, Dialpad transcript + call-details prefetch (ports of `get_transcript`/`get_call_details`), **CC disposition grounding at mode=on** (the injection that matters — triple-key match, verified-system-data block, hold-truth branching, Spanish audio-SOT wording), full prompt assembly (annotator + judge template + single-stage Plan B), workflow trigger with callback.

**Workflow v0.2** (published): `annotation_render.py` ported in ({{ANNOTATION_TEXT}} substitution — the judge reads the rendered record, not raw JSON), persist context echoed through.

**Persist** (callback): scorecard → section rows with manual/auto defaults, active formula/rubric version stamps, `evaluateFormula` + NUMERIC(5,1) half-up quantize, **§3.14 human-review gate** → auto-finalize (fires the `eval_approved` toast on the floor TV via qa_events) or parks as `flagged_human_review`. `models_used` records true judge provenance; `sections.ai_provider` stays `'gemini'` per the schema CHECK, matching Railway's write.

**Freshness**: `shadow_sync` now syncs `cc_*` incrementally (cc_calls upsert by `last_updated_at` watermark — `ON CONFLICT DO UPDATE`, never REPLACE which would cascade-delete hold intervals; hold_intervals/webhook_events append by id). Disposition grounding reads data at most ~30 min stale, aligned with Railway's own stats-pull cadence.

## Foundation commit (same branch)

`ruleEngine.ts` (formula scorer + trace), `ccContext.ts` (grounding), `scoringPrompts.ts` (annotator/judge/single-stage builders, byte-faithful blocks).

## Open items

- Judge model pinned `claude-sonnet-4-6` — confirm against Railway's `SCORING_ANTHROPIC_MODEL`.
- SOP retrieval (Pulpo) off until MCP secrets exist on Sandy → prompts take the designed `sop_context_missing` conservative path.
- First real end-to-end scored call: needs a scoring-console UI or a curl with SSO — suggest wiring the lookup page's Score button next (it already POSTs this exact contract).
- Scorecard review/approve/override actions (the audited paths) remain the next slice, per manifest port order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)