### PR TITLE
feat(sandy-qa): per-team RBAC — SSO-resolved roles, request-access flow, /admin

### DIFF
--- a/sandy-qa/migrations/0003_rbac.sql
+++ b/sandy-qa/migrations/0003_rbac.sql
@@ -1,0 +1,38 @@
+-- 0003_rbac.sql — per-team/per-role RBAC (pinned design 2026-08-03):
+-- roles keyed on the Cf-Access-Jwt-Assertion email Google SSO already
+-- injects, admin-editable in-app, NO Engineering involvement. Users never
+-- see auth until they hit a restricted page; the denial page offers a
+-- self-service access request that lands in qa_access_requests (the /admin
+-- page is the inbox until the Slack notification integration is designed).
+-- Replaces the interim LOOKUP_ALLOW secret (kept as a grandfather bridge in
+-- code until the secret is deleted).
+
+CREATE TABLE qa_roles (
+    email       TEXT PRIMARY KEY,     -- SSO email, lowercased
+    role        TEXT NOT NULL CHECK (role IN ('admin','qa','manager','viewer')),
+    -- NULL = all teams. Reserved for 'manager' scoping (per-team semantics
+    -- land when manager capabilities are defined); admin/qa are global.
+    team_id     TEXT,
+    granted_by  TEXT NOT NULL,
+    granted_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    note        TEXT
+);
+
+CREATE TABLE qa_access_requests (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    email       TEXT NOT NULL,
+    page        TEXT NOT NULL,        -- which wall they hit: 'lookup' | 'score'
+    team_id     TEXT,
+    note        TEXT,
+    status      TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','approved','denied')),
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    resolved_by TEXT,
+    resolved_at TEXT
+);
+
+CREATE INDEX idx_access_requests_status ON qa_access_requests (status, created_at);
+
+-- Bootstrap: the QA platform owner. Further grants happen in /admin.
+INSERT INTO qa_roles (email, role, granted_by, note)
+VALUES ('maximiliano.perez@hellolanding.com', 'admin', 'migration-0003', 'bootstrap admin');

