### PR TITLE
feat(sandy-qa): Pulpo SOP retrieval at mode=on — v1-essential, app-side

### DIFF
--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -21,6 +21,10 @@ export interface Env {
   // Dashboard-set app secret: comma-separated emails allowed on /lookup
   // (interim deny-by-default compliance lock until per-team RBAC lands).
   LOOKUP_ALLOW?: string;
+  // Dashboard-set app secrets: Pulpo MCP (SOP retrieval at prompt-build —
+  // v1-essential; absent → prompts take the sop_context_missing path).
+  PULPO_MCP_URL?: string;
+  PULPO_MCP_TOKEN?: string;
   // Optional: pre-select a specific workflow. Leave unset to list all available.
   WORKFLOW_ID?: string;
   // Provisioned automatically by Sandy at publish time for apps with cron schedules.
@@ -44,7 +48,8 @@ export default {
 
     // ── Ported QA pages + team analytics APIs (PortManifest §3/§4/§6.1) ──
     const teamRes = await handleTeamRoutes(
-      request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW
+      request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW,
+      { url: env.PULPO_MCP_URL, token: env.PULPO_MCP_TOKEN }
     );
     if (teamRes) return teamRes;
 

--- a/sandy-qa/src/lib/sopRetrieval.ts
+++ b/sandy-qa/src/lib/sopRetrieval.ts
@@ -1,0 +1,280 @@
+// SOP retrieval — ports of backend/services/rag/{pulpo,sop_retrieval}.py
+// (PulpoConnection §4.1/§4.2). Speaks MCP over Streamable HTTP against
+// PULPO_MCP_URL via plain fetch: initialize handshake, then tools/call
+// JSON-RPC POSTs, Bearer-authenticated; SSE-or-JSON responses handled;
+// expired session (404) re-initializes once.
+//
+// Policy: the verified DISPOSITION is the query (transcript head as the
+// absence fallback) → search → τ threshold → fetch bodies → render the
+// numbered SOP block (flag cautions, char cap honored lowest-score-first).
+// Never throws: any failure returns an empty context with skipped_reason —
+// retrieval is an enhancement, never a scoring blocker.
+
+const PROTOCOL_VERSION = "2025-03-26";
+const CLIENT_INFO = { name: "landing-qa-scoring-sandy", version: "1.0" };
+const QUERY_MAX_CHARS = 500; // Pulpo's server-side zod cap
+const MAX_DOCS = 3;
+const BLOCK_CHAR_CAP = 16_000;
+const DEFAULT_THRESHOLD = 0.55;
+
+export interface SopContext {
+  query: string;
+  sop_title: string;
+  block_text: string;
+  provenance: any[];
+  skipped_reason: string;
+}
+
+const empty = (query = "", reason = ""): SopContext => ({
+  query,
+  sop_title: "",
+  block_text: "",
+  provenance: [],
+  skipped_reason: reason,
+});
+
+// Isolate-lifetime caches (stateless workers: helpful within bursts; the
+// finite disposition label space makes even short-lived caches pay off).
+const searchCache = new Map<string, { exp: number; hits: any[] }>();
+const docCache = new Map<string, { exp: number; doc: any | null }>();
+const CACHE_TTL_MS = 3600_000;
+
+class PulpoClient {
+  private sessionId: string | null = null;
+  private initialized = false;
+  private nextId = 0;
+  constructor(
+    private url: string,
+    private token: string
+  ) {}
+
+  private async post(body: any): Promise<Response> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      Accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    };
+    if (this.sessionId) headers["Mcp-Session-Id"] = this.sessionId;
+    return fetch(this.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(11_000),
+    });
+  }
+
+  private parseRpc(contentType: string, text: string): any | null {
+    const t = text.trim();
+    if (!t) return null;
+    if (contentType.includes("text/event-stream")) {
+      let message: any = null;
+      for (let line of t.split("\n")) {
+        line = line.trim();
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        if (!payload) continue;
+        try {
+          const candidate = JSON.parse(payload);
+          if (candidate && typeof candidate === "object" && ("result" in candidate || "error" in candidate))
+            message = candidate;
+        } catch {}
+      }
+      return message;
+    }
+    return JSON.parse(t);
+  }
+
+  private async initialize(): Promise<void> {
+    this.nextId += 1;
+    const resp = await this.post({
+      jsonrpc: "2.0",
+      id: this.nextId,
+      method: "initialize",
+      params: { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: CLIENT_INFO },
+    });
+    if (resp.status >= 400)
+      throw new Error(`pulpo initialize HTTP ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+    const message = this.parseRpc(resp.headers.get("content-type") ?? "", await resp.text());
+    if (!message || message.error) throw new Error(`pulpo initialize rejected: ${JSON.stringify(message)?.slice(0, 200)}`);
+    this.sessionId = resp.headers.get("mcp-session-id") ?? this.sessionId;
+    await this.post({ jsonrpc: "2.0", method: "notifications/initialized" });
+    this.initialized = true;
+  }
+
+  async toolCall(tool: string, args: any): Promise<any> {
+    if (!this.initialized) await this.initialize();
+    this.nextId += 1;
+    const body = {
+      jsonrpc: "2.0",
+      id: this.nextId,
+      method: "tools/call",
+      params: { name: tool, arguments: args },
+    };
+    let resp = await this.post(body);
+    if (resp.status === 404 && this.sessionId) {
+      this.initialized = false;
+      this.sessionId = null;
+      await this.initialize();
+      resp = await this.post(body);
+    }
+    if (resp.status >= 400)
+      throw new Error(`pulpo ${tool} HTTP ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+    const message = this.parseRpc(resp.headers.get("content-type") ?? "", await resp.text());
+    if (!message) throw new Error(`pulpo ${tool}: no response message`);
+    if (message.error) throw new Error(`pulpo ${tool} error: ${JSON.stringify(message.error).slice(0, 200)}`);
+    const result = message.result ?? {};
+    if (result.isError) throw new Error(`pulpo ${tool} tool error`);
+    if ("structuredContent" in result) return result.structuredContent;
+    for (const block of result.content ?? []) {
+      if (block.type === "text") {
+        try {
+          return JSON.parse(block.text ?? "");
+        } catch {
+          return block.text;
+        }
+      }
+    }
+    return result;
+  }
+}
+
+function mapHit(raw: any) {
+  return {
+    id: String(raw.id ?? ""),
+    title: raw.title ?? "",
+    score: Number(raw.score ?? 0),
+    score_kind: raw.score_type ?? "",
+    updated_at: String(raw.last_verified ?? raw.updated_at ?? ""),
+  };
+}
+
+function mapDoc(raw: any) {
+  return {
+    id: String(raw.id ?? ""),
+    title: raw.title ?? "",
+    body: raw.body ?? "",
+    flags: (raw.open_flags ?? []).map((f: any) => ({ quote: f.quote ?? "" })),
+    updated_at: String(raw.last_verified ?? raw.updated_at ?? ""),
+  };
+}
+
+export function buildSopQuery(
+  dispositionCategory: string | null,
+  disposition: string | null,
+  transcriptText: string
+): string | null {
+  if (dispositionCategory) {
+    return disposition ? `${dispositionCategory} — ${disposition}` : dispositionCategory;
+  }
+  const head = (transcriptText ?? "").trim().slice(0, 600);
+  return head || null;
+}
+
+export function renderSopBlock(docs: { doc: any; hit: any }[]): string {
+  if (!docs.length) return "";
+  const sections: string[] = [];
+  docs.forEach(({ doc }, i) => {
+    const lines = [`[SOP ${i + 1}] ${doc.title}`];
+    for (const flag of doc.flags ?? []) {
+      lines.push(
+        `  NOTE: the passage "${(flag.quote ?? "").slice(0, 120)}" is under ` +
+          "review — verify before treating it as current policy."
+      );
+    }
+    lines.push((doc.body ?? "").trim());
+    sections.push(lines.join("\n"));
+  });
+  // cap from the lowest-scoring doc up; retruncate guard mirrors Python
+  while (sections.length && sections.reduce((a, s) => a + s.length, 0) > BLOCK_CHAR_CAP) {
+    if (sections[sections.length - 1].length > 2_100) {
+      sections[sections.length - 1] = sections[sections.length - 1].slice(0, 2_000) + "\n[truncated]";
+    } else {
+      sections.pop();
+    }
+  }
+  return sections.join("\n\n");
+}
+
+function cacheGet<T>(cache: Map<string, { exp: number } & any>, key: string): T | null {
+  const entry = cache.get(key);
+  if (entry && entry.exp > Date.now()) return entry as unknown as T;
+  cache.delete(key);
+  return null;
+}
+
+export async function fetchSopContext(opts: {
+  pulpoUrl?: string;
+  pulpoToken?: string;
+  threshold?: number;
+  dispositionCategory: string | null;
+  disposition: string | null;
+  transcriptText: string;
+}): Promise<SopContext> {
+  const query = buildSopQuery(opts.dispositionCategory, opts.disposition, opts.transcriptText);
+  if (query === null) return empty("", "no_query_material");
+  if (!opts.pulpoUrl || !opts.pulpoToken) return empty(query, "no_provider");
+
+  try {
+    const client = new PulpoClient(opts.pulpoUrl, opts.pulpoToken);
+    const sent = query.slice(0, QUERY_MAX_CHARS);
+    let hits: any[];
+    const cached = cacheGet<{ hits: any[] }>(searchCache, sent);
+    if (cached) {
+      hits = cached.hits;
+    } else {
+      // rerank false by design (§4.2): the judge reads full bodies itself
+      const payload = await client.toolCall("search_knowledge_base", {
+        queries: [sent],
+        limit: 5,
+        rerank: false,
+      });
+      const batches = payload?.batches ?? [];
+      const batch = batches.find((b: any) => b.query === sent) ?? batches[0] ?? {};
+      hits = (batch.results ?? []).map(mapHit);
+      searchCache.set(sent, { exp: Date.now() + CACHE_TTL_MS, hits });
+    }
+
+    const tau = opts.threshold ?? DEFAULT_THRESHOLD;
+    const selected = hits.filter((h) => h.score >= tau).slice(0, MAX_DOCS);
+    if (!selected.length) return empty(query, "below_threshold");
+
+    const docs: { doc: any; hit: any }[] = [];
+    for (const hit of selected) {
+      let doc: any;
+      const cachedDoc = cacheGet<{ doc: any }>(docCache, hit.id);
+      if (cachedDoc) {
+        doc = cachedDoc.doc;
+      } else {
+        try {
+          const payload = await client.toolCall("get_document", { id: hit.id });
+          const raw =
+            payload && typeof payload.document === "object" ? payload.document : payload;
+          doc = raw?.id ? mapDoc(raw) : null;
+        } catch (e) {
+          if (String(e).toLowerCase().includes("not found")) doc = null;
+          else throw e;
+        }
+        docCache.set(hit.id, { exp: Date.now() + CACHE_TTL_MS, doc });
+      }
+      if (doc && (doc.body ?? "").trim()) docs.push({ doc, hit });
+    }
+    if (!docs.length) return empty(query, "no_bodies");
+
+    return {
+      query,
+      sop_title: docs[0].doc.title,
+      block_text: renderSopBlock(docs),
+      provenance: docs.map(({ doc, hit }) => ({
+        id: doc.id,
+        title: doc.title,
+        score: hit.score,
+        score_kind: hit.score_kind,
+        updated_at: doc.updated_at,
+        open_flags: (doc.flags ?? []).length,
+      })),
+      skipped_reason: "",
+    };
+  } catch {
+    return empty(query, "provider_error");
+  }
+}

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -25,6 +25,7 @@ import {
   buildSystemPrompt,
 } from "../lib/scoringPrompts.js";
 import { evaluateFormula, quantizeScore } from "../lib/ruleEngine.js";
