### PR TITLE
feat(sandy-qa): scorecard editor — approve, override, edit-of-finalized (actions slice complete)

### DIFF
--- a/sandy-qa/pages/onepager.html
+++ b/sandy-qa/pages/onepager.html
@@ -50,7 +50,7 @@
         + (month ? `?month=${encodeURIComponent(month)}` : '');
       let res;
       try {
-        res = await fetch(url, { headers: { 'Authorization': 'Bearer ' + key } });
+        res = await fetch(url); // Sandy: SSO cookie auth — no Authorization header
       } catch (e) {
         status.innerHTML = '<span class="err">Network error loading the one-pager.</span>';
         return;

--- a/sandy-qa/pages/scorecard.html
+++ b/sandy-qa/pages/scorecard.html
@@ -1,0 +1,1120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scorecard — Landing QA</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #E7EFFB;
+      --surface: #ffffff;
+      --border: #c9d5e8;
+      --text: #15192D;
+      --muted: #5a6478;
+      --accent: #1A61D9;
+      --navy: #15192D;
+      --success: #2d6a4f;
+      --warning: #b45309;
+      --error: #991b1b;
+      --badge-high: #d1fae5;
+      --badge-medium: #fef3c7;
+      --badge-low: #fee2e2;
+    }
+
+    body {
+      font-family: 'DM Mono', monospace;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 0;
+    }
+
+    /* Navy banner header — matches index.html typography exactly so the
+       /score and /scorecard pages feel like one app. The flex layout +
+       header-nav are scorecard-only (back link + scoring link). */
+    header {
+      background: var(--navy);
+      color: #ffffff;
+      padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    header h1 {
+      font-family: 'Fraunces', serif;
+      font-weight: 300;
+      font-size: 2rem;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.25rem;
+      color: #ffffff;
+    }
+    header p { color: rgba(255, 255, 255, 0.7); font-size: 0.8rem; }
+    .header-nav { display: flex; gap: 8px; }
+    .header-nav a {
+      color: #ffffff; text-decoration: none; font-size: 0.82rem;
+      padding: 8px 16px; border: 1px solid rgba(255,255,255,0.3); border-radius: 6px;
+      transition: background 0.2s;
+    }
+    .header-nav a:hover { background: rgba(255,255,255,0.1); }
+
+    /* Card wrapper — mirrors index.html so the panel sits inside a white
+       surface with a navy h2 header (same shape as /score's "Scoring Progress"
+       card). */
+    .card {
+      max-width: 720px;
+      margin: 0 auto 1.5rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .card h2 {
+      font-family: 'Fraunces', serif;
+      font-weight: 400;
+      font-size: 1.1rem;
+      padding: 0.75rem 1.25rem;
+      margin: 0;
+      background: var(--navy);
+      color: #ffffff;
+    }
+    .job-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 1rem 1.25rem;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+    .job-row .err-detail { color: var(--error); font-size: 0.78rem; }
+
+    /* --- Scorecard panel styles (mirrored from index.html so this page renders
+       a panel identical to the upload flow). Keep these in sync until the
+       shared-module extraction lands as a follow-up. --- */
+
+    .status-badge { padding: 0.2rem 0.6rem; border-radius: 20px; font-size: 0.7rem; font-weight: 500; }
+    .status-pending  { background: #e5e7eb; color: #374151; }
+    .status-scoring  { background: #dbeafe; color: #1e40af; }
+    .status-complete { background: var(--badge-high); color: var(--success); }
+    .status-error    { background: var(--badge-low); color: var(--error); }
+
+    .scorecard-panel {
+      margin-top: 0.5rem; margin-bottom: 3rem;
+      border: 1px solid var(--border); border-radius: 6px; overflow: hidden;
+      border-top: 4px solid var(--navy); border-bottom: 4px solid var(--navy);
+    }
+
+    .scorecard-header {
+      padding: 1rem 1.25rem; background: var(--navy); color: #ffffff;
+      display: flex; justify-content: space-between; align-items: center; font-size: 0.82rem;
+    }
+
+    .scorecard-header .header-meta {
+      font-size: 0.7rem; color: rgba(255,255,255,0.6); margin-top: 2px;
+      display: flex; gap: 0.75rem; align-items: center;
+    }
+
+    .scorecard-avg {
+      font-family: 'Fraunces', serif; font-size: 1.3rem; font-weight: 300; color: #ffffff;
+    }
+
+    .long-call-flag {
+      font-size: 0.72rem; padding: 0.2rem 0.6rem; background: #fef3c7; color: #b45309;
+      border-radius: 20px;
+    }
+
+    .section-row {
+      display: grid; grid-template-columns: 1fr 60px 80px; gap: 0.5rem;
+      align-items: start; padding: 0.85rem 1rem; border-bottom: 1px solid var(--border);
+      font-size: 0.78rem;
+    }
+    .section-row:last-child { border-bottom: none; }
+    .section-name { font-weight: 500; }
+    .section-reasoning { color: var(--muted); font-size: 0.72rem; margin-top: 0.2rem; }
+    .section-flags { color: var(--warning); font-size: 0.68rem; margin-top: 0.15rem; }
+
+    .confidence-badge {
+      font-size: 0.65rem; padding: 0.15rem 0.4rem; border-radius: 3px;
+      text-transform: uppercase; letter-spacing: 0.05em; text-align: center;
+    }
+
+    .notes-section {
+      padding: 1rem 1.25rem; background: #f9fafe; border-top: 2px solid var(--border);
+      font-size: 0.78rem;
+    }
+    .notes-label {
+      font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--muted); margin-bottom: 0.35rem;
+    }
+
+    /* SOP reference footnotes — numbering matches the [SOP n] citations
+       inside the AI reasoning text above. */
+    .references-section {
+      padding: 1rem 1.25rem; background: #f9fafe; border-top: 1px solid var(--border);
+      font-size: 0.75rem;
+    }
+    .reference-item {
+      display: grid; grid-template-columns: 52px 1fr; gap: 0.5rem;
+      padding: 0.3rem 0; line-height: 1.5;
+    }
+    .reference-num { color: var(--muted); font-variant-numeric: tabular-nums; }
+    .reference-meta { color: var(--muted); font-size: 0.68rem; }
+    .reference-flag { color: var(--warning); font-size: 0.68rem; }
+    .disposition-chip {
+      font-size: 0.7rem; padding: 0.2rem 0.6rem; background: #d0ddf0;
+      color: var(--text); border-radius: 20px;
+    }
+
+    .transcript-panel { border-top: 2px solid var(--navy); margin-top: 0.5rem; }
+    .transcript-toggle {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.65rem 1rem; cursor: pointer; font-size: 0.78rem; font-weight: 500;
+      background: var(--navy); color: #ffffff; user-select: none;
+    }
+    .transcript-toggle:hover { background: #1e2340; }
+    .transcript-toggle .arrow {
+      transition: transform 0.2s; font-size: 0.7rem; color: rgba(255, 255, 255, 0.7);
+    }
+    .transcript-toggle.open .arrow { transform: rotate(90deg); }
+    .transcript-body {
+      display: none; max-height: 400px; overflow-y: auto; padding: 0.5rem 1rem;
+      font-size: 0.75rem; line-height: 1.6;
+    }
+    .transcript-body.open { display: block; }
+    .transcript-line {
+      display: grid; grid-template-columns: 48px 1fr; gap: 0.5rem;
+      padding: 0.3rem 0; border-bottom: 1px solid #edf2fa;
+    }
+    .transcript-line:last-child { border-bottom: none; }
+    .transcript-ts { color: var(--muted); font-size: 0.7rem; font-variant-numeric: tabular-nums; padding-top: 0.1rem; }
+    .transcript-speaker { font-weight: 500; margin-right: 0.3rem; }
+    .moments-list { padding: 0.5rem 1rem; border-top: 1px solid var(--border); }
+    .moment-item {
+      display: inline-flex; align-items: center; gap: 0.35rem;
+      padding: 0.2rem 0.55rem; margin: 0.2rem 0.2rem; background: #d0ddf0;
+      border-radius: 12px; font-size: 0.68rem; color: var(--text);
+    }
+    .moment-ts { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+    .score-select, .confidence-select {
+      font-family: 'DM Mono', monospace; padding: 0.2rem 0.3rem;
+      border: 1px solid var(--border); border-radius: 4px; background: var(--bg);
+      color: var(--text); text-align: center; width: 100%; cursor: pointer;
+    }
+    .score-select { font-size: 0.78rem; }
+    .confidence-select { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .score-select:focus, .confidence-select:focus { border-color: var(--accent); outline: none; }
+    .score-select:disabled, .confidence-select:disabled { opacity: 0.6; cursor: default; }
+
+    .reasoning-textarea, .notes-textarea {
+      font-family: 'DM Mono', monospace; width: 100%;
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 0.35rem 0.5rem; resize: vertical; background: var(--bg); line-height: 1.4;
+    }
+    .reasoning-textarea { font-size: 0.72rem; color: var(--muted); margin-top: 0.2rem; min-height: 2.5rem; }
+    .notes-textarea { font-size: 0.78rem; min-height: 3rem; background: #fff; line-height: 1.5; padding: 0.5rem; }
+    .reasoning-textarea:focus, .notes-textarea:focus { border-color: var(--accent); outline: none; }
+    .reasoning-textarea:disabled, .notes-textarea:disabled { opacity: 0.6; cursor: default; }
+
+    .approve-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1rem 1.25rem; background: var(--navy);
+    }
+    .btn-approve {
+      font-family: 'DM Mono', monospace; font-size: 0.82rem;
+      padding: 0.7rem 2rem; background: var(--success); color: white;
+      border: none; border-radius: 4px; cursor: pointer; font-weight: 500;
+      transition: background 0.15s;
+    }
+    .btn-approve:hover { background: #245a42; }
+    .btn-approve:disabled { background: var(--border); cursor: not-allowed; }
+    .approve-status { font-size: 0.78rem; color: rgba(255,255,255,0.7); }
+    /* S7 override form — lives on the dark approve-bar, so every text
+       element needs explicit light color (body text is dark and labels
+       would otherwise inherit it: invisible dark-on-dark, the 2026-07-27
+       report). Inputs get explicit white bg + dark text. */
+    .override-form {
+      display: none; width: 100%; margin-top: 0.75rem; padding: 0.75rem;
+      border: 1px solid rgba(255,255,255,0.25); border-radius: 8px;
+      background: rgba(255,255,255,0.05);
+    }
+    .override-form label {
+      font-size: 0.8rem; color: rgba(255,255,255,0.85);
+    }
+    .override-form input[type="number"],
+    .override-form input[type="email"],
+    .override-form select,
+    .override-form textarea {
+      background: #ffffff; color: #1a2238;
+      border: 1px solid var(--border); border-radius: 4px;
+      padding: 4px 6px; font-family: inherit; font-size: 0.8rem;
+    }
+    .override-form input[type="checkbox"] { accent-color: #7c2d12; }
+  </style>
+</head>
+<body>
+
+<header>
+  <div>
+    <h1>Scorecard</h1>
+    <p id="scHeaderMeta">Loading job…</p>
+  </div>
+  <div class="header-nav">
+    <a id="backLink" href="#">← Back to lookup</a>
+    <a href="/" target="_self">Scoring</a>
+  </div>
+</header>
+
+<div class="card">
+  <h2>Scoring Progress</h2>
+  <div id="job-list">
+    <div id="loadingRow" class="job-row">
+      <span>Loading scorecard…</span>
+      <span id="loadingPill" class="status-badge status-pending">pending</span>
+      <span id="loadingDetail" class="err-detail"></span>
+    </div>
+  </div>
+</div>
+
+<script>
+// Path: /scorecard/{team_id}/{job_id}
+const _pathParts = location.pathname.split('/').filter(Boolean);
+const TEAM_ID = _pathParts[1] || 'member_support';
+const JOB_ID  = _pathParts[2] || '';
+const API_BASE = `/api/${TEAM_ID}`;
+
+document.getElementById('backLink').href = `/lookup/${TEAM_ID}`;
+
+// --- Auth — localStorage so the API key carries across tabs (new tab from
+// /lookup must inherit auth without re-prompting). ---
+function getApiKey() { return 'sso'; } // Sandy: SSO owns auth
+function authHeaders() {
+  const key = getApiKey();
+  return key ? { 'Authorization': 'Bearer ' + key } : {};
+}
+
+// --- Team-section cache (drives manual-section rows + approve-gate logic) ---
+let _teamSections = [];
+let _scorecardData = {};
+
+async function loadTeamSections() {
+  if (_teamSections.length > 0) return _teamSections;
+  const res = await fetch(`${API_BASE}/team/sections`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`team/sections HTTP ${res.status}`);
+  _teamSections = await res.json();
+  return _teamSections;
+}
+
+// --- Bootstrap ---
+(async function init() {
+  if (!JOB_ID) {
+    showLoadError('No job_id in URL.');
+    return;
+  }
+  try {
+    await loadTeamSections();
+  } catch (e) {
+    showLoadError(`Could not load team sections: ${e.message}`);
+    return;
+  }
+  pollAndRender();
+})();
+
+let _pollTimer = null;
+
+async function pollAndRender() {
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}`, { headers: authHeaders() });
+    if (res.status === 401) {
+      localStorage.removeItem('qa_api_key');
+      showLoadError('Invalid API key. Reload to re-enter.');
+      return;
+    }
+    if (res.status === 404) {
+      showLoadError('Job not found. It may have been started in a different browser session.');
+      return;
+    }
+    if (!res.ok) {
+      showLoadError(`HTTP ${res.status}`);
+      return;
+    }
+    const data = await res.json();
+    updateLoadingPill(data.status);
+
+    if (data.status === 'complete' || data.status === 'approved') {
+      renderPanel(data);
+      return;
+    }
+    if (data.status === 'error') {
+      showLoadError(`Scoring error: ${data.error || 'unknown'}`);
+      return;
+    }
+    // pending / scoring — keep polling
+    _pollTimer = setTimeout(pollAndRender, 3000);
+  } catch (e) {
+    showLoadError(e.message);
+  }
+}
+
+function updateLoadingPill(status) {
+  const pill = document.getElementById('loadingPill');
+  if (!pill) return;  // already removed once the panel rendered
+  pill.textContent = status || 'pending';
+  pill.className = `status-badge status-${status || 'pending'}`;
+  document.getElementById('scHeaderMeta').textContent =
+    `Job ${JOB_ID} — ${TEAM_ID} — ${status || 'pending'}`;
+}
+
+function showLoadError(msg) {
+  const detail = document.getElementById('loadingDetail');
+  const pill = document.getElementById('loadingPill');
+  if (detail) detail.textContent = msg;
+  if (pill) {
+    pill.className = 'status-badge status-error';
+    pill.textContent = 'error';
+  }
+}
+
+// Job-level meta the action flows consult (ScorecardActions S6):
+// scoring_status drives the §4.3a resolution acknowledgment; state
+// gates the override control.
+let _jobMeta = {};
+
+function renderPanel(data) {
+  _jobMeta = {
+    scoring_status: data.scoring_status || null,
+    state: data.state || null,
+    overall_score: data.overall_score != null ? data.overall_score : null,
+    agent_name: data.agent_name || '',
+  };
+  const loadingRow = document.getElementById('loadingRow');
+  if (loadingRow) loadingRow.remove();
+  document.getElementById('scHeaderMeta').textContent =
+    `Job ${JOB_ID} — ${TEAM_ID} — ${data.status}`;
+  // Filename isn't stored server-side; synthesize from call_id for the header.
+  const callId = (data.scorecard && data.scorecard.call_id) || JOB_ID.split('_')[0];
+  const filename = `${callId}.mp3`;
+  const panel = buildScorecardPanel(JOB_ID, data.scorecard, filename, callId, data.sheets_row);
+  // Append into the card's job-list (mirrors index.html's DOM structure).
+  document.getElementById('job-list').appendChild(panel);
+
+  // If we arrived after approval, lock everything down.
+  if (data.status === 'approved') {
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+    const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+    if (btn) { btn.disabled = true; btn.textContent = 'Sent'; btn.style.background = '#065f46'; }
+    const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+    if (statusEl) statusEl.textContent = 'Approved — evaluation email already dispatched.';
+  }
+
+  // Post-cutover (CutoverDesign §5): an engine-finalized evaluation is
+  // immutable — render everything, then lock it down completely. The
+  // S6 override doorway is the ONE designed hole in this wall
+  // (ScorecardActionsDesign §4.3) — injected after the lockdown so its
+  // controls stay live.
+  if (data.state === 'finalized') {
+    panel.querySelectorAll('select, textarea, input, button').forEach(el => el.disabled = true);
+    const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+    if (btn) { btn.textContent = 'Finalized'; btn.style.background = '#065f46'; }
+    const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+    if (statusEl) {
+      const score = data.overall_score != null ? ` — overall score ${data.overall_score}` : '';
+      statusEl.textContent = `Finalized by the scoring engine${score}. This evaluation is read-only.`;
+    }
+    document.getElementById('scHeaderMeta').textContent =
+      `Job ${JOB_ID} — ${TEAM_ID} — finalized (read-only)`;
+    injectOverrideBar(panel, data);
+    injectFinalizedActions(panel);
+  }
+}
+
+// --------------------------------------------------------------------
+// S6 — Override doorway (ScorecardActionsDesign §4.3 / §4.3a).
+// Scorecard surface ONLY by design — the datapoint page must never
+// render this control (an approval-flow action, not archaeology).
+// --------------------------------------------------------------------
+
+const ACK_TEXT =
+  'You are manually modifying an AI-scored evaluation. By continuing ' +
+  'you commit to at least notifying the agent that their progression ' +
+  'was manually modified by a human.';
+
+function injectOverrideBar(panel, data) {
+  const bar = document.createElement('div');
+  bar.className = 'approve-bar';
+  bar.id = `override-bar-${JOB_ID}`;
+  bar.style.flexWrap = 'wrap';
+  bar.innerHTML = `
+    <span class="approve-status">Wrong score? A human can stand behind a different one.</span>
+    <button class="btn-approve" style="background:#7c2d12;" id="override-toggle-${JOB_ID}"
+            onclick="toggleOverrideForm()">Override Score…</button>
+    <div class="override-form" id="override-form-${JOB_ID}">
+      <div style="display:flex; gap:0.75rem; flex-wrap:wrap; margin-bottom:0.5rem;">
+        <label>New score (0–100)
+          <input type="number" id="ov-score-${JOB_ID}" min="0" max="100" step="0.1"
+                 style="width:6rem; display:block; margin-top:2px;">
+        </label>
+        <label>Your role
+          <select id="ov-role-${JOB_ID}" style="display:block; margin-top:2px;">
+            <option value="team_lead">Team lead</option>
+            <option value="manager" selected>Manager</option>
+            <option value="hr">HR</option>
+            <option value="external">External</option>
+          </select>
+        </label>
+        <label>Your email
+          <input type="email" id="ov-email-${JOB_ID}" placeholder="you@landing.com"
+                 style="display:block; width:14rem; margin-top:2px;">
+        </label>
+      </div>
+      <label style="display:block; margin-bottom:0.5rem;">Reasoning (required — this is the audit record)
+        <textarea id="ov-reasoning-${JOB_ID}" rows="2" style="width:100%; margin-top:2px;"></textarea>
+      </label>
+      <label style="display:block; margin-bottom:0.5rem;">SOP gap (optional — outdated/missing SOP evidence)
+        <textarea id="ov-sopgap-${JOB_ID}" rows="1" style="width:100%; margin-top:2px;"></textarea>
+      </label>
+      <label style="display:block; margin-bottom:0.35rem;">
+        <input type="checkbox" id="ov-suppress-${JOB_ID}"> Do NOT re-send the evaluation email
+        (leaves your notification duty pending)
+      </label>
+      <label style="display:block; margin-bottom:0.6rem;">
+        <input type="checkbox" id="ov-ack-${JOB_ID}"> ${ACK_TEXT}
+      </label>
+      <button class="btn-approve" style="background:#7c2d12;" id="ov-submit-${JOB_ID}"
+              onclick="submitOverride()">Override & Record</button>
+      <span class="approve-status" id="ov-status-${JOB_ID}"></span>
+    </div>`;
+  panel.appendChild(bar);
+  const saved = localStorage.getItem('qa_evaluator_email');
+  if (saved) document.getElementById(`ov-email-${JOB_ID}`).value = saved;
+}
+
+function toggleOverrideForm() {
+  // The CSS class hides the form by default (inline style starts empty),
+  // so key off the explicit 'block' rather than comparing to 'none'.
+  const form = document.getElementById(`override-form-${JOB_ID}`);
+  if (form) form.style.display = form.style.display === 'block' ? 'none' : 'block';
+}
+
+async function submitOverride() {
+  const g = id => document.getElementById(`${id}-${JOB_ID}`);
+  const statusEl = g('ov-status');
+  const score = parseFloat(g('ov-score').value);
+  const reasoning = g('ov-reasoning').value.trim();
+  const email = g('ov-email').value.trim();
+  const sopNote = g('ov-sopgap').value.trim();
+
+  if (Number.isNaN(score) || score < 0 || score > 100) {
+    statusEl.textContent = 'Enter a score between 0 and 100.'; return;
+  }
+  if (!reasoning) { statusEl.textContent = 'Reasoning is required.'; return; }
+  if (!email) { statusEl.textContent = 'Your email is required.'; return; }
+  if (!g('ov-ack').checked) {
+    statusEl.textContent = 'You must acknowledge the notification duty (§4.3a).'; return;
+  }
+  localStorage.setItem('qa_evaluator_email', email);
+
+  const btn = g('ov-submit');
+  btn.disabled = true; btn.textContent = 'Recording…';
+  statusEl.textContent = 'Applying override, rebuilding stats, dispatching…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}/override`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({
+        overall_score: score,
+        reasoning,
+        conducted_by_role: g('ov-role').value,
+        sop_gap: sopNote ? { note: sopNote } : null,
+        acknowledged: true,
+        suppress_email: g('ov-suppress').checked,
+        evaluator_email: email,
+      }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(typeof err.detail === 'string' ? err.detail : JSON.stringify(err.detail));
+    }
+    const data = await res.json();
+    btn.textContent = 'Overridden';
+    btn.style.background = '#065f46';
+    const duty = data.coaching_status === 'completed'
+      ? 'Agent notified via the disclaimer email.'
+      : `Notification duty PENDING (coaching #${data.coaching_id}, 3-day deadline) — you owe the agent a conversation.`;
+    statusEl.textContent =
+      `Score ${data.old_score} → ${data.new_score}. ${duty}`;
+    document.getElementById('scHeaderMeta').textContent =
+      `Job ${JOB_ID} — ${TEAM_ID} — overridden (${data.new_score})`;
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}`;
+    btn.disabled = false; btn.textContent = 'Override & Record';
+  }
+}
+
+// --------------------------------------------------------------------
+// Below: scorecard-panel rendering + edit + approve logic mirrored from
+// frontend/index.html. Kept in sync manually; see the panel-style block
+// at the top of this file for the matching CSS.
+// --------------------------------------------------------------------
+
+function buildScorecardPanel(jobId, sc, filename, callId, sheetsRow) {
+  _scorecardData[jobId] = sc;
+
+  // C5 (DispositionDesign §6): the old badge here averaged the numeric
+  // sections into an X/5 that was SOT for nothing. It is replaced by
+  // Dialpad's AI-CSAT estimate — clearly labeled as Ai, NOT a member
+  // survey — and omitted entirely when Dialpad produced none.
+  const aiCsatBadge = (sc.ai_csat !== null && sc.ai_csat !== undefined)
+    ? `<span class="scorecard-avg" title="Dialpad Ai CSAT — model estimate, not a member survey">${sc.ai_csat}<span style="font-family:'DM Mono'; font-size:0.75rem; color:rgba(255,255,255,0.7);">/5 Ai CSAT</span></span>`
+    : '';
+
+  const flagged = sc.flagged_long_call;
+  const panel = document.createElement('div');
+  panel.id = `scorecard-${jobId}`;
+  panel.className = 'scorecard-panel';
+
+  const sheetsNote = sheetsRow > 0 ? `<span>Sheets row ${sheetsRow}</span>` : '';
+
+  // Verified Dialpad disposition (DispositionDesign §5) — the same fact
+  // the grounding block fed the scoring prompt. Absent = CC never saw
+  // the call or it was undispositioned; render nothing.
+  const dispositionChip = sc.dialpad_disposition_category
+    ? `<span class="disposition-chip" title="Verified Dialpad disposition">${escHtml(
+        sc.dialpad_disposition
+          ? `${sc.dialpad_disposition_category} — ${sc.dialpad_disposition}`
+          : sc.dialpad_disposition_category)}</span>`
+    : '';
+
+  const header = `
+    <div class="scorecard-header">
+      <div>
+        <div>${filename}</div>
+        <div class="header-meta">
+          <span>Call ${callId || ''}</span>
+          <span class="status-badge status-complete">complete</span>
+          ${dispositionChip}
+          ${sheetsNote}
+        </div>
+      </div>
+      <div style="display:flex; gap:0.5rem; align-items:center;">
+        ${flagged ? '<span class="long-call-flag">Long call — manager review</span>' : ''}
+        ${aiCsatBadge}
+      </div>
+    </div>
+  `;
+
+  const aiById = Object.fromEntries(sc.sections.map(s => [s.id, s]));
+
+  const sectionRows = _teamSections
+    .filter(ts => !ts.auto_value)
+    .map(ts => {
+      if (ts.score_type === 'manual' || ts.score_type === 'manual_yn') {
+        const manualNaOpt = ts.na_applicable ? `<option value="NA">N/A</option>` : '';
+        const options = ts.score_type === 'manual_yn'
+          ? `<option value="" selected>—</option>
+             <option value="Y">Y</option>
+             <option value="N">N</option>
+             ${manualNaOpt}`
+          : `<option value="" selected>—</option>
+             <option value="1">1/5</option>
+             <option value="2">2/5</option>
+             <option value="3">3/5</option>
+             <option value="4">4/5</option>
+             <option value="5">5/5</option>
+             ${manualNaOpt}`;
+        return `
+          <div class="section-row" style="border-left:3px solid var(--warning);">
+            <div>
+              <div class="section-name" style="color:var(--warning);">${ts.name} — Score Required</div>
+              <textarea class="section-reasoning" id="manual-reasoning-${ts.id}-${jobId}"
+                placeholder="Enter reasoning for ${ts.name} score (persisted for progression analysis)"
+                rows="2" style="width:100%; margin-top:0.4rem; font-family:'DM Mono',monospace; font-size:0.82rem; border:1px solid #d1d5db; border-radius:4px; padding:0.4rem; resize:vertical;"></textarea>
+            </div>
+            <div>
+              <select class="score-select" id="manual-score-${ts.id}-${jobId}" onchange="checkManualScores('${jobId}')">
+                ${options}
+              </select>
+            </div>
+            <div><span class="confidence-badge" style="background:#e5e7eb; color:#6b7280;">MANUAL</span></div>
+          </div>
+        `;
+      }
+
+      const s = aiById[ts.id];
+      if (!s) {
+        console.warn(`No AI data for section "${ts.id}"`);
+        return '';
+      }
+      const flags = s.flags && s.flags.length
+        ? `<div class="section-flags">${s.flags.join(', ')}</div>` : '';
+      const audioTag = s.audio_dependent ? ' <span style="color:var(--muted); font-size:0.68rem;">[audio]</span>' : '';
+
+      // Dropdown shape is driven by team config (ts), not by the AI's
+      // echoed score_type — the AI can drift (e.g. return "numeric" on a
+      // yn section). The selected-value attributes still consult s.* so
+      // the current AI value renders correctly.
+      let scoreControl;
+      const naOpt = ts.na_applicable
+        ? `<option value="NA" ${s.yn_value==='NA'?'selected':''}>N/A</option>`
+        : '';
+      if (ts.score_type === 'yn') {
+        scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="yn_value">
+          <option value="Y" ${s.yn_value==='Y'?'selected':''}>Y</option>
+          <option value="N" ${s.yn_value==='N'?'selected':''}>N</option>
+          ${naOpt}
+        </select>`;
+      } else {
+        scoreControl = `<select class="score-select" data-section-id="${s.id}" data-field="score">
+          ${[1,2,3,4,5].map(v => `<option value="${v}" ${s.score===v?'selected':''}>${v}/5</option>`).join('')}
+          ${naOpt}
+        </select>`;
+      }
+
+      const confControl = `<select class="confidence-select" data-section-id="${s.id}" data-field="confidence">
+        <option value="high" ${s.confidence==='high'?'selected':''}>HIGH</option>
+        <option value="medium" ${s.confidence==='medium'?'selected':''}>MEDIUM</option>
+        <option value="low" ${s.confidence==='low'?'selected':''}>LOW</option>
+      </select>`;
+
+      return `
+        <div class="section-row">
+          <div>
+            <div class="section-name">${s.name}${audioTag}</div>
+            <textarea class="reasoning-textarea" data-section-id="${s.id}" data-field="reasoning" rows="2">${s.reasoning}</textarea>
+            ${flags}
+          </div>
+          <div>${scoreControl}</div>
+          <div>${confControl}</div>
+        </div>
+      `;
+    });
+
+  const notes = `
+    <div class="notes-section">
+      ${sc.call_summary ? `<div class="notes-label">Call Summary</div><div style="margin-bottom:0.75rem;">${sc.call_summary}</div>` : ''}
+      <div class="notes-label">Key Strengths</div>
+      <textarea class="notes-textarea" id="strengths-${jobId}" rows="3">${sc.key_strengths || ''}</textarea>
+      <div style="margin-top:0.75rem;">
+        <div class="notes-label">Opportunities for Improvement</div>
+        <textarea class="notes-textarea" id="opportunities-${jobId}" rows="3">${sc.opportunities || ''}</textarea>
+      </div>
+    </div>
+  `;
+
+  const manualSecs = _teamSections.filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn');
+  const initialDisabled = manualSecs.length > 0;
+  const initialStatus = initialDisabled
+    ? `Score ${manualSecs.map(s => s.name).join(' + ')} to enable Approve & Send.`
+    : 'Review scores and click to send evaluation email.';
+  const approveBar = `
+    <div class="approve-bar" id="approve-bar-${jobId}">
+      <span class="approve-status" id="approve-status-${jobId}">${initialStatus}</span>
+      <button class="btn-approve" id="approve-btn-${jobId}" onclick="approveScorecard('${jobId}')" ${initialDisabled ? 'disabled' : ''}>Approve & Send</button>
+    </div>
+  `;
+
+  const transcriptId = `transcript-${jobId}`;
+  let transcriptPanel = '';
+  if (sc.transcript_display && sc.transcript_display.length > 0) {
+    const transcriptLines = sc.transcript_display.map(line => `
+      <div class="transcript-line">
+        <div class="transcript-ts">${line.timestamp || ''}</div>
+        <div><span class="transcript-speaker">${line.speaker}:</span> ${line.text}</div>
+      </div>
+    `).join('');
+
+    const momentsHtml = sc.moments_display && sc.moments_display.length > 0
+      ? `<div class="moments-list">
+          <div class="notes-label" style="margin-bottom:0.4rem;">Signal Moments</div>
+          ${sc.moments_display.map(m => `
+            <span class="moment-item"><span class="moment-ts">${m.timestamp || ''}</span> ${m.type}</span>
+          `).join('')}
+        </div>`
+      : '';
+
+    transcriptPanel = `
+      <div class="transcript-panel">
+        <div class="transcript-toggle" onclick="
+          this.classList.toggle('open');
+          document.getElementById('${transcriptId}').classList.toggle('open');
+        ">
+          <span>Transcript (${sc.transcript_display.length} lines)</span>
+          <span class="arrow">&#9654;</span>
+        </div>
+        <div class="transcript-body" id="${transcriptId}">
+          ${transcriptLines}
+        </div>
+        ${momentsHtml}
+      </div>
+    `;
+  }
+
+  panel.innerHTML = header + sectionRows.join('') + approveBar + notes
+    + buildReferencesSection(sc) + transcriptPanel;
+  return panel;
+}
+
+function escHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str == null ? '' : String(str);
+  return div.innerHTML;
+}
+
+// SOP reference footnotes (PulpoConnection §4.2 provenance). The AI's
+// reasoning cites "[SOP n]" — pulpo_docs preserves the injection order,
+// so footnote numbering lines up with those citations. Falls back to the
+// bare sop_used title for evals scored before provenance existed.
+function buildReferencesSection(sc) {
+  const docs = Array.isArray(sc.pulpo_docs) ? sc.pulpo_docs : [];
+  let items = '';
+  if (docs.length > 0) {
+    items = docs.map((d, i) => {
+      const metaBits = [];
+      if (d.score != null) metaBits.push(`match ${Number(d.score).toFixed(2)}`);
+      if (d.updated_at) metaBits.push(`updated ${String(d.updated_at).slice(0, 10)}`);
+      const meta = metaBits.length ? `<span class="reference-meta"> — ${metaBits.join(', ')}</span>` : '';
+      const flagNote = d.open_flags > 0
+        ? `<div class="reference-flag">⚑ ${d.open_flags} open flag${d.open_flags > 1 ? 's' : ''} — passages under review; verify before treating as current policy.</div>`
+        : '';
+      return `
+        <div class="reference-item">
+          <div class="reference-num">[SOP ${i + 1}]</div>
+          <div>${escHtml(d.title || d.id || '')}${meta}${flagNote}</div>
+        </div>`;
+    }).join('');
+  } else if (sc.sop_used) {
+    items = `
+      <div class="reference-item">
+        <div class="reference-num">[SOP 1]</div>
+        <div>${escHtml(sc.sop_used)}</div>
+      </div>`;
+  }
+  if (!items) return '';
+  return `
+    <div class="references-section">
+      <div class="notes-label">References — SOPs consulted by the AI evaluator</div>
+      ${items}
+    </div>`;
+}
+
+function checkManualScores(jobId) {
+  const btn = document.getElementById(`approve-btn-${jobId}`);
+  const statusEl = document.getElementById(`approve-status-${jobId}`);
+  if (!btn || !statusEl) return;
+
+  const missing = _teamSections
+    .filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn')
+    .filter(s => {
+      const sel = document.getElementById(`manual-score-${s.id}-${jobId}`);
+      return !sel || !sel.value;
+    });
+  if (missing.length === 0) {
+    btn.disabled = false;
+    statusEl.textContent = 'Review scores and click to send evaluation email.';
+  } else {
+    btn.disabled = true;
+    statusEl.textContent = `Score ${missing.map(s => s.name).join(' + ')} to enable Approve & Send.`;
+  }
+}
+
+async function approveScorecard(jobId) {
+  const btn = document.getElementById(`approve-btn-${jobId}`);
+  const statusEl = document.getElementById(`approve-status-${jobId}`);
+  const panel = document.getElementById(`scorecard-${jobId}`);
+
+  // §4.3a (S6): resolving a flagged human review is a manual mutation
+  // of an agent-visible score — explicit acknowledgment or nothing.
+  const resolvingReview = _jobMeta.scoring_status === 'flagged_human_review';
+  if (resolvingReview && !window.confirm(ACK_TEXT + '\n\nProceed with the resolution?')) {
+    return;
+  }
+
+  btn.disabled = true;
+  btn.textContent = 'Sending...';
+  statusEl.textContent = 'Updating sheets and sending email...';
+
+  const payload = buildApprovalPayload(jobId);
+  payload.acknowledged = resolvingReview;  // §4.3a — the route 422s a resolution without it
+
+  try {
+    const res = await fetch(`${API_BASE}/score/${jobId}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      localStorage.removeItem('qa_api_key');
+      alert('Invalid API key. Please reload and try again.');
+      btn.disabled = false;
+      btn.textContent = 'Approve & Send';
+      return;
+    }
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.detail || 'Unknown error');
+    }
+
+    const data = await res.json();
+
+    btn.textContent = 'Sent';
+    btn.style.background = '#065f46';
+    statusEl.textContent = `Approved — destination row ${data.destination_row}. Email dispatched.`;
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}. You can retry.`;
+    statusEl.style.color = '#fca5a5';
+    btn.disabled = false;
+    btn.textContent = 'Retry Approve & Send';
+  }
+}
+
+// Collects the full ApprovalRequest sections payload from the DOM —
+// shared by the normal approve and the S7 edit-of-finalized re-approval.
+function buildApprovalPayload(jobId) {
+  const panel = document.getElementById(`scorecard-${jobId}`);
+  const sc = _scorecardData[jobId];
+
+  const sections = sc.sections.map(s => {
+    const scoreEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="score"]`);
+    const ynEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="yn_value"]`);
+    const confEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="confidence"]`);
+    const reasonEl = panel.querySelector(`[data-section-id="${s.id}"][data-field="reasoning"]`);
+
+    // Numeric+na_applicable selects expose an "NA" option inside the
+    // score select. Split it: explicit NA -> score=null, yn_value="NA";
+    // otherwise the numeric value parses as int.
+    let score = null;
+    let yn_value = null;
+    if (ynEl) {
+      yn_value = ynEl.value || null;
+    } else if (scoreEl) {
+      if (scoreEl.value === 'NA') {
+        yn_value = 'NA';
+      } else {
+        score = parseInt(scoreEl.value);
+      }
+    }
+
+    return {
+      id: s.id,
+      name: s.name,
+      score,
+      score_type: s.score_type,
+      yn_value,
+      confidence: confEl ? confEl.value : s.confidence,
+      reasoning: reasonEl ? reasonEl.value : s.reasoning,
+      audio_dependent: s.audio_dependent,
+      flags: s.flags || [],
+    };
+  });
+
+  _teamSections
+    .filter(s => s.score_type === 'manual' || s.score_type === 'manual_yn')
+    .forEach(ms => {
+      const scoreEl = document.getElementById(`manual-score-${ms.id}-${jobId}`);
+      const reasonEl = document.getElementById(`manual-reasoning-${ms.id}-${jobId}`);
+      const rawValue = scoreEl && scoreEl.value ? scoreEl.value : '';
+      const isYn = ms.score_type === 'manual_yn';
+      const reasoning = (reasonEl && reasonEl.value || '').trim();
+
+      // Explicit NA wins for either shape — score=null, yn_value="NA".
+      let score = null;
+      let yn_value = null;
+      if (rawValue === 'NA') {
+        yn_value = 'NA';
+      } else if (isYn && rawValue) {
+        yn_value = rawValue;
+      } else if (!isYn && rawValue) {
+        score = parseInt(rawValue);
+      }
+
+      sections.push({
+        id: ms.id,
+        name: ms.name,
+        score,
+        score_type: ms.score_type,
+        yn_value,
+        confidence: 'manual',
+        reasoning: reasoning || 'Scored manually by manager.',
+        audio_dependent: false,
+        flags: [],
+      });
+    });
+
+  return {
+    sections,
+    key_strengths: document.getElementById(`strengths-${jobId}`).value,
+    opportunities: document.getElementById(`opportunities-${jobId}`).value,
+  };
+}
+
+// --------------------------------------------------------------------
+// S7 — finalized lifecycle actions: unlock-to-edit (§4.1), rescore
+// (§4.2), delete (§4.4, privileged-only rendering via /whoami).
+// --------------------------------------------------------------------
+
+function getEvaluatorEmail() {
+  let e = localStorage.getItem('qa_evaluator_email') || '';
+  if (!e) {
+    e = (prompt('Your email (recorded in the audit trail):') || '').trim();
+    if (e) localStorage.setItem('qa_evaluator_email', e);
+  }
+  return e;
+}
+
+async function injectFinalizedActions(panel) {
+  const bar = document.createElement('div');
+  bar.className = 'approve-bar';
+  bar.id = `actions-bar-${JOB_ID}`;
+  bar.innerHTML = `
+    <span class="approve-status">Lifecycle actions (audited):</span>
+    <button class="btn-approve" id="unlock-btn-${JOB_ID}"
+            onclick="unlockForEdit()">Unlock to Edit…</button>
+    <button class="btn-approve" id="rescore-btn-${JOB_ID}"
+            onclick="rescoreFromScorecard()">Re-score (fresh AI pass)</button>
+    <button class="btn-approve" id="delete-btn-${JOB_ID}" style="display:none; background:#7f1d1d;"
+            onclick="deleteFromScorecard()">Delete…</button>
+    <span class="approve-status" id="actions-status-${JOB_ID}"></span>`;
+  panel.appendChild(bar);
+  try {
+    const res = await fetch(`${API_BASE}/whoami`, { headers: authHeaders() });
+    if (res.ok) {
+      const who = await res.json();
+      if (who.role === 'privileged') {
+        document.getElementById(`delete-btn-${JOB_ID}`).style.display = '';
+      }
+    }
+  } catch (e) { /* rendering only — routes still enforce */ }
+}
+
+function unlockForEdit() {
+  if (!window.confirm(ACK_TEXT + '\n\nUnlock this finalized evaluation for editing?')) return;
+  const panel = document.getElementById(`scorecard-${JOB_ID}`);
+  panel.querySelectorAll('select, textarea').forEach(el => el.disabled = false);
+  const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+  if (btn) {
+    btn.disabled = false;
+    btn.textContent = 'Re-approve & Send';
+    btn.style.background = '#7c2d12';
+    btn.onclick = reapproveFinalized;
+  }
+  const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+  if (statusEl) {
+    statusEl.textContent =
+      'UNLOCKED (§4.3a acknowledged) — re-approving re-runs the engine and clears any manual override.';
+  }
+  const unlockBtn = document.getElementById(`unlock-btn-${JOB_ID}`);
+  if (unlockBtn) unlockBtn.disabled = true;
+}
+
+async function reapproveFinalized() {
+  const btn = document.getElementById(`approve-btn-${JOB_ID}`);
+  const statusEl = document.getElementById(`approve-status-${JOB_ID}`);
+  const panel = document.getElementById(`scorecard-${JOB_ID}`);
+  const email = getEvaluatorEmail();
+  if (!email) return;
+  const suppress = !window.confirm(
+    'Re-send the evaluation email (with the edit disclaimer)?\n\n'
+    + 'OK = send (default) · Cancel = suppress');
+
+  btn.disabled = true;
+  btn.textContent = 'Re-approving…';
+  const payload = buildApprovalPayload(JOB_ID);
+  payload.acknowledged = true;       // §4.3a — acknowledged at unlock
+  payload.suppress_email = suppress;
+  payload.evaluator_email = email;
+
+  try {
+    const res = await fetch(`${API_BASE}/datapoints/${encodeURIComponent(JOB_ID)}/edit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    btn.textContent = 'Re-approved';
+    btn.style.background = '#065f46';
+    const duty = data.coaching_id
+      ? (suppress
+         ? ` Notification duty PENDING (coaching #${data.coaching_id}) — you owe the agent a conversation.`
+         : ' Agent notified via the disclaimer email.')
+      : '';
+    statusEl.textContent =
+      `Re-approved — engine score ${data.old_score} → ${data.overall_score}.${duty}`;
+    panel.querySelectorAll('select, textarea').forEach(el => el.disabled = true);
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}. You can retry.`;
+    statusEl.style.color = '#fca5a5';
+    btn.disabled = false;
+    btn.textContent = 'Re-approve & Send';
+  }
+}
+
+async function rescoreFromScorecard() {
+  const statusEl = document.getElementById(`actions-status-${JOB_ID}`);
+  const email = getEvaluatorEmail();
+  if (!email) return;
+  if (!window.confirm(
+      'Re-score discards this AI pass and re-runs the pipeline on the same '
+      + 'call (same row, audited). Continue?')) return;
+  const suppress = !window.confirm(
+    'Re-send the evaluation email (with the re-score disclaimer) when the '
+    + 'fresh pass finalizes?\n\nOK = send (default) · Cancel = suppress');
+  statusEl.textContent = 'Scheduling fresh AI pass…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}/rescore`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ evaluator_email: email, suppress_email: suppress }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    statusEl.textContent =
+      `Re-score scheduled (superseding ${data.superseded_score}). Reload to follow the fresh pass.`;
+  } catch (err) {
+    statusEl.textContent = `Re-score error: ${err.message}`;
+  }
+}
+
+async function deleteFromScorecard() {
+  const statusEl = document.getElementById(`actions-status-${JOB_ID}`);
+  const agentName = (_scorecardData[JOB_ID] || {}).agent_name || _jobMeta.agent_name || '';
+  const typed = prompt(
+    `PERMANENT DELETE — removes the evaluation, sections, and stat point, `
+    + `and blanks the Sheets row.\n\nType the agent name ("${agentName}") to confirm:`);
+  if (typed === null) return;
+  if (typed.trim() !== agentName) {
+    alert('Name did not match — delete cancelled.');
+    return;
+  }
+  statusEl.textContent = 'Deleting…';
+  try {
+    const res = await fetch(`${API_BASE}/score/${JOB_ID}`, {
+      method: 'DELETE', headers: authHeaders(),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(
+      typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail));
+    const blob = new Blob([JSON.stringify(data.snapshot, null, 2)],
+                          { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `eval_${data.evaluation_id}_backup.json`;
+    a.click();
+    statusEl.textContent = `Deleted evaluation ${data.evaluation_id}. Backup downloaded.`;
+  } catch (err) {
+    statusEl.textContent = `Delete error: ${err.message}`;
+  }
+}
+</script>
+
+</body>
+</html>

--- a/sandy-qa/pages/scorecard.html
+++ b/sandy-qa/pages/scorecard.html
@@ -292,10 +292,7 @@ document.getElementById('backLink').href = `/lookup/${TEAM_ID}`;
 // --- Auth — localStorage so the API key carries across tabs (new tab from
 // /lookup must inherit auth without re-prompting). ---
 function getApiKey() { return 'sso'; } // Sandy: SSO owns auth
-function authHeaders() {
-  const key = getApiKey();
-  return key ? { 'Authorization': 'Bearer ' + key } : {};
-}
+function authHeaders() { return {}; } // Sandy: never send Authorization — the SSO edge rejects foreign bearer tokens
 
 // --- Team-section cache (drives manual-section rows + approve-gate logic) ---
 let _teamSections = [];

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -47,11 +47,22 @@ export default {
     }
 
     // ── Ported QA pages + team analytics APIs (PortManifest §3/§4/§6.1) ──
-    const teamRes = await handleTeamRoutes(
-      request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW,
-      { url: env.PULPO_MCP_URL, token: env.PULPO_MCP_TOKEN }
-    );
-    if (teamRes) return teamRes;
+    // Global guard: a thrown handler must surface as JSON, never as
+    // Cloudflare's HTML 1101 page (observed: the editor's re-approve
+    // showed "Unexpected token '<'" instead of the real error).
+    try {
+      const teamRes = await handleTeamRoutes(
+        request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW,
+        { url: env.PULPO_MCP_URL, token: env.PULPO_MCP_TOKEN }
+      );
+      if (teamRes) return teamRes;
+    } catch (err) {
+      console.log(`[route-error] ${url.pathname}: ${String(err).slice(0, 500)}`);
+      return Response.json(
+        { detail: `internal: ${String((err as any)?.message ?? err).slice(0, 300)}` },
+        { status: 500 }
+      );
+    }
 
     // ── SSE transport spike (PortManifest §"SSE on Sandy") ───────────────
     // Answers one question empirically: does the Sandy edge stack

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -461,6 +461,334 @@ export async function deleteEvaluation(
   return json({ ok: true, deleted_evaluation_id: ev.id });
 }
 
+// ── scorecard payload + approve / override / edit (§4.1 / §4.3 / S7) ───────
+
+async function evalSections(db: D1Database, evalId: number) {
+  return (
+    await db
+      .prepare(
+        "SELECT section_id, section_number, score_type, numeric_score, binary_value, score_source, confidence, reasoning FROM qa_evaluation_sections WHERE evaluation_id = ? ORDER BY section_number"
+      )
+      .bind(evalId)
+      .all<any>()
+  ).results;
+}
+
+// Restored-job dict — scoring.py::_job_from_ref shape, rendered forever
+// for any evaluation (the S1 reconstruction seam).
+export async function scorecardPayload(
+  db: D1Database,
+  teamId: string,
+  ref: string
+): Promise<Response> {
+  const { loadTeamConfig: load } = await import("../lib/teamConfig.js");
+  const config = await load(db, teamId);
+  const ev = await db
+    .prepare(
+      `SELECT * FROM qa_evaluations
+       WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
+       ORDER BY id DESC LIMIT 1`
+    )
+    .bind(teamId, ref, ref)
+    .first<any>();
+  if (!ev) {
+    // fall back to the live job store (in-flight scoring)
+    const job = await db
+      .prepare("SELECT run_id, status, result FROM workflow_runs WHERE run_id = ?")
+      .bind(ref)
+      .first<any>();
+    if (!job) return json({ detail: "Job not found" }, 404);
+    let r: any = {};
+    try { r = job.result ? JSON.parse(job.result) : {}; } catch {}
+    return json({
+      ...r,
+      status: job.status === "running" ? "pending" : job.status,
+      error: r.ok === false ? r.note : r.error ?? null,
+    });
+  }
+  const rows = await evalSections(db, ev.id);
+  const byId = new Map(rows.map((r: any) => [r.section_id, r]));
+  const sections = config.prompt_config.sections
+    .filter((s: any) => !s.auto_value)
+    .map((s: any) => {
+      const row: any = byId.get(s.id) ?? {};
+      const isYn = String(s.score_type).endsWith("yn");
+      return {
+        id: s.id,
+        name: s.name,
+        score: row.numeric_score ?? null,
+        score_type: isYn ? "yn" : "numeric",
+        yn_value: row.binary_value ?? null,
+        confidence: row.confidence ?? null,
+        reasoning: row.reasoning ?? null,
+        audio_dependent: !!s.audio_dependent,
+        flags: [],
+      };
+    });
+  let model: string | null = null;
+  try { model = JSON.parse(ev.models_used ?? "{}")?.text?.model ?? null; } catch {}
+  return json({
+    status: "complete",
+    state: ev.state,
+    scoring_status: ev.scoring_status,
+    evaluation_id: ev.id,
+    call_id: ev.dialpad_call_id ?? ev.dialpad_entry_point_call_id ?? ref,
+    agent_name: ev.agent_name_raw,
+    agent_email: ev.agent_email ?? "",
+    overall_score: ev.overall_score,
+    restored_from_db: true,
+    sandy_born: ev.id >= SANDY_BASE,
+    scorecard: {
+      sections,
+      manager_email: ev.evaluator_email ?? "",
+      dialpad_link: ev.dialpad_link,
+      call_summary: ev.call_summary ?? "",
+      key_strengths: ev.key_strengths ?? "",
+      opportunities: ev.opportunities ?? "",
+      agent_name: ev.agent_name_raw,
+      model,
+    },
+  });
+}
+
+async function coachingReceipt(
+  db: D1Database,
+  ev: any,
+  teamId: string,
+  evaluatorEmail: string,
+  role: string,
+  plan: string
+): Promise<number> {
+  const idRow = await db
+    .prepare("SELECT COALESCE(MAX(id) + 1, ?) AS v FROM qa_coachings WHERE id >= ?")
+    .bind(SANDY_BASE, SANDY_BASE)
+    .first<any>();
+  const cid = idRow?.v ?? SANDY_BASE;
+  await db
+    .prepare(
+      `INSERT INTO qa_coachings (id, agent_id, team_id, conducted_by_role,
+        conducted_by_email, status, action_plan) VALUES (?,?,?,?,?, 'pending', ?)`
+    )
+    .bind(cid, ev.agent_id, teamId, role, evaluatorEmail, plan)
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO qa_coaching_evaluations (id, coaching_id, evaluation_id, opportunities_snapshot)
+       VALUES (?,?,?,?)`
+    )
+    .bind(cid, cid, ev.id, ev.opportunities ?? null)
+    .run();
+  return cid;
+}
+
+// Shared finalize-with-edits core: approve (§4.1), edit-of-finalized (S7).
+export async function approveEvaluation(
+  request: Request,
+  db: D1Database,
+  teamId: string,
+  ref: string,
+  opts: { editOfFinalized: boolean }
+): Promise<Response> {
+  let body: any = {};
+  try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
+  const evaluatorEmail = (body.evaluator_email ?? "").trim().toLowerCase();
+  if (!evaluatorEmail) return json({ detail: "evaluator_email required" }, 422);
+
+  const ev = await db
+    .prepare(
+      `SELECT * FROM qa_evaluations
+       WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
+       ORDER BY id DESC LIMIT 1`
+    )
+    .bind(teamId, ref, ref)
+    .first<any>();
+  if (!ev) return json({ detail: "No evaluation matches this call id" }, 404);
+  if (ev.id < SANDY_BASE)
+    return json(
+      { detail: "This evaluation is Railway-owned during the shadow period — act on Railway." },
+      409
+    );
+  const wasFlagged = ev.scoring_status === "flagged_human_review";
+  if ((wasFlagged || opts.editOfFinalized) && body.acknowledged !== true)
+    return json(
+      { detail: "acknowledged=true required — you are modifying an agent's progression record" },
+      422
+    );
+
+  const { loadTeamConfig: load } = await import("../lib/teamConfig.js");
+  const config = await load(db, teamId);
+  const existing = await evalSections(db, ev.id);
+  const existingById = new Map(existing.map((r: any) => [r.section_id, r]));
+
+  // sections payload → rows; detect edits (source flip to ai_reviewed)
+  const rows: any[] = [];
+  let edited = false;
+  for (const sec of config.prompt_config.sections) {
+    if (sec.auto_value) {
+      const prev: any = existingById.get(sec.id);
+      rows.push({
+        section_id: sec.id, section_number: sec.section_number,
+        score_type: "auto_value",
+        numeric_score: null,
+        binary_value: prev?.binary_value ?? (sec.auto_value.toUpperCase().startsWith("Y") ? "Y" : "N"),
+        score_source: "auto_value", ai_provider: null,
+        confidence: null, reasoning: null,
+      });
+      continue;
+    }
+    const sent = (body.sections ?? []).find((s: any) => s.id === sec.id);
+    if (!sent) return json({ detail: `sections payload missing '${sec.id}'` }, 422);
+    const isYn = String(sec.score_type).endsWith("yn") || sent.score_type === "yn";
+    const numeric =
+      sent.score !== null && sent.score !== undefined ? Math.trunc(Number(sent.score)) : null;
+    const yn = sent.yn_value ?? null;
+    const prev: any = existingById.get(sec.id);
+    const changed =
+      !prev || (prev.numeric_score ?? null) !== numeric || (prev.binary_value ?? null) !== yn;
+    if (changed) edited = true;
+    const dbScoreType =
+      sec.score_type === "numeric" ? "numeric"
+      : sec.score_type === "yn" ? "binary"
+      : sec.score_type === "manual" ? "manual_numeric"
+      : "manual_binary";
+    rows.push({
+      section_id: sec.id, section_number: sec.section_number,
+      score_type: dbScoreType,
+      numeric_score: dbScoreType.includes("numeric") && yn !== "NA" ? numeric : null,
+      binary_value: dbScoreType.includes("numeric") && yn !== "NA" ? null : yn,
+      score_source: changed ? "manual" : prev?.score_source ?? "ai",
+      ai_provider: changed ? null : prev?.score_source === "ai" ? "gemini" : null,
+      confidence: sent.confidence ?? prev?.confidence ?? null,
+      reasoning: sent.reasoning ?? prev?.reasoning ?? null,
+    });
+  }
+
+  const answers: Record<string, number | string> = {};
+  for (const r of rows) {
+    if (r.binary_value !== null) answers[r.section_id] = r.binary_value;
+    else if (r.numeric_score !== null) answers[r.section_id] = r.numeric_score;
+  }
+  const fvRow = await db
+    .prepare(
+      "SELECT formula_version, formula_json FROM qa_formula_versions WHERE formula_version = ?"
+    )
+    .bind(ev.formula_version)
+    .first<any>();
+  if (!fvRow) return json({ detail: `formula ${ev.formula_version} not archived` }, 500);
+  const { evaluateFormula: evalF, quantizeScore: quant } = await import("../lib/ruleEngine.js");
+  const overall = quant(evalF(JSON.parse(fvRow.formula_json), answers).final_score);
+
+  const now = new Date().toISOString();
+  await db.prepare("DELETE FROM qa_evaluation_sections WHERE evaluation_id = ?").bind(ev.id).run();
+  for (const r of rows) {
+    await db
+      .prepare(
+        `INSERT INTO qa_evaluation_sections (id, evaluation_id, section_id, section_number,
+          score_type, numeric_score, binary_value, score_source, ai_provider,
+          confidence, reasoning) VALUES (?,?,?,?,?,?,?,?,?,?,?)`
+      )
+      .bind(
+        ev.id * 100 + r.section_number, ev.id, r.section_id, r.section_number,
+        r.score_type, r.numeric_score, r.binary_value, r.score_source,
+        r.ai_provider, r.confidence, r.reasoning
+      )
+      .run();
+  }
+  await db
+    .prepare(
+      `UPDATE qa_evaluations SET state='finalized', scoring_status='complete',
+        source=?, evaluator_email=?, overall_score=?,
+        key_strengths=?, opportunities=?,
+        approved_at=COALESCE(approved_at, ?), finalized_at=?
+       WHERE id=?`
+    )
+    .bind(
+      edited ? "ai_reviewed" : ev.source, evaluatorEmail, overall,
+      body.key_strengths ?? ev.key_strengths, body.opportunities ?? ev.opportunities,
+      now, now, ev.id
+    )
+    .run();
+
+  // S7: an edit-of-finalized creates the coaching receipt binding the
+  // notification duty (email dispatch itself is a later GAS-integration slice).
+  let coachingId: number | null = null;
+  if (opts.editOfFinalized && edited) {
+    coachingId = await coachingReceipt(
+      db, ev, teamId, evaluatorEmail, "manager",
+      `Scorecard edited post-finalize (was ${ev.overall_score}, now ${overall}). Notify the agent.`
+    );
+  }
+  await auditRow(db, {
+    role: "privileged", evaluator: evaluatorEmail, agentEmail: ev.agent_email ?? "",
+    agentName: ev.agent_name_raw, callId: ev.dialpad_call_id ?? ref, team: teamId,
+    action: "approved",
+    notes: `${wasFlagged ? "resolved_flagged " : ""}${edited ? "edited " : ""}score=${overall}${coachingId ? ` coaching=${coachingId}` : ""}`,
+  });
+  await db
+    .prepare("INSERT INTO qa_events (team_id, type, payload) VALUES (?, 'eval_approved', ?)")
+    .bind(
+      teamId,
+      JSON.stringify({
+        call_id: ev.dialpad_call_id ?? "", eval_id: ev.dialpad_entry_point_call_id ?? ev.dialpad_call_id ?? "",
+        history_row: null, agent: ev.agent_name_raw, evaluator_email: evaluatorEmail,
+        overall_score: overall, summary: (ev.call_summary ?? "").slice(0, 280),
+        strengths: (body.key_strengths ?? ev.key_strengths ?? "").slice(0, 280),
+        opportunities: (body.opportunities ?? ev.opportunities ?? "").slice(0, 280),
+        dialpad_link: ev.dialpad_link ?? "", timestamp: now,
+      })
+    )
+    .run();
+  return json({
+    ok: true, evaluation_id: ev.id, overall_score: overall, state: "finalized",
+    edited, coaching_id: coachingId, email: "not_ported_yet",
+  });
+}
+
+export async function overrideEvaluation(
+  request: Request,
+  db: D1Database,
+  teamId: string,
+  ref: string
+): Promise<Response> {
+  let body: any = {};
+  try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
+  const evaluatorEmail = (body.evaluator_email ?? "").trim().toLowerCase();
+  if (!evaluatorEmail) return json({ detail: "evaluator_email required" }, 422);
+  if (body.acknowledged !== true)
+    return json({ detail: "acknowledged=true required for an override" }, 422);
+  const score = Number(body.overall_score);
+  if (!Number.isFinite(score)) return json({ detail: "overall_score required" }, 422);
+  const ev = await resolveEval(db, teamId, ref);
+  if (!ev) return json({ detail: "No evaluation matches this call id" }, 404);
+  if (ev.id < SANDY_BASE)
+    return json(
+      { detail: "This evaluation is Railway-owned during the shadow period — act on Railway." },
+      409
+    );
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      `UPDATE qa_evaluations SET overall_score=?, source='ai_reviewed',
+        evaluator_email=?, state='finalized', scoring_status='complete',
+        approved_at=COALESCE(approved_at, ?), finalized_at=? WHERE id=?`
+    )
+    .bind(score, evaluatorEmail, now, now, ev.id)
+    .run();
+  // §4.3: the override ALWAYS creates the coaching receipt + duty.
+  const coachingId = await coachingReceipt(
+    db, ev, teamId, evaluatorEmail, body.conducted_by_role ?? "manager",
+    `Score overridden to ${score} (was ${ev.overall_score}). ${body.reasoning ?? ""}` +
+      (body.sop_gap?.note ? ` SOP gap: ${body.sop_gap.note}` : "")
+  );
+  await auditRow(db, {
+    role: "privileged", evaluator: evaluatorEmail, agentEmail: ev.agent_email ?? "",
+    agentName: ev.agent_name_raw, callId: ev.dialpad_call_id ?? ref, team: teamId,
+    action: "overridden",
+    notes: `override=${score} was=${ev.overall_score ?? "null"} coaching=${coachingId}${body.sop_gap?.note ? " sop_gap" : ""}`,
+  });
+  return json({ ok: true, evaluation_id: ev.id, overall_score: score, coaching_id: coachingId });
+}
+
 // ── callback persist ───────────────────────────────────────────────────────
 
 function sectionRowsFromScorecard(config: TeamConfig, scorecard: any) {

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -642,6 +642,11 @@ export async function approveEvaluation(
     const numeric =
       sent.score !== null && sent.score !== undefined ? Math.trunc(Number(sent.score)) : null;
     const yn = sent.yn_value ?? null;
+    if (numeric === null && yn === null)
+      return json(
+        { detail: `section '${sec.id}': needs a score or yn_value before approval` },
+        422
+      );
     const prev: any = existingById.get(sec.id);
     const changed =
       !prev || (prev.numeric_score ?? null) !== numeric || (prev.binary_value ?? null) !== yn;
@@ -676,7 +681,15 @@ export async function approveEvaluation(
     .first<any>();
   if (!fvRow) return json({ detail: `formula ${ev.formula_version} not archived` }, 500);
   const { evaluateFormula: evalF, quantizeScore: quant } = await import("../lib/ruleEngine.js");
-  const overall = quant(evalF(JSON.parse(fvRow.formula_json), answers).final_score);
+  let overall: number;
+  try {
+    overall = quant(evalF(JSON.parse(fvRow.formula_json), answers).final_score);
+  } catch (err) {
+    return json(
+      { detail: `formula rejected the edited sections: ${String((err as any)?.message ?? err).slice(0, 300)}` },
+      422
+    );
+  }
 
   const now = new Date().toISOString();
   await db.prepare("DELETE FROM qa_evaluation_sections WHERE evaluation_id = ?").bind(ev.id).run();

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -508,8 +508,15 @@ export async function scorecardPayload(
   }
   const rows = await evalSections(db, ev.id);
   const byId = new Map(rows.map((r: any) => [r.section_id, r]));
+  // AI-scored sections ONLY — Railway's Scorecard shape. The editor
+  // renders manual sections from /team/sections separately; including
+  // them here duplicated their ids in the approval payload (the first,
+  // null-valued copy shadowed the real manual input — the observed
+  // "needs a score or yn_value" 422 on human_review_required).
   const sections = config.prompt_config.sections
-    .filter((s: any) => !s.auto_value)
+    .filter(
+      (s: any) => !s.auto_value && !["manual", "manual_yn"].includes(s.score_type)
+    )
     .map((s: any) => {
       const row: any = byId.get(s.id) ?? {};
       const isYn = String(s.score_type).endsWith("yn");
@@ -636,7 +643,10 @@ export async function approveEvaluation(
       });
       continue;
     }
-    const sent = (body.sections ?? []).find((s: any) => s.id === sec.id);
+    // Last entry wins: the editor appends manual-input values after the
+    // scorecard-panel pass, so duplicates resolve to the real value.
+    const matches = (body.sections ?? []).filter((s: any) => s.id === sec.id);
+    const sent = matches[matches.length - 1];
     if (!sent) return json({ detail: `sections payload missing '${sec.id}'` }, 422);
     const isYn = String(sec.score_type).endsWith("yn") || sent.score_type === "yn";
     const numeric =

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -25,6 +25,8 @@ import lookupHtml from "../../pages/lookup.html?raw";
 // @ts-ignore vite ?raw
 import onepagerShellHtml from "../../pages/onepager.html?raw";
 // @ts-ignore vite ?raw
+import scorecardHtml from "../../pages/scorecard.html?raw";
+// @ts-ignore vite ?raw
 import headerCss from "../../pages/static/header.css?raw";
 // @ts-ignore vite ?raw
 import headerJs from "../../pages/static/header.js?raw";
@@ -198,45 +200,10 @@ export async function handleTeamRoutes(
   m = path.match(/^\/dashboard\/([^/]+)\/agent\/(.+)$/);
   if (m && KNOWN_TEAMS.has(m[1])) return html(agentDashboardHtml);
 
-  // Scorecard by job id: finalized → the datapoint page; flagged → the
-  // review-console interim; pending → self-refreshing status page.
+  // Scorecard editor (§4.1/§4.3 + flagged-review console) — the Railway
+  // page served verbatim; it renders any evaluation via GET /score/{id}.
   m = path.match(/^\/scorecard\/([^/]+)\/([^/]+)$/);
-  if (m && KNOWN_TEAMS.has(m[1])) {
-    const row = await db
-      .prepare("SELECT status, result FROM workflow_runs WHERE run_id = ?")
-      .bind(decodeURIComponent(m[2]))
-      .first<any>();
-    let r: any = {};
-    try {
-      r = row?.result ? JSON.parse(row.result) : {};
-    } catch {}
-    if (r.state === "finalized" && r.eval_id)
-      return new Response(null, {
-        status: 302,
-        headers: { Location: `/datapoint/${m[1]}/${encodeURIComponent(r.eval_id)}` },
-      });
-    if (r.scoring_status === "flagged_human_review")
-      return html(
-        `<!DOCTYPE html><html><head><title>Flagged for review</title></head>
-<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
-<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:560px">
-<h2 style="margin-top:0">This call is parked for human review</h2>
-<p>A section score tripped the §3.14 human-review gate, so the evaluation
-is a draft awaiting an analyst. The review console (approve / edit /
-override) is the next port slice — until it lands, flagged Sandy-scored
-calls wait here.</p>
-<p><a href="javascript:history.back()" style="color:#5a6478">&larr; Back</a></p>
-</div></body></html>`
-      );
-    return html(
-      `<!DOCTYPE html><html><head><title>Scoring…</title><meta http-equiv="refresh" content="5"></head>
-<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
-<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:520px">
-<h2 style="margin-top:0">Scoring in progress…</h2>
-<p>Job <code>${m[2]}</code> is ${row?.status ?? "unknown"}. This page refreshes every 5&nbsp;seconds.</p>
-</div></body></html>`
-    );
-  }
+  if (m && KNOWN_TEAMS.has(m[1])) return html(scorecardHtml);
   m = path.match(/^\/lookup\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1]))
     return lookupAllowed(request, lookupAllow)
@@ -265,14 +232,33 @@ calls wait here.</p>
       PULPO_MCP_TOKEN: pulpo?.token,
     });
   }
+  m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/approve$/);
+  if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const { approveEvaluation } = await import("./scoring.js");
+    return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
+      editOfFinalized: false,
+    });
+  }
+  m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/override$/);
+  if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const { overrideEvaluation } = await import("./scoring.js");
+    return overrideEvaluation(request, db, m[1], decodeURIComponent(m[2]));
+  }
+  m = path.match(/^\/api\/([^/]+)\/datapoints\/([^/]+)\/edit$/);
+  if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const { approveEvaluation } = await import("./scoring.js");
+    return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
+      editOfFinalized: true,
+    });
+  }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "DELETE") {
     const { deleteEvaluation } = await import("./scoring.js");
     return deleteEvaluation(request, db, m[1], decodeURIComponent(m[2]), url);
   }
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "GET") {
-    const { scoreStatus } = await import("./scoring.js");
-    return scoreStatus(db, decodeURIComponent(m[2]));
+    const { scorecardPayload } = await import("./scoring.js");
+    return scorecardPayload(db, m[1], decodeURIComponent(m[2]));
   }
 
   // ── drill-down + record APIs ─────────────────────────────────────────────


### PR DESCRIPTION
## The review console is live (v0.14)

`scorecard.html` served verbatim with the SSO shim — flagged-review editor, read-only finalized view, edit-then-approve, override modal, re-score, and the S7 edit-of-finalized flow all render against the ported APIs:

- **GET `/score/{id}`** — the S1 "restored-job" payload: any evaluation renders forever (sections rebuilt from rows + config), in-flight jobs fall through to the live job store.
- **Approve (§4.1)** — edits flip `source→ai_reviewed` / section `score_source→manual`, the formula re-evaluates + quantizes, finalize + audit + floor-TV toast. Flagged resolutions and finalized edits **require `acknowledged=true`** (§4.3a — the human-modified-progression acknowledgment).
- **Override (§4.3)** — always creates the **coaching receipt** (pending `qa_coachings` + eval link) binding the notification duty; SOP-gap note lands in the receipt + audit.
- **Edit-of-finalized (S7)** via `/datapoints/{id}/edit` — same core; coaching receipt when sections actually changed.

Doctrine held: **Sandy-born rows only** during shadow (Railway-born → 409). Known gap, stated in responses: the disclaimer **email dispatch is the GAS-integration slice** (`email: "not_ported_yet"`) — the audit trail and coaching receipts land regardless, so the tampering doctrine's paper trail is complete.

## Try it

- A **flagged** call: score one that trips the gate → lookup shows `flagged · Open Editor` → resolve the Human Review section → Approve (it will demand the acknowledgment).
- A **finalized** call: datapoint → Edit in Scorecard Editor → unlock, change a section, re-approve → check the coaching receipt row and the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)