--- a/sandy-qa/pages/admin.html
+++ b/sandy-qa/pages/admin.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QA Scoring — Access Admin</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #E7EFFB; --surface: #fff; --border: #c9d5e8; --text: #15192D;
+      --muted: #5a6478; --accent: #1A61D9; --navy: #15192D;
+      --success: #2d6a4f; --warning: #b45309; --error: #991b1b;
+      --badge-high: #d1fae5; --badge-medium: #fef3c7; --badge-low: #fee2e2;
+    }
+    body { font-family: 'DM Mono', monospace; background: var(--bg); color: var(--text); min-height: 100vh; }
+    header { background: var(--navy); color: #fff; padding: 1.5rem 2rem; margin-bottom: 2rem; }
+    header h1 { font-family: 'Fraunces', serif; font-weight: 300; font-size: 2rem; letter-spacing: -0.02em; }
+    header p { color: rgba(255,255,255,0.7); font-size: 0.8rem; margin-top: 0.25rem; }
+    .card { max-width: 860px; margin: 0 auto 1.5rem; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .card h2 { font-family: 'Fraunces', serif; font-weight: 400; font-size: 1.1rem; padding: 0.75rem 1.25rem; background: var(--navy); color: #fff; display: flex; justify-content: space-between; align-items: center; }
+    .count { font-size: 0.7rem; padding: 0.15rem 0.6rem; border-radius: 20px; background: rgba(255,255,255,0.15); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+    th { text-align: left; padding: 0.6rem 1rem; color: var(--muted); font-weight: 400; text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.65rem; border-bottom: 1px solid var(--border); }
+    td { padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); vertical-align: middle; }
+    tr:last-child td { border-bottom: none; }
+    .empty { padding: 1.25rem; font-size: 0.8rem; color: var(--muted); text-align: center; }
+    .pill { padding: 0.15rem 0.6rem; border-radius: 20px; font-size: 0.68rem; }
+    .pill.admin { background: #ede9fe; color: #5b21b6; }
+    .pill.qa { background: var(--badge-high); color: var(--success); }
+    .pill.manager { background: var(--badge-medium); color: var(--warning); }
+    .pill.viewer { background: #e5e7eb; color: #374151; }
+    select, input {
+      font-family: 'DM Mono', monospace; font-size: 0.78rem; padding: 0.4rem 0.55rem;
+      border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text); outline: none;
+    }
+    input:focus, select:focus { border-color: var(--accent); }
+    .btn {
+      font-family: 'DM Mono', monospace; font-size: 0.72rem; padding: 4px 12px;
+      border-radius: 4px; cursor: pointer; border: 1px solid var(--accent);
+      background: transparent; color: var(--accent); white-space: nowrap;
+    }
+    .btn:hover { background: var(--accent); color: #fff; }
+    .btn.danger { border-color: var(--error); color: var(--error); }
+    .btn.danger:hover { background: var(--error); color: #fff; }
+    .btn.go { border-color: var(--success); color: var(--success); }
+    .btn.go:hover { background: var(--success); color: #fff; }
+    .add-row { display: flex; gap: 0.5rem; padding: 1rem; border-top: 1px solid var(--border); flex-wrap: wrap; }
+    .add-row input[type="email"] { flex: 1; min-width: 220px; }
+    .note-cell { font-size: 0.7rem; color: var(--muted); max-width: 220px; }
+    .muted { color: var(--muted); font-size: 0.7rem; }
+    #flash { max-width: 860px; margin: 0 auto 1rem; padding: 0 0.25rem; font-size: 0.75rem; color: var(--error); min-height: 1.1em; }
+  </style>
+</head>
+<body>
+<header>
+  <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px;">
+    <div>
+      <h1>Access Admin</h1>
+      <p>Roles resolve automatically from Google SSO — grant, revoke, and triage access requests here.</p>
+    </div>
+    <a href="/" style="font-family:'DM Mono',monospace;font-size:0.82rem;padding:8px 16px;border:1px solid rgba(255,255,255,0.3);border-radius:6px;color:#fff;text-decoration:none;">Home</a>
+  </div>
+</header>
+
+<div id="flash"></div>
+
+<div class="card">
+  <h2>Access Requests <span class="count" id="req-count">…</span></h2>
+  <div id="requests"><div class="empty">Loading…</div></div>
+</div>
+
+<div class="card">
+  <h2>Roles <span class="count" id="role-count">…</span></h2>
+  <div id="roles"><div class="empty">Loading…</div></div>
+  <div class="add-row">
+    <input type="email" id="new-email" placeholder="person@hellolanding.com" />
+    <select id="new-role">
+      <option value="qa" selected>qa — evaluator (lookup + scoring + actions)</option>
+      <option value="admin">admin — everything + this page</option>
+      <option value="viewer">viewer — dashboards only (revokes privileges)</option>
+    </select>
+    <button type="button" class="btn go" onclick="addRole()">Grant</button>
+  </div>
+</div>
+
+<script>
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+function flash(msg) {
+  document.getElementById('flash').textContent = msg || '';
+  if (msg) setTimeout(() => flash(''), 6000);
+}
+
+async function api(path, opts) {
+  const res = await fetch(path, opts);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+  return data;
+}
+
+async function load() {
+  try {
+    const data = await api('/api/admin/overview');
+    renderRequests(data.requests || []);
+    renderRoles(data.roles || []);
+  } catch (e) {
+    flash(`Load failed: ${e.message}`);
+  }
+}
+
+function renderRequests(reqs) {
+  const el = document.getElementById('requests');
+  document.getElementById('req-count').textContent = String(reqs.length);
+  if (!reqs.length) {
+    el.innerHTML = '<div class="empty">No pending requests.</div>';
+    return;
+  }
+  el.innerHTML = `<div style="overflow-x:auto"><table>
+    <thead><tr><th>Who</th><th>Wants</th><th>Note</th><th>When</th><th></th></tr></thead>
+    <tbody>${reqs.map(r => `<tr>
+      <td>${esc(r.email)}</td>
+      <td>${esc(r.page)}${r.team_id ? ` (${esc(r.team_id)})` : ''}</td>
+      <td class="note-cell">${esc(r.note || '')}</td>
+      <td class="muted">${esc((r.created_at || '').slice(0, 10))}</td>
+      <td style="white-space:nowrap">
+        <select id="req-role-${r.id}"><option value="qa" selected>qa</option><option value="admin">admin</option></select>
+        <button type="button" class="btn go" onclick="resolveReq(${r.id}, 'approve')">Approve</button>
+        <button type="button" class="btn danger" onclick="resolveReq(${r.id}, 'deny')">Deny</button>
+      </td>
+    </tr>`).join('')}</tbody>
+  </table></div>`;
+}
+
+function renderRoles(roles) {
+  const el = document.getElementById('roles');
+  document.getElementById('role-count').textContent = String(roles.length);
+  if (!roles.length) {
+    el.innerHTML = '<div class="empty">No explicit roles yet.</div>';
+    return;
+  }
+  el.innerHTML = `<div style="overflow-x:auto"><table>
+    <thead><tr><th>Email</th><th>Role</th><th>Granted by</th><th>When</th><th>Note</th><th></th></tr></thead>
+    <tbody>${roles.map(r => `<tr>
+      <td>${esc(r.email)}</td>
+      <td><span class="pill ${esc(r.role)}">${esc(r.role)}</span></td>
+      <td class="muted">${esc(r.granted_by)}</td>
+      <td class="muted">${esc((r.granted_at || '').slice(0, 10))}</td>
+      <td class="note-cell">${esc(r.note || '')}</td>
+      <td><button type="button" class="btn danger" onclick="removeRole('${esc(r.email)}')">Remove</button></td>
+    </tr>`).join('')}</tbody>
+  </table></div>`;
+}
+
+async function addRole() {
+  const email = document.getElementById('new-email').value.trim().toLowerCase();
+  const role = document.getElementById('new-role').value;
+  if (!email || !email.includes('@')) { flash('Enter a valid email.'); return; }
+  try {
+    await api('/api/admin/roles', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, role }),
+    });
+    document.getElementById('new-email').value = '';
+    load();
+  } catch (e) { flash(`Grant failed: ${e.message}`); }
+}
+
+async function removeRole(email) {
+  if (!confirm(`Remove the explicit role for ${email}?\n\nThey fall back to viewer (dashboards only).`)) return;
+  try {
+    await api('/api/admin/roles', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, action: 'remove' }),
+    });
+    load();
+  } catch (e) { flash(`Remove failed: ${e.message}`); }
+}
+
+async function resolveReq(id, action) {
+  const role = action === 'approve'
+    ? (document.getElementById(`req-role-${id}`) || { value: 'qa' }).value
+    : undefined;
+  try {
+    await api(`/api/admin/access-requests/${id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, role }),
+    });
+    load();
+  } catch (e) { flash(`${action} failed: ${e.message}`); }
+}
+
+load();
+</script>
+</body>
+</html>

--- a/sandy-qa/src/lib/rbac.ts
+++ b/sandy-qa/src/lib/rbac.ts
@@ -1,0 +1,74 @@
+// Per-team/per-role RBAC (pinned design 2026-08-03) — roles resolve
+// AUTOMATICALLY from the Cf-Access-Jwt-Assertion email Google SSO already
+// injects at the Sandy edge. There is no login, no session, no auth UX:
+// users discover restrictions only by hitting one, and the denial page
+// offers a self-service access request (qa_access_requests; /admin is the
+// inbox until the Slack notification integration is designed properly).
+//
+// Roles:
+//   admin   — everything + /admin (role grants, request triage)
+//   qa      — privileged evaluator: lookup, scoring console, all actions
+//   manager — RESERVED (per-team semantics land when manager capabilities
+//             are defined; today it maps to viewer)
+//   viewer  — any SSO-authenticated employee: dashboards, drill-downs
+//
+// LOOKUP_ALLOW (the interim secret) stays as a grandfather bridge: members
+// without a qa_roles row act as 'qa' until the secret is deleted. A roles
+// row always wins over the bridge.
+
+export type Role = "admin" | "qa" | "manager" | "viewer";
+
+export interface Access {
+  email: string;
+  role: Role;
+  /** admin|qa — may use lookup, trigger scoring, and run scorecard actions */
+  privileged: boolean;
+}
+
+// SSO identity: signature validation happens at the Access edge before the
+// request reaches the worker (Engineering confirmation of the header
+// guarantee is a standing sit-down item).
+export function accessEmail(request: Request): string {
+  const jwt =
+    request.headers.get("Cf-Access-Jwt-Assertion") ??
+    request.headers.get("cf-access-jwt-assertion") ??
+    "";
+  const parts = jwt.split(".");
+  if (parts.length < 2) return "";
+  try {
+    const payload = JSON.parse(
+      atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))
+    );
+    return (payload.email ?? "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+export async function resolveAccess(
+  request: Request,
+  db: D1Database,
+  lookupAllow?: string
+): Promise<Access> {
+  const email = accessEmail(request);
+  if (!email) return { email: "", role: "viewer", privileged: false };
+  const row = await db
+    .prepare("SELECT role FROM qa_roles WHERE email = ?")
+    .bind(email)
+    .first<{ role: Role }>();
+  if (row) {
+    const privileged = row.role === "admin" || row.role === "qa";
+    return { email, role: row.role, privileged };
+  }
+  if (
+    lookupAllow &&
+    lookupAllow
+      .split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean)
+      .includes(email)
+  ) {
+    return { email, role: "qa", privileged: true };
+  }
+  return { email, role: "viewer", privileged: false };
+}

--- a/sandy-qa/src/routes/teamApi.ts
+++ b/sandy-qa/src/routes/teamApi.ts
@@ -29,9 +29,12 @@ import scorecardHtml from "../../pages/scorecard.html?raw";
 // @ts-ignore vite ?raw
 import scoringConsoleHtml from "../../pages/index.html?raw";
 // @ts-ignore vite ?raw
+import adminHtml from "../../pages/admin.html?raw";
+// @ts-ignore vite ?raw
 import headerCss from "../../pages/static/header.css?raw";
 // @ts-ignore vite ?raw
 import headerJs from "../../pages/static/header.js?raw";
+import { accessEmail, resolveAccess, type Access } from "../lib/rbac.js";
 
 const RAILWAY_BASE = "https://hellolanding-qa.up.railway.app";
 const KNOWN_TEAMS = new Set(["member_support", "sales"]);
@@ -108,59 +111,70 @@ const json = (data: unknown, status = 200) =>
     headers: { "Content-Type": "application/json" },
   });
 
-// SSO identity: Sandy's edge injects the platform-verified CF Access JWT.
-// We read the email claim for app-level authorization (signature validation
-// happens at the Access edge before the request reaches the worker; worth an
-// Engineering confirmation that tenant workers can rely on this header).
-function accessEmail(request: Request): string {
-  const jwt =
-    request.headers.get("Cf-Access-Jwt-Assertion") ??
-    request.headers.get("cf-access-jwt-assertion") ??
-    "";
-  const parts = jwt.split(".");
-  if (parts.length < 2) return "";
+// RBAC (lib/rbac.ts): roles resolve automatically from the SSO email —
+// users discover restrictions only by hitting one, and the denial page
+// offers a self-service access request. LOOKUP_ALLOW remains a grandfather
+// bridge inside resolveAccess until the secret is deleted.
+
+// Denial page with the request-access flow. The person never needed to
+// know RBAC existed until this moment — the page explains the wall and
+// lets them request through it in place.
+function deniedPage(kind: "lookup" | "score", teamId: string): Response {
+  const copy =
+    kind === "lookup"
+      ? {
+          title: "Call lookup is restricted",
+          why: "This page surfaces call history and recordings across the company, so it is limited to authorized QA staff.",
+        }
+      : {
+          title: "The scoring console is restricted",
+          why: "Triggering AI evaluations creates progression records for agents, so it is limited to authorized QA staff.",
+        };
+  const body = `<!DOCTYPE html><html><head><title>${copy.title}</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap" rel="stylesheet"></head>
+<body style="font-family:'DM Mono',monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
+<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:560px">
+<h2 style="margin-top:0">${copy.title}</h2>
+<p style="font-size:.85rem;line-height:1.55">${copy.why}</p>
+<div id="req" style="margin-top:20px">
+  <textarea id="req-note" placeholder="Optional: why do you need access?"
+    style="width:100%;font-family:inherit;font-size:.8rem;padding:10px;border:1px solid #c9d5e8;border-radius:6px;background:#E7EFFB;min-height:64px"></textarea>
+  <button id="req-btn" onclick="requestAccess()"
+    style="margin-top:10px;font-family:inherit;font-size:.82rem;padding:10px 20px;border:1px solid #1A61D9;border-radius:6px;background:#1A61D9;color:#fff;cursor:pointer">
+    Request access</button>
+  <span id="req-status" style="display:block;margin-top:10px;font-size:.75rem;color:#5a6478"></span>
+</div>
+<p style="color:#5a6478;font-size:.72rem;margin-top:18px"><a href="/" style="color:#1A61D9">&larr; Back to dashboards</a></p>
+</div>
+<script>
+async function requestAccess() {
+  const btn = document.getElementById('req-btn');
+  const status = document.getElementById('req-status');
+  btn.disabled = true;
   try {
-    const payload = JSON.parse(
-      atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))
-    );
-    return (payload.email ?? "").toLowerCase();
-  } catch {
-    return "";
+    const res = await fetch('/api/access-request', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ page: '${kind}', team_id: '${teamId}',
+        note: document.getElementById('req-note').value.trim() }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || ('HTTP ' + res.status));
+    status.textContent = data.deduped
+      ? 'You already have a pending request — the QA team will review it.'
+      : 'Request sent — the QA team will review it.';
+    btn.style.display = 'none';
+    document.getElementById('req-note').style.display = 'none';
+  } catch (e) {
+    status.textContent = 'Request failed: ' + e.message;
+    btn.disabled = false;
   }
 }
-
-// Interim lookup lock (compliance): /lookup exposes every agent's calls +
-// recordings, so it is DENY-BY-DEFAULT until per-team/role RBAC lands.
-// LOOKUP_ALLOW (Dashboard app secret) = comma-separated allowed emails.
-function lookupAllowed(request: Request, lookupAllow?: string): boolean {
-  if (!lookupAllow) return false;
-  const email = accessEmail(request);
-  if (!email) return false;
-  return lookupAllow
-    .split(",")
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean)
-    .includes(email);
+</script></body></html>`;
+  return new Response(body, {
+    status: 403,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
 }
-
-const LOOKUP_DENIED_PAGE = `<!DOCTYPE html><html><head><title>Lookup — restricted</title></head>
-<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
-<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:540px">
-<h2 style="margin-top:0">Call lookup is restricted</h2>
-<p>This page surfaces call recordings across the company, so access is
-limited to authorized QA staff while per-team role-based access is built.</p>
-<p style="color:#5a6478">If you need access, contact the QA team.</p>
-</div></body></html>`;
-
-const SCORING_DENIED_PAGE = `<!DOCTYPE html><html><head><title>Scoring — restricted</title></head>
-<body style="font-family:monospace;background:#E7EFFB;color:#15192D;display:grid;place-items:center;min-height:100vh;margin:0">
-<div style="background:#fff;border:1px solid #c9d5e8;border-radius:12px;padding:32px;max-width:540px">
-<h2 style="margin-top:0">The scoring console is restricted</h2>
-<p>Triggering AI evaluations creates progression records for agents, so
-access is limited to authorized QA staff while per-team role-based access
-is built.</p>
-<p style="color:#5a6478">If you need access, contact the QA team.</p>
-</div></body></html>`;
 
 export async function handleTeamRoutes(
   request: Request,
@@ -220,27 +234,139 @@ export async function handleTeamRoutes(
   m = path.match(/^\/scorecard\/([^/]+)\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1])) return html(scorecardHtml);
   m = path.match(/^\/lookup\/([^/]+)$/);
-  if (m && KNOWN_TEAMS.has(m[1]))
-    return lookupAllowed(request, lookupAllow)
-      ? html(lookupHtml)
-      : new Response(LOOKUP_DENIED_PAGE, {
-          status: 403,
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        });
+  if (m && KNOWN_TEAMS.has(m[1])) {
+    const access = await resolveAccess(request, db, lookupAllow);
+    return access.privileged ? html(lookupHtml) : deniedPage("lookup", m[1]);
+  }
 
   // Scoring console (index.html port) — batch score-by-call-ID + the §0.3
-  // review queue. Same interim QA-staff gate as /lookup (scoring creates
-  // progression records; per-team RBAC replaces this).
+  // review queue. Privileged (admin|qa): scoring creates progression records.
   m = path.match(/^\/score\/([^/]+)$/);
-  if (m && KNOWN_TEAMS.has(m[1]))
-    return lookupAllowed(request, lookupAllow)
-      ? html(scoringConsoleHtml)
-      : new Response(SCORING_DENIED_PAGE, {
-          status: 403,
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        });
+  if (m && KNOWN_TEAMS.has(m[1])) {
+    const access = await resolveAccess(request, db, lookupAllow);
+    return access.privileged ? html(scoringConsoleHtml) : deniedPage("score", m[1]);
+  }
+
+  // ── access admin (roles + request inbox) ─────────────────────────────────
+  if (path === "/admin") {
+    const access = await resolveAccess(request, db, lookupAllow);
+    if (access.role !== "admin")
+      return new Response("Admins only.", { status: 403 });
+    return html(adminHtml);
+  }
+  if (path === "/api/admin/overview" && request.method === "GET") {
+    const access = await resolveAccess(request, db, lookupAllow);
+    if (access.role !== "admin") return json({ detail: "Admins only." }, 403);
+    const roles = await db
+      .prepare("SELECT email, role, team_id, granted_by, granted_at, note FROM qa_roles ORDER BY role, email")
+      .all<any>();
+    const requests = await db
+      .prepare("SELECT id, email, page, team_id, note, created_at FROM qa_access_requests WHERE status = 'pending' ORDER BY created_at")
+      .all<any>();
+    return json({ roles: roles.results, requests: requests.results, me: access.email });
+  }
+  if (path === "/api/admin/roles" && request.method === "POST") {
+    const access = await resolveAccess(request, db, lookupAllow);
+    if (access.role !== "admin") return json({ detail: "Admins only." }, 403);
+    let body: any = {};
+    try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
+    const email = (body.email ?? "").trim().toLowerCase();
+    if (!email.includes("@")) return json({ detail: "valid email required" }, 422);
+    if (body.action === "remove") {
+      if (email === access.email)
+        return json({ detail: "You can't remove your own admin role (lockout guard)." }, 422);
+      await db.prepare("DELETE FROM qa_roles WHERE email = ?").bind(email).run();
+      return json({ ok: true, removed: email });
+    }
+    const role = body.role;
+    if (!["admin", "qa", "manager", "viewer"].includes(role))
+      return json({ detail: "role must be admin|qa|manager|viewer" }, 422);
+    if (email === access.email && role !== "admin")
+      return json({ detail: "You can't demote your own admin role (lockout guard)." }, 422);
+    await db
+      .prepare(
+        `INSERT INTO qa_roles (email, role, team_id, granted_by, note) VALUES (?,?,?,?,?)
+         ON CONFLICT(email) DO UPDATE SET role=excluded.role, team_id=excluded.team_id,
+           granted_by=excluded.granted_by, granted_at=strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+           note=excluded.note`
+      )
+      .bind(email, role, body.team_id ?? null, access.email, body.note ?? null)
+      .run();
+    return json({ ok: true, email, role });
+  }
+  m = path.match(/^\/api\/admin\/access-requests\/(\d+)$/);
+  if (m && request.method === "POST") {
+    const access = await resolveAccess(request, db, lookupAllow);
+    if (access.role !== "admin") return json({ detail: "Admins only." }, 403);
+    let body: any = {};
+    try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
+    const reqRow = await db
+      .prepare("SELECT id, email, page, status FROM qa_access_requests WHERE id = ?")
+      .bind(Number(m[1]))
+      .first<any>();
+    if (!reqRow) return json({ detail: "request not found" }, 404);
+    if (reqRow.status !== "pending") return json({ detail: `already ${reqRow.status}` }, 409);
+    const action = body.action;
+    if (!["approve", "deny"].includes(action))
+      return json({ detail: "action must be approve|deny" }, 422);
+    if (action === "approve") {
+      const role = ["admin", "qa"].includes(body.role) ? body.role : "qa";
+      await db
+        .prepare(
+          `INSERT INTO qa_roles (email, role, granted_by, note) VALUES (?,?,?,?)
+           ON CONFLICT(email) DO UPDATE SET role=excluded.role,
+             granted_by=excluded.granted_by, granted_at=strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+             note=excluded.note`
+        )
+        .bind(reqRow.email, role, access.email, `via access request #${reqRow.id} (${reqRow.page})`)
+        .run();
+    }
+    await db
+      .prepare(
+        "UPDATE qa_access_requests SET status = ?, resolved_by = ?, resolved_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?"
+      )
+      .bind(action === "approve" ? "approved" : "denied", access.email, reqRow.id)
+      .run();
+    return json({ ok: true, id: reqRow.id, status: action === "approve" ? "approved" : "denied" });
+  }
+
+  // Self-service access request (any SSO-authenticated employee) — the
+  // denial pages POST here. /admin is the inbox.
+  if (path === "/api/access-request" && request.method === "POST") {
+    const email = accessEmail(request);
+    if (!email) return json({ detail: "No SSO identity on this request." }, 401);
+    let body: any = {};
+    try { body = await request.json(); } catch { return json({ detail: "JSON body required" }, 422); }
+    const page = body.page === "score" ? "score" : "lookup";
+    const pending = await db
+      .prepare(
+        "SELECT id FROM qa_access_requests WHERE email = ? AND page = ? AND status = 'pending' LIMIT 1"
+      )
+      .bind(email, page)
+      .first<any>();
+    if (pending) return json({ ok: true, deduped: true });
+    await db
+      .prepare(
+        "INSERT INTO qa_access_requests (email, page, team_id, note) VALUES (?,?,?,?)"
+      )
+      .bind(email, page, body.team_id ?? null, (body.note ?? "").toString().slice(0, 500) || null)
+      .run();
+    // Slack notification seam — deliberately NOT built yet (the Slack
+    // integration gets its own design pass rather than a rushed webhook).
+    // When it lands: notify the QA admin channel/DM here with the request
+    // row; until then /admin's pending badge is the inbox.
+    return json({ ok: true });
+  }
 
   // ── scoring trigger + status (scoring.ts) ────────────────────────────────