+import { fetchSopContext } from "../lib/sopRetrieval.js";
 
 const WORKFLOW_NAME = "qa-scoring-pipeline";
 const DP = "https://dialpad.com/api/v2";
@@ -130,7 +131,11 @@ export async function scoreTrigger(
   request: Request,
   db: D1Database,
   teamId: string,
-  env: { DIALPAD_API_KEY?: string; WORKFLOW_ID?: string }
+  env: {
+    DIALPAD_API_KEY?: string;
+    PULPO_MCP_URL?: string;
+    PULPO_MCP_TOKEN?: string;
+  }
 ): Promise<Response> {
   if (!env.DIALPAD_API_KEY)
     return json({ detail: "DIALPAD_API_KEY app secret not configured" }, 503);
@@ -188,11 +193,22 @@ export async function scoreTrigger(
   });
   const callContextText = buildCallContextBlock(ccCtx);
 
+  // SOP retrieval (PulpoConnection §4.2, mode=on — v1-essential): the
+  // verified disposition is the query; empty/sub-τ retrieval falls through
+  // to the sop_context_missing conservative path automatically.
+  const sop = await fetchSopContext({
+    pulpoUrl: env.PULPO_MCP_URL,
+    pulpoToken: env.PULPO_MCP_TOKEN,
+    dispositionCategory: ccCtx?.disposition_category ?? null,
+    disposition: ccCtx?.disposition ?? null,
+    transcriptText: transcript.transcript_text,
+  });
+
   const durationMs = Number(details.total_duration ?? 0);
   const extraNotes = buildLongCallNote(config.prompt_config, durationMs);
   const promptExtras = {
-    sopTitle: "",
-    sopContent: "", // Pulpo SOP retrieval lands when PULPO_MCP secrets exist
+    sopTitle: sop.sop_title,
+    sopContent: sop.block_text,
     agentName: agentName,
     extraNotes,
     callContextText,
@@ -248,6 +264,10 @@ export async function scoreTrigger(
       transcript_display: transcript.transcript_display,
       moments_display: transcript.moments_display,
       flagged_long_call: durationMs > 25 * 60 * 1000,
+      // PulpoConnection §4.2 step 6 — provenance stamped in shadow AND on
+      sop_used: sop.sop_title || null,
+      pulpo_docs: sop.provenance,
+      sop_skipped_reason: sop.skipped_reason || null,
     },
   };
 
