### PR TITLE
feat(sandy-qa): on-platform crons — hourly queue pump + daily D1 maintenance

### DIFF
--- a/sandy-qa/migrations/0004_cron_log.sql
+++ b/sandy-qa/migrations/0004_cron_log.sql
@@ -1,0 +1,14 @@
+-- 0004_cron_log.sql — observability for the on-platform crons (ladder:
+-- crons slice). Each /_sandy/cron dispatch appends a row; the daily
+-- maintenance prunes its own history. This is how we VERIFY fires without
+-- platform-side cron logs (and how a silent cron outage becomes visible:
+-- the newest row goes stale).
+
+CREATE TABLE cron_runs (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    cron    TEXT NOT NULL,          -- the schedule expression that fired
+    ran_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    note    TEXT                    -- what the run did (JSON summary)
+);
+
+CREATE INDEX idx_cron_runs_ran_at ON cron_runs (ran_at DESC);

--- a/sandy-qa/references/RetellAPI.md
+++ b/sandy-qa/references/RetellAPI.md
@@ -1,0 +1,115 @@
+# Retell AI — API reference + provider-seam design notes
+
+*Researched 2026-08-06 from docs.retellai.com for the Sofia AI scoring slice
+(Landing's in-testing Voice AI agent lives on Retell; we score its calls for
+SOP adherence + human-likeness). Companion to
+[[project_sofia_retell_provider]] (memory) and PortManifest.md.*
+
+## 1. API contract (what we call)
+
+Auth for everything: `Authorization: Bearer <RETELL_API_KEY>` (dashboard key).
+Base: `https://api.retellai.com`.
+
+### GET `/v2/get-call/{call_id}` — the workhorse
+
+Returns the full call object (`V2PhoneCallResponse` | `V2WebCallResponse`).
+Fields we care about:
+
+| Field | Shape | Use in our pipeline |
+|---|---|---|
+| `call_id` | `call_…` string | primary ref (fits our TEXT call-id columns) |
+| `agent_id` / `agent_name` / `agent_version` | string / string / int | which Sofia build took the call — version stamps matter while she's in testing |
+| `call_status` | `registered\|not_connected\|ongoing\|ended\|error` | only score `ended` |
+| `start_timestamp` / `end_timestamp` / `duration_ms` | epoch ms / epoch ms / int | `call_connected_at` / `call_ended_at` / `call_duration_ms` |
+| `transcript` | plain string | reference-transcript block (audio stays SOT) |
+| `transcript_object` | `[{role: agent\|user\|transfer_target, content, words: [{word, start, end}]}]` | word-level timestamps — richer than Dialpad's line times; feeds transcript_display + hold/silence hints |
+| `recording_url` | S3 WAV URL | audio leg — Gemini accepts WAV. **Signed URLs expire in 24 h when `opt_in_signed_url`** → fetch fresh at trigger time, never persist |
+| `recording_multi_channel_url` | S3 WAV (per-party channels) | prefer for the annotator if present — clean speaker separation |
+| `call_analysis` | `{call_summary, in_voicemail, user_sentiment: Neg\|Pos\|Neutral\|Unknown, call_successful, custom_analysis_data}` | Retell's own post-call analysis = the CC-grounding analog (Sofia has no Dialpad dispositions) |
+| `latency` | per-category `{p50,p90,p95,p99,max,min,num}`; categories `e2e,asr,llm,tts,knowledge_base,s2s` | **human-likeness gold**: objective response-gap stats to feed the annotator hints (a human doesn't answer in 80 ms or 4 s) |
+| `disconnection_reason` | 40+ enum (`user_hangup`, `agent_hangup`, `voicemail_reached`, `inactivity`, `max_duration_reached`, `error_*`, …) | call-outcome context + auto-skip lists (voicemail etc.) |
+| `from_number` / `to_number` / `direction` | phone-call variant | caller identity (`caller_phone`), inbound/outbound |
+| `public_log_url` | string | the "open the call" link (our `dialpad_link` analog) — LLM req/resp + latency debug view |
+| `metadata` / `retell_llm_dynamic_variables` / `collected_dynamic_variables` | objects | reservation/member context Sofia was given or collected — candidate grounding block |
+| `disconnection_reason`, `transfer_destination` | | transfer handling (role `transfer_target` appears in transcript) |
+
+HTTP: 200 ok, 401 bad key, 422 call not found.
+
+### POST `/v3/list-calls` — discovery/backfill
+
+v3 supersedes the deprecated v2/GET forms. Body:
+`{ filter_criteria, sort_order: ascending|descending (by start_timestamp),
+limit (≤1000, default 50), skip | pagination_key (mutually exclusive),
+include_total }` → `{ items: [...], pagination_key, has_more, total? }`.
+
+Filterable: `agent`(ids), `call_status`, `call_type`, `direction`,
+`start_timestamp` ranges, `duration_ms`, `disconnection_reason`,
+`user_sentiment`, `call_successful`, `in_voicemail`, `metadata`, more.
+
+**⚠ v3 list items OMIT `transcript*` and `recording_url`** — always follow
+with get-call per call. Pattern: hourly pull = list (`call_status: ended`,
+`start_timestamp_gte` watermark) → get-call each → score.
+
+## 2. Provider seam (how it lands in sandy-qa)
+
+Today `src/routes/scoring.ts` hardcodes Dialpad (`getTranscript`,
+`getCallDetails`, `DP` base). The seam:
+
+```
+src/lib/providers/
+  types.ts     — CallProvider interface: fetchCall(ref) → NormalizedCall
+  dialpad.ts   — extract of today's getTranscript/getCallDetails (no behavior change)
+  retell.ts    — the new client (get-call v2 + list-calls v3)
+```
+
+`NormalizedCall` (the shape scoreTriggerInternal already consumes):
+`{ call_id, transcript_text, transcript_display[], moments_display[],
+caller_name, caller_phone, connected_at, ended_at, duration_ms,
+entry_point_call_id?, review_link, audio: {url, format} | {provider:'dialpad'},
+grounding: {…provider-specific block} }`
+
+Provider selection by **team**: `sofia` team → retell, else dialpad
+(teams config row carries `provider`; Sofia joins as team 3 — the greeting
+page card already teases it).
+
+Retell mapping decisions:
+- **Audio leg**: app passes the fresh `recording_url` in the workflow
+  payload; the workflow just downloads it (no Retell key needed
+  workflow-side — unlike Dialpad). Prefer `recording_multi_channel_url`.
+- **Grounding block**: `call_analysis` + `disconnection_reason` + latency
+  summary replace the CC/disposition block; `metadata` +
+  `collected_dynamic_variables` fold in when present.
+- **Human-likeness hints**: pass `latency.e2e` percentiles + interruption/
+  word-gap stats derived from `transcript_object` into the annotator
+  prompt (the "Dialpad signal markers" slot generalizes to
+  "platform signal markers").
+- **SOP retrieval**: no dispositions → query Pulpo by
+  `call_analysis.call_summary` + custom_analysis intent when the
+  disposition key is absent (falls into the existing sub-τ conservative
+  path when retrieval is weak).
+- **Roster**: `sofia` team roster = one synthetic agent row per Retell
+  `agent_id`+version? Start simple: single "Sofia" agent; stamp
+  `agent_version` into `models_used`/metadata for per-build trend cuts.
+  **Email dispatch: suppress for Sofia** (no inbox; scorecards live on
+  dashboards; owner digest is a later choice).
+- **Rubric**: new `sofia` rubric/formula versions (human-likeness +
+  SOP sections) — separate design pass with the owner; the engine is
+  config-driven so no code changes expected there.
+
+## 3. Secrets
+
+`RETELL_API_KEY` (15 chars — fits Sandy's 20-char cap): **app secret**
+(Dashboard-set) — all Retell calls originate app-side; the workflow only
+receives a pre-signed recording URL. Keys currently live in
+qa-automation `.env` (Railway side, unused there for scoring).
+
+## 4. Open questions for the slice
+
+1. Sofia team id: `sofia` (teams table + KNOWN_TEAMS + greeting card flip).
+2. Which Retell agent_ids are "Sofia prod-test" vs scratch agents —
+   filter list-calls by agent ids (user provides).
+3. Scoring cadence: manual console-first (paste call ids / a Retell
+   lookup page variant), or auto-pull hourly? Start manual, add the
+   hourly list-calls pull once rubric stabilizes.
+4. `data_storage_setting` on Sofia's agent: if `everything_except_pii`,
+   scrubbed fields replace raw ones — verify what her config stores.

--- a/sandy-qa/src/index.tsx
+++ b/sandy-qa/src/index.tsx
@@ -179,10 +179,21 @@ es.onerror = () => { if (v.className === 'wait') { v.textContent = 'CONNECTION E
         return Response.json({ ok: false, error: "Unauthorized" }, { status: 401 });
       }
       const { cron } = await request.json() as { cron: string; timestamp: string };
-      console.log("[cron] fired", cron, "at", new Date().toISOString());
-      // TODO: add your scheduled logic here. env.DB is available for database access.
-      // Switch on `cron` if you have multiple schedules doing different things.
-      return Response.json({ ok: true });
+      const { runHourlyPump, runDailyMaintenance } = await import("./lib/maintenance.js");
+      let note: string;
+      try {
+        note =
+          cron === "37 9 * * *"
+            ? await runDailyMaintenance(env.DB, request)
+            : await runHourlyPump(env.DB, request); // "7 * * * *" + default
+      } catch (err) {
+        note = JSON.stringify({ error: String((err as any)?.message ?? err).slice(0, 300) });
+      }
+      await env.DB.prepare("INSERT INTO cron_runs (cron, note) VALUES (?, ?)")
+        .bind(cron, note)
+        .run();
+      console.log(`[cron] ${cron}: ${note}`);
+      return Response.json({ ok: true, note });
     }
 
     // POST /api/v1/callbacks/:workflow-name — receives results POSTed back by a Sandy Workflow.

--- a/sandy-qa/src/lib/maintenance.ts
+++ b/sandy-qa/src/lib/maintenance.ts
@@ -1,0 +1,69 @@
+// On-platform cron work (ladder: crons slice).
+//
+// Two schedules (wrangler.toml [triggers].crons; Sandy caps at 2):
+//   hourly "7 * * * *"  → queue pump. drainScoreQueue is otherwise pumped
+//     by enqueue, callbacks, and status polls — this closes the one gap
+//     where a lost callback + nobody watching left a queued job wedged
+//     until someone next opened the console.
+//   daily  "37 9 * * *" (09:37 UTC = early-morning LA) → maintenance:
+//     prune terminal workflow_runs + qa_score_queue rows, old qa_events
+//     (the SSE bus only ever tails NEW ids; history has no reader), and
+//     cron_runs' own history. Then pumps the queue too.
+//
+// NOT here (still laptop-side until the sast_ push double-write / cutover):
+// shadow_sync.py + nightly parity — both read Railway Postgres directly,
+// which a Worker cron cannot.
+
+const nowMinus = (mod: string) => `strftime('%Y-%m-%dT%H:%M:%fZ','now','${mod}')`;
+
+export async function runHourlyPump(
+  db: D1Database,
+  request: Request
+): Promise<string> {
+  const { drainScoreQueue } = await import("../routes/scoring.js");
+  const started = await drainScoreQueue(db, request);
+  const queued = await db
+    .prepare("SELECT COUNT(*) AS n FROM qa_score_queue WHERE status = 'queued'")
+    .first<any>();
+  return JSON.stringify({
+    pumped: started ?? null,
+    still_queued: queued?.n ?? 0,
+  });
+}
+
+export async function runDailyMaintenance(
+  db: D1Database,
+  request: Request
+): Promise<string> {
+  const summary: Record<string, number> = {};
+  const run = async (label: string, sql: string) => {
+    const res = await db.prepare(sql).run();
+    summary[label] = res.meta.changes ?? 0;
+  };
+
+  // Terminal job rows: the 409 double-score guard lives on qa_evaluations,
+  // not here, so old complete/error runs are safely prunable. In-flight
+  // rows (queued/pending/running) are never touched.
+  await run(
+    "workflow_runs",
+    `DELETE FROM workflow_runs WHERE status IN ('complete','error') AND created_at < ${nowMinus("-14 days")}`
+  );
+  await run(
+    "score_queue",
+    `DELETE FROM qa_score_queue WHERE status IN ('done','error') AND enqueued_at < ${nowMinus("-14 days")}`
+  );
+  // SSE bus: consumers tail ids from "now" (initial cursor = max id);
+  // reconnects only ever look back seconds. Week-old events are dead rows.
+  await run(
+    "qa_events",
+    `DELETE FROM qa_events WHERE created_at < ${nowMinus("-7 days")}`
+  );
+  await run(
+    "cron_runs",
+    `DELETE FROM cron_runs WHERE ran_at < ${nowMinus("-30 days")}`
+  );
+
+  const { drainScoreQueue } = await import("../routes/scoring.js");
+  const started = await drainScoreQueue(db, request);
+  return JSON.stringify({ pruned: summary, pumped: started ?? null });
+}

--- a/sandy-qa/wrangler.toml
+++ b/sandy-qa/wrangler.toml
@@ -50,9 +50,9 @@ database_id = "local-placeholder"
 #   - Day-of-week accepts: * | single value (MON or 1) | range (MON-FRI) | comma list (MON,WED,FRI)
 #   - Cloudflare day names: SUN MON TUE WED THU FRI SAT
 #
-# Uncomment and edit to enable:
-# [triggers]
-# crons = ["0 * * * *"]              # hourly at :00
-# crons = ["30 * * * *"]             # hourly at :30
-# crons = ["0 9 * * MON-FRI"]        # 9:00 AM weekdays
-# crons = ["0 9 * * *", "0 21 * * *"] # 9 AM and 9 PM daily (2 schedules)
+# hourly :07 = scoring-queue pump (recovers wedged queued jobs when no
+# callback/poll is alive to pump); daily 09:37 UTC (early morning LA) =
+# D1 maintenance pruning (workflow_runs, qa_score_queue, qa_events bus,
+# cron_runs history). Handlers: src/lib/maintenance.ts via /_sandy/cron.
+[triggers]
+crons = ["7 * * * *", "37 9 * * *"]


### PR DESCRIPTION
## Ladder: crons slice (v0.25 live)

Two Sandy cron schedules (the platform cap), dispatched through `/_sandy/cron` into `lib/maintenance.ts`:

| Schedule | Job |
|---|---|
| `7 * * * *` (hourly) | **Scoring-queue pump** — `drainScoreQueue`. Closes the last wedge scenario: a lost workflow callback with nobody polling left a queued job stuck until someone next opened the console. Now the queue self-heals within the hour, guaranteed. |
| `37 9 * * *` (09:37 UTC ≈ 2:37 AM LA) | **D1 maintenance** — prune terminal `workflow_runs` + `qa_score_queue` rows (>14d; the 409 double-score guard lives on `qa_evaluations`, so job-row pruning is safe), `qa_events` bus rows (>7d — SSE tails from max id; history has no reader), and `cron_runs` history (>30d). Also pumps the queue. |

**Observability:** every dispatch appends to the new `cron_runs` table (migration 0004, applied) with a JSON summary of what it did — fire verification without platform cron logs, and a visible staleness signal if the scheduler ever stops (`SELECT * FROM cron_runs ORDER BY id DESC LIMIT 5`).

**Deliberately out of scope** (honest boundaries):
- `shadow_sync.py` + nightly parity stay on the laptop — both read Railway **Postgres directly**, which a Worker cron cannot; they retire with the `sast_` push double-write or at cutover.
- The Dialpad disposition pull stays with the CC slice, where the history-depth test (still time-sensitive) lives.

Deployed + published **v0.25** (deploy 4c6d7ea7, clean scan). First hourly fire lands at the next `:07` — verifying via `cron_runs` and will report on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KBKf3zj1dKghEv9CnaWX3