### PR TITLE
fix(sandy-qa): Sales always-human-review gate — Railway parity (v0.26)

### DIFF
--- a/sandy-qa/references/SalesHumanReview.md
+++ b/sandy-qa/references/SalesHumanReview.md
@@ -1,0 +1,56 @@
+# Sales always-human-review — parity fix spec (v0.26, 2026-08-06)
+
+**Behavior:** every scored SALES call parks at `scoring_status =
+'flagged_human_review'` (draft, no overall_score, queue marker stamped) until
+an analyst resolves it in the editor. Sales evals never auto-finalize and
+never auto-email. Member Support is unaffected. This was Railway behavior;
+the original Sandy port carried only half the gate.
+
+## Mechanism (Railway parity — not a hardcoded team name)
+
+Railway's finalize decision (`backend/routes/scoring.py`):
+
+```
+flagged = human_review_trigger_fired(formula, sections)   # §3.14 thresholds
+          OR requires_analyst_review(config)               # ← this half was dropped
+```
+
+`requires_analyst_review` (`backend/services/eval_store.py:84`): true when the
+team's rubric has **manual sections** (`score_type` `manual`|`manual_yn`) whose
+formula section lacks **`na_default`** — the AI cannot legitimately fill those
+scores, so the eval must hold for an analyst. Provenance: production find
+2026-07-06, when Sales' `potential_booking`/`notes_mc` rode NA-default drafts
+into full credit under the full_credit NA policy.
+
+Why it hits exactly Sales:
+
+| team | manual sections | formula na_default set | fires |
+|---|---|---|---|
+| sales (`sales_v2`) | `potential_booking`, `notes_mc` | ∅ | **always** |
+| member_support (`member_support_v5`) | `human_review_required` | `{human_review_required}` | never (NA is its designed auto value) |
+
+Verified against live D1 (qa_rubric_versions current + qa_formula_versions
+active) on 2026-08-06 before shipping.
+
+## Sandy implementation
+
+`src/routes/scoring.ts` → `requiresAnalystReview(config, formula)` (rubric
+sections by `id`, formula sections by `key` — same namespace), OR-ed into the
+callback gate ahead of the §3.14 trigger loop. Flagged rows follow the
+existing paths: draft insert, `human_review_required_at` stamp, review-queue
+visibility, approve/override exits, no eval_approved event, no GAS email.
+
+Notes:
+- Config-derived, so a future formula granting `na_default` to Sales' manual
+  sections (or a new team with uncovered manual sections) changes behavior
+  with **zero code change** — same as Railway.
+- Railway's `human_review.mode` (`authoritative`|`informative`) is not ported;
+  both teams run the `authoritative` default, which is the only behavior the
+  Sandy gate implements. Port the mode switch if a team ever flips.
+
+## Verification
+
+1. Data-level: predicate replicated in Python against live D1 → sales=True,
+   member_support=False (above table).
+2. Operator check: score one Sales call → it must land in the review queue
+   (red editor), with no email; approve it → finalize + email as usual.

--- a/sandy-qa/src/routes/scoring.ts
+++ b/sandy-qa/src/routes/scoring.ts
@@ -1165,6 +1165,24 @@ function sectionRowsFromScorecard(config: TeamConfig, scorecard: any) {
   return rows;
 }
 
+// Port of eval_store.requires_analyst_review (backend/services/eval_store.py):
+// true when the team's rubric has manual sections (score_type manual|manual_yn)
+// whose formula section lacks na_default — the AI cannot legitimately fill
+// them, so the eval must hold for an analyst. Formula sections are keyed by
+// `key`, rubric sections by `id` (same namespace, Railway parity).
+function requiresAnalystReview(config: TeamConfig, formula: any): boolean {
+  const naDefaults = new Set(
+    (formula.sections ?? [])
+      .filter((s: any) => s?.na_default)
+      .map((s: any) => s.key)
+  );
+  return config.sections_by_number.some(
+    (s) =>
+      (s.score_type === "manual" || s.score_type === "manual_yn") &&
+      !naDefaults.has(s.id)
+  );
+}
+
 function answersFromSectionRows(rows: any[]): Record<string, number | string> {
   const answers: Record<string, number | string> = {};
   for (const r of rows) {
@@ -1206,8 +1224,19 @@ export async function scoringCallback(
   const result = evaluateFormula(formula, answers);
   const overallScore = quantizeScore(result.final_score);
 
-  // §3.14 human-review gate
-  let flagged = false;
+  // §3.14 human-review gate — two conditions, matching Railway
+  // routes/scoring.py (`human_review_trigger_fired(...) OR
+  // requires_analyst_review(config)`):
+  //   1. score-threshold triggers from formula_json.human_review_triggers;
+  //   2. requiresAnalystReview — a team whose rubric has MANUAL sections
+  //      lacking a formula na_default can NEVER auto-finalize: those scores
+  //      must come from an analyst. This is what makes every SALES eval
+  //      flag (manual potential_booking/notes_mc, no na_default anywhere in
+  //      sales_v2 — Railway production find 2026-07-06, when NA drafts rode
+  //      into full credit). MS is unaffected: its human_review_required
+  //      section declares na_default=true. Condition 2 was dropped in the
+  //      original port — restored 2026-08-06 (parity fix).
+  let flagged = requiresAnalystReview(config, formula);
   for (const trig of formula.human_review_triggers ?? []) {
     const a = answers[trig.section_id];
     if (typeof a === "number" && a <= trig.max_score_to_trigger) {


### PR DESCRIPTION
Follow-up to #180 (merged before this commit landed on the branch).

The scoring callback ported only half of Railway's finalize gate: the §3.14
`human_review_triggers` thresholds, but not `requires_analyst_review`
(eval_store.py:84) — true when a team's rubric has manual sections
(`manual`/`manual_yn`) whose formula section lacks `na_default`.

Sales' sales_v2 has manual `potential_booking`/`notes_mc`, zero `na_default`,
and an EMPTY §3.14 trigger list — so on Railway, 100% of Sales flags came from
this condition: **Sales scores never auto-finalize; they always park for human
review.** The Sandy port silently auto-finalized them.

- `requiresAnalystReview(config, formula)` restored in `routes/scoring.ts`,
  OR-ed ahead of the §3.14 loop (config-derived, no hardcoded team name).
- Spec: `sandy-qa/references/SalesHumanReview.md`.
- Predicate validated against live D1: sales=True, member_support=False.
- Deployed as qa-scoring v0.26 (clean scan).
- Backscan: exactly one Sandy-born Sales eval auto-finalized under the gap
  (id 10000025) — flagged to the operator for retroactive review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7cSv4Vy1wFY3DTt8wKvTB