@@ -418,6 +438,9 @@ export async function scoringCallback(
   const meta = {
     moments: persist.moments_display ?? [],
     transcript_display: persist.transcript_display ?? [],
+    sop_used: persist.sop_used ?? null,
+    pulpo_docs: persist.pulpo_docs ?? [],
+    ...(persist.sop_skipped_reason ? { sop_skipped_reason: persist.sop_skipped_reason } : {}),
     sandy_pipeline: {
       run_id: body.run_id,
       timings_ms: p.timings_ms,

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -149,7 +149,8 @@ export async function handleTeamRoutes(
   db: D1Database,
   url: URL,
   dialpadKey?: string,
-  lookupAllow?: string
+  lookupAllow?: string,
+  pulpo?: { url?: string; token?: string }
 ): Promise<Response | null> {
   const path = url.pathname;
 
@@ -205,7 +206,11 @@ export async function handleTeamRoutes(
   m = path.match(/^\/api\/([^/]+)\/score$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
     const { scoreTrigger } = await import("./scoring.js");
-    return scoreTrigger(request, db, m[1], { DIALPAD_API_KEY: dialpadKey });
+    return scoreTrigger(request, db, m[1], {
+      DIALPAD_API_KEY: dialpadKey,
+      PULPO_MCP_URL: pulpo?.url,
+      PULPO_MCP_TOKEN: pulpo?.token,
+    });
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "GET") {


### PR DESCRIPTION
## What this is

The SOP leg of the scoring pipeline, declared v1-essential: `sopRetrieval.ts` ports the Pulpo MCP client (`rag/pulpo.py` — Streamable HTTP handshake, JSON-RPC tools/call, SSE-tolerant parsing, session re-handshake, 500-char query clamp, `rerank=false` by design) and the retrieval policy (`rag/sop_retrieval.py` — disposition-keyed query with transcript-head fallback, τ=0.55, ≤3 docs, 16k block cap, flag cautions, provenance). Never a scoring blocker: any failure or sub-τ result takes the designed `sop_context_missing` conservative path.

The trigger now runs it right after CC grounding — the verified **disposition is the retrieval key** (the DispositionDesign §5 / PulpoConnection §4.2 coupling), and `sop_used` + `pulpo_docs` provenance land in `dialpad_call_metadata` exactly like Railway's eval rows. Deployed as **v0.11**.

## ⚠ Secrets placement (the user question this PR answers)

**Rule: a secret lives where the network call originates.**
- Pulpo retrieval runs **app-side** at prompt-build → `PULPO_MCP_URL` + `PULPO_MCP_TOKEN` must be **App Secrets** (Sandy Dashboard → qa-scoring → Edit Secrets). Workflow-side copies are inert — the workflow never talks to Pulpo.
- `PULPO_MCP_BENCHMARK_TOKEN` — benchmark-harness reproducibility token, not in the serving path (and its 25-char name exceeds the 20-char cap anyway). Keep it local.
- `TRIAGE_DRIVE_ID` / `COMPENDIUM_DOC_ID` — belong to the weekly compendium pipeline (PR #159), which is not part of scoring and not yet ported; they're identifiers, not credentials. When that pipeline becomes its own Sandy workflow, they ride with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)