+  // One shared privileged gate for every mutating scoring action — the
+  // pages render buttons by whoami role, but the API is the real wall.
+  const requirePrivileged = async (): Promise<Response | null> => {
+    const access = await resolveAccess(request, db, lookupAllow);
+    return access.privileged
+      ? null
+      : json({ detail: "This action is restricted to QA staff — request access from the Lookup or Scoring page." }, 403);
+  };
   m = path.match(/^\/api\/([^/]+)\/review-queue$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "GET") {
     const { reviewQueue } = await import("./scoring.js");
@@ -248,13 +374,8 @@ export async function handleTeamRoutes(
   }
   m = path.match(/^\/api\/([^/]+)\/score$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
-    // Both trigger surfaces (/lookup, /score console) sit behind the QA-staff
-    // gate; the API enforces the same line so the pages aren't the only wall.
-    if (!lookupAllowed(request, lookupAllow))
-      return json(
-        { detail: "Scoring is restricted to QA staff pending role-based access." },
-        403
-      );
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { scoreTrigger } = await import("./scoring.js");
     return scoreTrigger(request, db, m[1], {
       DIALPAD_API_KEY: dialpadKey,
@@ -264,6 +385,8 @@ export async function handleTeamRoutes(
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/rescore$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { rescoreEvaluation } = await import("./scoring.js");
     return rescoreEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
       DIALPAD_API_KEY: dialpadKey,
@@ -273,6 +396,8 @@ export async function handleTeamRoutes(
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/approve$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { approveEvaluation } = await import("./scoring.js");
     return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
       editOfFinalized: false,
@@ -281,11 +406,15 @@ export async function handleTeamRoutes(
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)\/override$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { overrideEvaluation } = await import("./scoring.js");
     return overrideEvaluation(request, db, m[1], decodeURIComponent(m[2]), gasUrls);
   }
   m = path.match(/^\/api\/([^/]+)\/datapoints\/([^/]+)\/edit$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "POST") {
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { approveEvaluation } = await import("./scoring.js");
     return approveEvaluation(request, db, m[1], decodeURIComponent(m[2]), {
       editOfFinalized: true,
@@ -294,6 +423,8 @@ export async function handleTeamRoutes(
   }
   m = path.match(/^\/api\/([^/]+)\/score\/([^/]+)$/);
   if (m && KNOWN_TEAMS.has(m[1]) && request.method === "DELETE") {
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     const { deleteEvaluation } = await import("./scoring.js");
     return deleteEvaluation(request, db, m[1], decodeURIComponent(m[2]), url);
   }
@@ -342,19 +473,23 @@ export async function handleTeamRoutes(
       503
     );
   m = path.match(/^\/api\/([^/]+)\/whoami$/);
-  if (m && KNOWN_TEAMS.has(m[1]))
-    // QA staff on LOOKUP_ALLOW get privileged-key semantics (Delete etc.
-    // render); everyone else is a team-role viewer. Routes still guard.
+  if (m && KNOWN_TEAMS.has(m[1])) {
+    // Pages render action buttons off `role` (privileged|team — the
+    // Railway contract); rbac_role/email are the richer RBAC identity.
+    const access = await resolveAccess(request, db, lookupAllow);
     return json({
-      role: lookupAllowed(request, lookupAllow) ? "privileged" : "team",
+      role: access.privileged ? "privileged" : "team",
       team_id: m[1],
+      rbac_role: access.role,
+      email: access.email,
     });
+  }
 
   // ── lookup APIs (Dialpad-backed; needs the DIALPAD_API_KEY app secret) ───
   m = path.match(/^\/api\/([^/]+)\/lookup(\/calls|\/recording-link|\/scoring-permission)?$/);
   if (m && KNOWN_TEAMS.has(m[1])) {
-    if (!lookupAllowed(request, lookupAllow))
-      return json({ detail: "Lookup access restricted pending role-based access." }, 403);
+    const deny = await requirePrivileged();
+    if (deny) return deny;
     return lookupRoutes(db, m[1], m[2] ?? "", url, request, dialpadKey);
   }
 


### PR DESCRIPTION
## Ladder item: RBAC (v0.24 live)

Implements the pinned design with today's UX contract: **RBAC is invisible**. Roles resolve automatically from the `Cf-Access-Jwt-Assertion` email Google SSO already injects at the Sandy edge — no login, no session, no visible auth. A user learns restrictions exist only when they hit one, and the denial page lets them **request access in place**.

### Model (`migrations/0003_rbac.sql`, applied to live D1)
| Role | Grants |
|---|---|
| `admin` | everything + `/admin` (role grants, request triage) |
| `qa` | privileged evaluator: lookup, scoring console, all scorecard actions |
| `manager` | **reserved** — per-team semantics land when manager capabilities are defined (maps to viewer today; `team_id` column ready) |
| `viewer` | default for any SSO employee: dashboards + drill-downs (unchanged, ungated) |

Bootstrap: maximiliano.perez@hellolanding.com seeded `admin`. **Grandfather bridge:** `LOOKUP_ALLOW` members without a roles row still resolve as `qa` — delete the secret whenever the roles table covers everyone; a roles row always wins over the bridge.

### Enforcement — API-level, not just pages
Previously only the two pages and `POST /score` were walled; every privileged surface is now gated: `/lookup` + `/score` pages, lookup APIs, score trigger, **rescore, approve, override, edit-of-finalized, delete**. `whoami` keeps the `privileged|team` contract the editors render buttons from, and adds `rbac_role` + `email`.

### Request-access flow
Denial page (403) → optional note → `POST /api/access-request` (deduped per email+page) → row in `qa_access_requests`. **Slack notification seam is deliberately unbuilt** — the integration gets its own design pass; a marked TODO sits at the insertion point and `/admin` serves as the inbox meanwhile.

### `/admin` (admin-only)
Pending requests with approve-as-role (qa/admin) or deny; role grant/update/remove with self-lockout guards (can't demote or remove your own admin row).

### Verification
- Migration applied + seed verified against live D1; build + deploy 050daad1 clean.
- Click-path for @mxg108: `/admin` should render with your admin row; an incognito-ish test (a colleague without a role) should see dashboards normally, hit the request wall on `/lookup/member_support`, and their request should appear in `/admin`.
- After roles cover all QA staff: delete `LOOKUP_ALLOW` in the Dashboard to retire the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KBKf3zj1dKghEv9CnaWX3