### PR TITLE
feat(sandy-qa): GAS email dispatch — payload mode, sheet-free

### DIFF
--- a/qa-automation/src/Main.js
+++ b/qa-automation/src/Main.js
@@ -12,7 +12,9 @@
  * destination tab → readback → Analyst_History row) lives in the backend.
  * This script is a dumb email-dispatcher.
  *
- * Payload shape:
+ * Payload shapes (two modes):
+ *
+ *   Row mode (Railway / FastAPI — reads Analyst_History):
  *   { "historyRowNumber": <int>,
  *     "disclaimer": "<cause>"?    // ScorecardActions S7 — optional tag
  *                                 // (rescore_manual | rescore_auto |
@@ -22,6 +24,31 @@
  *                                 //  supersedes a previous one
  *   }
  *
+ *   Payload mode (Sandy — SandyMigration email slice): fully
+ *   self-contained; NO sheet reads. Sandy-born evaluations never reach
+ *   Analyst_History (the shadow sync is one-way into D1), so the app
+ *   sends everything inline — including the progression history, which
+ *   D1 covers more completely than the sheet once Sandy scoring is live.
+ *   { "entry": {
+ *       agentName, agentEmail, managerEmail, dialpadLink,
+ *       "timestamp": "<ISO 8601>",          // call_connected_at
+ *       overallScore: <number>,
+ *       numericScores: { "<section_id>": <number|null NA> },
+ *       binaryChecks:  { "<section_id>": <true|false|null NA> },
+ *       aiReasoning:   { "<section_id>": "<text>" },
+ *       aiConfidence:  { "<section_id>": "high|medium|low|''" },
+ *       strengths, improvements, callSummary, callerName, callerPhone,
+ *       disposition, aiCsat,
+ *       sopReferences: ["SOP 1: Title", ...]
+ *     },
+ *     "pastEntries": [                       // newest-first, CURRENT
+ *       { "timestamp": "<ISO>",              // call INCLUDED as [0]
+ *         "overallScore": <number>,          // (getHistory contract)
+ *         "source": "<ai|manual|ai_reviewed>" }, ...
+ *     ],
+ *     "disclaimer": "<cause>"?
+ *   }
+ *
  * Response:
  *   { "status": "ok"|"error", "message": "..." }
  */
@@ -29,9 +56,30 @@
 function doPost(e) {
   try {
     var payload = JSON.parse(e.postData.contents);
-    var rowNum  = payload.historyRowNumber;
     var disclaimer = (typeof payload.disclaimer === 'string')
       ? payload.disclaimer : '';
+
+    // ── Payload mode (Sandy) — self-contained, no sheet reads ──────
+    if (payload.entry && typeof payload.entry === 'object') {
+      var pEntry = QAEntry.fromPayload(payload.entry);
+      var history = (payload.pastEntries || []).map(function(p) {
+        return {
+          timestamp:    new Date(p.timestamp),
+          overallScore: parseFloat(p.overallScore) || 0,
+          source:       (p.source || '').toString(),
+        };
+      });
+      Logger.log('[doPost] payload mode: agent=%s, history=%s entries',
+                 pEntry.agentName, history.length);
+      _processEntry(pEntry, history, disclaimer);
+      return _jsonResponse({
+        status: 'ok',
+        message: 'payload-mode email dispatched to ' + pEntry.agentEmail,
+      });
+    }
+
+    // ── Row mode (Railway) — read Analyst_History ──────────────────
+    var rowNum = payload.historyRowNumber;
 
     if (!rowNum || typeof rowNum !== 'number') {
       return _jsonResponse({
@@ -87,9 +135,6 @@ function doPost(e) {
  * @private
  */
 function _processHistoryRow(entry, disclaimer) {
-  Logger.log('[_processHistoryRow] agent=%s, overallScore=%s, agentEmail=%s',
-             entry.agentName, entry.overallScore, entry.agentEmail);
-
   var ss      = SpreadsheetApp.getActiveSpreadsheet();
   var history = new AnalystHistory(ss);
 
@@ -98,7 +143,25 @@ function _processHistoryRow(entry, disclaimer) {
   // needed — that would duplicate the current call in the progression
   // card. ProgressionCard marks `entries[length-1]` as current.
   var pastEntries = history.getHistory(entry.agentName);
-  Logger.log('[_processHistoryRow] pastEntries count=%s', pastEntries.length);
+  _processEntry(entry, pastEntries, disclaimer);
+}
+
+/**
+ * Shared card-building + send core for both modes. `pastEntries` follows
+ * the AnalystHistory.getHistory contract: newest-first, current call
+ * included as the most-recent entry (payload mode senders must honor
+ * this — Sandy queries D1 AFTER persisting the evaluation, so the
+ * current call is naturally the newest row).
+ *
+ * @param {QAEntry}  entry
+ * @param {Object[]} pastEntries
+ * @param {string=}  disclaimer
+ * @private
+ */
+function _processEntry(entry, pastEntries, disclaimer) {
+  Logger.log('[_processEntry] agent=%s, overallScore=%s, agentEmail=%s, history=%s',
+             entry.agentName, entry.overallScore, entry.agentEmail,
+             pastEntries.length);
 
   var scoreCard       = new ScoreCard(entry);
   var feedbackCard    = new FeedbackCard(entry);
@@ -107,7 +170,7 @@ function _processHistoryRow(entry, disclaimer) {
 
   var sender = new EmailSender(entry);
   sender.send(renderer.renderEmail());
-  Logger.log('[_processHistoryRow] DONE — email sent to %s', entry.agentEmail);
+  Logger.log('[_processEntry] DONE — email sent to %s', entry.agentEmail);
 }
 
 function _jsonResponse(obj) {

--- a/qa-automation/src/QAEntry.js
+++ b/qa-automation/src/QAEntry.js
@@ -73,6 +73,48 @@ class QAEntry {
     return entry;
   }
 
+  /**
+   * Constructs a QAEntry from an inline JSON payload (Sandy's payload
+   * mode — see Main.js). The sender is authoritative for NA semantics:
+   * numericScores values arrive as number|null and binaryChecks as
+   * true|false|null, so no sentinel parsing happens here. Unknown
+   * section keys are carried as-is; the email cards only iterate
+   * CONFIG.*_CATEGORIES, so extras are ignored.
+   *
+   * @param  {Object} obj — the `entry` object of a payload-mode POST
+   * @return {QAEntry}
+   */
+  static fromPayload(obj) {
+    var entry = Object.create(QAEntry.prototype);
+    var str = function(v) { return (v || '').toString().trim(); };
+
+    entry.agentName    = str(obj.agentName);
+    entry.agentEmail   = str(obj.agentEmail);
+    entry.timestamp    = new Date(obj.timestamp || Date.now());
+    entry.managerEmail = str(obj.managerEmail);
+    entry.dialpadLink  = str(obj.dialpadLink);
+    entry.overallScore = parseFloat(obj.overallScore) || 0;
+
+    entry.numericScores = obj.numericScores || {};
+    entry.binaryChecks  = obj.binaryChecks  || {};
+    entry.aiReasoning   = obj.aiReasoning   || {};
+    entry.aiConfidence  = obj.aiConfidence  || {};
+
+    entry.strengths    = str(obj.strengths);
+    entry.improvements = str(obj.improvements);
+    entry.callSummary  = str(obj.callSummary);
+    entry.callerName   = str(obj.callerName);
+    entry.callerPhone  = str(obj.callerPhone);
+
+    entry.disposition = str(obj.disposition);
+    entry.aiCsat      = str(obj.aiCsat);
+    entry.sopReferences = (obj.sopReferences || [])
+      .map(function(s) { return (s || '').toString().trim(); })
+      .filter(String);
+
+    return entry;
+  }
+
   // ────────────────────────────────────────────────────────────────
   // Public helpers
   // ────────────────────────────────────────────────────────────────

--- a/sandy-qa/pages/index.html
+++ b/sandy-qa/pages/index.html
@@ -468,7 +468,12 @@
         const res = await fetch(`${API_BASE}/score`, { method: 'POST', body: formData });
         const data = await res.json().catch(() => ({ detail: res.statusText }));
         if (!res.ok) {
-          failed.push({ callId, detail: data.detail || `HTTP ${res.status}` });
+          failed.push({
+            callId,
+            detail: data.detail || `HTTP ${res.status}`,
+            rescoreAvailable: res.status === 409 && data.rescore_available === true,
+            evaluationId: data.evaluation_id,
+          });
         } else {
           jobs.push({ jobId: data.job_id, callId });
         }
@@ -491,7 +496,7 @@
     // Batch (or partial failure): stay here, render per-row status.
     statusArea.style.display = 'block';
     statusArea.scrollIntoView({ behavior: 'smooth' });
-    saveActiveJobs(jobs);
+    trackJobs(jobs);
     pollJobs(jobs, failed);
   });
 
@@ -503,20 +508,33 @@
   // tab, dropped session) had no recovery path but resubmitting.
   const JOBS_KEY = `qa_score_active_jobs_${TEAM_ID}`;
   const JOBS_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+  let _activeJobs = []; // every in-flight job across batches + rescores
 
-  function saveActiveJobs(jobs) {
+  function saveActiveJobs() {
     try {
-      localStorage.setItem(JOBS_KEY, JSON.stringify({ ts: Date.now(), jobs }));
+      if (!_activeJobs.length) { localStorage.removeItem(JOBS_KEY); return; }
+      localStorage.setItem(JOBS_KEY, JSON.stringify({ ts: Date.now(), jobs: _activeJobs }));
     } catch {}
   }
-  function clearActiveJobs() {
-    try { localStorage.removeItem(JOBS_KEY); } catch {}
+  function trackJobs(jobs) {
+    for (const j of jobs) {
+      if (!_activeJobs.some(a => a.jobId === j.jobId)) _activeJobs.push(j);
+    }
+    saveActiveJobs();
+  }
+  function untrackJob(jobId) {
+    _activeJobs = _activeJobs.filter(a => a.jobId !== jobId);
+    saveActiveJobs();
   }
   function restoreActiveJobs() {
     try {
       const saved = JSON.parse(localStorage.getItem(JOBS_KEY) || 'null');
       if (!saved || !Array.isArray(saved.jobs) || !saved.jobs.length) return;
-      if (Date.now() - (saved.ts || 0) > JOBS_MAX_AGE_MS) { clearActiveJobs(); return; }
+      if (Date.now() - (saved.ts || 0) > JOBS_MAX_AGE_MS) {
+        localStorage.removeItem(JOBS_KEY);
+        return;
+      }
+      _activeJobs = saved.jobs;
       statusArea.style.display = 'block';
       pollJobs(saved.jobs, []);
     } catch {}
@@ -526,14 +544,28 @@
   // --- Batch polling ---
   function pollJobs(jobs, failed) {
     jobListEl.innerHTML = '';
-    for (const { callId, detail } of failed || []) {
+    for (const f of failed || []) {
       const row = document.createElement('div');
       row.className = 'job-row';
-      row.innerHTML = `
-        <span>${esc(callId)}</span>
-        <span class="status-badge status-error">rejected</span>
-        <span class="job-error-detail">${esc(detail)}</span>
-      `;
+      row.id = `job-reject-${f.callId}`;
+      if (f.rescoreAvailable) {
+        // Already scored on Sandy → offer the §4.2 Re-score action in
+        // place (same audited endpoint as the datapoint page's button).
+        row.innerHTML = `
+          <span>${esc(f.callId)}</span>
+          <span class="status-badge status-flagged">already scored</span>
+          <span class="job-error-detail" style="color:var(--muted)">evaluation ${esc(f.evaluationId)}</span>
+          <button type="button" class="open-editor-link" style="background:none;cursor:pointer"
+            onclick="rescoreFromConsole('${esc(f.callId)}', '${esc(f.evaluationId)}', this)">Re-score</button>
+          <a class="open-editor-link" href="/scorecard/${TEAM_ID}/${encodeURIComponent(f.callId)}" target="_blank" rel="noopener">Open</a>
+        `;
+      } else {
+        row.innerHTML = `
+          <span>${esc(f.callId)}</span>
+          <span class="status-badge status-error">rejected</span>
+          <span class="job-error-detail">${esc(f.detail)}</span>
+        `;
+      }
       jobListEl.appendChild(row);
     }
     jobs.forEach(({ jobId, callId }) => {
@@ -546,7 +578,7 @@
       `;
       jobListEl.appendChild(row);
     });
-    if (!jobs.length) { clearActiveJobs(); return; }
+    if (!jobs.length) return;
 
     // Poll failures must be VISIBLE: a silent catch froze the badge on
     // its last state indefinitely (observed: "pending" forever while the
@@ -574,8 +606,10 @@
           const data = await res.json();
           failCounts[jobId] = 0;
           updateJobRow(jobId, callId, data);
-          if (['complete', 'approved', 'error'].includes(data.status)) terminal[jobId] = true;
-          else allDone = false;
+          if (['complete', 'approved', 'error'].includes(data.status)) {
+            terminal[jobId] = true;
+            untrackJob(jobId);
+          } else allDone = false;
         } catch (e) {
           allDone = false;
           failCounts[jobId] = (failCounts[jobId] || 0) + 1;
@@ -584,8 +618,81 @@
       }
       if (allDone) {
         clearInterval(interval);
-        clearActiveJobs();
         loadReviewQueue(); // flagged jobs land in the queue below
+      }
+    }, 3000);
+  }
+
+  // --- Console re-score (§4.2) ---
+  // Same audited endpoint as the datapoint page's Re-Score button: a fresh
+  // AI pass REPLACES the evaluation on the same record; the operator picks
+  // whether the re-scored email goes out (S4 suppress).
+  async function rescoreFromConsole(callId, evalId, btn) {
+    const managerEmail = (document.getElementById('manager-email').value || '').trim();
+    if (!managerEmail) {
+      alert('Enter your manager email first — it stamps the audit row.');
+      return;
+    }
+    if (!window.confirm(
+      `Re-score call ${callId}?\n\nA fresh AI pass will REPLACE evaluation ` +
+      `${evalId} on the same record. The intervention is audited.`)) return;
+    const suppress = !window.confirm(
+      'Send the evaluation email (with the re-score disclaimer) when the ' +
+      'fresh pass finalizes?\n\nOK = send (default) · Cancel = suppress');
+    btn.disabled = true;
+    try {
+      const res = await fetch(`${API_BASE}/score/${encodeURIComponent(callId)}/rescore`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ evaluator_email: managerEmail, suppress_email: suppress }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+      const row = document.getElementById(`job-reject-${callId}`);
+      if (row) {
+        row.id = `job-${data.job_id}`;
+        row.innerHTML = `
+          <span>${esc(callId)}</span>
+          <span class="status-badge status-pending">${esc(data.status || 'pending')}</span>
+        `;
+      }
+      trackJobs([{ jobId: data.job_id, callId }]);
+      pollOne(data.job_id, callId);
+    } catch (e) {
+      alert(`Re-score failed: ${e.message}`);
+      btn.disabled = false;
+    }
+  }
+
+  // Single-job poller for rescores started after the batch interval began
+  // (pollJobs' interval closes over its own job list).
+  function pollOne(jobId, callId) {
+    let fails = 0;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`${API_BASE}/score/${encodeURIComponent(jobId)}`,
+          { cache: 'no-store' });
+        if (res.status === 404) {
+          updateJobRow(jobId, callId, { status: 'error', error: 'Job not found — it may have expired.' });
+          clearInterval(interval);
+          untrackJob(jobId);
+          return;
+        }
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        fails = 0;
+        updateJobRow(jobId, callId, data);
+        if (['complete', 'approved', 'error'].includes(data.status)) {
+          clearInterval(interval);
+          untrackJob(jobId);
+          loadReviewQueue();
+        }
+      } catch (e) {
+        fails += 1;
+        if (fails >= 3) showPollWarning(jobId, e.message);
       }
     }, 3000);
   }

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -25,6 +25,12 @@ export interface Env {
   // v1-essential; absent → prompts take the sop_context_missing path).
   PULPO_MCP_URL?: string;
   PULPO_MCP_TOKEN?: string;
+  // Dashboard-set app secrets: per-team GAS webapp URLs for scorecard email
+  // dispatch (payload mode — qa-automation/src/Main.js). Absent → actions
+  // report email_dispatch {status:'skipped'}; setting them is the go-live
+  // switch for agent-facing email from Sandy.
+  GAS_WEBAPP_URL_MS?: string;
+  GAS_WEBAPP_URL_SALES?: string;
   // Optional: pre-select a specific workflow. Leave unset to list all available.
   WORKFLOW_ID?: string;
   // Provisioned automatically by Sandy at publish time for apps with cron schedules.
@@ -53,7 +59,8 @@ export default {
     try {
       const teamRes = await handleTeamRoutes(
         request, env.DB, url, env.DIALPAD_API_KEY, env.LOOKUP_ALLOW,
-        { url: env.PULPO_MCP_URL, token: env.PULPO_MCP_TOKEN }
+        { url: env.PULPO_MCP_URL, token: env.PULPO_MCP_TOKEN },
+        { member_support: env.GAS_WEBAPP_URL_MS, sales: env.GAS_WEBAPP_URL_SALES }
       );
       if (teamRes) return teamRes;
     } catch (err) {
@@ -209,7 +216,10 @@ es.onerror = () => { if (v.className === 'wait') { v.textContent = 'CONNECTION E
       if (workflowName === "qa-scoring-pipeline") {
         const { scoringCallback, drainScoreQueue } = await import("./routes/scoring.js");
         try {
-          const outcome = await scoringCallback(body, env.DB);
+          const outcome = await scoringCallback(body, env.DB, {
+            member_support: env.GAS_WEBAPP_URL_MS,
+            sales: env.GAS_WEBAPP_URL_SALES,
+          });
           const jobId = (body as any).persist
             ? `score-${(body as any).team_id}-${(body as any).call_id}-${String((body as any).persist.agent_name ?? "")
                 .toLowerCase()

--- a/sandy-qa/src/lib/emailDispatch.ts
+++ b/sandy-qa/src/lib/emailDispatch.ts
@@ -1,0 +1,178 @@
+// Scorecard email dispatch — port of the Railway finalize-email seam
+// (backend/routes/scoring.py::_dispatch_finalize_email + the GAS trigger in
+// services/sheets_service.py::trigger_apps_script).
+//
+// Railway POSTs { historyRowNumber } and the Apps Script reads the
+// Analyst_History sheet row. Sandy-born evaluations never reach that sheet
+// (the shadow sync is one-way into D1), so Sandy uses the GAS webapp's
+// PAYLOAD MODE (qa-automation/src/Main.js): the full entry + progression
+// history inline, built from D1 — which covers Railway-born AND Sandy-born
+// evals, more completely than the sheet.
+//
+// Secrets (Dashboard-only, ≤20-char names): GAS_WEBAPP_URL_MS /
+// GAS_WEBAPP_URL_SALES. Absent → {status:'skipped'} — setting the secret is
+// the go-live switch for real agent-facing email.
+
+const MAX_HISTORY = 5; // CONFIG.EMAIL.MAX_HISTORY in the GAS Branding.js
+
+export type EmailDispatchResult = { status: string; message: string };
+
+export function gasUrlForTeam(
+  gasUrls: { member_support?: string; sales?: string } | undefined,
+  teamId: string
+): string | undefined {
+  if (!gasUrls) return undefined;
+  return teamId === "sales" ? gasUrls.sales : gasUrls.member_support;
+}
+
+// Mirrors sheets_projection._render_disposition — "Category — Sub".
+function renderDisposition(ev: any): string {
+  const category = ev.dialpad_disposition_category || "";
+  const sub = ev.dialpad_disposition || "";
+  if (category && sub) return `${category} — ${sub}`;
+  return category || sub;
+}
+
+// Mirrors sheets_projection._render_sop_references — "SOP n: Title" lines,
+// numbering matching the [SOP n] citations in the AI reasoning.
+function renderSopReferences(metadata: any): string[] {
+  const docs = metadata?.pulpo_docs;
+  if (Array.isArray(docs) && docs.length) {
+    return docs
+      .map((d: any, i: number) => (d?.title ? `SOP ${i + 1}: ${d.title}` : ""))
+      .filter(Boolean);
+  }
+  return metadata?.sop_used ? [String(metadata.sop_used)] : [];
+}
+
+function buildEntry(ev: any, sections: any[]): any {
+  const numericScores: Record<string, number | null> = {};
+  const binaryChecks: Record<string, boolean | null> = {};
+  const aiReasoning: Record<string, string> = {};
+  const aiConfidence: Record<string, string> = {};
+  for (const s of sections) {
+    const isNa = s.binary_value === "NA";
+    numericScores[s.section_id] = isNa ? null : (s.numeric_score ?? 0);
+    binaryChecks[s.section_id] = isNa
+      ? null
+      : s.binary_value === null
+        ? false
+        : String(s.binary_value).toUpperCase().startsWith("Y");
+    aiReasoning[s.section_id] = s.reasoning ?? "";
+    aiConfidence[s.section_id] = String(s.confidence ?? "").toLowerCase();
+  }
+  let metadata: any = {};
+  try {
+    metadata =
+      typeof ev.dialpad_call_metadata === "string"
+        ? JSON.parse(ev.dialpad_call_metadata)
+        : ev.dialpad_call_metadata ?? {};
+  } catch {}
+  return {
+    agentName: ev.agent_name_raw ?? "",
+    agentEmail: ev.agent_email ?? "",
+    managerEmail: ev.evaluator_email ?? "",
+    dialpadLink: ev.dialpad_link ?? "",
+    timestamp: ev.call_connected_at ?? ev.created_at ?? new Date().toISOString(),
+    overallScore: ev.overall_score ?? 0,
+    numericScores,
+    binaryChecks,
+    aiReasoning,
+    aiConfidence,
+    strengths: ev.key_strengths ?? "",
+    improvements: ev.opportunities ?? "",
+    callSummary: ev.call_summary ?? "",
+    callerName: ev.caller_name ?? "",
+    callerPhone: ev.caller_phone ?? "",
+    disposition: renderDisposition(ev),
+    aiCsat: ev.ai_csat != null ? String(ev.ai_csat) : "",
+    sopReferences: renderSopReferences(metadata),
+  };
+}
+
+// AnalystHistory.getHistory contract: newest-first, the CURRENT call
+// included as the most-recent entry (we query after the eval is persisted,
+// so it lands there naturally). ProgressionCard consumes timestamp +
+// overallScore; source rides along for parity with the sheet reader.
+async function fetchPastEntries(
+  db: D1Database,
+  teamId: string,
+  agentNameRaw: string
+): Promise<any[]> {
+  const rows = await db
+    .prepare(
+      `SELECT call_connected_at, created_at, overall_score, source
+       FROM qa_evaluations
+       WHERE team_id = ? AND agent_name_raw = ? AND state = 'finalized'
+         AND overall_score IS NOT NULL
+       ORDER BY COALESCE(call_connected_at, created_at) DESC
+       LIMIT ?`
+    )
+    .bind(teamId, agentNameRaw, MAX_HISTORY)
+    .all<any>();
+  return rows.results.map((r) => ({
+    timestamp: r.call_connected_at ?? r.created_at,
+    overallScore: r.overall_score,
+    source: r.source ?? "",
+  }));
+}
+
+// The one entry point actions call: re-reads the finalized evaluation +
+// sections from D1 (so callers dispatch AFTER their writes commit), builds
+// the payload, POSTs to the team's GAS webapp. Never throws — the result
+// object is the caller's visible receipt (Railway's job.email_dispatch
+// parity: ok | skipped | suppressed | error).
+export async function dispatchScorecardEmail(
+  db: D1Database,
+  teamId: string,
+  evaluationId: number,
+  gasUrl: string | undefined,
+  disclaimer?: string | null
+): Promise<EmailDispatchResult> {
+  if (!gasUrl)
+    return {
+      status: "skipped",
+      message: `GAS_WEBAPP_URL_${teamId === "sales" ? "SALES" : "MS"} app secret not configured`,
+    };
+  try {
+    const ev = await db
+      .prepare("SELECT * FROM qa_evaluations WHERE id = ?")
+      .bind(evaluationId)
+      .first<any>();
+    if (!ev) return { status: "error", message: `evaluation ${evaluationId} not found` };
+    const sections = await db
+      .prepare(
+        "SELECT section_id, numeric_score, binary_value, confidence, reasoning FROM qa_evaluation_sections WHERE evaluation_id = ? ORDER BY section_number"
+      )
+      .bind(evaluationId)
+      .all<any>();
+    const body: any = {
+      entry: buildEntry(ev, sections.results),
+      pastEntries: await fetchPastEntries(db, teamId, ev.agent_name_raw ?? ""),
+    };
+    if (disclaimer) body.disclaimer = disclaimer;
+
+    // GAS /exec answers via a 302 to googleusercontent — follow it.
+    const res = await fetch(gasUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      redirect: "follow",
+      signal: AbortSignal.timeout(60_000),
+    });
+    const text = await res.text();
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.status === "string") return parsed;
+      return { status: "error", message: `unexpected GAS response: ${text.slice(0, 200)}` };
+    } catch {
+      // GAS surfaces script errors as an HTML page with HTTP 200.
+      return {
+        status: "error",
+        message: `GAS webapp returned non-JSON (HTTP ${res.status}): ${text.slice(0, 200)}`,
+      };
+    }
+  } catch (err) {
+    return { status: "error", message: String((err as any)?.message ?? err).slice(0, 300) };
+  }
+}

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -200,7 +200,18 @@ async function scoreTriggerInternal(
       .bind(teamId, callId)
       .first<any>();
     if (already)
-      return json({ detail: `call ${callId} already has evaluation ${already.id}` }, 409);
+      // Structured so the console can offer the §4.2 Re-score action in
+      // place (Sandy-born only — Railway-born rows re-score on Railway).
+      return json(
+        {
+          detail: `call ${callId} already has evaluation ${already.id}`,
+          evaluation_id: already.id,
+          call_id: callId,
+          sandy_born: already.id >= SANDY_BASE,
+          rescore_available: already.id >= SANDY_BASE,
+        },
+        409
+      );
   }
 
   const config = await loadTeamConfig(db, teamId);
@@ -525,17 +536,45 @@ export async function reviewQueue(
 
 const SANDY_BASE = 10_000_000;
 
-async function resolveEval(db: D1Database, teamId: string, ref: string) {
-  return db
-    .prepare(
-      `SELECT id, agent_id, agent_name_raw, agent_email, overall_score,
-              models_used, dialpad_call_id, dialpad_entry_point_call_id, state
-       FROM qa_evaluations
-       WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
-       ORDER BY id DESC LIMIT 1`
-    )
-    .bind(teamId, ref, ref)
+// A job-id ref (score-{team}-{call}-{agent}) maps to the call ref its run
+// persisted. Actions arrive with the editor URL's ref — which IS the job id
+// whenever the editor was opened from a batch/console "Open editor" link
+// (observed: approve on such a tab answered "No evaluation matches this
+// call id" while the eval sat finalized in D1).
+async function jobRefToCallRef(
+  db: D1Database,
+  ref: string
+): Promise<string | null> {
+  const job = await db
+    .prepare("SELECT result FROM workflow_runs WHERE run_id = ?")
+    .bind(ref)
     .first<any>();
+  if (!job?.result) return null;
+  try {
+    const r = JSON.parse(job.result);
+    const mapped = r.eval_id ?? r.call_id;
+    return mapped ? String(mapped) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveEval(db: D1Database, teamId: string, ref: string) {
+  const byRef = (r: string) =>
+    db
+      .prepare(
+        `SELECT id, agent_id, agent_name_raw, agent_email, overall_score,
+                models_used, dialpad_call_id, dialpad_entry_point_call_id, state
+         FROM qa_evaluations
+         WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
+         ORDER BY id DESC LIMIT 1`
+      )
+      .bind(teamId, r, r)
+      .first<any>();
+  const direct = await byRef(ref);
+  if (direct) return direct;
+  const mapped = await jobRefToCallRef(db, ref);
+  return mapped ? byRef(mapped) : null;
 }
 
 async function auditRow(
@@ -803,14 +842,21 @@ export async function approveEvaluation(
   const evaluatorEmail = (body.evaluator_email ?? "").trim().toLowerCase();
   if (!evaluatorEmail) return json({ detail: "evaluator_email required" }, 422);
 
-  const ev = await db
-    .prepare(
-      `SELECT * FROM qa_evaluations
-       WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
-       ORDER BY id DESC LIMIT 1`
-    )
-    .bind(teamId, ref, ref)
-    .first<any>();
+  const fullByRef = (r: string) =>
+    db
+      .prepare(
+        `SELECT * FROM qa_evaluations
+         WHERE team_id = ? AND (dialpad_call_id = ? OR dialpad_entry_point_call_id = ?)
+         ORDER BY id DESC LIMIT 1`
+      )
+      .bind(teamId, r, r)
+      .first<any>();
+  let ev = await fullByRef(ref);
+  if (!ev) {
+    // Editor tabs opened from a batch link carry the JOB id as the ref.
+    const mapped = await jobRefToCallRef(db, ref);
+    if (mapped) ev = await fullByRef(mapped);
+  }
   if (!ev) return json({ detail: "No evaluation matches this call id" }, 404);
   if (ev.id < SANDY_BASE)
     return json(

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -159,7 +159,13 @@ async function scoreTriggerInternal(
     PULPO_MCP_URL?: string;
     PULPO_MCP_TOKEN?: string;
   },
-  opts: { callId: string; agentEmail: string; managerEmail: string; rescoreOf?: number }
+  opts: {
+    callId: string;
+    agentEmail: string;
+    managerEmail: string;
+    rescoreOf?: number;
+    rescoreSuppressEmail?: boolean;
+  }
 ): Promise<Response> {
   if (!env.DIALPAD_API_KEY)
     return json({ detail: "DIALPAD_API_KEY app secret not configured" }, 503);
@@ -294,6 +300,9 @@ async function scoreTriggerInternal(
       pulpo_docs: sop.provenance,
       sop_skipped_reason: sop.skipped_reason || null,
       rescore_of: opts.rescoreOf ?? null,
+      // S4: the operator's re-send choice rides the queue payload so the
+      // callback (which owns the finalize email) can honor it.
+      rescore_suppress_email: opts.rescoreSuppressEmail ?? false,
     },
   };
 
@@ -583,6 +592,7 @@ export async function rescoreEvaluation(
     agentEmail: ev.agent_email ?? "",
     managerEmail: evaluatorEmail,
     rescoreOf: ev.id,
+    rescoreSuppressEmail: body.suppress_email === true,
   });
   if (trigger.status !== 200) return trigger;
   const data: any = await trigger.clone().json();
@@ -783,7 +793,10 @@ export async function approveEvaluation(
   db: D1Database,
   teamId: string,
   ref: string,
-  opts: { editOfFinalized: boolean }
+  opts: {
+    editOfFinalized: boolean;
+    gasUrls?: { member_support?: string; sales?: string };
+  }
 ): Promise<Response> {
   let body: any = {};
   try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
@@ -952,9 +965,25 @@ export async function approveEvaluation(
       })
     )
     .run();
+  // Finalize-seam email (Railway line: review_resolution wins over
+  // edit_finalized; suppress_email leaves a visible receipt — S7's §8.1
+  // checkbox on the edit-of-finalized flow).
+  let emailDispatch: any;
+  if (body.suppress_email === true) {
+    emailDispatch = { status: "suppressed", message: "caller requested suppress_email" };
+  } else {
+    const { dispatchScorecardEmail, gasUrlForTeam } = await import(
+      "../lib/emailDispatch.js"
+    );
+    emailDispatch = await dispatchScorecardEmail(
+      db, teamId, ev.id, gasUrlForTeam(opts.gasUrls, teamId),
+      wasFlagged ? "review_resolution" : opts.editOfFinalized ? "edit_finalized" : null
+    );
+  }
+
   return json({
     ok: true, evaluation_id: ev.id, overall_score: overall, state: "finalized",
-    edited, coaching_id: coachingId, email: "not_ported_yet",
+    edited, coaching_id: coachingId, email_dispatch: emailDispatch,
   });
 }
 
@@ -962,7 +991,8 @@ export async function overrideEvaluation(
   request: Request,
   db: D1Database,
   teamId: string,
-  ref: string
+  ref: string,
+  gasUrls?: { member_support?: string; sales?: string }
 ): Promise<Response> {
   let body: any = {};
   try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
@@ -1003,7 +1033,23 @@ export async function overrideEvaluation(
     action: "overridden",
     notes: `override=${score} was=${ev.overall_score ?? "null"} coaching=${coachingId}${body.sop_gap?.note ? " sop_gap" : ""}`,
   });
-  return json({ ok: true, evaluation_id: ev.id, overall_score: score, coaching_id: coachingId });
+  // §4.3: the corrected scorecard reaches the agent with the override
+  // disclaimer unless the caller suppresses (coaching-first conversations).
+  let emailDispatch: any;
+  if (body.suppress_email === true) {
+    emailDispatch = { status: "suppressed", message: "caller requested suppress_email" };
+  } else {
+    const { dispatchScorecardEmail, gasUrlForTeam } = await import(
+      "../lib/emailDispatch.js"
+    );
+    emailDispatch = await dispatchScorecardEmail(
+      db, teamId, ev.id, gasUrlForTeam(gasUrls, teamId), "override"
+    );
+  }
+  return json({
+    ok: true, evaluation_id: ev.id, overall_score: score,
+    coaching_id: coachingId, email_dispatch: emailDispatch,
+  });
 }
 
 // ── callback persist ───────────────────────────────────────────────────────
@@ -1084,7 +1130,8 @@ function answersFromSectionRows(rows: any[]): Record<string, number | string> {
 
 export async function scoringCallback(
   body: any,
-  db: D1Database
+  db: D1Database,
+  gasUrls?: { member_support?: string; sales?: string }
 ): Promise<{ ok: boolean; note: string }> {
   const jobStatus = body.status === "complete" ? "complete" : "error";
   const p = body; // workflow result payload
@@ -1252,6 +1299,27 @@ export async function scoringCallback(
       .run();
   }
 
+  // Finalize-seam email (Railway parity: the auto-flow dispatches with no
+  // disclaimer; a rescore's re-finalize carries its cause). Flagged rows
+  // don't email — the approve that resolves them does.
+  let emailDispatch: any = null;
+  if (!flagged) {
+    if (persist.rescore_of && persist.rescore_suppress_email) {
+      emailDispatch = {
+        status: "suppressed",
+        message: "rescore (manual) requested suppress_email",
+      };
+    } else {
+      const { dispatchScorecardEmail, gasUrlForTeam } = await import(
+        "../lib/emailDispatch.js"
+      );
+      emailDispatch = await dispatchScorecardEmail(
+        db, teamId, evalId, gasUrlForTeam(gasUrls, teamId),
+        persist.rescore_of ? "rescore_manual" : null
+      );
+    }
+  }
+
   return {
     ok: true,
     note: flagged
@@ -1262,5 +1330,6 @@ export async function scoringCallback(
     scoring_status: flagged ? "flagged_human_review" : "complete",
     overall_score: flagged ? null : overallScore,
     eval_id: persist.dialpad_entry_point_call_id || p.call_id,
+    ...(emailDispatch ? { email_dispatch: emailDispatch } : {}),
   };
 }

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -168,7 +168,8 @@ export async function handleTeamRoutes(
   url: URL,
   dialpadKey?: string,
   lookupAllow?: string,
-  pulpo?: { url?: string; token?: string }
+  pulpo?: { url?: string; token?: string },
+  gasUrls?: { member_support?: string; sales?: string }
 ): Promise<Response | null> {
   const path = url.pathname;
 
@@ -275,18 +276,20 @@ export async function handleTeamRoutes(
     const { approveEvaluation } = await import("./scoring.js");
     return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
       editOfFinalized: false,
+      gasUrls,
     });
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/override$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
     const { overrideEvaluation } = await import("./scoring.js");
-    return overrideEvaluation(request, db, m[1], decodeURIComponent(m[2]));
+    return overrideEvaluation(request, db, m[1], decodeURIComponent(m[2]), gasUrls);
   }
   m = path.match(/^\/api\/([^/]+)\/datapoints\/([^/]+)\/edit$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
     const { approveEvaluation } = await import("./scoring.js");
     return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
       editOfFinalized: true,
+      gasUrls,
     });
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)$/);


### PR DESCRIPTION
## Ladder item: scorecard email from Sandy (v0.22 live)

**The problem:** Railway dispatches email by POSTing `{historyRowNumber}` to the team's Apps Script webapp, which reads the **Analyst_History sheet row**. Sandy-born evaluations never reach that sheet (the shadow sync is one-way into D1) — row-number dispatch cannot work for them, and post-cutover the sheet goes stale entirely.

**The design: payload mode.** The GAS webapp gains a second, fully self-contained payload shape — the entry and progression history inline, zero sheet reads. D1 actually covers history *better* than the sheet: it has Railway-born AND Sandy-born evals.

### GAS side (`qa-automation/src` — ⚠ manual `push.sh` for BOTH teams after merge)
- `Main.js` `doPost`: detects `payload.entry` → `QAEntry.fromPayload` + inline history → same cards/renderer/sender via a shared `_processEntry` core. Row mode untouched — Railway keeps using it during shadow.
- `QAEntry.fromPayload`: sender-authoritative NA semantics (`number|null` scores, `true|false|null` checks) — no `"Not Applicable"` sentinel parsing.
- ⚠ After `push.sh`, the **webapp deployment needs a new version** for `/exec` to serve the new code (and remember the piped-yes false-success gotcha — verify with `clasp push -f` if in doubt).

### App side (`sandy-qa`)
- **`lib/emailDispatch.ts`** — re-reads the finalized eval + sections from D1 (callers dispatch after their writes), builds the entry mirroring `sheets_projection` exactly: disposition `"Category — Sub"`, `"SOP n: Title"` footnotes numbered to the `[SOP n]` citations, lowercased confidence, `call_connected_at` timestamps. Progression = 5 newest finalized, current included (the `getHistory` contract ProgressionCard expects). 60s timeout, follows GAS's 302, never throws.
- **Dispatch seams, Railway-parity disclaimers:**
  | Seam | Disclaimer | Suppress? |
  |---|---|---|
  | callback auto-finalize | *(none)* | n/a |
  | rescore re-finalize | `rescore_manual` | ✅ rides the queue payload (datapoint sent `suppress_email`; rescore previously **dropped it** — fixed) |
  | approve (flagged resolution) | `review_resolution` | ✅ |
  | edit-of-finalized | `edit_finalized` | ✅ (S7 §8.1 checkbox) |
  | override | `override` | ✅ |
- Every action's response now carries an **`email_dispatch` receipt** (`ok|skipped|suppressed|error`) replacing `email:"not_ported_yet"`; the callback outcome carries it too (visible in job results).

### Go-live switch = the secrets
`GAS_WEBAPP_URL_MS` / `GAS_WEBAPP_URL_SALES` (Dashboard-only; 20-char cap respected). **Until set, every dispatch reports `skipped` and no agent receives email from Sandy.** Suggested rollout: merge → push.sh + webapp redeploy → set the MS secret only → score a test call for a roster row pointing at a TEST inbox → verify rendering → then Sales.

### Verification
- Worker build + deploy 9029413b clean; GAS files `node --check` pass.
- Not yet E2E-testable: needs the GAS deploy + secrets (user-held). The `skipped` path is the deployed default — zero email risk at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KBKf3zj1dKghEv9CnaWX3

---

## Update: smoke-test fixes (v0.23)

Live smoke testing (secrets set, **emails confirmed sending**) surfaced two stragglers, both in the action-ref family:

1. **"No evaluation matches this call id" from the editor** — editor tabs opened via a batch/console "Open editor" link carry the *job id* in the URL. The page rendered fine (payload resolution), but approve/override/rescore/delete POSTed that same job-id ref, which the actions only matched against call-id columns. All actions now map a job ref to the call ref its run persisted.
2. **Console resubmit of a scored call dead-ended at the 409.** The dedupe guard stays (double-score protection), but the response is now structured and the console renders an **"already scored" row with a Re-score button** — the same audited §4.2 endpoint as the datapoint page (replace-confirm + email send/suppress choice), after which the row polls like any job. Railway-born evals keep the plain rejection during shadow.

Also unified in-flight job tracking (`_activeJobs`) so refresh restores batches and rescores together, and one finishing batch no longer wipes the other's saved state. Deployed as **v0.23** (deploy 700c3e50, clean scan).
