### PR TITLE
feat(mass-notifications): P2 send pipeline, P3 SMS companion, /edit surface (v0.5–v0.9)

### DIFF
--- a/sandy-mass-notifications/PRD.md
+++ b/sandy-mass-notifications/PRD.md
@@ -198,7 +198,7 @@ Same pattern as qa-scoring v0.22 (live, smoke-tested): a minimal Apps Script Web
 
 ### 6.4 Dialpad SMS
 
-`POST api.dialpad.com/v2/sms` from the workflow, `DIALPAD_API_KEY` secret, **from +1 (415) 980-4986** (verified Member Support Line, D4). Sent per member after that member's email send succeeds. Quiet hours: queue by `MS_TIMEZONE` (no SMS outside 08:00–21:00 local; configurable). Members with `text_notifications_enabled = false` (GraphQL `User`) are skipped and audited as `skipped_optout`.
+`POST dialpad.com/api/v2/sms` from the workflow, `DIALPAD_API_KEY` secret, **from +1 (415) 980-4986** (verified Member Support Line, D4). Sent per member after that member's email send succeeds. Quiet hours (as built, v0.8): no SMS outside 08:00–21:00 local (`MS_TIMEZONE`, Rails→IANA mapped) — members outside the window are **marked `skipped_quiet_hours` and re-sent via the one-click "Send SMS to N emailed recipients" action** rather than scheduled (v1 simplification; timed scheduling can come later). Members with `text_notifications_enabled = false` (GraphQL `User`) are skipped as `skipped_optout`; a lookup failure degrades to sending with an audited warning (parity: the manual Hub-Manager process had no opt-out check). One AI summary per campaign (not per member); operator can preview/regenerate it and test-send to their own number before anything goes to members.
 
 ### 6.5 AI calls — Cloudflare AI Gateway
 

--- a/sandy-mass-notifications/README.md
+++ b/sandy-mass-notifications/README.md
@@ -23,6 +23,14 @@ fetch workflow `ffaa18b1-92a6-4eef-8219-c85c950c9068`.
 
 ## Change Log
 
+> v0.5 : 2026-08-06
+- P2 send pipeline: `emailkit.ts` (token engine with HTML-escape-by-default +
+  {{html:}} escape hatch, body composer, 6 cards, 6 seeded templates — legacy
+  parity), campaign Configure/Preview/Send UI, `mass-notify-dispatch` workflow
+  (batched GAS dispatcher calls, per-recipient results, callback), runs audit
+  with undo, dry-run drafts + test-send. E2E verified: draft created in
+  member.support@ for a real Wayland recipient, D1 states updated end-to-end.
+
 > v0.1 : 2026-08-05
 - P1 recipient pipeline: campaigns CRUD, warehouse fetch via
   `mass-notify-fetch` (Snowflake `LANDING.CORE`, legacy Looker "Active

--- a/sandy-mass-notifications/README.md
+++ b/sandy-mass-notifications/README.md
@@ -23,6 +23,17 @@ fetch workflow `ffaa18b1-92a6-4eef-8219-c85c950c9068`.
 
 ## Change Log
 
+> v0.8 : 2026-08-06
+- P3 SMS companion (OpsVP): dispatch workflow v0.2 adds an SMS phase — one
+  AI summary per campaign (AI Gateway, ≤320 chars, length-guarded, sentence
+  truncate + flag), Dialpad sends from +14159804986, quiet hours 08:00–21:00
+  local (MS_TIMEZONE Rails→IANA), GraphQL opt-out respect (graceful degrade).
+  New kinds: sms_preview / sms_test (to any number) / sms_only (post-send
+  retry). App: per-campaign SMS toggle, preview card with regenerate, test
+  input, retry button, per-recipient SMS states in the grid; migration 003
+  caches the preview on campaigns. SSE watcher upgraded to a change-signature
+  model covering SMS operations. E2E: preview verified (185-char summary).
+
 > v0.7 : 2026-08-06
 - Frontend polish (operator feedback): custom navy app header + slim footer
   (no stock marketing dead links), OG GAS WebApp background (#E7EFFB);

--- a/sandy-mass-notifications/README.md
+++ b/sandy-mass-notifications/README.md
@@ -23,6 +23,14 @@ fetch workflow `ffaa18b1-92a6-4eef-8219-c85c950c9068`.
 
 ## Change Log
 
+> v0.9 : 2026-08-06
+- Card editor upgrades: native color picker + Landing palette swatches for
+  the accent field; "Describe your notification card" AI helper — Haiku
+  (claude-haiku-4-5, via workflow kind card_gen) drafts the row HTML straight
+  into Body HTML on saved cards, editor polls and reloads when it lands.
+  E2E: elevator-maintenance description → 1.7k chars of correctly patterned
+  rows with {{property_name}}/{{date_range}} tokens.
+
 > v0.8 : 2026-08-06
 - P3 SMS companion (OpsVP): dispatch workflow v0.2 adds an SMS phase — one
   AI summary per campaign (AI Gateway, ≤320 chars, length-guarded, sentence

--- a/sandy-mass-notifications/README.md
+++ b/sandy-mass-notifications/README.md
@@ -23,6 +23,16 @@ fetch workflow `ffaa18b1-92a6-4eef-8219-c85c950c9068`.
 
 ## Change Log
 
+> v0.6 : 2026-08-06
+- Editable email assets: cards + disclaimers live in D1 (templates table,
+  seeded from emailkit SEED_* on first run), managed at **/edit** (list,
+  editor with sample-token preview, active toggle; new cards/disclaimers
+  become Configure chiclets). Card + disclaimer selection is now
+  **instant-apply chiclets** (fixes select-without-save doing nothing).
+  **SSE live status** (`/c/:id/events` + page watcher) replaces
+  refresh-to-see-results during fetching/sending. Migration 002 adds
+  templates.updated_by/updated_at.
+
 > v0.5 : 2026-08-06
 - P2 send pipeline: `emailkit.ts` (token engine with HTML-escape-by-default +
   {{html:}} escape hatch, body composer, 6 cards, 6 seeded templates — legacy

--- a/sandy-mass-notifications/README.md
+++ b/sandy-mass-notifications/README.md
@@ -23,6 +23,15 @@ fetch workflow `ffaa18b1-92a6-4eef-8219-c85c950c9068`.
 
 ## Change Log
 
+> v0.7 : 2026-08-06
+- Frontend polish (operator feedback): custom navy app header + slim footer
+  (no stock marketing dead links), OG GAS WebApp background (#E7EFFB);
+  flash banners auto-clear from the URL (no stale "Fetch queued");
+  recipient status is one pill-styled auto-saving select (duplicate chip +
+  cramped Set button gone); Configure gains labeled Templates vs Card
+  sub-panels with layman explanations; /edit icon field accepts plain
+  emoji and stores Gmail-safe hex entities (round-trips back as emoji).
+
 > v0.6 : 2026-08-06
 - Editable email assets: cards + disclaimers live in D1 (templates table,
   seeded from emailkit SEED_* on first run), managed at **/edit** (list,

--- a/sandy-mass-notifications/migrations/002_editable_assets.sql
+++ b/sandy-mass-notifications/migrations/002_editable_assets.sql
@@ -1,0 +1,4 @@
+-- Migration 002 — audit columns for editable email assets (cards/disclaimers).
+-- Seeding happens at runtime from emailkit SEED_CARDS / SEED_DISCLAIMERS.
+ALTER TABLE templates ADD COLUMN updated_by TEXT;
+ALTER TABLE templates ADD COLUMN updated_at TEXT;

--- a/sandy-mass-notifications/migrations/003_sms_companion.sql
+++ b/sandy-mass-notifications/migrations/003_sms_companion.sql
@@ -1,0 +1,3 @@
+-- Migration 003 — SMS companion (P3): per-campaign AI summary cache.
+ALTER TABLE campaigns ADD COLUMN sms_preview_text TEXT;
+ALTER TABLE campaigns ADD COLUMN sms_preview_truncated INTEGER NOT NULL DEFAULT 0;

--- a/sandy-mass-notifications/src/App.tsx
+++ b/sandy-mass-notifications/src/App.tsx
@@ -50,6 +50,7 @@ export interface AppProps {
   editorKind?: "card" | "disclaimer";
   editing?: AssetRow;
   editorPreviewHtml?: string;
+  generating?: boolean;
   config?: CampaignConfig;
   previewHtml?: string;
   previewSubject?: string;
@@ -696,7 +697,16 @@ function EditListPage({ cards, disclaimers, flash, error }: AppProps) {
   );
 }
 
-function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: AppProps) {
+const ACCENT_SWATCHES: { name: string; hex: string }[] = [
+  { name: "Accent blue", hex: "#1A61D9" },
+  { name: "Dark navy", hex: "#15192D" },
+  { name: "Amber", hex: "#E8A317" },
+  { name: "Orange", hex: "#D4600A" },
+  { name: "Red", hex: "#D9534F" },
+  { name: "Green", hex: "#28A745" },
+];
+
+function EditorPage({ editorKind, editing, editorPreviewHtml, generating, flash, error }: AppProps) {
   const isCard = editorKind === "card";
   const cfg = editing?.config ?? {};
   return (
@@ -731,13 +741,56 @@ function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: Ap
                   <Field label="Card title (header bar)">
                     <input type="text" name="title" defaultValue={cfg.title ?? ""} className="ds-input" style={inputStyle} />
                   </Field>
-                  <Field label="Accent color">
-                    <input type="text" name="accent" defaultValue={cfg.accent ?? "#1A61D9"} className="ds-input" style={inputStyle} />
-                  </Field>
                   <Field label="Icon (type or paste an emoji — stored Gmail-safe automatically)">
                     <input type="text" name="icon" defaultValue={entitiesToEmoji(cfg.icon ?? "")} className="ds-input" style={inputStyle} />
                   </Field>
                 </div>
+                <div>
+                  <span className="label-xs" style={{ color: "var(--text-secondary)", display: "block", marginBottom: 2 }}>
+                    Accent color (border &amp; header bar)
+                  </span>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <input type="color" name="accent" defaultValue={/^#[0-9a-fA-F]{6}$/.test(cfg.accent ?? "") ? cfg.accent : "#1A61D9"}
+                      style={{ width: 56, height: 36, padding: 2, border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)", background: "#fff", cursor: "pointer" }} />
+                    {ACCENT_SWATCHES.map((s) => (
+                      <button key={s.hex} type="button" data-set-accent={s.hex} title={`${s.name} ${s.hex}`}
+                        style={{
+                          width: 28, height: 28, borderRadius: "50%", background: s.hex,
+                          border: "2px solid #fff", boxShadow: "0 0 0 1px var(--border-secondary)", cursor: "pointer",
+                        }} />
+                    ))}
+                    <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>
+                      pick any color, or tap a Landing palette swatch
+                    </span>
+                  </div>
+                </div>
+                {editing ? (
+                  <div style={{
+                    border: "1px dashed var(--landing-bright-blue)", borderRadius: "var(--radius-sm)",
+                    padding: "var(--space-3) var(--space-4)",
+                  }}>
+                    <span className="label-xs" style={{ color: "var(--landing-blue)", display: "block", marginBottom: 2 }}>
+                      ✨ Describe your notification card (optional)
+                    </span>
+                    <p className="body-xs" style={{ color: "var(--text-secondary)", margin: "0 0 var(--space-2)" }}>
+                      Say what the card should tell residents — AI (Haiku) drafts the row HTML
+                      straight into Body HTML below. Review, tweak, then Save.
+                    </p>
+                    <div className="flex gap-2 flex-wrap items-start">
+                      <textarea name="description" form="gen-form" rows={2}
+                        placeholder="e.g. Pool closed for resurfacing during the window; residents should use the north pool; contact the office with questions"
+                        className="ds-input" style={{ flex: 1, minWidth: 240, fontSize: "var(--label-xs)" }} />
+                      <button type="submit" form="gen-form" className="btn btn-secondary btn-sm" disabled={generating}>
+                        {generating ? "Generating…" : "Generate with AI"}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: 0 }}>
+                    💡 Save the card first — then a "describe your card" AI helper appears here
+                    to draft the Body HTML for you.
+                  </p>
+                )}
                 <Field label="Body HTML ({{tokens}} supported; inline styles only — Gmail strips <style> blocks)">
                   <textarea name="body_html" rows={10} defaultValue={cfg.body_html ?? ""} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
                 </Field>
@@ -761,6 +814,10 @@ function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: Ap
               <button type="submit" className="btn btn-primary btn-sm">Save</button>
             </div>
           </form>
+          {/* External form target for the AI describe field (forms can't nest). */}
+          {isCard && editing && (
+            <form id="gen-form" method="POST" action={`/api/edit/card/${editing.id}/generate`} />
+          )}
         </SectionCard>
 
         {editing && (

--- a/sandy-mass-notifications/src/App.tsx
+++ b/sandy-mass-notifications/src/App.tsx
@@ -17,6 +17,7 @@ export interface AssetRow {
 export interface CampaignRow {
   id: string; mode: string; property_name: string; event_name: string;
   status: string; fetch_stats_json: string | null;
+  sms_enabled: number; sms_preview_text: string | null; sms_preview_truncated: number;
   created_by: string; created_at: string;
 }
 
@@ -26,6 +27,7 @@ export interface RecipientRow {
   phone_e164: string | null; segment_timezone: string | null;
   agm_name: string | null; source: string; status: string; notes: string;
   email_state: string; email_sent_at: string | null;
+  sms_state: string; sms_error: string | null;
 }
 
 export interface RoleRow { email: string; role: string; created_at: string }
@@ -312,6 +314,16 @@ function RecipientsSection({ c, recipients }: { c: CampaignRow; recipients: Reci
                   <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", wordBreak: "break-all" }}>{r.email}</td>
                   <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", color: r.phone_e164 ? "var(--text-primary)" : "var(--text-tertiary)" }}>
                     {r.phone_e164 ?? "—"}
+                    {r.sms_state !== "off" && (
+                      <span className="label-xs" style={{
+                        display: "block",
+                        color: r.sms_state === "sent" ? "var(--status-success-text)"
+                          : r.sms_state === "error" ? "var(--status-error-text)"
+                          : "var(--text-tertiary)",
+                      }}>
+                        SMS: {r.sms_state.replace(/_/g, " ")}
+                      </span>
+                    )}
                   </td>
                   <td style={{ padding: "var(--space-2) var(--space-3)" }}>
                     {["PENDING", "READY", "REVIEW", ""].includes(r.status) ? (
@@ -769,6 +781,103 @@ function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: Ap
   );
 }
 
+function SmsSection({ c, recipients }: { c: CampaignRow; recipients: RecipientRow[] }) {
+  const withPhone = recipients.filter((r) => r.phone_e164).length;
+  const counts: Record<string, number> = {};
+  for (const r of recipients) counts[r.sms_state] = (counts[r.sms_state] ?? 0) + 1;
+  const pendingRetry = recipients.filter((r) =>
+    r.status === "SENT" && r.phone_e164 && !["sent", "skipped_optout"].includes(r.sms_state)).length;
+  const enabled = c.sms_enabled === 1;
+  const stateSummary = Object.entries(counts)
+    .filter(([k]) => k !== "off")
+    .map(([k, v]) => `${v} ${k.replace(/_/g, " ")}`)
+    .join(" · ");
+
+  return (
+    <SectionCard icon="phone" title="5 · SMS companion (Dialpad)">
+      <div className="flex items-center gap-3 flex-wrap" style={{ marginBottom: "var(--space-3)" }}>
+        <form method="POST" action={`/api/campaigns/${c.id}/sms-toggle`} className="flex items-center gap-2">
+          <label className="body-sm flex items-center gap-2" style={{ color: "var(--text-primary)" }}>
+            <input type="checkbox" name="sms_enabled" data-autosubmit defaultChecked={enabled} />
+            Text each member an AI summary after their email sends
+          </label>
+          <noscript><button type="submit" className="btn btn-tertiary btn-sm">Save</button></noscript>
+        </form>
+        <span className="flex-1" />
+        <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>
+          {withPhone} of {recipients.length} recipients have an SMS-ready phone
+        </span>
+      </div>
+
+      {/* Preview of the AI summary */}
+      <div style={{
+        border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)",
+        padding: "var(--space-3) var(--space-4)", marginBottom: "var(--space-3)",
+        background: "var(--bg-secondary)",
+      }}>
+        <div className="flex items-center gap-2 flex-wrap" style={{ marginBottom: "var(--space-2)" }}>
+          <span className="label-xs" style={{ color: "var(--text-secondary)" }}>
+            SMS text (from +1 415 980-4986)
+          </span>
+          {c.sms_preview_truncated === 1 && (
+            <span className="label-xs" style={{ color: "var(--status-warning-text)" }}>
+              hard-truncated to fit — consider regenerating
+            </span>
+          )}
+          <span className="flex-1" />
+          <form method="POST" action={`/api/campaigns/${c.id}/dispatch`}>
+            <input type="hidden" name="kind" value="sms_preview" />
+            <button type="submit" className="btn btn-secondary btn-sm">
+              {c.sms_preview_text ? "Regenerate preview" : "Generate preview"}
+            </button>
+          </form>
+        </div>
+        {c.sms_preview_text ? (
+          <p className="body-sm" style={{
+            margin: 0, color: "var(--text-primary)",
+            fontFamily: "monospace", whiteSpace: "pre-wrap",
+          }}>
+            {c.sms_preview_text}
+            <span className="body-xs" style={{ color: "var(--text-tertiary)" }}> ({c.sms_preview_text.length} chars)</span>
+          </p>
+        ) : (
+          <p className="body-sm" style={{ margin: 0, color: "var(--text-tertiary)" }}>
+            No preview yet — generate one to see exactly what members would receive.
+            The same summary is regenerated fresh at send time.
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <form method="POST" action={`/api/campaigns/${c.id}/dispatch`} className="flex items-center gap-2">
+          <input type="hidden" name="kind" value="sms_test" />
+          <input type="tel" name="test_number" placeholder="+15551234567" className="ds-input"
+            style={{ height: 32, width: 160, fontSize: "var(--label-xs)" }} />
+          <button type="submit" className="btn btn-secondary btn-sm">Test SMS to this number</button>
+        </form>
+        <span className="flex-1" />
+        <form method="POST" action={`/api/campaigns/${c.id}/dispatch`}>
+          <input type="hidden" name="kind" value="sms_only" />
+          <button type="submit" className="btn btn-primary btn-sm" disabled={pendingRetry === 0}>
+            Send SMS to {pendingRetry} emailed recipient{pendingRetry === 1 ? "" : "s"}
+          </button>
+        </form>
+      </div>
+
+      {stateSummary && (
+        <p className="body-xs" style={{ color: "var(--text-secondary)", margin: "var(--space-3) 0 0" }}>
+          SMS states: {stateSummary}
+        </p>
+      )}
+      <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-2) 0 0" }}>
+        Quiet hours: texts only go out 08:00–21:00 in each member's local time (by market
+        segment); anyone outside the window is marked "skipped quiet hours" — re-send later
+        with the button above. Members who opted out of texts are always skipped.
+      </p>
+    </SectionCard>
+  );
+}
+
 function CampaignPage(props: AppProps) {
   const { campaigns, recipients, runs, config, flash, error, user } = props;
   const c = campaigns[0];
@@ -807,6 +916,7 @@ function CampaignPage(props: AppProps) {
           previewHtml={props.previewHtml} previewSubject={props.previewSubject}
           previewFor={props.previewFor} previewRecipientId={props.previewRecipientId} />}
         {config && <SendSection c={c} recipients={recipients} runs={runs} cfg={config} userEmail={user.email} />}
+        {config && <SmsSection c={c} recipients={recipients} />}
       </div>
     </main>
   );

--- a/sandy-mass-notifications/src/App.tsx
+++ b/sandy-mass-notifications/src/App.tsx
@@ -5,7 +5,14 @@
 import { Navbar } from "./brand/Navbar.js";
 import { Footer } from "./brand/Footer.js";
 import { Icon } from "./brand/Icon.js";
-import { CARD_REGISTRY, EMAIL_TEMPLATES, type CampaignConfig } from "./emailkit.js";
+import { EMAIL_TEMPLATES, type CampaignConfig } from "./emailkit.js";
+
+// A D1-backed editable email asset (templates table, kind='card'|'disclaimer').
+export interface AssetRow {
+  id: string; kind: string; name: string; active: boolean;
+  config: Record<string, string>;
+  updated_by: string | null; updated_at: string | null;
+}
 
 export interface CampaignRow {
   id: string; mode: string; property_name: string; event_name: string;
@@ -29,13 +36,18 @@ export interface RunRow {
 }
 
 export interface AppProps {
-  page: "access" | "home" | "campaign";
+  page: "access" | "home" | "campaign" | "edit" | "editor";
   user: { email: string; username: string };
   role: string | null;
   campaigns: CampaignRow[];
   recipients: RecipientRow[];
   roleRequests: RoleRow[];
   runs: RunRow[];
+  cards?: AssetRow[];
+  disclaimers?: AssetRow[];
+  editorKind?: "card" | "disclaimer";
+  editing?: AssetRow;
+  editorPreviewHtml?: string;
   config?: CampaignConfig;
   previewHtml?: string;
   previewSubject?: string;
@@ -159,6 +171,9 @@ function HomePage({ role, campaigns, roleRequests, flash, error }: AppProps) {
             Member Support · Property Notifications
           </span>
           <h1 className="display-sm" style={{ margin: 0 }}>Mass Notifications</h1>
+          <a href="/edit" className="label-xs" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
+            ✎ Manage cards &amp; disclaimers
+          </a>
         </div>
 
         {flash && <Banner kind="success">{flash}</Banner>}
@@ -339,7 +354,11 @@ function RecipientsSection({ c, recipients }: { c: CampaignRow; recipients: Reci
   );
 }
 
-function ConfigureSection({ c, cfg }: { c: CampaignRow; cfg: CampaignConfig }) {
+function ConfigureSection({ c, cfg, cards, disclaimers }: {
+  c: CampaignRow; cfg: CampaignConfig; cards: AssetRow[]; disclaimers: AssetRow[];
+}) {
+  const activeCards = cards.filter((a) => a.active);
+  const activeDisclaimers = disclaimers.filter((a) => a.active);
   return (
     <SectionCard icon="pencil" title="2 · Configure">
       {/* Template chips */}
@@ -350,6 +369,51 @@ function ConfigureSection({ c, cfg }: { c: CampaignRow; cfg: CampaignConfig }) {
             <button type="submit" className="btn btn-secondary btn-sm">{name}</button>
           </form>
         ))}
+      </div>
+
+      {/* Notification card chiclets — instant apply, no Save needed */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <div className="flex items-baseline gap-2" style={{ marginBottom: "var(--space-2)" }}>
+          <span className="label-xs" style={{ color: "var(--text-secondary)" }}>Notification card</span>
+          <a href="/edit" className="label-xs" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
+            ✎ Manage cards &amp; disclaimers
+          </a>
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          <form method="POST" action={`/api/campaigns/${c.id}/config-card`}>
+            <input type="hidden" name="card" value="" />
+            <button type="submit" className={`btn btn-sm ${cfg.notification_card === "" ? "btn-primary" : "btn-tertiary"}`}>
+              None
+            </button>
+          </form>
+          {activeCards.map((a) => (
+            <form key={a.id} method="POST" action={`/api/campaigns/${c.id}/config-card`}>
+              <input type="hidden" name="card" value={String(a.config.key)} />
+              <button type="submit"
+                className={`btn btn-sm ${cfg.notification_card === String(a.config.key) ? "btn-primary" : "btn-tertiary"}`}>
+                {a.config.label || a.config.key}
+              </button>
+            </form>
+          ))}
+        </div>
+      </div>
+
+      {/* Disclaimer chiclets — instant apply, fills the disclaimer field below */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <span className="label-xs" style={{ color: "var(--text-secondary)", display: "block", marginBottom: "var(--space-2)" }}>
+          Disclaimer presets
+        </span>
+        <div className="flex gap-2 flex-wrap">
+          {activeDisclaimers.map((a) => (
+            <form key={a.id} method="POST" action={`/api/campaigns/${c.id}/config-disclaimer`}>
+              <input type="hidden" name="template_id" value={a.id} />
+              <button type="submit"
+                className={`btn btn-sm ${cfg.disclaimer_html === String(a.config.html) ? "btn-primary" : "btn-tertiary"}`}>
+                {a.name}
+              </button>
+            </form>
+          ))}
+        </div>
       </div>
 
       <form method="POST" action={`/api/campaigns/${c.id}/config`} className="flex flex-col gap-3">
@@ -368,14 +432,6 @@ function ConfigureSection({ c, cfg }: { c: CampaignRow; cfg: CampaignConfig }) {
           <input type="text" name="subject_template" defaultValue={cfg.subject_template} className="ds-input" style={inputStyle} />
         </Field>
         <div className="flex gap-3 flex-wrap">
-          <Field label="Notification card">
-            <select name="notification_card" defaultValue={cfg.notification_card} className="ds-input" style={inputStyle}>
-              <option value="">— none —</option>
-              {Object.entries(CARD_REGISTRY).map(([key, card]) => (
-                <option key={key} value={key}>{card.label}</option>
-              ))}
-            </select>
-          </Field>
           <Field label="Sender display name">
             <input type="text" name="sender_display_name" defaultValue={cfg.sender_display_name} className="ds-input" style={inputStyle} />
           </Field>
@@ -551,6 +607,147 @@ function SendSection({ c, recipients, runs, cfg, userEmail }: {
   );
 }
 
+function EditListPage({ cards, disclaimers, flash, error }: AppProps) {
+  const list = (items: AssetRow[], kind: string, columns: (a: AssetRow) => string) => (
+    items.length === 0
+      ? <p className="body-sm" style={{ color: "var(--text-tertiary)", margin: 0 }}>None yet.</p>
+      : <ul style={{ listStyle: "none", margin: 0, padding: 0, border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)" }}>
+          {items.map((a, i) => (
+            <li key={a.id} style={{ borderTop: i === 0 ? "none" : "1px solid var(--border-secondary)" }}>
+              <a href={`/edit/${kind}/${a.id}`} className="flex items-center gap-3"
+                style={{ padding: "var(--space-2) var(--space-4)", textDecoration: "none" }}>
+                <span className="body-sm flex-1" style={{ color: a.active ? "var(--text-primary)" : "var(--text-tertiary)" }}>
+                  {columns(a)}
+                </span>
+                {!a.active && <span className="label-xs" style={{ color: "var(--text-tertiary)" }}>inactive</span>}
+                <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>
+                  {a.updated_by === "seed" ? "built-in" : `${(a.updated_by ?? "").split("@")[0]} · ${(a.updated_at ?? "").slice(0, 10)}`}
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+  );
+  return (
+    <main className="ds-container flex-1">
+      <div className="ds-content w-full max-w-2xl mx-auto flex flex-col gap-6"
+        style={{ paddingTop: "var(--space-7)", paddingBottom: "var(--space-9)" }}>
+        <div className="flex items-center gap-3">
+          <a href="/" className="label-sm flex items-center gap-1" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
+            <Icon name="arrow-short-left" size="sm" /> Campaigns
+          </a>
+          <span className="flex-1" />
+        </div>
+        <h1 className="header-lg" style={{ margin: 0 }}>Cards &amp; disclaimers</h1>
+        {flash && <Banner kind="success">{flash}</Banner>}
+        {error && <Banner kind="error">{error}</Banner>}
+
+        <SectionCard icon="pencil" title="Notification cards">
+          <div style={{ marginBottom: "var(--space-3)" }}>
+            <a href="/edit/card/new" className="btn btn-primary btn-sm" style={{ textDecoration: "none" }}>+ New card</a>
+          </div>
+          {list(cards ?? [], "card", (a) => `${a.config.label || a.config.key} — ${a.config.title}`)}
+          <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-3) 0 0" }}>
+            Active cards appear as chiclets in every campaign's Configure section.
+          </p>
+        </SectionCard>
+
+        <SectionCard icon="more-info" title="Disclaimer presets">
+          <div style={{ marginBottom: "var(--space-3)" }}>
+            <a href="/edit/disclaimer/new" className="btn btn-primary btn-sm" style={{ textDecoration: "none" }}>+ New disclaimer</a>
+          </div>
+          {list(disclaimers ?? [], "disclaimer", (a) => a.name)}
+        </SectionCard>
+      </div>
+    </main>
+  );
+}
+
+function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: AppProps) {
+  const isCard = editorKind === "card";
+  const cfg = editing?.config ?? {};
+  return (
+    <main className="ds-container flex-1">
+      <div className="ds-content w-full max-w-2xl mx-auto flex flex-col gap-5"
+        style={{ paddingTop: "var(--space-6)", paddingBottom: "var(--space-9)" }}>
+        <div className="flex items-center gap-3">
+          <a href="/edit" className="label-sm flex items-center gap-1" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
+            <Icon name="arrow-short-left" size="sm" /> Cards &amp; disclaimers
+          </a>
+        </div>
+        <h1 className="header-lg" style={{ margin: 0 }}>
+          {editing ? `Edit ${isCard ? "card" : "disclaimer"}` : `New ${isCard ? "card" : "disclaimer"}`}
+        </h1>
+        {flash && <Banner kind="success">{flash}</Banner>}
+        {error && <Banner kind="error">{error}</Banner>}
+
+        <SectionCard icon="pencil" title={isCard ? "Card definition" : "Disclaimer definition"}>
+          <form method="POST" action={`/api/edit/${editorKind}`} className="flex flex-col gap-3">
+            {editing && <input type="hidden" name="id" value={editing.id} />}
+            {isCard ? (
+              <>
+                <div className="flex gap-3 flex-wrap">
+                  <Field label="Key (SCREAMING_SNAKE, stored in campaign config)">
+                    <input type="text" name="key" required defaultValue={cfg.key ?? ""} placeholder="POOL_CLOSURE" className="ds-input" style={inputStyle} />
+                  </Field>
+                  <Field label="Chiclet label">
+                    <input type="text" name="label" defaultValue={cfg.label ?? ""} placeholder="🏊 Pool Closure" className="ds-input" style={inputStyle} />
+                  </Field>
+                </div>
+                <div className="flex gap-3 flex-wrap">
+                  <Field label="Card title (header bar)">
+                    <input type="text" name="title" defaultValue={cfg.title ?? ""} className="ds-input" style={inputStyle} />
+                  </Field>
+                  <Field label="Accent color">
+                    <input type="text" name="accent" defaultValue={cfg.accent ?? "#1A61D9"} className="ds-input" style={inputStyle} />
+                  </Field>
+                  <Field label="Icon (HTML entity, e.g. &amp;#x1F525;)">
+                    <input type="text" name="icon" defaultValue={cfg.icon ?? ""} className="ds-input" style={inputStyle} />
+                  </Field>
+                </div>
+                <Field label="Body HTML ({{tokens}} supported; inline styles only — Gmail strips <style> blocks)">
+                  <textarea name="body_html" rows={10} defaultValue={cfg.body_html ?? ""} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+                </Field>
+              </>
+            ) : (
+              <>
+                <Field label="Name (chiclet label)">
+                  <input type="text" name="name" required defaultValue={cfg.name ?? ""} className="ds-input" style={inputStyle} />
+                </Field>
+                <Field label="Disclaimer HTML ({{tokens}} supported)">
+                  <textarea name="html" rows={6} defaultValue={cfg.html ?? ""} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+                </Field>
+              </>
+            )}
+            <div className="flex items-center gap-4">
+              <label className="body-sm flex items-center gap-2" style={{ color: "var(--text-secondary)" }}>
+                <input type="checkbox" name="active" defaultChecked={editing ? editing.active : true} />
+                Active (shown as a chiclet in Configure)
+              </label>
+              <span className="flex-1" />
+              <button type="submit" className="btn btn-primary btn-sm">Save</button>
+            </div>
+          </form>
+        </SectionCard>
+
+        {editing && (
+          <SectionCard icon="search" title="Preview (sample tokens)">
+            <iframe
+              srcDoc={editorPreviewHtml ?? ""}
+              sandbox=""
+              style={{ width: "100%", height: 320, border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)", background: "#fff" }}
+              title="Asset preview"
+            />
+            <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-2) 0 0" }}>
+              Rendered with sample data (Woodhill / Jordan Sample / unit 101). Save, then refresh to update.
+            </p>
+          </SectionCard>
+        )}
+      </div>
+    </main>
+  );
+}
+
 function CampaignPage(props: AppProps) {
   const { campaigns, recipients, runs, config, flash, error, user } = props;
   const c = campaigns[0];
@@ -584,7 +781,7 @@ function CampaignPage(props: AppProps) {
         {c.status === "errored" && stats?.error ? <Banner kind="error">Last operation failed: {String(stats.error)}</Banner> : null}
 
         <RecipientsSection c={c} recipients={recipients} />
-        {config && <ConfigureSection c={c} cfg={config} />}
+        {config && <ConfigureSection c={c} cfg={config} cards={props.cards ?? []} disclaimers={props.disclaimers ?? []} />}
         {config && <PreviewSection c={c} recipients={recipients}
           previewHtml={props.previewHtml} previewSubject={props.previewSubject}
           previewFor={props.previewFor} previewRecipientId={props.previewRecipientId} />}
@@ -600,6 +797,8 @@ export default function App(props: AppProps) {
       <Navbar />
       {props.page === "access" ? <AccessPage user={props.user} role={props.role} />
         : props.page === "campaign" ? <CampaignPage {...props} />
+        : props.page === "edit" ? <EditListPage {...props} />
+        : props.page === "editor" ? <EditorPage {...props} />
         : <HomePage {...props} />}
       <Footer />
     </div>

--- a/sandy-mass-notifications/src/App.tsx
+++ b/sandy-mass-notifications/src/App.tsx
@@ -5,7 +5,7 @@
 import { Navbar } from "./brand/Navbar.js";
 import { Footer } from "./brand/Footer.js";
 import { Icon } from "./brand/Icon.js";
-import { EMAIL_TEMPLATES, type CampaignConfig } from "./emailkit.js";
+import { EMAIL_TEMPLATES, entitiesToEmoji, type CampaignConfig } from "./emailkit.js";
 
 // A D1-backed editable email asset (templates table, kind='card'|'disclaimer').
 export interface AssetRow {
@@ -171,9 +171,6 @@ function HomePage({ role, campaigns, roleRequests, flash, error }: AppProps) {
             Member Support · Property Notifications
           </span>
           <h1 className="display-sm" style={{ margin: 0 }}>Mass Notifications</h1>
-          <a href="/edit" className="label-xs" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
-            ✎ Manage cards &amp; disclaimers
-          </a>
         </div>
 
         {flash && <Banner kind="success">{flash}</Banner>}
@@ -317,21 +314,29 @@ function RecipientsSection({ c, recipients }: { c: CampaignRow; recipients: Reci
                     {r.phone_e164 ?? "—"}
                   </td>
                   <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    <form method="POST" action={`/api/recipients/${r.id}`} className="flex items-center gap-1">
-                      <input type="hidden" name="action" value="status" />
+                    {["PENDING", "READY", "REVIEW", ""].includes(r.status) ? (
+                      // One control: a pill-styled select that saves on change.
+                      <form method="POST" action={`/api/recipients/${r.id}`} className="flex items-center gap-1">
+                        <input type="hidden" name="action" value="status" />
+                        <select name="status" data-autosubmit defaultValue={r.status || "PENDING"}
+                          style={{
+                            height: 26, fontSize: "var(--label-xs)", fontWeight: 600,
+                            padding: "0 var(--space-2)", borderRadius: 999,
+                            border: "1px solid transparent", cursor: "pointer",
+                            background: (STATUS_COLORS[r.status || "PENDING"] ?? STATUS_COLORS.PENDING).bg,
+                            color: (STATUS_COLORS[r.status || "PENDING"] ?? STATUS_COLORS.PENDING).text,
+                          }}>
+                          <option value="PENDING">PENDING</option>
+                          <option value="READY">READY</option>
+                          <option value="REVIEW">REVIEW</option>
+                        </select>
+                        <noscript>
+                          <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 26, padding: "0 8px" }}>Set</button>
+                        </noscript>
+                      </form>
+                    ) : (
                       <StatusChip status={r.status} />
-                      {["PENDING", "READY", "REVIEW", ""].includes(r.status) && (
-                        <>
-                          <select name="status" defaultValue={r.status || "PENDING"} className="ds-input"
-                            style={{ height: 28, fontSize: "var(--label-xs)", padding: "0 var(--space-1)" }}>
-                            <option value="PENDING">PENDING</option>
-                            <option value="READY">READY</option>
-                            <option value="REVIEW">REVIEW</option>
-                          </select>
-                          <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 28, padding: "0 8px" }}>Set</button>
-                        </>
-                      )}
-                    </form>
+                    )}
                   </td>
                   <td className="body-xs" style={{ padding: "var(--space-2) var(--space-3)", color: r.email_state === "error" ? "var(--status-error-text)" : "var(--text-tertiary)", maxWidth: 200 }}>{r.notes}</td>
                   <td style={{ padding: "var(--space-2) var(--space-3)" }}>
@@ -359,26 +364,46 @@ function ConfigureSection({ c, cfg, cards, disclaimers }: {
 }) {
   const activeCards = cards.filter((a) => a.active);
   const activeDisclaimers = disclaimers.filter((a) => a.active);
+  const subPanel = {
+    border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)",
+    padding: "var(--space-3) var(--space-4)", marginBottom: "var(--space-4)",
+    background: "var(--bg-secondary)",
+  } as const;
   return (
     <SectionCard icon="pencil" title="2 · Configure">
-      {/* Template chips */}
-      <div className="flex gap-2 flex-wrap" style={{ marginBottom: "var(--space-4)" }}>
-        {Object.keys(EMAIL_TEMPLATES).map((name) => (
-          <form key={name} method="POST" action={`/api/campaigns/${c.id}/template`}>
-            <input type="hidden" name="name" value={name} />
-            <button type="submit" className="btn btn-secondary btn-sm">{name}</button>
-          </form>
-        ))}
+      {/* ── Email templates: whole-email starting points ── */}
+      <div style={subPanel}>
+        <div className="flex items-baseline gap-2 flex-wrap" style={{ marginBottom: "var(--space-1)" }}>
+          <span className="label-sm" style={{ color: "var(--landing-blue)" }}>Email templates</span>
+        </div>
+        <p className="body-xs" style={{ color: "var(--text-secondary)", margin: "0 0 var(--space-3)" }}>
+          A template rewrites the <strong>entire email</strong> — subject, banner, card,
+          body copy, and closing — as a ready-made starting point. Load one, then fill in
+          the blanks (manager, dates) and tweak below.
+        </p>
+        <div className="flex gap-2 flex-wrap">
+          {Object.keys(EMAIL_TEMPLATES).map((name) => (
+            <form key={name} method="POST" action={`/api/campaigns/${c.id}/template`}>
+              <input type="hidden" name="name" value={name} />
+              <button type="submit" className="btn btn-secondary btn-sm">{name}</button>
+            </form>
+          ))}
+        </div>
       </div>
 
-      {/* Notification card chiclets — instant apply, no Save needed */}
-      <div style={{ marginBottom: "var(--space-4)" }}>
-        <div className="flex items-baseline gap-2" style={{ marginBottom: "var(--space-2)" }}>
-          <span className="label-xs" style={{ color: "var(--text-secondary)" }}>Notification card</span>
+      {/* ── Notification card: one swappable block inside the email ── */}
+      <div style={subPanel}>
+        <div className="flex items-baseline gap-2 flex-wrap" style={{ marginBottom: "var(--space-1)" }}>
+          <span className="label-sm" style={{ color: "var(--landing-blue)" }}>Notification card</span>
           <a href="/edit" className="label-xs" style={{ color: "var(--landing-bright-blue)", textDecoration: "none" }}>
             ✎ Manage cards &amp; disclaimers
           </a>
         </div>
+        <p className="body-xs" style={{ color: "var(--text-secondary)", margin: "0 0 var(--space-3)" }}>
+          Unlike a template, a card is just <strong>one highlight block</strong> dropped into
+          the middle of your email. Swap or remove it without touching the rest — applies
+          instantly, check the preview below.
+        </p>
         <div className="flex gap-2 flex-wrap">
           <form method="POST" action={`/api/campaigns/${c.id}/config-card`}>
             <input type="hidden" name="card" value="" />
@@ -396,14 +421,10 @@ function ConfigureSection({ c, cfg, cards, disclaimers }: {
             </form>
           ))}
         </div>
-      </div>
-
-      {/* Disclaimer chiclets — instant apply, fills the disclaimer field below */}
-      <div style={{ marginBottom: "var(--space-4)" }}>
-        <span className="label-xs" style={{ color: "var(--text-secondary)", display: "block", marginBottom: "var(--space-2)" }}>
-          Disclaimer presets
-        </span>
-        <div className="flex gap-2 flex-wrap">
+        <div className="flex gap-2 flex-wrap" style={{ marginTop: "var(--space-3)" }}>
+          <span className="label-xs" style={{ color: "var(--text-secondary)", alignSelf: "center" }}>
+            Disclaimer presets:
+          </span>
           {activeDisclaimers.map((a) => (
             <form key={a.id} method="POST" action={`/api/campaigns/${c.id}/config-disclaimer`}>
               <input type="hidden" name="template_id" value={a.id} />
@@ -701,8 +722,8 @@ function EditorPage({ editorKind, editing, editorPreviewHtml, flash, error }: Ap
                   <Field label="Accent color">
                     <input type="text" name="accent" defaultValue={cfg.accent ?? "#1A61D9"} className="ds-input" style={inputStyle} />
                   </Field>
-                  <Field label="Icon (HTML entity, e.g. &amp;#x1F525;)">
-                    <input type="text" name="icon" defaultValue={cfg.icon ?? ""} className="ds-input" style={inputStyle} />
+                  <Field label="Icon (type or paste an emoji — stored Gmail-safe automatically)">
+                    <input type="text" name="icon" defaultValue={entitiesToEmoji(cfg.icon ?? "")} className="ds-input" style={inputStyle} />
                   </Field>
                 </div>
                 <Field label="Body HTML ({{tokens}} supported; inline styles only — Gmail strips <style> blocks)">
@@ -792,9 +813,11 @@ function CampaignPage(props: AppProps) {
 }
 
 export default function App(props: AppProps) {
+  const active = props.page === "edit" || props.page === "editor" ? "edit" : "campaigns";
   return (
-    <div className="min-h-screen flex flex-col" style={{ background: "var(--bg-secondary)" }}>
-      <Navbar />
+    // #E7EFFB — the OG GAS WebApp page background (Landing light blue).
+    <div className="min-h-screen flex flex-col" style={{ background: "#E7EFFB" }}>
+      <Navbar userEmail={props.role ? props.user.email : undefined} active={active} />
       {props.page === "access" ? <AccessPage user={props.user} role={props.role} />
         : props.page === "campaign" ? <CampaignPage {...props} />
         : props.page === "edit" ? <EditListPage {...props} />

--- a/sandy-mass-notifications/src/App.tsx
+++ b/sandy-mass-notifications/src/App.tsx
@@ -1,9 +1,11 @@
 // mass-notifications UI — SSR, Landing design system.
-// Pages: access (no role), home (campaign list + admin), campaign (detail grid).
+// Pages: access (no role), home (campaign list + admin), campaign
+// (recipients grid + configure + preview + send).
 
 import { Navbar } from "./brand/Navbar.js";
 import { Footer } from "./brand/Footer.js";
 import { Icon } from "./brand/Icon.js";
+import { CARD_REGISTRY, EMAIL_TEMPLATES, type CampaignConfig } from "./emailkit.js";
 
 export interface CampaignRow {
   id: string; mode: string; property_name: string; event_name: string;
@@ -16,9 +18,15 @@ export interface RecipientRow {
   email: string; name: string; unit: string;
   phone_e164: string | null; segment_timezone: string | null;
   agm_name: string | null; source: string; status: string; notes: string;
+  email_state: string; email_sent_at: string | null;
 }
 
 export interface RoleRow { email: string; role: string; created_at: string }
+
+export interface RunRow {
+  id: string; campaign_id: string; kind: string; actor: string; count: number;
+  started_at: string; completed_at: string | null; error: string | null;
+}
 
 export interface AppProps {
   page: "access" | "home" | "campaign";
@@ -27,6 +35,12 @@ export interface AppProps {
   campaigns: CampaignRow[];
   recipients: RecipientRow[];
   roleRequests: RoleRow[];
+  runs: RunRow[];
+  config?: CampaignConfig;
+  previewHtml?: string;
+  previewSubject?: string;
+  previewFor?: string;
+  previewRecipientId?: string;
   flash?: string;
   error?: string;
 }
@@ -82,6 +96,32 @@ function Banner({ kind, children }: { kind: "success" | "error"; children: any }
   );
 }
 
+function SectionCard({ icon, title, children }: { icon: string; title: string; children: any }) {
+  return (
+    <div className="ds-card" style={{ padding: "var(--space-5)" }}>
+      <div className="flex items-center gap-2" style={{ marginBottom: "var(--space-3)" }}>
+        <span style={{ color: "var(--landing-bright-blue)" }}><Icon name={icon as any} size="sm" /></span>
+        <h2 className="header-xs" style={{ margin: 0, color: "var(--landing-blue)" }}>{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const inputStyle = { height: 36 } as const;
+const labelStyle = {
+  color: "var(--text-secondary)", display: "block", marginBottom: 2,
+} as const;
+
+function Field({ label, children, grow }: { label: string; children: any; grow?: number }) {
+  return (
+    <label className="label-xs" style={{ ...labelStyle, flex: grow ?? 1, minWidth: 160 }}>
+      {label}
+      {children}
+    </label>
+  );
+}
+
 function AccessPage({ user, role }: { user: AppProps["user"]; role: string | null }) {
   return (
     <main className="ds-container flex-1">
@@ -89,11 +129,9 @@ function AccessPage({ user, role }: { user: AppProps["user"]; role: string | nul
         style={{ paddingTop: "var(--space-9)", paddingBottom: "var(--space-9)" }}>
         <h1 className="header-lg" style={{ margin: 0 }}>Mass Notifications</h1>
         {role === "requested" ? (
-          <>
-            <p className="body-md" style={{ color: "var(--text-secondary)", margin: 0 }}>
-              Access request pending for <strong>{user.email}</strong>. An admin will review it shortly.
-            </p>
-          </>
+          <p className="body-md" style={{ color: "var(--text-secondary)", margin: 0 }}>
+            Access request pending for <strong>{user.email}</strong>. An admin will review it shortly.
+          </p>
         ) : (
           <>
             <p className="body-md" style={{ color: "var(--text-secondary)", margin: 0 }}>
@@ -109,7 +147,7 @@ function AccessPage({ user, role }: { user: AppProps["user"]; role: string | nul
   );
 }
 
-function HomePage({ user, role, campaigns, roleRequests, flash, error }: AppProps) {
+function HomePage({ role, campaigns, roleRequests, flash, error }: AppProps) {
   const pending = roleRequests.filter((r) => r.role === "requested");
   const granted = roleRequests.filter((r) => r.role !== "requested");
   return (
@@ -126,12 +164,7 @@ function HomePage({ user, role, campaigns, roleRequests, flash, error }: AppProp
         {flash && <Banner kind="success">{flash}</Banner>}
         {error && <Banner kind="error">{error}</Banner>}
 
-        {/* New campaign */}
-        <div className="ds-card" style={{ padding: "var(--space-5)" }}>
-          <div className="flex items-center gap-2" style={{ marginBottom: "var(--space-3)" }}>
-            <span style={{ color: "var(--landing-bright-blue)" }}><Icon name="house" size="sm" /></span>
-            <h2 className="header-xs" style={{ margin: 0, color: "var(--landing-blue)" }}>New campaign</h2>
-          </div>
+        <SectionCard icon="house" title="New campaign">
           <form method="POST" action="/api/campaigns" className="flex gap-2 flex-wrap">
             <input type="text" name="property_name" required placeholder="Property name (exact, e.g. Woodhill)"
               className="ds-input" style={{ flex: 2, minWidth: 200, height: 40 }} />
@@ -143,14 +176,9 @@ function HomePage({ user, role, campaigns, roleRequests, flash, error }: AppProp
             Property name must match the warehouse exactly — same value as the Sigma
             "Member Information/Emails" Property Name filter.
           </p>
-        </div>
+        </SectionCard>
 
-        {/* Campaign list */}
-        <div className="ds-card" style={{ padding: "var(--space-5)" }}>
-          <div className="flex items-center gap-2" style={{ marginBottom: "var(--space-3)" }}>
-            <span style={{ color: "var(--landing-bright-blue)" }}><Icon name="refresh" size="sm" /></span>
-            <h2 className="header-xs" style={{ margin: 0, color: "var(--landing-blue)" }}>Campaigns</h2>
-          </div>
+        <SectionCard icon="refresh" title="Campaigns">
           {campaigns.length === 0 ? (
             <p className="body-sm text-center" style={{ color: "var(--text-tertiary)", margin: 0 }}>
               No campaigns yet — create one above.
@@ -175,12 +203,10 @@ function HomePage({ user, role, campaigns, roleRequests, flash, error }: AppProp
               ))}
             </ul>
           )}
-        </div>
+        </SectionCard>
 
-        {/* Admin: access management */}
         {role === "admin" && (
-          <div className="ds-card" style={{ padding: "var(--space-5)" }}>
-            <h2 className="header-xs" style={{ margin: "0 0 var(--space-3)", color: "var(--landing-blue)" }}>Access</h2>
+          <SectionCard icon="more-info" title="Access">
             {pending.length > 0 && (
               <div style={{ marginBottom: "var(--space-4)" }}>
                 <h3 className="label-xs" style={{ color: "var(--text-secondary)", textTransform: "uppercase", margin: "0 0 var(--space-2)" }}>
@@ -211,18 +237,323 @@ function HomePage({ user, role, campaigns, roleRequests, flash, error }: AppProp
                 ))}
               </ul>
             </details>
-          </div>
+          </SectionCard>
         )}
       </div>
     </main>
   );
 }
 
-function CampaignPage({ campaigns, recipients, flash, error }: AppProps) {
-  const c = campaigns[0];
+function RecipientsSection({ c, recipients }: { c: CampaignRow; recipients: RecipientRow[] }) {
   const eligible = recipients.filter((r) => ["", "PENDING", "READY"].includes(r.status)).length;
   const review = recipients.filter((r) => r.status === "REVIEW").length;
   const smsReady = recipients.filter((r) => r.phone_e164).length;
+  return (
+    <SectionCard icon="house" title="1 · Recipients">
+      <div className="flex items-center gap-3 flex-wrap" style={{ marginBottom: "var(--space-3)" }}>
+        <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>
+          {recipients.length} total · {eligible} eligible · {review} review · {smsReady} with SMS-ready phone
+        </span>
+        <span className="flex-1" />
+        <form method="POST" action={`/api/campaigns/${c.id}/fetch`}>
+          <button type="submit" className="btn btn-primary btn-sm" disabled={c.status === "fetching" || c.status === "sending"}>
+            {recipients.some((r) => r.source === "warehouse") ? "Re-fetch active residents" : "Fetch active residents"}
+          </button>
+        </form>
+      </div>
+      {c.status === "fetching" && (
+        <p className="body-sm" style={{ color: "var(--status-warning-text)", margin: "0 0 var(--space-3)" }}>
+          Fetching from the warehouse — refresh this page in a few seconds.
+        </p>
+      )}
+
+      <form method="POST" action={`/api/campaigns/${c.id}/recipients`} className="flex gap-2 flex-wrap"
+        style={{ marginBottom: "var(--space-4)" }}>
+        <input type="email" name="email" required placeholder="email@example.com" className="ds-input" style={{ flex: 2, minWidth: 180, height: 36 }} />
+        <input type="text" name="name" placeholder="Name" className="ds-input" style={{ flex: 2, minWidth: 140, height: 36 }} />
+        <input type="text" name="unit" placeholder="Unit" className="ds-input" style={{ flex: 1, minWidth: 80, height: 36 }} />
+        <button type="submit" className="btn btn-secondary btn-sm">Add manually</button>
+      </form>
+
+      {recipients.length === 0 ? (
+        <p className="body-sm text-center" style={{ color: "var(--text-tertiary)", margin: 0 }}>
+          No recipients yet — fetch active residents or add manually.
+        </p>
+      ) : (
+        <div style={{ overflowX: "auto", border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)", maxHeight: 420, overflowY: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "var(--bg-tertiary)" }}>
+                {["Unit", "Name", "Email", "Phone (E.164)", "Status", "Notes", ""].map((h) => (
+                  <th key={h} className="label-xs" style={{
+                    textAlign: "left", padding: "var(--space-2) var(--space-3)",
+                    color: "var(--text-secondary)", whiteSpace: "nowrap",
+                  }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {recipients.map((r) => (
+                <tr key={r.id} style={{ borderTop: "1px solid var(--border-secondary)" }}>
+                  <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>{r.unit}</td>
+                  <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)" }}>{r.name}</td>
+                  <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", wordBreak: "break-all" }}>{r.email}</td>
+                  <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", color: r.phone_e164 ? "var(--text-primary)" : "var(--text-tertiary)" }}>
+                    {r.phone_e164 ?? "—"}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                    <form method="POST" action={`/api/recipients/${r.id}`} className="flex items-center gap-1">
+                      <input type="hidden" name="action" value="status" />
+                      <StatusChip status={r.status} />
+                      {["PENDING", "READY", "REVIEW", ""].includes(r.status) && (
+                        <>
+                          <select name="status" defaultValue={r.status || "PENDING"} className="ds-input"
+                            style={{ height: 28, fontSize: "var(--label-xs)", padding: "0 var(--space-1)" }}>
+                            <option value="PENDING">PENDING</option>
+                            <option value="READY">READY</option>
+                            <option value="REVIEW">REVIEW</option>
+                          </select>
+                          <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 28, padding: "0 8px" }}>Set</button>
+                        </>
+                      )}
+                    </form>
+                  </td>
+                  <td className="body-xs" style={{ padding: "var(--space-2) var(--space-3)", color: r.email_state === "error" ? "var(--status-error-text)" : "var(--text-tertiary)", maxWidth: 200 }}>{r.notes}</td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                    <form method="POST" action={`/api/recipients/${r.id}`}>
+                      <input type="hidden" name="action" value="delete" />
+                      <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 28, padding: "0 8px" }}
+                        title="Remove recipient">✕</button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-3) 0 0" }}>
+        Eligible statuses: blank, PENDING, READY. Re-fetch replaces warehouse rows; manual rows are kept.
+      </p>
+    </SectionCard>
+  );
+}
+
+function ConfigureSection({ c, cfg }: { c: CampaignRow; cfg: CampaignConfig }) {
+  return (
+    <SectionCard icon="pencil" title="2 · Configure">
+      {/* Template chips */}
+      <div className="flex gap-2 flex-wrap" style={{ marginBottom: "var(--space-4)" }}>
+        {Object.keys(EMAIL_TEMPLATES).map((name) => (
+          <form key={name} method="POST" action={`/api/campaigns/${c.id}/template`}>
+            <input type="hidden" name="name" value={name} />
+            <button type="submit" className="btn btn-secondary btn-sm">{name}</button>
+          </form>
+        ))}
+      </div>
+
+      <form method="POST" action={`/api/campaigns/${c.id}/config`} className="flex flex-col gap-3">
+        <div className="flex gap-3 flex-wrap">
+          <Field label="Event name" grow={2}>
+            <input type="text" name="event_name" defaultValue={c.event_name} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Window start">
+            <input type="date" name="window_start" defaultValue={cfg.window_start} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Window end">
+            <input type="date" name="window_end" defaultValue={cfg.window_end} className="ds-input" style={inputStyle} />
+          </Field>
+        </div>
+        <Field label="Subject template" grow={1}>
+          <input type="text" name="subject_template" defaultValue={cfg.subject_template} className="ds-input" style={inputStyle} />
+        </Field>
+        <div className="flex gap-3 flex-wrap">
+          <Field label="Notification card">
+            <select name="notification_card" defaultValue={cfg.notification_card} className="ds-input" style={inputStyle}>
+              <option value="">— none —</option>
+              {Object.entries(CARD_REGISTRY).map(([key, card]) => (
+                <option key={key} value={key}>{card.label}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Sender display name">
+            <input type="text" name="sender_display_name" defaultValue={cfg.sender_display_name} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Reply-to">
+            <input type="text" name="reply_to" defaultValue={cfg.reply_to} className="ds-input" style={inputStyle} />
+          </Field>
+        </div>
+        <div className="flex gap-3 flex-wrap">
+          <Field label="Manager email (CC'd + {{manager_email}})">
+            <input type="text" name="manager_email" defaultValue={cfg.manager_email} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Manager name ({{manager_name}})">
+            <input type="text" name="manager_name" defaultValue={cfg.manager_name} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Extra CC (comma-separated)">
+            <input type="text" name="cc_extra" defaultValue={cfg.cc_extra} className="ds-input" style={inputStyle} />
+          </Field>
+        </div>
+        <div className="flex gap-4 flex-wrap body-sm" style={{ color: "var(--text-secondary)" }}>
+          <label className="flex items-center gap-2">
+            <input type="checkbox" name="include_disclaimer" defaultChecked={cfg.include_disclaimer} /> Include disclaimer
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="checkbox" name="include_unit_line" defaultChecked={cfg.include_unit_line} /> Include unit line
+          </label>
+        </div>
+        <Field label="Disclaimer HTML (blank = default)">
+          <textarea name="disclaimer_html" rows={2} defaultValue={cfg.disclaimer_html} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+        </Field>
+        <Field label="Greeting HTML">
+          <textarea name="greeting_template" rows={2} defaultValue={cfg.greeting_template} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+        </Field>
+        <Field label="Body intro HTML">
+          <textarea name="body_intro_html" rows={5} defaultValue={cfg.body_intro_html} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+        </Field>
+        <Field label="Closing HTML">
+          <textarea name="closing_html" rows={3} defaultValue={cfg.closing_html} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+        </Field>
+        <Field label="Signature HTML">
+          <textarea name="signature_html" rows={2} defaultValue={cfg.signature_html} className="ds-input font-mono" style={{ fontSize: "var(--label-xs)" }} />
+        </Field>
+        <div className="flex gap-3 flex-wrap">
+          <Field label="Attachment Drive IDs (or one folder ID)" grow={2}>
+            <input type="text" name="attachment_file_ids" defaultValue={cfg.attachment_file_ids} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Email background color">
+            <input type="text" name="email_background_color" defaultValue={cfg.email_background_color} placeholder="#F5F1E8" className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Header image URL">
+            <input type="text" name="email_header_image_url" defaultValue={cfg.email_header_image_url} className="ds-input" style={inputStyle} />
+          </Field>
+        </div>
+        <div className="flex gap-3 flex-wrap items-end">
+          <Field label="Dry-run draft limit">
+            <input type="number" name="dry_run_limit" defaultValue={cfg.dry_run_limit} min={1} max={50} className="ds-input" style={inputStyle} />
+          </Field>
+          <Field label="Max recipients per send">
+            <input type="number" name="max_per_run" defaultValue={cfg.max_per_run} min={1} max={1500} className="ds-input" style={inputStyle} />
+          </Field>
+          <span className="flex-1" />
+          <button type="submit" className="btn btn-primary btn-sm">Save configuration</button>
+        </div>
+        <p className="body-xs" style={{ margin: 0, color: "var(--text-tertiary)" }}>
+          Tokens: {"{{property_name}} {{event_name}} {{date_range}} {{today}} {{first_name}} {{member_name}} {{member_email}} {{unit}} {{manager_name}} {{manager_email}}"} — values are HTML-escaped automatically.
+        </p>
+      </form>
+    </SectionCard>
+  );
+}
+
+function PreviewSection({ c, recipients, previewHtml, previewSubject, previewFor, previewRecipientId }: {
+  c: CampaignRow; recipients: RecipientRow[];
+  previewHtml?: string; previewSubject?: string; previewFor?: string; previewRecipientId?: string;
+}) {
+  return (
+    <SectionCard icon="search" title="3 · Preview">
+      <form method="GET" action={`/c/${c.id}`} className="flex items-center gap-2 flex-wrap" style={{ marginBottom: "var(--space-3)" }}>
+        <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>Previewing for: <strong>{previewFor}</strong></span>
+        <span className="flex-1" />
+        <select name="preview" defaultValue={previewRecipientId ?? ""} className="ds-input" style={{ height: 32, fontSize: "var(--label-xs)", maxWidth: 280 }}>
+          {recipients.map((r) => (
+            <option key={r.id} value={r.id}>{r.unit ? `${r.unit} · ` : ""}{r.email}</option>
+          ))}
+        </select>
+        <button type="submit" className="btn btn-secondary btn-sm">Preview as</button>
+      </form>
+      <p className="body-sm" style={{ margin: "0 0 var(--space-2)", color: "var(--text-primary)" }}>
+        <strong>Subject:</strong> {previewSubject}
+      </p>
+      <iframe
+        srcDoc={previewHtml ?? ""}
+        sandbox=""
+        style={{ width: "100%", height: 460, border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)", background: "#fff" }}
+        title="Email preview"
+      />
+    </SectionCard>
+  );
+}
+
+function SendSection({ c, recipients, runs, cfg, userEmail }: {
+  c: CampaignRow; recipients: RecipientRow[]; runs: RunRow[]; cfg: CampaignConfig; userEmail: string;
+}) {
+  const eligible = recipients.filter((r) => ["", "PENDING", "READY"].includes(r.status));
+  const sendCount = Math.min(eligible.length, cfg.max_per_run);
+  const draftCount = Math.min(eligible.length, cfg.dry_run_limit);
+  const canUndo = runs.some((r) => r.kind === "send" && r.completed_at);
+  const busy = c.status === "sending" || c.status === "fetching";
+  return (
+    <SectionCard icon="arrow-right" title="4 · Send">
+      {c.status === "sending" && (
+        <Banner kind="success">Send in progress — refresh for per-recipient results.</Banner>
+      )}
+      <div className="flex gap-2 flex-wrap items-center" style={{ marginBottom: "var(--space-4)" }}>
+        <form method="POST" action={`/api/campaigns/${c.id}/dispatch`}>
+          <input type="hidden" name="kind" value="dryrun" />
+          <button type="submit" className="btn btn-secondary btn-sm" disabled={busy || eligible.length === 0}>
+            Create {draftCount} draft{draftCount === 1 ? "" : "s"} (dry run)
+          </button>
+        </form>
+        <form method="POST" action={`/api/campaigns/${c.id}/dispatch`}>
+          <input type="hidden" name="kind" value="test" />
+          <button type="submit" className="btn btn-secondary btn-sm" disabled={busy}>
+            Test send to me
+          </button>
+        </form>
+        {canUndo && (
+          <form method="POST" action={`/api/campaigns/${c.id}/undo`}>
+            <button type="submit" className="btn btn-tertiary btn-sm" disabled={busy}>
+              Undo last send
+            </button>
+          </form>
+        )}
+      </div>
+      <form method="POST" action={`/api/campaigns/${c.id}/dispatch`} className="flex items-center gap-3 flex-wrap"
+        style={{ border: "1px solid var(--border-primary)", borderRadius: "var(--radius-sm)", padding: "var(--space-3) var(--space-4)" }}>
+        <input type="hidden" name="kind" value="send" />
+        <label className="body-sm flex items-center gap-2" style={{ color: "var(--text-primary)" }}>
+          <input type="checkbox" name="confirm" />
+          Send to <strong>{sendCount}</strong> recipient{sendCount === 1 ? "" : "s"} from member.support@hellolanding.com
+        </label>
+        <span className="flex-1" />
+        <button type="submit" className="btn btn-primary btn-sm" disabled={busy || eligible.length === 0}>
+          Send campaign
+        </button>
+      </form>
+      <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-2) 0 0" }}>
+        Drafts land in the member.support@ mailbox with subject "[DRAFT] …". Test emails go to {userEmail} with "TEST — …".
+        Undo reverts recipient statuses only — emails already sent are not recalled.
+      </p>
+
+      {runs.length > 0 && (
+        <div style={{ marginTop: "var(--space-4)" }}>
+          <h3 className="label-xs" style={{ color: "var(--text-secondary)", textTransform: "uppercase", margin: "0 0 var(--space-2)" }}>Run history</h3>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)" }}>
+            {runs.map((r, i) => (
+              <li key={r.id} className="flex items-center gap-3 body-xs"
+                style={{ padding: "var(--space-2) var(--space-3)", borderTop: i === 0 ? "none" : "1px solid var(--border-secondary)", color: "var(--text-secondary)" }}>
+                <span className="label-xs" style={{ minWidth: 52, color: "var(--text-primary)", textTransform: "uppercase" }}>{r.kind}</span>
+                <span>{r.started_at.slice(0, 16).replace("T", " ")}</span>
+                <span>{r.actor.split("@")[0]}</span>
+                <span className="flex-1" />
+                {r.error
+                  ? <span style={{ color: "var(--status-error-text)" }}>{r.error}</span>
+                  : r.completed_at
+                    ? <span style={{ color: "var(--status-success-text)" }}>{r.count} ok</span>
+                    : <span style={{ color: "var(--status-warning-text)" }}>running…</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function CampaignPage(props: AppProps) {
+  const { campaigns, recipients, runs, config, flash, error, user } = props;
+  const c = campaigns[0];
   let stats: Record<string, unknown> | null = null;
   try { stats = c.fetch_stats_json ? JSON.parse(c.fetch_stats_json) : null; } catch { /* ignore */ }
 
@@ -250,98 +581,14 @@ function CampaignPage({ campaigns, recipients, flash, error }: AppProps) {
 
         {flash && <Banner kind="success">{flash}</Banner>}
         {error && <Banner kind="error">{error}</Banner>}
-        {c.status === "errored" && stats?.error ? <Banner kind="error">Fetch failed: {String(stats.error)}</Banner> : null}
+        {c.status === "errored" && stats?.error ? <Banner kind="error">Last operation failed: {String(stats.error)}</Banner> : null}
 
-        {/* Recipients toolbar */}
-        <div className="ds-card" style={{ padding: "var(--space-5)" }}>
-          <div className="flex items-center gap-3 flex-wrap" style={{ marginBottom: "var(--space-3)" }}>
-            <h2 className="header-xs" style={{ margin: 0, color: "var(--landing-blue)" }}>
-              Recipients
-            </h2>
-            <span className="body-xs" style={{ color: "var(--text-tertiary)" }}>
-              {recipients.length} total · {eligible} eligible · {review} review · {smsReady} with SMS-ready phone
-            </span>
-            <span className="flex-1" />
-            <form method="POST" action={`/api/campaigns/${c.id}/fetch`}>
-              <button type="submit" className="btn btn-primary btn-sm"
-                disabled={c.status === "fetching"}>
-                {recipients.some((r) => r.source === "warehouse") ? "Re-fetch active residents" : "Fetch active residents"}
-              </button>
-            </form>
-          </div>
-          {c.status === "fetching" && (
-            <p className="body-sm" style={{ color: "var(--status-warning-text)", margin: "0 0 var(--space-3)" }}>
-              Fetching from the warehouse — refresh this page in a few seconds.
-            </p>
-          )}
-
-          {/* Manual add */}
-          <form method="POST" action={`/api/campaigns/${c.id}/recipients`} className="flex gap-2 flex-wrap"
-            style={{ marginBottom: "var(--space-4)" }}>
-            <input type="email" name="email" required placeholder="email@example.com" className="ds-input" style={{ flex: 2, minWidth: 180, height: 36 }} />
-            <input type="text" name="name" placeholder="Name" className="ds-input" style={{ flex: 2, minWidth: 140, height: 36 }} />
-            <input type="text" name="unit" placeholder="Unit" className="ds-input" style={{ flex: 1, minWidth: 80, height: 36 }} />
-            <button type="submit" className="btn btn-secondary btn-sm">Add manually</button>
-          </form>
-
-          {recipients.length === 0 ? (
-            <p className="body-sm text-center" style={{ color: "var(--text-tertiary)", margin: 0 }}>
-              No recipients yet — fetch active residents or add manually.
-            </p>
-          ) : (
-            <div style={{ overflowX: "auto", border: "1px solid var(--border-secondary)", borderRadius: "var(--radius-sm)" }}>
-              <table style={{ width: "100%", borderCollapse: "collapse" }}>
-                <thead>
-                  <tr style={{ background: "var(--bg-tertiary)" }}>
-                    {["Unit", "Name", "Email", "Phone (E.164)", "Status", "Notes", ""].map((h) => (
-                      <th key={h} className="label-xs" style={{
-                        textAlign: "left", padding: "var(--space-2) var(--space-3)",
-                        color: "var(--text-secondary)", whiteSpace: "nowrap",
-                      }}>{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {recipients.map((r) => (
-                    <tr key={r.id} style={{ borderTop: "1px solid var(--border-secondary)" }}>
-                      <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>{r.unit}</td>
-                      <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)" }}>{r.name}</td>
-                      <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", wordBreak: "break-all" }}>{r.email}</td>
-                      <td className="body-sm" style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", color: r.phone_e164 ? "var(--text-primary)" : "var(--text-tertiary)" }}>
-                        {r.phone_e164 ?? "—"}
-                      </td>
-                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                        <form method="POST" action={`/api/recipients/${r.id}`} className="flex items-center gap-1">
-                          <input type="hidden" name="action" value="status" />
-                          <StatusChip status={r.status} />
-                          <select name="status" defaultValue={r.status || "PENDING"} className="ds-input"
-                            style={{ height: 28, fontSize: "var(--label-xs)", padding: "0 var(--space-1)" }}>
-                            <option value="PENDING">PENDING</option>
-                            <option value="READY">READY</option>
-                            <option value="REVIEW">REVIEW</option>
-                          </select>
-                          <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 28, padding: "0 8px" }}>Set</button>
-                        </form>
-                      </td>
-                      <td className="body-xs" style={{ padding: "var(--space-2) var(--space-3)", color: "var(--text-tertiary)", maxWidth: 200 }}>{r.notes}</td>
-                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                        <form method="POST" action={`/api/recipients/${r.id}`}>
-                          <input type="hidden" name="action" value="delete" />
-                          <button type="submit" className="btn btn-tertiary btn-sm" style={{ height: 28, padding: "0 8px" }}
-                            title="Remove recipient">✕</button>
-                        </form>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-          <p className="body-xs" style={{ color: "var(--text-tertiary)", margin: "var(--space-3) 0 0" }}>
-            Eligible statuses: blank, PENDING, READY. Re-fetch replaces warehouse rows; manual rows are kept.
-            Configure &amp; send arrives in the next release — this build is the recipient pipeline (P1).
-          </p>
-        </div>
+        <RecipientsSection c={c} recipients={recipients} />
+        {config && <ConfigureSection c={c} cfg={config} />}
+        {config && <PreviewSection c={c} recipients={recipients}
+          previewHtml={props.previewHtml} previewSubject={props.previewSubject}
+          previewFor={props.previewFor} previewRecipientId={props.previewRecipientId} />}
+        {config && <SendSection c={c} recipients={recipients} runs={runs} cfg={config} userEmail={user.email} />}
       </div>
     </main>
   );

--- a/sandy-mass-notifications/src/brand/Footer.tsx
+++ b/sandy-mass-notifications/src/brand/Footer.tsx
@@ -1,71 +1,23 @@
-// Landing footer — dark navy surface with the white logomark, tagline, and link
-// columns. Mirrors the design system's marketing footer pattern.
+// App footer — slim navy strip for an internal tool. No marketing links.
 
 import { Logomark } from "./Logo.js";
-
-const COLUMNS: { title: string; links: string[] }[] = [
-  { title: "Company", links: ["About", "Careers", "Press", "Contact"] },
-  { title: "Stays", links: ["Find a Landing", "Cities", "For business", "Refer a friend"] },
-  { title: "Support", links: ["Help center", "Concierge", "Trust & safety", "Terms"] },
-];
 
 export function Footer() {
   return (
     <footer style={{ background: "var(--landing-blue)", color: "var(--landing-white)" }}>
       <div className="ds-container">
         <div
-          className="grid gap-10 md:grid-cols-[1.5fr_1fr_1fr_1fr]"
-          style={{ paddingTop: "var(--space-9)", paddingBottom: "var(--space-7)" }}
+          className="flex items-center gap-3 flex-wrap"
+          style={{ paddingTop: "var(--space-4)", paddingBottom: "var(--space-4)" }}
         >
-          <div className="flex flex-col gap-4">
-            <Logomark height={40} color="var(--landing-white)" />
-            <p
-              className="font-display"
-              style={{ color: "var(--landing-white)", maxWidth: 260, lineHeight: "var(--lh-140)", margin: 0 }}
-            >
-              Where every stay feels like home.
-            </p>
-          </div>
-          {COLUMNS.map((col) => (
-            <div key={col.title} className="flex flex-col gap-3">
-              <span
-                className="label-xs"
-                style={{ color: "var(--landing-medium-grey)", textTransform: "uppercase", letterSpacing: "0.04em" }}
-              >
-                {col.title}
-              </span>
-              {col.links.map((link) => (
-                <a
-                  key={link}
-                  href="#"
-                  className="text-sm no-underline hover:underline"
-                  style={{ color: "var(--landing-white)" }}
-                >
-                  {link}
-                </a>
-              ))}
-            </div>
-          ))}
-        </div>
-        <div
-          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
-          style={{
-            borderTop: "1px solid var(--landing-tonal-blue)",
-            paddingTop: "var(--space-5)",
-            paddingBottom: "var(--space-7)",
-          }}
-        >
-          <span className="body-sm" style={{ color: "var(--landing-medium-grey)" }}>
-            © Landing. Wherever life takes you.
+          <Logomark height={22} color="var(--landing-white)" />
+          <span className="body-xs" style={{ opacity: 0.75 }}>
+            Mass Notifications · Member Support internal tool
           </span>
-          <div className="flex gap-5">
-            <a href="#" className="body-sm no-underline hover:underline" style={{ color: "var(--landing-medium-grey)" }}>
-              Privacy
-            </a>
-            <a href="#" className="body-sm no-underline hover:underline" style={{ color: "var(--landing-medium-grey)" }}>
-              Terms
-            </a>
-          </div>
+          <span className="flex-1" />
+          <span className="body-xs" style={{ opacity: 0.55 }}>
+            Sends as member.support@hellolanding.com · Sandy platform
+          </span>
         </div>
       </div>
     </footer>

--- a/sandy-mass-notifications/src/brand/Navbar.tsx
+++ b/sandy-mass-notifications/src/brand/Navbar.tsx
@@ -1,55 +1,63 @@
-// Landing top navigation — sticky, translucent white with a soft blur, wordmark
-// on the left, nav links, and a primary CTA. Mirrors the design system's
-// marketing-website navbar. Purely presentational (links are placeholders).
+// App header — dark navy bar echoing the original GAS WebApp chrome:
+// white Landing wordmark, app title, real nav links (no placeholders),
+// and the signed-in operator on the right.
 
 import { Wordmark } from "./Logo.js";
 
-const NAV_ITEMS = ["Stays", "Cities", "For business", "About"];
-
 interface NavbarProps {
-  active?: string;
+  userEmail?: string;
+  active?: "campaigns" | "edit";
 }
 
-export function Navbar({ active = "Stays" }: NavbarProps) {
+const LINKS: { key: "campaigns" | "edit"; href: string; label: string }[] = [
+  { key: "campaigns", href: "/", label: "Campaigns" },
+  { key: "edit", href: "/edit", label: "Cards & disclaimers" },
+];
+
+export function Navbar({ userEmail, active = "campaigns" }: NavbarProps) {
   return (
     <header
       className="sticky top-0 z-50"
-      style={{
-        background: "rgba(255,255,255,0.92)",
-        backdropFilter: "blur(12px)",
-        WebkitBackdropFilter: "blur(12px)",
-        borderBottom: "1px solid var(--border-secondary)",
-      }}
+      style={{ background: "var(--landing-blue)", borderBottom: "3px solid var(--landing-bright-blue)" }}
     >
       <div className="ds-container">
-        <div className="flex items-center gap-8" style={{ height: 80 }}>
-          <Wordmark height={22} />
-          <nav className="hidden md:flex items-center gap-7 ml-2">
-            {NAV_ITEMS.map((item) => (
+        <div className="flex items-center gap-4" style={{ height: 60 }}>
+          <a href="/" className="flex items-center gap-3" style={{ textDecoration: "none" }}>
+            <Wordmark height={18} color="var(--landing-white)" />
+            <span
+              className="label-sm"
+              style={{
+                color: "var(--landing-white)", opacity: 0.85,
+                borderLeft: "1px solid rgba(255,255,255,0.3)", paddingLeft: 12,
+                letterSpacing: "0.04em",
+              }}
+            >
+              Mass Notifications
+            </span>
+          </a>
+          <nav className="flex items-center gap-5 ml-4">
+            {LINKS.map((l) => (
               <a
-                key={item}
-                href="#"
-                className="font-sans text-sm no-underline hover:no-underline"
+                key={l.key}
+                href={l.href}
+                className="label-sm no-underline hover:no-underline"
                 style={{
-                  fontWeight: "var(--fw-medium)" as unknown as number,
-                  color: item === active ? "var(--landing-blue)" : "var(--text-secondary)",
+                  color: "var(--landing-white)",
+                  opacity: l.key === active ? 1 : 0.65,
+                  borderBottom: l.key === active ? "2px solid var(--landing-bright-blue)" : "2px solid transparent",
+                  paddingBottom: 2,
                 }}
               >
-                {item}
+                {l.label}
               </a>
             ))}
           </nav>
           <div className="flex-1" />
-          <a
-            href="#"
-            className="hidden sm:inline text-sm no-underline"
-            style={{ fontWeight: "var(--fw-medium)" as unknown as number, color: "var(--landing-blue)" }}
-          >
-            Sign in
-          </a>
-          <button type="button" className="btn btn-primary btn-sm">
-            Book a stay
-          </button>
+          {userEmail && (
+            <span className="body-xs hidden sm:inline" style={{ color: "var(--landing-white)", opacity: 0.6 }}>
+              {userEmail}
+            </span>
+          )}
         </div>
       </div>
     </header>

--- a/sandy-mass-notifications/src/db.ts
+++ b/sandy-mass-notifications/src/db.ts
@@ -16,6 +16,8 @@ export const campaigns = sqliteTable("campaigns", {
   status: text("status").notNull().default("draft"), // draft|fetching|ready|sending|complete|errored|undone
   config_json: text("config_json").notNull().default("{}"),
   sms_enabled: integer("sms_enabled").notNull().default(0),
+  sms_preview_text: text("sms_preview_text"),
+  sms_preview_truncated: integer("sms_preview_truncated").notNull().default(0),
   fetch_stats_json: text("fetch_stats_json"),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull(),

--- a/sandy-mass-notifications/src/db.ts
+++ b/sandy-mass-notifications/src/db.ts
@@ -89,13 +89,16 @@ export const runs = sqliteTable("runs", {
   error: text("error"),
 });
 
-// Seeded email templates / cards / prompts — editable in Admin, no redeploys.
+// Editable email assets — cards and disclaimers (kind='card'|'disclaimer'),
+// seeded from emailkit SEED_* on first run, curated at /edit. No redeploys.
 export const templates = sqliteTable("templates", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
-  kind: text("kind").notNull(), // email|card|prompt
+  kind: text("kind").notNull(), // card|disclaimer (email templates + prompts later)
   config_json: text("config_json").notNull().default("{}"),
   active: integer("active").notNull().default(1),
+  updated_by: text("updated_by"),
+  updated_at: text("updated_at"),
 });
 
 export const appConfig = sqliteTable("app_config", {

--- a/sandy-mass-notifications/src/emailkit.ts
+++ b/sandy-mass-notifications/src/emailkit.ts
@@ -54,6 +54,25 @@ export function renderTokens(
   );
 }
 
+// Card icons: operators type/paste a plain emoji; we store HTML hex entities
+// (Gmail-safe, matches the legacy GAS convention of escaping non-ASCII).
+export function emojiToEntities(s: string): string {
+  const trimmed = String(s ?? "").trim();
+  if (!trimmed) return "";
+  if (/^(&#x?[0-9a-fA-F]+;\s*)+$/.test(trimmed)) return trimmed.replace(/\s+/g, "");
+  return Array.from(trimmed).map((ch) => {
+    const cp = ch.codePointAt(0)!;
+    return cp > 127 ? `&#x${cp.toString(16).toUpperCase()};` : ch;
+  }).join("");
+}
+
+// Inverse — show the emoji back in the editor field.
+export function entitiesToEmoji(s: string): string {
+  return String(s ?? "")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)));
+}
+
 export function normalizeTelLinks(html: string): string {
   if (!html) return "";
   let out = String(html);

--- a/sandy-mass-notifications/src/emailkit.ts
+++ b/sandy-mass-notifications/src/emailkit.ts
@@ -1,0 +1,505 @@
+// emailkit — token engine, body composer, notification cards, seeded templates.
+// Ported from the legacy GAS app (Tokenizer.gs / Cards.gs / Templates.gs) with
+// one deliberate change: token VALUES are HTML-escaped by default (legacy
+// injected them raw — audit defect 5). Raw-HTML fragment tokens use the
+// {{html:name}} prefix.
+//
+// The per-recipient token substitution is duplicated in
+// workflows/mass-notify-dispatch.js (renderTokens) — keep the two in sync.
+
+export const LANDING_IVR_PHONE = "+14152311701";
+export const LANDING_IVR_PHONE_DISPLAY = "(415) 231-1701";
+
+export const LANDING_COLORS = {
+  DARK_NAVY: "#15192D",
+  ACCENT_BLUE: "#1A61D9",
+  LIGHT_BLUE: "#E7EFFB",
+  WHITE: "#FFFFFF",
+  AMBER: "#E8A317",
+  ORANGE: "#D4600A",
+  RED: "#D9534F",
+  GREEN: "#28A745",
+  TEXT_GRAY: "#4A4A4A",
+};
+const C = LANDING_COLORS;
+
+// ── Token engine ─────────────────────────────────────────────────────────────
+
+export function escapeHtml(s: unknown): string {
+  return String(s)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// {{key}} / {{key | fallback}} / {{html:key}} (raw fragment, no escaping).
+// `escapeValues=false` is for plain-text targets (subject lines).
+export function renderTokens(
+  template: string,
+  tokens: Record<string, string>,
+  escapeValues = true
+): string {
+  if (!template) return "";
+  return String(template).replace(
+    /\{\{\s*(html:)?([a-zA-Z0-9_]+)\s*(?:\|\s*([^}]+))?\s*\}\}/g,
+    (_, htmlPrefix, key, fallback) => {
+      const val = tokens[key];
+      const out = (val !== undefined && val !== null && String(val).trim() !== "")
+        ? String(val)
+        : (fallback != null ? String(fallback).trim() : "");
+      return (htmlPrefix || !escapeValues) ? out : escapeHtml(out);
+    }
+  );
+}
+
+export function normalizeTelLinks(html: string): string {
+  if (!html) return "";
+  let out = String(html);
+  out = out.replace(/<a([^>]*?)\/>/gi, "<a$1></a>");
+  out = out.replace(/href\s*=\s*(['"])\s*tel\s*:\s*([^'"]+)\1/gi, (_m, _q, num) =>
+    `href="tel:${String(num).replace(/[^\d+]/g, "")}"`);
+  return out;
+}
+
+// ── Date formatting (legacy formatDateRange_ / today, via Intl) ──────────────
+
+function fmtDate(d: Date, tz: string, withYear: boolean): string {
+  const opts: Intl.DateTimeFormatOptions = withYear
+    ? { weekday: "short", month: "short", day: "numeric", year: "numeric", timeZone: tz }
+    : { weekday: "short", month: "short", day: "numeric", timeZone: tz };
+  return new Intl.DateTimeFormat("en-US", opts).format(d); // "Wed, Aug 6, 2026"
+}
+
+export function formatDateRange(startIso: string, endIso: string, tz: string): string {
+  if (!startIso || !endIso) return "";
+  // Date-only strings anchor at noon UTC so tz shifts can't move the calendar day.
+  const s = new Date(startIso.length <= 10 ? `${startIso}T12:00:00Z` : startIso);
+  const e = new Date(endIso.length <= 10 ? `${endIso}T12:00:00Z` : endIso);
+  if (isNaN(s.getTime()) || isNaN(e.getTime())) return "";
+  const sameDay = fmtDate(s, tz, true) === fmtDate(e, tz, true);
+  if (sameDay) return fmtDate(s, tz, true);
+  const sameYear = s.getUTCFullYear() === e.getUTCFullYear();
+  return sameYear
+    ? `${fmtDate(s, tz, false)}–${fmtDate(e, tz, true)}`
+    : `${fmtDate(s, tz, true)}–${fmtDate(e, tz, true)}`;
+}
+
+export function formatToday(tz: string): string {
+  return fmtDate(new Date(), tz, true);
+}
+
+// ── Campaign config (legacy Config.gs keys + defaults) ───────────────────────
+
+export interface CampaignConfig {
+  subject_template: string;
+  greeting_template: string;
+  include_disclaimer: boolean;
+  disclaimer_html: string;
+  notification_card: string;
+  body_intro_html: string;
+  include_unit_line: boolean;
+  closing_html: string;
+  signature_html: string;
+  body_full_html: string;
+  sender_display_name: string;
+  manager_email: string;
+  manager_name: string;
+  reply_to: string;
+  cc_extra: string;
+  window_start: string; // yyyy-mm-dd
+  window_end: string;
+  timezone: string;
+  dry_run_limit: number;
+  max_per_run: number;
+  email_background_color: string;
+  email_header_image_url: string;
+  attachment_file_ids: string;
+}
+
+export const CONFIG_DEFAULTS: CampaignConfig = {
+  subject_template: "Notice: {{event_name}} — {{property_name}} ({{date_range}})",
+  greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+  include_disclaimer: true,
+  disclaimer_html: "",
+  notification_card: "",
+  body_intro_html: "",
+  include_unit_line: true,
+  closing_html: "<p>Thank you for your cooperation and understanding.</p>",
+  signature_html: "",
+  body_full_html: "",
+  sender_display_name: "Landing Notifications",
+  manager_email: "",
+  manager_name: "",
+  reply_to: "",
+  cc_extra: "",
+  window_start: "",
+  window_end: "",
+  timezone: "America/Mexico_City",
+  dry_run_limit: 10,
+  max_per_run: 500,
+  email_background_color: "",
+  email_header_image_url: "",
+  attachment_file_ids: "",
+};
+
+export function parseConfig(configJson: string | null): CampaignConfig {
+  let raw: Record<string, unknown> = {};
+  try { raw = configJson ? JSON.parse(configJson) : {}; } catch { /* defaults */ }
+  const cfg: CampaignConfig = { ...CONFIG_DEFAULTS };
+  for (const key of Object.keys(CONFIG_DEFAULTS) as (keyof CampaignConfig)[]) {
+    const v = raw[key];
+    if (v === undefined || v === null) continue;
+    if (typeof CONFIG_DEFAULTS[key] === "boolean") (cfg as any)[key] = v === true || v === "YES" || v === "true";
+    else if (typeof CONFIG_DEFAULTS[key] === "number") (cfg as any)[key] = Number(v) || CONFIG_DEFAULTS[key];
+    else (cfg as any)[key] = String(v);
+  }
+  return cfg;
+}
+
+// ── Notification cards (legacy Cards.gs, resident set) ───────────────────────
+// Card HTML keeps {{tokens}} intact; substitution happens per recipient.
+
+function cardShell(accent: string, codepoint: string, title: string, bodyHtml: string): string {
+  return `
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+  style="border:2px solid ${accent};border-radius:8px;overflow:hidden;margin:12px 0;font-family:Arial,Helvetica,sans-serif;">
+  <tr>
+    <td style="background:${accent};padding:10px 16px;color:${C.WHITE};font-size:15px;font-weight:bold;">
+      ${codepoint}&nbsp; ${title}
+    </td>
+  </tr>
+  <tr>
+    <td style="background:${C.LIGHT_BLUE};padding:14px 16px;">
+      ${bodyHtml}
+    </td>
+  </tr>
+</table>`.trim();
+}
+
+function cardRow(label: string, value: string, valueColor?: string): string {
+  const color = valueColor || C.DARK_NAVY;
+  return `
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+  style="margin-bottom:6px;">
+  <tr>
+    <td style="font-size:12px;color:${C.TEXT_GRAY};text-transform:uppercase;
+               letter-spacing:0.5px;width:38%;vertical-align:top;padding-right:8px;">
+      ${label}
+    </td>
+    <td style="font-size:14px;font-weight:bold;color:${color};vertical-align:top;">
+      ${value}
+    </td>
+  </tr>
+</table>`.trim();
+}
+
+export const CARD_REGISTRY: Record<string, { label: string; render: () => string }> = {
+  FIRE_INSPECTION: {
+    label: "🔥 Fire Inspection",
+    render: () => cardShell(C.ACCENT_BLUE, "&#x1F525;", "Annual Fire Inspection", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Dates", "{{date_range}}", C.ACCENT_BLUE),
+      cardRow("Action required",
+        "Inspectors will need <strong>access to your unit</strong>. " +
+        "Please ensure your smoke detectors are unobstructed."),
+    ].join("")),
+  },
+  WATER_OUTAGE: {
+    label: "🚿 Water Outage",
+    render: () => cardShell(C.AMBER, "&#x1F6BF;", "Planned Water Outage", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Outage window", "{{date_range}}", C.AMBER),
+      cardRow("What to expect",
+        "Water service will be temporarily <strong>unavailable</strong> during this window. " +
+        "We apologize for the inconvenience."),
+    ].join("")),
+  },
+  MAINTENANCE: {
+    label: "🔧 Maintenance",
+    render: () => cardShell(C.DARK_NAVY, "&#x1F527;", "Scheduled Maintenance", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Scheduled", "{{date_range}}", C.ACCENT_BLUE),
+      cardRow("Details",
+        "Our maintenance team will be on-site for <strong>{{event_name}}</strong>. " +
+        "Some common areas may be temporarily unavailable."),
+    ].join("")),
+  },
+  WEATHER_ALERT: {
+    label: "⛈️ Weather Alert",
+    render: () => cardShell(C.RED, "&#x26C8;&#xFE0F;", "Weather Advisory", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Period", "{{date_range}}", C.RED),
+      cardRow("Advisory",
+        "A <strong>weather advisory</strong> has been issued for your area. " +
+        "Please take necessary precautions for your safety and secure any outdoor belongings."),
+    ].join("")),
+  },
+  POWER_OUTAGE: {
+    label: "⚡ Power Outage",
+    render: () => cardShell(C.ORANGE, "&#x26A1;", "Power Outage — Active", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Reported", "{{today}}", C.ORANGE),
+      cardRow("Status",
+        "<strong>Active</strong> — Landing is engaged with the property " +
+        "and working toward the fastest possible resolution."),
+      cardRow("Immediate steps",
+        "Unplug sensitive electronics &nbsp;·&nbsp; " +
+        "Keep fridge &amp; freezer closed &nbsp;·&nbsp; " +
+        "Use flashlights, not candles"),
+    ].join("")),
+  },
+  WIFI_OUTAGE: {
+    label: "📶 WiFi Outage",
+    render: () => cardShell(C.AMBER, "&#x1F4F6;", "WiFi Service Disruption — Active", [
+      cardRow("Property", "{{property_name}}"),
+      cardRow("Reported", "{{today}}", C.AMBER),
+      cardRow("Status",
+        "<strong>Active</strong> — Landing is coordinating with the property " +
+        "and the internet service provider on a resolution."),
+      cardRow("In the meantime",
+        "Mobile data is available as a backup &nbsp;·&nbsp; " +
+        "Disable WiFi on your device to switch automatically"),
+    ].join("")),
+  },
+};
+
+// ── Body composer (legacy buildHtmlBody_) ────────────────────────────────────
+// Produces the COMPOSED body template with {{tokens}} intact. Per-recipient
+// substitution happens in the workflow (or in-app for preview).
+
+const DEFAULT_DISCLAIMER =
+  "<p><em>This is an automated mass notification to all active residents.</em></p>";
+
+export function composeBodyTemplate(cfg: CampaignConfig): string {
+  if (cfg.body_full_html && cfg.body_full_html.trim()) {
+    return wrapWithBranding(cfg, normalizeTelLinks(cfg.body_full_html + (cfg.signature_html || "")));
+  }
+  const parts: string[] = [];
+  parts.push(cfg.greeting_template);
+  if (cfg.include_disclaimer) parts.push(cfg.disclaimer_html || DEFAULT_DISCLAIMER);
+  if (cfg.notification_card && CARD_REGISTRY[cfg.notification_card]) {
+    parts.push(CARD_REGISTRY[cfg.notification_card].render());
+  }
+  parts.push(cfg.body_intro_html);
+  if (cfg.include_unit_line) parts.push("{{html:unit_line}}");
+  parts.push(cfg.closing_html);
+  const body = parts.filter(Boolean).join("")
+    .replace(/<p>/gi, '<p style="margin:0 0 0.8em 0;">');
+  return wrapWithBranding(cfg, normalizeTelLinks(body + (cfg.signature_html || "")));
+}
+
+export function wrapWithBranding(cfg: CampaignConfig, html: string): string {
+  const bg = cfg.email_background_color || "";
+  const imgUrl = cfg.email_header_image_url || "";
+  if (!bg && !imgUrl) return html;
+  const header = imgUrl
+    ? `<div style="text-align:center;padding:0 0 16px 0;">` +
+        `<img src="${escapeHtml(imgUrl)}" alt="Landing" ` +
+        `style="max-width:240px;height:auto;border:0;display:inline-block;">` +
+      `</div>`
+    : "";
+  return [
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:transparent;">`,
+      `<tr><td align="center" style="padding:0;">`,
+        `<table role="presentation" cellpadding="0" cellspacing="0" border="0" `,
+        `style="max-width:640px;width:100%;background-color:${bg || "#FFFFFF"};border-radius:8px;">`,
+          `<tr><td style="padding:32px 36px;font-family:Arial,Helvetica,sans-serif;">`,
+            header,
+            `<div>`, html, `</div>`,
+          `</td></tr>`,
+        `</table>`,
+      `</td></tr>`,
+    `</table>`,
+  ].join("");
+}
+
+// ── Token maps (legacy buildGlobalTokens_ / buildPerRowTokens_) ──────────────
+
+export function buildGlobalTokens(
+  propertyName: string, eventName: string, cfg: CampaignConfig
+): Record<string, string> {
+  return {
+    property_name: propertyName || "",
+    event_name: eventName || "",
+    date_range: formatDateRange(cfg.window_start, cfg.window_end, cfg.timezone),
+    today: formatToday(cfg.timezone),
+    manager_email: cfg.manager_email || "",
+    manager_name: cfg.manager_name || "",
+  };
+}
+
+// Keep in sync with buildRecipientTokens in workflows/mass-notify-dispatch.js.
+export function buildRecipientTokens(
+  globals: Record<string, string>,
+  r: { email: string; name: string; unit: string },
+  includeUnitLine: boolean
+): Record<string, string> {
+  const firstName = r.name ? String(r.name).trim().split(/\s+/)[0] : "";
+  return {
+    ...globals,
+    member_email: r.email || "",
+    member_name: r.name || "",
+    first_name: firstName || "Resident",
+    unit: r.unit || "",
+    unit_line: includeUnitLine && r.unit
+      ? `<p style="margin:0 0 0.8em 0;"><strong>Your unit number is:</strong> ${escapeHtml(r.unit)}</p>`
+      : "",
+  };
+}
+
+// ── Seeded templates (legacy Templates.gs, resident set) ─────────────────────
+// Move-In Notification ships in P4 with its own mode.
+
+const DISCLAIMER_BANNER =
+  '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is a notification to all active residents at {{property_name}}. Please see the message below:</div>';
+const URGENT_BANNER =
+  '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is an urgent notification to all active residents at {{property_name}}. Please see the message below:</div>';
+const IVR_LINK = `<a href="tel:${LANDING_IVR_PHONE}">${LANDING_IVR_PHONE_DISPLAY}</a>`;
+
+// Applied on every template load for fields the operator must re-enter.
+export const TEMPLATE_BLANK_KEYS: (keyof CampaignConfig)[] = [
+  "manager_email", "manager_name", "window_start", "window_end",
+  "reply_to", "cc_extra", "attachment_file_ids", "body_full_html",
+  "email_background_color", "email_header_image_url",
+];
+
+export const EMAIL_TEMPLATES: Record<string, Partial<CampaignConfig> & { event_name?: string }> = {
+  "Annual Fire Inspection": {
+    event_name: "Annual Fire Inspection",
+    subject_template: "Important Notice: Annual Fire Inspection — {{property_name}} ({{date_range}})",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: DISCLAIMER_BANNER,
+    notification_card: "FIRE_INSPECTION",
+    body_intro_html: "<p>Our property will undergo its <strong>annual fire inspection</strong> during the window shown above. Inspectors will require access to all units — please ensure your unit is accessible and your smoke/CO detectors are unobstructed.</p>",
+    include_unit_line: true,
+    closing_html: `<p>If you have any questions, please contact your General Manager {{manager_name}} or our 24/7 Member Support Line at ${IVR_LINK}.</p><p>Warm regards,<br>The Landing Team</p>`,
+  },
+  "Water Outage": {
+    event_name: "Planned Water Outage",
+    subject_template: "Water Outage Notice — {{property_name}} ({{date_range}})",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: DISCLAIMER_BANNER,
+    notification_card: "WATER_OUTAGE",
+    body_intro_html: "<p>We want to give you advance notice of a <strong>planned water outage</strong> at {{property_name}}. Our maintenance team will be working to complete this as quickly as possible and minimize disruption.</p><p>We recommend storing some water beforehand for your convenience.</p>",
+    include_unit_line: false,
+    closing_html: `<p>We apologize for any inconvenience. For questions, contact your General Manager {{manager_name}} or Member Support at ${IVR_LINK}.</p><p>Warm regards,<br>The Landing Team</p>`,
+  },
+  "General Maintenance": {
+    event_name: "Scheduled Property Maintenance",
+    subject_template: "Maintenance Notice — {{property_name}} ({{date_range}})",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: DISCLAIMER_BANNER,
+    notification_card: "MAINTENANCE",
+    body_intro_html: "<p>We will be conducting <strong>scheduled maintenance</strong> at {{property_name}} during the window shown above. Some common areas may be temporarily unavailable, and maintenance staff may be present on the property.</p>",
+    include_unit_line: false,
+    closing_html: `<p>Thank you for your patience. For questions, reach your General Manager {{manager_name}} or call Member Support at ${IVR_LINK}.</p><p>Warm regards,<br>The Landing Team</p>`,
+  },
+  "Weather Alert": {
+    event_name: "Weather Advisory",
+    subject_template: "Weather Advisory — {{property_name}} ({{date_range}})",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: DISCLAIMER_BANNER,
+    notification_card: "WEATHER_ALERT",
+    body_intro_html: "<p>A <strong>weather advisory</strong> has been issued for the area surrounding {{property_name}}. Please take appropriate precautions for your safety, secure any outdoor belongings, and follow guidance from local authorities.</p>",
+    include_unit_line: false,
+    closing_html: `<p>Your safety is our priority. For urgent property concerns, contact your General Manager {{manager_name}} or our 24/7 Member Support at ${IVR_LINK}.</p><p>Stay safe,<br>The Landing Team</p>`,
+  },
+  "Power Outage": {
+    event_name: "Power Outage",
+    subject_template: "Urgent: Power Outage at {{property_name}} — {{today}}",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: URGENT_BANNER,
+    notification_card: "POWER_OUTAGE",
+    body_intro_html:
+      "<p>We are reaching out because <strong>{{property_name}}</strong> is currently " +
+      "experiencing an <strong>unexpected power outage</strong> affecting your unit. " +
+      "We understand how disruptive this is — Landing is actively engaged with the " +
+      "property management team and working toward the fastest possible resolution.</p>" +
+      "<p>While service is being restored, please take the following precautions:</p>" +
+      "<ul>" +
+      "<li><strong>Unplug sensitive electronics</strong> (laptops, TVs, gaming consoles) " +
+      "to protect them from potential power surges when electricity is restored.</li>" +
+      "<li><strong>Keep your refrigerator and freezer doors closed</strong> — a closed " +
+      "refrigerator will maintain safe temperatures for approximately 4 hours.</li>" +
+      "<li>Use <strong>flashlights instead of candles</strong> for your safety.</li>" +
+      "<li>If you rely on <strong>powered medical equipment</strong>, please contact us " +
+      "immediately so we can assist you.</li>" +
+      "</ul>",
+    include_unit_line: false,
+    closing_html:
+      "<p>For the latest updates or if you need immediate assistance, please reach out to " +
+      "your General Manager <strong>{{manager_name}}</strong> directly, or contact our " +
+      `<strong>24/7 Member Support</strong> team at ${IVR_LINK} — we are standing by to help.</p>` +
+      "<p>We sincerely apologize for the inconvenience and thank you for your patience.<br>" +
+      "The Landing Team</p>",
+  },
+  "WiFi Outage": {
+    event_name: "WiFi Service Disruption",
+    subject_template: "Service Notice: WiFi Outage at {{property_name}} — {{today}}",
+    greeting_template: "<p>Dear {{first_name | Resident}},</p>",
+    include_disclaimer: true,
+    disclaimer_html: DISCLAIMER_BANNER,
+    notification_card: "WIFI_OUTAGE",
+    body_intro_html:
+      "<p>We are writing to let you know that <strong>{{property_name}}</strong> is " +
+      "currently experiencing a <strong>WiFi service disruption</strong> affecting your unit. " +
+      "Our team is actively coordinating with the property and the internet service provider " +
+      "to identify the cause and restore service as quickly as possible.</p>" +
+      "<p>In the meantime, here are a few things that may help:</p>" +
+      "<ul>" +
+      "<li>Your <strong>mobile data plan</strong> can serve as a reliable backup for " +
+      "essential connectivity while service is restored.</li>" +
+      "<li>If your device connects automatically to the property WiFi, consider " +
+      "<strong>disabling WiFi on your device temporarily</strong> so it falls back to " +
+      "mobile data without interruption.</li>" +
+      "<li>Once service is restored, <strong>restarting your devices or toggling WiFi " +
+      "off and back on</strong> should reconnect you automatically.</li>" +
+      "</ul>",
+    include_unit_line: false,
+    closing_html:
+      "<p>For updates on the status of this outage or if you need any assistance, please " +
+      "reach out to your General Manager <strong>{{manager_name}}</strong>, or contact our " +
+      `<strong>24/7 Member Support</strong> team at ${IVR_LINK}.</p>` +
+      "<p>We appreciate your patience and apologize for any inconvenience this causes.<br>" +
+      "The Landing Team</p>",
+  },
+};
+
+export function applyTemplate(cfg: CampaignConfig, templateName: string): { cfg: CampaignConfig; event_name?: string } | null {
+  const t = EMAIL_TEMPLATES[templateName];
+  if (!t) return null;
+  const next = { ...cfg };
+  for (const [key, value] of Object.entries(t)) {
+    if (key === "event_name") continue;
+    (next as any)[key] = value;
+  }
+  for (const key of TEMPLATE_BLANK_KEYS) {
+    if (!(key in t)) (next as any)[key] = typeof CONFIG_DEFAULTS[key] === "boolean" ? CONFIG_DEFAULTS[key] : "";
+  }
+  return { cfg: next, event_name: t.event_name };
+}
+
+// ── Validation (real, blocking — fixes audit defect 4) ───────────────────────
+
+export function validateForDispatch(
+  cfg: CampaignConfig, propertyName: string, eligibleCount: number, kind: string
+): string[] {
+  const errors: string[] = [];
+  if (!cfg.subject_template.trim()) errors.push("Subject template is empty.");
+  const hasBody = cfg.body_full_html.trim() || cfg.greeting_template.trim() ||
+    cfg.body_intro_html.trim() || cfg.closing_html.trim() || cfg.notification_card;
+  if (!hasBody) errors.push("Email body is empty — set a template, card, or body text.");
+  if (!propertyName.trim()) errors.push("Property name is empty.");
+  if (kind !== "test" && eligibleCount === 0) errors.push("No eligible recipients (blank, PENDING, or READY).");
+  if (cfg.notification_card && !CARD_REGISTRY[cfg.notification_card]) {
+    errors.push(`Unknown notification card: ${cfg.notification_card}`);
+  }
+  return errors;
+}

--- a/sandy-mass-notifications/src/emailkit.ts
+++ b/sandy-mass-notifications/src/emailkit.ts
@@ -195,50 +195,74 @@ function cardRow(label: string, value: string, valueColor?: string): string {
 </table>`.trim();
 }
 
-export const CARD_REGISTRY: Record<string, { label: string; render: () => string }> = {
-  FIRE_INSPECTION: {
-    label: "🔥 Fire Inspection",
-    render: () => cardShell(C.ACCENT_BLUE, "&#x1F525;", "Annual Fire Inspection", [
+// A card is DATA (editable in the app's /edit surface, persisted in D1
+// templates rows with kind='card'): the standard shell wraps an accent color,
+// icon entity, title, and inner body HTML. SEED_CARDS carries the six legacy
+// cards and seeds D1 on first run; after that, D1 is the registry of record.
+export interface CardDef {
+  key: string;      // SCREAMING_SNAKE config value (legacy parity)
+  label: string;    // chiclet label shown in Configure
+  accent: string;   // shell border/header color
+  icon: string;     // HTML hex entity (avoids Gmail emoji-encoding issues)
+  title: string;    // shell header text
+  body_html: string; // inner content ({{tokens}} allowed)
+}
+
+export function renderCard(def: CardDef): string {
+  return cardShell(def.accent, def.icon, def.title, def.body_html);
+}
+
+export { cardRow }; // exported for editor previews / future card tooling
+
+export const SEED_CARDS: CardDef[] = [
+  {
+    key: "FIRE_INSPECTION", label: "🔥 Fire Inspection",
+    accent: C.ACCENT_BLUE, icon: "&#x1F525;", title: "Annual Fire Inspection",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Dates", "{{date_range}}", C.ACCENT_BLUE),
       cardRow("Action required",
         "Inspectors will need <strong>access to your unit</strong>. " +
         "Please ensure your smoke detectors are unobstructed."),
-    ].join("")),
+    ].join(""),
   },
-  WATER_OUTAGE: {
-    label: "🚿 Water Outage",
-    render: () => cardShell(C.AMBER, "&#x1F6BF;", "Planned Water Outage", [
+  {
+    key: "WATER_OUTAGE", label: "🚿 Water Outage",
+    accent: C.AMBER, icon: "&#x1F6BF;", title: "Planned Water Outage",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Outage window", "{{date_range}}", C.AMBER),
       cardRow("What to expect",
         "Water service will be temporarily <strong>unavailable</strong> during this window. " +
         "We apologize for the inconvenience."),
-    ].join("")),
+    ].join(""),
   },
-  MAINTENANCE: {
-    label: "🔧 Maintenance",
-    render: () => cardShell(C.DARK_NAVY, "&#x1F527;", "Scheduled Maintenance", [
+  {
+    key: "MAINTENANCE", label: "🔧 Maintenance",
+    accent: C.DARK_NAVY, icon: "&#x1F527;", title: "Scheduled Maintenance",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Scheduled", "{{date_range}}", C.ACCENT_BLUE),
       cardRow("Details",
         "Our maintenance team will be on-site for <strong>{{event_name}}</strong>. " +
         "Some common areas may be temporarily unavailable."),
-    ].join("")),
+    ].join(""),
   },
-  WEATHER_ALERT: {
-    label: "⛈️ Weather Alert",
-    render: () => cardShell(C.RED, "&#x26C8;&#xFE0F;", "Weather Advisory", [
+  {
+    key: "WEATHER_ALERT", label: "⛈️ Weather Alert",
+    accent: C.RED, icon: "&#x26C8;&#xFE0F;", title: "Weather Advisory",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Period", "{{date_range}}", C.RED),
       cardRow("Advisory",
         "A <strong>weather advisory</strong> has been issued for your area. " +
         "Please take necessary precautions for your safety and secure any outdoor belongings."),
-    ].join("")),
+    ].join(""),
   },
-  POWER_OUTAGE: {
-    label: "⚡ Power Outage",
-    render: () => cardShell(C.ORANGE, "&#x26A1;", "Power Outage — Active", [
+  {
+    key: "POWER_OUTAGE", label: "⚡ Power Outage",
+    accent: C.ORANGE, icon: "&#x26A1;", title: "Power Outage — Active",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Reported", "{{today}}", C.ORANGE),
       cardRow("Status",
@@ -248,11 +272,12 @@ export const CARD_REGISTRY: Record<string, { label: string; render: () => string
         "Unplug sensitive electronics &nbsp;·&nbsp; " +
         "Keep fridge &amp; freezer closed &nbsp;·&nbsp; " +
         "Use flashlights, not candles"),
-    ].join("")),
+    ].join(""),
   },
-  WIFI_OUTAGE: {
-    label: "📶 WiFi Outage",
-    render: () => cardShell(C.AMBER, "&#x1F4F6;", "WiFi Service Disruption — Active", [
+  {
+    key: "WIFI_OUTAGE", label: "📶 WiFi Outage",
+    accent: C.AMBER, icon: "&#x1F4F6;", title: "WiFi Service Disruption — Active",
+    body_html: [
       cardRow("Property", "{{property_name}}"),
       cardRow("Reported", "{{today}}", C.AMBER),
       cardRow("Status",
@@ -261,9 +286,26 @@ export const CARD_REGISTRY: Record<string, { label: string; render: () => string
       cardRow("In the meantime",
         "Mobile data is available as a backup &nbsp;·&nbsp; " +
         "Disable WiFi on your device to switch automatically"),
-    ].join("")),
+    ].join(""),
   },
-};
+];
+
+export interface DisclaimerDef { name: string; html: string }
+
+export const SEED_DISCLAIMERS: DisclaimerDef[] = [
+  {
+    name: "Standard resident banner",
+    html: '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is a notification to all active residents at {{property_name}}. Please see the message below:</div>',
+  },
+  {
+    name: "Urgent resident banner",
+    html: '<div style="text-align:center;background-color:#E7EFFB;border:2.5px solid #15192D;border-radius:6px;padding:10px;color:#15192D;font-style:italic;">This is an urgent notification to all active residents at {{property_name}}. Please see the message below:</div>',
+  },
+  {
+    name: "Plain default",
+    html: "<p><em>This is an automated mass notification to all active residents.</em></p>",
+  },
+];
 
 // ── Body composer (legacy buildHtmlBody_) ────────────────────────────────────
 // Produces the COMPOSED body template with {{tokens}} intact. Per-recipient
@@ -272,15 +314,16 @@ export const CARD_REGISTRY: Record<string, { label: string; render: () => string
 const DEFAULT_DISCLAIMER =
   "<p><em>This is an automated mass notification to all active residents.</em></p>";
 
-export function composeBodyTemplate(cfg: CampaignConfig): string {
+export function composeBodyTemplate(cfg: CampaignConfig, cards?: Record<string, CardDef>): string {
+  const cardMap = cards ?? Object.fromEntries(SEED_CARDS.map((c) => [c.key, c]));
   if (cfg.body_full_html && cfg.body_full_html.trim()) {
     return wrapWithBranding(cfg, normalizeTelLinks(cfg.body_full_html + (cfg.signature_html || "")));
   }
   const parts: string[] = [];
   parts.push(cfg.greeting_template);
   if (cfg.include_disclaimer) parts.push(cfg.disclaimer_html || DEFAULT_DISCLAIMER);
-  if (cfg.notification_card && CARD_REGISTRY[cfg.notification_card]) {
-    parts.push(CARD_REGISTRY[cfg.notification_card].render());
+  if (cfg.notification_card && cardMap[cfg.notification_card]) {
+    parts.push(renderCard(cardMap[cfg.notification_card]));
   }
   parts.push(cfg.body_intro_html);
   if (cfg.include_unit_line) parts.push("{{html:unit_line}}");
@@ -489,8 +532,10 @@ export function applyTemplate(cfg: CampaignConfig, templateName: string): { cfg:
 // ── Validation (real, blocking — fixes audit defect 4) ───────────────────────
 
 export function validateForDispatch(
-  cfg: CampaignConfig, propertyName: string, eligibleCount: number, kind: string
+  cfg: CampaignConfig, propertyName: string, eligibleCount: number, kind: string,
+  cardKeys?: Set<string>
 ): string[] {
+  const known = cardKeys ?? new Set(SEED_CARDS.map((c) => c.key));
   const errors: string[] = [];
   if (!cfg.subject_template.trim()) errors.push("Subject template is empty.");
   const hasBody = cfg.body_full_html.trim() || cfg.greeting_template.trim() ||
@@ -498,7 +543,7 @@ export function validateForDispatch(
   if (!hasBody) errors.push("Email body is empty — set a template, card, or body text.");
   if (!propertyName.trim()) errors.push("Property name is empty.");
   if (kind !== "test" && eligibleCount === 0) errors.push("No eligible recipients (blank, PENDING, or READY).");
-  if (cfg.notification_card && !CARD_REGISTRY[cfg.notification_card]) {
+  if (cfg.notification_card && !known.has(cfg.notification_card)) {
     errors.push(`Unknown notification card: ${cfg.notification_card}`);
   }
   return errors;

--- a/sandy-mass-notifications/src/index.tsx
+++ b/sandy-mass-notifications/src/index.tsx
@@ -4,28 +4,35 @@
 
 import "./polyfills.js";
 import { renderToString } from "react-dom/server";
-import App, { type AppProps, type CampaignRow, type RecipientRow, type RoleRow } from "./App.js";
+import App, { type AppProps, type CampaignRow, type RecipientRow, type RoleRow, type RunRow } from "./App.js";
 // @ts-ignore — Vite resolves ?inline to a CSS string at build time
 import styles from "./styles.css?inline";
-import { createDb, campaigns, recipients, roles, workflowRuns, appConfig } from "./db.js";
-import { desc, eq, and, asc } from "drizzle-orm";
+import { createDb, campaigns, recipients, roles, runs, workflowRuns, appConfig } from "./db.js";
+import { desc, eq, and, asc, inArray } from "drizzle-orm";
 import { triggerWorkflowWithCallback } from "./workflow.js";
 // MCP server disabled in v0.1: the agents/mcp package pulls mimetext's node
 // build (`node:os`), which Sandy's deploy config rejects. Re-enable in P2 with
 // a pinned agents version (qa-scoring runs one successfully).
 // import { mcpHandler } from "./mcp.js";
 import { serveFont } from "./design-system/fonts.js";
+import {
+  parseConfig, composeBodyTemplate, buildGlobalTokens, buildRecipientTokens,
+  renderTokens, applyTemplate, validateForDispatch, CONFIG_DEFAULTS,
+  type CampaignConfig,
+} from "./emailkit.js";
 
 export interface Env {
   DB: D1Database;
   SANDY_CRON_DISPATCH_SECRET?: string;
 }
 
-// mass-notify-fetch workflow (created 2026-08-05). Override at runtime via
-// app_config key 'fetch_workflow_id' — Sandy strips wrangler [vars], so the
-// constant lives in source.
+// Workflow IDs (created 2026-08-05). Overridable at runtime via app_config keys
+// 'fetch_workflow_id' / 'dispatch_workflow_id' — Sandy strips wrangler [vars],
+// so the constants live in source.
 const FETCH_WORKFLOW_ID = "ffaa18b1-92a6-4eef-8219-c85c950c9068";
 const FETCH_WORKFLOW_NAME = "mass-notify-fetch";
+const DISPATCH_WORKFLOW_ID = "1afe1706-2986-4ee9-9436-133820030f7b";
+const DISPATCH_WORKFLOW_NAME = "mass-notify-dispatch";
 
 interface User { email: string; username: string }
 
@@ -40,7 +47,12 @@ function getUserFromRequest(request: Request): User {
   }
 }
 
-const ELIGIBLE_STATUSES = ["", "PENDING", "READY"];
+const ELIGIBLE = ["", "PENDING", "READY"];
+
+function parseIdList(s: string): string[] {
+  return String(s || "").split(/[\s,]+/).map((x) => x.trim()).filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i);
+}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -119,6 +131,67 @@ export default {
       return Response.json({ ok: true });
     }
 
+    // ── Workflow callback: dispatch results (send / dryrun / test) ───────────
+    if (url.pathname === `/api/v1/callbacks/${DISPATCH_WORKFLOW_NAME}` && request.method === "POST") {
+      if (request.headers.get("X-Sandy-Workflow-Callback") !== "verified") {
+        return Response.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+      }
+      const body = await request.json() as {
+        run_id?: string; status?: string; campaign_id?: string; app_run_id?: string;
+        kind?: string; error?: string | null; quota_remaining?: number | null;
+        results?: Array<{ id: string; email: string; ok: boolean; error: string | null }>;
+      };
+      if (!body.run_id) return Response.json({ ok: false, error: "missing run_id" }, { status: 400 });
+
+      await db.update(workflowRuns)
+        .set({ status: body.status ?? "error", result: JSON.stringify({ ...body, results: undefined }) })
+        .where(eq(workflowRuns.run_id, body.run_id));
+
+      const now = new Date().toISOString();
+      const results = body.results ?? [];
+      const okCount = results.filter((r) => r.ok).length;
+
+      // Per-recipient state updates (test uses a synthetic recipient — no rows match).
+      for (const r of results) {
+        if (!r.id || r.id === "test") continue;
+        if (r.ok) {
+          if (body.kind === "send") {
+            await db.update(recipients)
+              .set({ status: "SENT", email_state: "sent", email_sent_at: now })
+              .where(eq(recipients.id, r.id));
+          } else if (body.kind === "dryrun") {
+            await db.update(recipients)
+              .set({ status: "DRAFT" })
+              .where(eq(recipients.id, r.id));
+          }
+        } else {
+          await db.update(recipients)
+            .set({ email_state: "error", notes: r.error ?? "send failed" })
+            .where(eq(recipients.id, r.id));
+        }
+      }
+
+      if (body.app_run_id) {
+        await db.update(runs)
+          .set({
+            count: okCount,
+            completed_at: now,
+            error: body.status === "error" ? (body.error ?? "unknown")
+              : results.some((r) => !r.ok) ? `${results.filter((r) => !r.ok).length} failed` : null,
+          })
+          .where(eq(runs.id, body.app_run_id));
+      }
+
+      if (body.campaign_id) {
+        const newStatus = body.status !== "complete" ? "errored"
+          : body.kind === "send" ? "complete" : "ready";
+        await db.update(campaigns)
+          .set(newStatus === "complete" ? { status: newStatus, completed_at: now } : { status: newStatus })
+          .where(eq(campaigns.id, body.campaign_id));
+      }
+      return Response.json({ ok: true });
+    }
+
     // ── RBAC gate (everything below is a human surface) ──────────────────────
     const user = getUserFromRequest(request);
     const roleRow = (await db.select().from(roles).where(eq(roles.email, user.email)).limit(1))[0];
@@ -138,7 +211,7 @@ export default {
     if (!isOperator) {
       return renderPage({
         page: "access", user, role,
-        campaigns: [], recipients: [], roleRequests: [],
+        campaigns: [], recipients: [], roleRequests: [], runs: [],
       });
     }
 
@@ -148,10 +221,8 @@ export default {
       const email = form.get("email")?.toString().trim().toLowerCase();
       const newRole = form.get("role")?.toString();
       if (email && newRole && ["admin", "operator", "denied"].includes(newRole)) {
-        if (newRole === "denied") {
-          await db.delete(roles).where(eq(roles.email, email));
-        } else {
-          await db.delete(roles).where(eq(roles.email, email));
+        await db.delete(roles).where(eq(roles.email, email));
+        if (newRole !== "denied") {
           await db.insert(roles).values({
             email, role: newRole, granted_by: user.email,
             created_at: new Date().toISOString(),
@@ -178,12 +249,20 @@ export default {
       return Response.redirect(new URL(`/c/${id}`, request.url).toString(), 303);
     }
 
+    const campaignRoute = url.pathname.match(/^\/(?:api\/campaigns|c)\/([0-9a-f-]{36})(\/[a-z-]+)?$/);
+    const cid = campaignRoute?.[1];
+    const action = campaignRoute?.[2];
+    const campaign = cid
+      ? (await db.select().from(campaigns).where(eq(campaigns.id, cid)).limit(1))[0]
+      : undefined;
+    if (cid && !campaign) {
+      return Response.redirect(new URL("/?error=Campaign+not+found", request.url).toString(), 303);
+    }
+    const back = (msg: string, isError = false) =>
+      Response.redirect(new URL(`/c/${cid}?${isError ? "error" : "flash"}=${encodeURIComponent(msg)}`, request.url).toString(), 303);
+
     // ── Trigger warehouse fetch ──────────────────────────────────────────────
-    const fetchMatch = url.pathname.match(/^\/api\/campaigns\/([0-9a-f-]{36})\/fetch$/);
-    if (fetchMatch && request.method === "POST") {
-      const cid = fetchMatch[1];
-      const campaign = (await db.select().from(campaigns).where(eq(campaigns.id, cid)).limit(1))[0];
-      if (!campaign) return Response.redirect(new URL("/?error=Campaign+not+found", request.url).toString(), 303);
+    if (campaign && action === "/fetch" && request.method === "POST") {
       const wfId = (await db.select().from(appConfig).where(eq(appConfig.key, "fetch_workflow_id")).limit(1))[0]?.value
         ?? FETCH_WORKFLOW_ID;
       try {
@@ -195,44 +274,177 @@ export default {
           run_id: run.id, workflow_name: FETCH_WORKFLOW_NAME,
           status: "pending", created_at: new Date().toISOString(),
         });
-        await db.update(campaigns).set({ status: "fetching" }).where(eq(campaigns.id, cid));
-        return Response.redirect(new URL(`/c/${cid}?flash=Fetch+queued`, request.url).toString(), 303);
+        await db.update(campaigns).set({ status: "fetching" }).where(eq(campaigns.id, cid!));
+        return back("Fetch queued");
       } catch (e: any) {
-        return Response.redirect(
-          new URL(`/c/${cid}?error=${encodeURIComponent(e?.message ?? String(e))}`, request.url).toString(), 303);
+        return back(e?.message ?? String(e), true);
       }
     }
 
+    // ── Save campaign config ─────────────────────────────────────────────────
+    if (campaign && action === "/config" && request.method === "POST") {
+      const form = await request.formData();
+      const cfg = parseConfig(campaign.config_json);
+      for (const key of Object.keys(CONFIG_DEFAULTS) as (keyof CampaignConfig)[]) {
+        if (typeof CONFIG_DEFAULTS[key] === "boolean") {
+          (cfg as any)[key] = form.get(key) === "on";
+        } else if (form.has(key)) {
+          const v = form.get(key)!.toString();
+          (cfg as any)[key] = typeof CONFIG_DEFAULTS[key] === "number" ? (Number(v) || CONFIG_DEFAULTS[key]) : v;
+        }
+      }
+      const eventName = form.get("event_name")?.toString().trim() ?? campaign.event_name;
+      await db.update(campaigns)
+        .set({ config_json: JSON.stringify(cfg), event_name: eventName })
+        .where(eq(campaigns.id, cid!));
+      return back("Configuration saved");
+    }
+
+    // ── Apply template ───────────────────────────────────────────────────────
+    if (campaign && action === "/template" && request.method === "POST") {
+      const form = await request.formData();
+      const name = form.get("name")?.toString() ?? "";
+      const applied = applyTemplate(parseConfig(campaign.config_json), name);
+      if (!applied) return back(`Unknown template: ${name}`, true);
+      await db.update(campaigns)
+        .set({
+          config_json: JSON.stringify(applied.cfg),
+          event_name: applied.event_name ?? campaign.event_name,
+        })
+        .where(eq(campaigns.id, cid!));
+      return back(`Template "${name}" applied — fill in manager, dates, and review before sending`);
+    }
+
+    // ── Dispatch: send / dryrun / test ───────────────────────────────────────
+    if (campaign && action === "/dispatch" && request.method === "POST") {
+      const form = await request.formData();
+      const kind = form.get("kind")?.toString() ?? "";
+      if (!["send", "dryrun", "test"].includes(kind)) return back("Bad dispatch kind", true);
+      if (kind === "send" && form.get("confirm") !== "on") {
+        return back("Check the confirmation box to send", true);
+      }
+      const cfg = parseConfig(campaign.config_json);
+      const allRows = await db.select().from(recipients)
+        .where(eq(recipients.campaign_id, cid!))
+        .orderBy(asc(recipients.unit), asc(recipients.email));
+      const eligibleRows = allRows.filter((r) => ELIGIBLE.includes(r.status));
+
+      const errors = validateForDispatch(cfg, campaign.property_name, eligibleRows.length, kind);
+      if (errors.length) return back(errors.join(" "), true);
+
+      const limit = kind === "dryrun" ? cfg.dry_run_limit : cfg.max_per_run;
+      const targets = eligibleRows.slice(0, limit);
+      const globals = buildGlobalTokens(campaign.property_name, campaign.event_name, cfg);
+      const configAttachmentIds = parseIdList(cfg.attachment_file_ids);
+
+      const wfRecipients = kind === "test"
+        ? [{
+            id: "test", email: user.email,
+            name: targets[0]?.name || "Resident Test",
+            unit: targets[0]?.unit || "101",
+            attachmentIds: [],
+          }]
+        : targets.map((r) => ({
+            id: r.id, email: r.email, name: r.name, unit: r.unit,
+            attachmentIds: parseIdList(r.attach_ids_json ?? ""),
+          }));
+
+      const appRunId = crypto.randomUUID();
+      const rowStates = kind === "send"
+        ? targets.map((r) => ({ id: r.id, prevStatus: r.status }))
+        : null;
+
+      const wfId = (await db.select().from(appConfig).where(eq(appConfig.key, "dispatch_workflow_id")).limit(1))[0]?.value
+        ?? DISPATCH_WORKFLOW_ID;
+      try {
+        const run = await triggerWorkflowWithCallback(wfId, DISPATCH_WORKFLOW_NAME, request, {
+          campaign_id: cid,
+          app_run_id: appRunId,
+          kind,
+          config: {
+            subjectTemplate: cfg.subject_template,
+            bodyTemplate: composeBodyTemplate(cfg),
+            senderName: cfg.sender_display_name,
+            replyTo: cfg.reply_to,
+            cc: [cfg.manager_email, cfg.cc_extra].filter(Boolean).join(","),
+            includeUnitLine: cfg.include_unit_line,
+            globalTokens: globals,
+            configAttachmentIds,
+          },
+          recipients: wfRecipients,
+        });
+        await db.insert(runs).values({
+          id: appRunId, campaign_id: cid!, kind, actor: user.email,
+          count: 0, row_states_json: rowStates ? JSON.stringify(rowStates) : null,
+          started_at: new Date().toISOString(),
+        });
+        await db.insert(workflowRuns).values({
+          run_id: run.id, workflow_name: DISPATCH_WORKFLOW_NAME,
+          status: "pending", created_at: new Date().toISOString(),
+        });
+        if (kind === "send") {
+          await db.update(campaigns).set({ status: "sending" }).where(eq(campaigns.id, cid!));
+        }
+        const label = kind === "send" ? `Sending to ${wfRecipients.length} recipients`
+          : kind === "dryrun" ? `Creating ${wfRecipients.length} drafts in member.support@`
+          : `Test email queued to ${user.email}`;
+        return back(`${label} — refresh for results`);
+      } catch (e: any) {
+        return back(e?.message ?? String(e), true);
+      }
+    }
+
+    // ── Undo the latest completed send ───────────────────────────────────────
+    if (campaign && action === "/undo" && request.method === "POST") {
+      const lastSend = (await db.select().from(runs)
+        .where(and(eq(runs.campaign_id, cid!), eq(runs.kind, "send")))
+        .orderBy(desc(runs.started_at)).limit(1))[0];
+      if (!lastSend || !lastSend.completed_at || !lastSend.row_states_json) {
+        return back("No completed send run to undo", true);
+      }
+      let states: Array<{ id: string; prevStatus: string }> = [];
+      try { states = JSON.parse(lastSend.row_states_json); } catch { /* noop */ }
+      for (const s of states) {
+        await db.update(recipients)
+          .set({ status: s.prevStatus ?? "", email_state: "pending", email_sent_at: null })
+          .where(eq(recipients.id, s.id));
+      }
+      const now = new Date().toISOString();
+      await db.insert(runs).values({
+        id: crypto.randomUUID(), campaign_id: cid!, kind: "undo", actor: user.email,
+        count: states.length, row_states_json: null,
+        started_at: now, completed_at: now,
+      });
+      await db.update(campaigns).set({ status: "ready", completed_at: null }).where(eq(campaigns.id, cid!));
+      return back(`Undo complete — ${states.length} recipients reverted (emails already sent are NOT recalled)`);
+    }
+
     // ── Manual recipient add ─────────────────────────────────────────────────
-    const recAddMatch = url.pathname.match(/^\/api\/campaigns\/([0-9a-f-]{36})\/recipients$/);
-    if (recAddMatch && request.method === "POST") {
-      const cid = recAddMatch[1];
+    if (campaign && action === "/recipients" && request.method === "POST") {
       const form = await request.formData();
       const email = form.get("email")?.toString().trim() ?? "";
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)) {
-        return Response.redirect(new URL(`/c/${cid}?error=Invalid+email`, request.url).toString(), 303);
-      }
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email)) return back("Invalid email", true);
       await db.insert(recipients).values({
-        id: crypto.randomUUID(), campaign_id: cid, email,
+        id: crypto.randomUUID(), campaign_id: cid!, email,
         name: form.get("name")?.toString().trim() ?? "",
         unit: form.get("unit")?.toString().trim() ?? "",
         source: "manual", status: "PENDING",
         email_state: "pending", sms_state: "off",
       });
-      return Response.redirect(new URL(`/c/${cid}`, request.url).toString(), 303);
+      return back("Recipient added");
     }
 
-    // ── Recipient status update / delete (field-level, never grid overwrite) ─
+    // ── Recipient status update / delete (field-level) ───────────────────────
     const recEditMatch = url.pathname.match(/^\/api\/recipients\/([0-9a-f-]{36})$/);
     if (recEditMatch && request.method === "POST") {
       const rid = recEditMatch[1];
       const form = await request.formData();
-      const action = form.get("action")?.toString();
+      const act = form.get("action")?.toString();
       const row = (await db.select().from(recipients).where(eq(recipients.id, rid)).limit(1))[0];
       if (row) {
-        if (action === "delete") {
+        if (act === "delete") {
           await db.delete(recipients).where(eq(recipients.id, rid));
-        } else if (action === "status") {
+        } else if (act === "status") {
           const status = form.get("status")?.toString() ?? "";
           if (["PENDING", "READY", "REVIEW"].includes(status)) {
             await db.update(recipients).set({ status }).where(eq(recipients.id, rid));
@@ -244,17 +456,37 @@ export default {
     }
 
     // ── Campaign detail page ─────────────────────────────────────────────────
-    const detailMatch = url.pathname.match(/^\/c\/([0-9a-f-]{36})$/);
-    if (detailMatch && request.method === "GET") {
-      const cid = detailMatch[1];
-      const campaign = (await db.select().from(campaigns).where(eq(campaigns.id, cid)).limit(1))[0];
-      if (!campaign) return Response.redirect(new URL("/?error=Campaign+not+found", request.url).toString(), 303);
+    if (campaign && !action && request.method === "GET") {
       const recRows = await db.select().from(recipients)
-        .where(eq(recipients.campaign_id, cid))
+        .where(eq(recipients.campaign_id, cid!))
         .orderBy(asc(recipients.unit), asc(recipients.email));
+      const runRows = await db.select().from(runs)
+        .where(eq(runs.campaign_id, cid!))
+        .orderBy(desc(runs.started_at)).limit(10);
+
+      // Server-rendered preview against a chosen (or first eligible) recipient.
+      const cfg = parseConfig(campaign.config_json);
+      const previewId = url.searchParams.get("preview");
+      const eligibleRows = recRows.filter((r) => ELIGIBLE.includes(r.status));
+      const pr = (previewId && recRows.find((r) => r.id === previewId)) || eligibleRows[0];
+      const globals = buildGlobalTokens(campaign.property_name, campaign.event_name, cfg);
+      const tokens = buildRecipientTokens(
+        globals,
+        pr ? { email: pr.email, name: pr.name, unit: pr.unit }
+           : { email: "", name: "Resident", unit: "101" },
+        cfg.include_unit_line
+      );
+      const previewHtml = renderTokens(composeBodyTemplate(cfg), tokens, true);
+      const previewSubject = renderTokens(cfg.subject_template, tokens, false);
+
       return renderPage({
         page: "campaign", user, role,
-        campaigns: [campaign as CampaignRow], recipients: recRows as RecipientRow[], roleRequests: [],
+        campaigns: [campaign as CampaignRow], recipients: recRows as RecipientRow[],
+        roleRequests: [], runs: runRows as RunRow[],
+        config: cfg,
+        previewHtml, previewSubject,
+        previewFor: pr ? pr.email : "generic (no recipients)",
+        previewRecipientId: pr?.id,
         flash: url.searchParams.get("flash") ?? undefined,
         error: url.searchParams.get("error") ?? undefined,
       });
@@ -267,7 +499,7 @@ export default {
       : [];
     return renderPage({
       page: "home", user, role,
-      campaigns: campaignRows as CampaignRow[], recipients: [],
+      campaigns: campaignRows as CampaignRow[], recipients: [], runs: [],
       roleRequests: roleRequests as RoleRow[],
       flash: url.searchParams.get("flash") ?? undefined,
       error: url.searchParams.get("error") ?? undefined,

--- a/sandy-mass-notifications/src/index.tsx
+++ b/sandy-mass-notifications/src/index.tsx
@@ -8,7 +8,7 @@ import App, { type AppProps, type CampaignRow, type RecipientRow, type RoleRow, 
 // @ts-ignore — Vite resolves ?inline to a CSS string at build time
 import styles from "./styles.css?inline";
 import { createDb, campaigns, recipients, roles, runs, workflowRuns, appConfig, templates } from "./db.js";
-import { desc, eq, and, asc } from "drizzle-orm";
+import { desc, eq, and, asc, inArray, isNull } from "drizzle-orm";
 import { triggerWorkflowWithCallback } from "./workflow.js";
 // MCP server disabled in v0.1: the agents/mcp package pulls mimetext's node
 // build (`node:os`), which Sandy's deploy config rejects. Re-enable in P2 with
@@ -35,6 +35,8 @@ const FETCH_WORKFLOW_ID = "ffaa18b1-92a6-4eef-8219-c85c950c9068";
 const FETCH_WORKFLOW_NAME = "mass-notify-fetch";
 const DISPATCH_WORKFLOW_ID = "1afe1706-2986-4ee9-9436-133820030f7b";
 const DISPATCH_WORKFLOW_NAME = "mass-notify-dispatch";
+// PRD D4 — verified Member Support Line. Override via app_config 'sms_from_number'.
+const SMS_FROM_NUMBER = "+14159804986";
 
 interface User { email: string; username: string }
 
@@ -87,6 +89,19 @@ async function loadAssets(db: ReturnType<typeof createDb>) {
   const cardMap: Record<string, CardDef> = {};
   for (const c of cards) if (c.active) cardMap[String(c.config.key)] = c.config as unknown as CardDef;
   return { cards, disclaimers, cardMap };
+}
+
+// Change signature for the SSE watcher: campaign status + SMS preview length
+// + incomplete-run count. Any async completion shifts at least one component.
+async function campaignSig(db: ReturnType<typeof createDb>, cid: string): Promise<string> {
+  const row = (await db.select({
+    status: campaigns.status,
+    sms_preview_text: campaigns.sms_preview_text,
+  }).from(campaigns).where(eq(campaigns.id, cid)).limit(1))[0];
+  if (!row) return "gone";
+  const open = await db.select({ id: runs.id }).from(runs)
+    .where(and(eq(runs.campaign_id, cid), isNull(runs.completed_at)));
+  return `${row.status}|${row.sms_preview_text?.length ?? 0}|${open.length}`;
 }
 
 const SAMPLE_TOKENS: Record<string, string> = {
@@ -183,18 +198,20 @@ export default {
         run_id?: string; status?: string; campaign_id?: string; app_run_id?: string;
         kind?: string; error?: string | null; quota_remaining?: number | null;
         results?: Array<{ id: string; email: string; ok: boolean; error: string | null }>;
+        sms_text?: string | null; sms_truncated?: boolean; sms_warning?: string | null;
+        sms_results?: Array<{ id: string; state: string; error: string | null }>;
       };
       if (!body.run_id) return Response.json({ ok: false, error: "missing run_id" }, { status: 400 });
 
       await db.update(workflowRuns)
-        .set({ status: body.status ?? "error", result: JSON.stringify({ ...body, results: undefined }) })
+        .set({ status: body.status ?? "error", result: JSON.stringify({ ...body, results: undefined, sms_results: undefined }) })
         .where(eq(workflowRuns.run_id, body.run_id));
 
       const now = new Date().toISOString();
       const results = body.results ?? [];
       const okCount = results.filter((r) => r.ok).length;
 
-      // Per-recipient state updates (test uses a synthetic recipient — no rows match).
+      // Per-recipient email state updates (test uses a synthetic recipient — no rows match).
       for (const r of results) {
         if (!r.id || r.id === "test") continue;
         if (r.ok) {
@@ -214,18 +231,41 @@ export default {
         }
       }
 
+      // SMS: cache the summary on the campaign; apply per-recipient states.
+      if (body.campaign_id && body.sms_text) {
+        await db.update(campaigns)
+          .set({ sms_preview_text: body.sms_text, sms_preview_truncated: body.sms_truncated ? 1 : 0 })
+          .where(eq(campaigns.id, body.campaign_id));
+      }
+      for (const s of body.sms_results ?? []) {
+        if (!s.id || s.id === "sms_test") continue;
+        await db.update(recipients)
+          .set({
+            sms_state: s.state,
+            sms_error: s.error ?? null,
+            ...(s.state === "sent" ? { sms_sent_at: now, sms_body: body.sms_text ?? null } : {}),
+          })
+          .where(eq(recipients.id, s.id));
+      }
+
       if (body.app_run_id) {
+        const smsSent = (body.sms_results ?? []).filter((s) => s.state === "sent").length;
+        const emailFailed = results.filter((r) => !r.ok).length;
+        const parts: string[] = [];
+        if (body.status === "error") parts.push(body.error ?? "unknown");
+        if (emailFailed) parts.push(`${emailFailed} email(s) failed`);
+        if (body.sms_warning) parts.push(`warning: ${body.sms_warning}`);
         await db.update(runs)
           .set({
-            count: okCount,
+            count: body.kind === "sms_only" ? smsSent : okCount,
             completed_at: now,
-            error: body.status === "error" ? (body.error ?? "unknown")
-              : results.some((r) => !r.ok) ? `${results.filter((r) => !r.ok).length} failed` : null,
+            error: parts.length ? parts.join("; ") : null,
           })
           .where(eq(runs.id, body.app_run_id));
       }
 
-      if (body.campaign_id) {
+      // Campaign status: email kinds drive it; SMS-only kinds leave it alone.
+      if (body.campaign_id && ["send", "dryrun", "test"].includes(body.kind ?? "")) {
         const newStatus = body.status !== "complete" ? "errored"
           : body.kind === "send" ? "complete" : "ready";
         await db.update(campaigns)
@@ -382,7 +422,10 @@ export default {
       return back(`Disclaimer set: ${d.name}`);
     }
 
-    // ── SSE: live campaign status (replaces refresh-to-see-results) ──────────
+    // ── SSE: live campaign change signal (replaces refresh-to-see-results) ───
+    // Emits a change signature covering status transitions, SMS preview
+    // arrival, and run completions; the page reloads when it differs from the
+    // signature it rendered with.
     if (campaign && action === "/events" && request.method === "GET") {
       const enc = new TextEncoder();
       const stream = new ReadableStream({
@@ -391,10 +434,8 @@ export default {
             controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
           try {
             for (let i = 0; i < 25; i++) { // ~50s, then EventSource auto-reconnects
-              const row = (await db.select({ status: campaigns.status })
-                .from(campaigns).where(eq(campaigns.id, cid!)).limit(1))[0];
-              send({ status: row?.status ?? "gone" });
-              if (!row || !["fetching", "sending"].includes(row.status)) break;
+              const sig = await campaignSig(db, cid!);
+              send({ sig });
               await new Promise((r) => setTimeout(r, 2000));
             }
           } catch { /* client went away */ }
@@ -410,11 +451,20 @@ export default {
       });
     }
 
-    // ── Dispatch: send / dryrun / test ───────────────────────────────────────
+    // ── SMS enable/disable toggle ────────────────────────────────────────────
+    if (campaign && action === "/sms-toggle" && request.method === "POST") {
+      const form = await request.formData();
+      const enabled = form.get("sms_enabled") === "on" ? 1 : 0;
+      await db.update(campaigns).set({ sms_enabled: enabled }).where(eq(campaigns.id, cid!));
+      return back(enabled ? "SMS companion enabled for this campaign" : "SMS companion disabled");
+    }
+
+    // ── Dispatch: send / dryrun / test / sms_preview / sms_test / sms_only ───
     if (campaign && action === "/dispatch" && request.method === "POST") {
       const form = await request.formData();
       const kind = form.get("kind")?.toString() ?? "";
-      if (!["send", "dryrun", "test"].includes(kind)) return back("Bad dispatch kind", true);
+      const KINDS = ["send", "dryrun", "test", "sms_preview", "sms_test", "sms_only"];
+      if (!KINDS.includes(kind)) return back("Bad dispatch kind", true);
       if (kind === "send" && form.get("confirm") !== "on") {
         return back("Check the confirmation box to send", true);
       }
@@ -425,28 +475,53 @@ export default {
         .orderBy(asc(recipients.unit), asc(recipients.email));
       const eligibleRows = allRows.filter((r) => ELIGIBLE.includes(r.status));
 
-      const errors = validateForDispatch(cfg, campaign.property_name, eligibleRows.length, kind,
-        new Set(Object.keys(cardMap)));
+      // SMS kinds don't need eligible recipients (validate like "test").
+      const isSmsKind = kind.startsWith("sms_");
+      const errors = validateForDispatch(cfg, campaign.property_name, eligibleRows.length,
+        isSmsKind ? "test" : kind, new Set(Object.keys(cardMap)));
       if (errors.length) return back(errors.join(" "), true);
 
+      let testNumber = "";
+      if (kind === "sms_test") {
+        testNumber = (form.get("test_number")?.toString() ?? "").replace(/[^\d+]/g, "");
+        if (!/^\+\d{8,15}$/.test(testNumber)) {
+          return back("Test SMS needs a number in E.164 form, e.g. +15551234567", true);
+        }
+      }
+
+      // Target selection per kind.
       const limit = kind === "dryrun" ? cfg.dry_run_limit : cfg.max_per_run;
-      const targets = eligibleRows.slice(0, limit);
+      let targets: typeof allRows = [];
+      if (kind === "sms_only") {
+        targets = allRows.filter((r) =>
+          r.status === "SENT" && r.phone_e164 && !["sent", "skipped_optout"].includes(r.sms_state));
+        if (targets.length === 0) return back("No emailed recipients pending SMS", true);
+      } else if (!isSmsKind) {
+        targets = eligibleRows.slice(0, limit);
+      }
+
       const globals = buildGlobalTokens(campaign.property_name, campaign.event_name, cfg);
       const configAttachmentIds = parseIdList(cfg.attachment_file_ids);
-
+      const toWfRecipient = (r: typeof allRows[number]) => ({
+        id: r.id, email: r.email, name: r.name, unit: r.unit,
+        attachmentIds: parseIdList(r.attach_ids_json ?? ""),
+        phone_e164: r.phone_e164, segment_timezone: r.segment_timezone,
+      });
       const wfRecipients = kind === "test"
         ? [{
             id: "test", email: user.email,
             name: targets[0]?.name || "Resident Test",
             unit: targets[0]?.unit || "101",
-            attachmentIds: [],
+            attachmentIds: [] as string[], phone_e164: null, segment_timezone: null,
           }]
-        : targets.map((r) => ({
-            id: r.id, email: r.email, name: r.name, unit: r.unit,
-            attachmentIds: parseIdList(r.attach_ids_json ?? ""),
-          }));
+        : targets.map(toWfRecipient);
 
-      const appRunId = crypto.randomUUID();
+      const smsEnabled = campaign.sms_enabled === 1;
+      const smsFrom = (await db.select().from(appConfig).where(eq(appConfig.key, "sms_from_number")).limit(1))[0]?.value
+        ?? SMS_FROM_NUMBER;
+
+      const auditedKinds: Record<string, string> = { send: "send", dryrun: "dryrun", test: "test", sms_only: "sms" };
+      const appRunId = auditedKinds[kind] ? crypto.randomUUID() : null;
       const rowStates = kind === "send"
         ? targets.map((r) => ({ id: r.id, prevStatus: r.status }))
         : null;
@@ -469,22 +544,42 @@ export default {
             configAttachmentIds,
           },
           recipients: wfRecipients,
+          sms: {
+            enabled: smsEnabled,
+            from_number: smsFrom,
+            quiet_start: 8, quiet_end: 21,
+            ...(testNumber ? { test_number: testNumber } : {}),
+          },
         });
-        await db.insert(runs).values({
-          id: appRunId, campaign_id: cid!, kind, actor: user.email,
-          count: 0, row_states_json: rowStates ? JSON.stringify(rowStates) : null,
-          started_at: new Date().toISOString(),
-        });
+        if (appRunId) {
+          await db.insert(runs).values({
+            id: appRunId, campaign_id: cid!, kind: auditedKinds[kind], actor: user.email,
+            count: 0, row_states_json: rowStates ? JSON.stringify(rowStates) : null,
+            started_at: new Date().toISOString(),
+          });
+        }
         await db.insert(workflowRuns).values({
           run_id: run.id, workflow_name: DISPATCH_WORKFLOW_NAME,
           status: "pending", created_at: new Date().toISOString(),
         });
         if (kind === "send") {
           await db.update(campaigns).set({ status: "sending" }).where(eq(campaigns.id, cid!));
+          if (smsEnabled) {
+            // Live-feedback: mark targets with a phone as queued; callback finalizes.
+            const phoneIds = targets.filter((r) => r.phone_e164).map((r) => r.id);
+            for (let i = 0; i < phoneIds.length; i += 90) {
+              await db.update(recipients).set({ sms_state: "queued" })
+                .where(inArray(recipients.id, phoneIds.slice(i, i + 90)));
+            }
+          }
         }
-        const label = kind === "send" ? `Sending to ${wfRecipients.length} recipients`
+        const label =
+          kind === "send" ? `Sending to ${wfRecipients.length} recipients${smsEnabled ? " (email + SMS)" : ""}`
           : kind === "dryrun" ? `Creating ${wfRecipients.length} drafts in member.support@`
-          : `Test email queued to ${user.email}`;
+          : kind === "test" ? `Test email queued to ${user.email}`
+          : kind === "sms_preview" ? "Generating SMS preview"
+          : kind === "sms_test" ? `Test SMS queued to ${testNumber}`
+          : `SMS queued for ${wfRecipients.length} recipients`;
         return back(`${label} — results will appear here automatically`);
       } catch (e: any) {
         return back(e?.message ?? String(e), true);
@@ -660,23 +755,25 @@ export default {
       const previewHtml = renderTokens(composeBodyTemplate(cfg, cardMap), tokens, true);
       const previewSubject = renderTokens(cfg.subject_template, tokens, false);
 
-      // Live status watcher: SSE while fetching/sending, reload on transition.
-      const watchScript = ["fetching", "sending"].includes(campaign.status) ? `
+      // Live watcher: reload when the campaign's change signature moves
+      // (status transitions, SMS preview arrival, run completions).
+      const initialSig = await campaignSig(db, cid!);
+      const watchScript = `
 (function(){
   if (!window.EventSource) return;
-  var initial = ${JSON.stringify(campaign.status)};
+  var initial = ${JSON.stringify(initialSig)};
   function watch(){
     var es = new EventSource(location.pathname.replace(/\\/$/, "") + "/events");
     es.onmessage = function(ev){
       try {
         var d = JSON.parse(ev.data);
-        if (d.status && d.status !== initial) { es.close(); location.reload(); }
+        if (d.sig && d.sig !== initial) { es.close(); location.reload(); }
       } catch(e){}
     };
     es.onerror = function(){ es.close(); setTimeout(watch, 3000); };
   }
   watch();
-})();` : undefined;
+})();`;
 
       return renderPage({
         page: "campaign", user, role,
@@ -721,7 +818,7 @@ const BASE_SCRIPT = `
       history.replaceState(null, "", u.pathname + (q ? "?" + q : ""));
     }
   } catch(e){}
-  var sels = document.querySelectorAll("select[data-autosubmit]");
+  var sels = document.querySelectorAll("[data-autosubmit]");
   for (var i = 0; i < sels.length; i++) {
     (function(s){ s.addEventListener("change", function(){ if (s.form) s.form.submit(); }); })(sels[i]);
   }

--- a/sandy-mass-notifications/src/index.tsx
+++ b/sandy-mass-notifications/src/index.tsx
@@ -7,8 +7,8 @@ import { renderToString } from "react-dom/server";
 import App, { type AppProps, type CampaignRow, type RecipientRow, type RoleRow, type RunRow } from "./App.js";
 // @ts-ignore — Vite resolves ?inline to a CSS string at build time
 import styles from "./styles.css?inline";
-import { createDb, campaigns, recipients, roles, runs, workflowRuns, appConfig } from "./db.js";
-import { desc, eq, and, asc, inArray } from "drizzle-orm";
+import { createDb, campaigns, recipients, roles, runs, workflowRuns, appConfig, templates } from "./db.js";
+import { desc, eq, and, asc } from "drizzle-orm";
 import { triggerWorkflowWithCallback } from "./workflow.js";
 // MCP server disabled in v0.1: the agents/mcp package pulls mimetext's node
 // build (`node:os`), which Sandy's deploy config rejects. Re-enable in P2 with
@@ -17,9 +17,11 @@ import { triggerWorkflowWithCallback } from "./workflow.js";
 import { serveFont } from "./design-system/fonts.js";
 import {
   parseConfig, composeBodyTemplate, buildGlobalTokens, buildRecipientTokens,
-  renderTokens, applyTemplate, validateForDispatch, CONFIG_DEFAULTS,
-  type CampaignConfig,
+  renderTokens, renderCard, applyTemplate, validateForDispatch, CONFIG_DEFAULTS,
+  SEED_CARDS, SEED_DISCLAIMERS, formatToday,
+  type CampaignConfig, type CardDef,
 } from "./emailkit.js";
+import type { AssetRow } from "./App.js";
 
 export interface Env {
   DB: D1Database;
@@ -53,6 +55,47 @@ function parseIdList(s: string): string[] {
   return String(s || "").split(/[\s,]+/).map((x) => x.trim()).filter(Boolean)
     .filter((v, i, a) => a.indexOf(v) === i);
 }
+
+// Cards + disclaimers live in D1 (templates: kind='card'|'disclaimer'), seeded
+// once from emailkit SEED_* and curated at /edit thereafter.
+async function loadAssets(db: ReturnType<typeof createDb>) {
+  let rows = await db.select().from(templates);
+  if (!rows.some((r) => r.kind === "card")) {
+    const now = new Date().toISOString();
+    for (const c of SEED_CARDS) {
+      await db.insert(templates).values({
+        id: crypto.randomUUID(), name: c.key, kind: "card",
+        config_json: JSON.stringify(c), active: 1, updated_by: "seed", updated_at: now,
+      });
+    }
+    for (const d of SEED_DISCLAIMERS) {
+      await db.insert(templates).values({
+        id: crypto.randomUUID(), name: d.name, kind: "disclaimer",
+        config_json: JSON.stringify(d), active: 1, updated_by: "seed", updated_at: now,
+      });
+    }
+    rows = await db.select().from(templates);
+  }
+  const parse = (r: typeof rows[number]): AssetRow => {
+    let cfg: Record<string, string> = {};
+    try { cfg = JSON.parse(r.config_json); } catch { /* ignore */ }
+    return { id: r.id, kind: r.kind, name: r.name, active: r.active === 1, config: cfg,
+      updated_by: r.updated_by, updated_at: r.updated_at };
+  };
+  const cards = rows.filter((r) => r.kind === "card").map(parse);
+  const disclaimers = rows.filter((r) => r.kind === "disclaimer").map(parse);
+  const cardMap: Record<string, CardDef> = {};
+  for (const c of cards) if (c.active) cardMap[String(c.config.key)] = c.config as unknown as CardDef;
+  return { cards, disclaimers, cardMap };
+}
+
+const SAMPLE_TOKENS: Record<string, string> = {
+  property_name: "Woodhill", event_name: "Sample Event",
+  date_range: "Mon, Aug 10–Fri, Aug 14, 2026", today: "",
+  manager_name: "Alex Doe", manager_email: "alex.doe@hellolanding.com",
+  first_name: "Jordan", member_name: "Jordan Sample",
+  member_email: "jordan@example.com", unit: "101",
+};
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -315,6 +358,58 @@ export default {
       return back(`Template "${name}" applied — fill in manager, dates, and review before sending`);
     }
 
+    // ── Instant-apply chiclets: notification card / disclaimer ───────────────
+    if (campaign && action === "/config-card" && request.method === "POST") {
+      const form = await request.formData();
+      const key = form.get("card")?.toString() ?? "";
+      const { cardMap } = await loadAssets(db);
+      if (key && !cardMap[key]) return back(`Unknown card: ${key}`, true);
+      const cfg = parseConfig(campaign.config_json);
+      cfg.notification_card = key;
+      await db.update(campaigns).set({ config_json: JSON.stringify(cfg) }).where(eq(campaigns.id, cid!));
+      return back(key ? `Card set: ${key}` : "Card removed");
+    }
+    if (campaign && action === "/config-disclaimer" && request.method === "POST") {
+      const form = await request.formData();
+      const tid = form.get("template_id")?.toString() ?? "";
+      const { disclaimers } = await loadAssets(db);
+      const d = disclaimers.find((x) => x.id === tid && x.active);
+      if (!d) return back("Unknown disclaimer", true);
+      const cfg = parseConfig(campaign.config_json);
+      cfg.disclaimer_html = String(d.config.html ?? "");
+      cfg.include_disclaimer = true;
+      await db.update(campaigns).set({ config_json: JSON.stringify(cfg) }).where(eq(campaigns.id, cid!));
+      return back(`Disclaimer set: ${d.name}`);
+    }
+
+    // ── SSE: live campaign status (replaces refresh-to-see-results) ──────────
+    if (campaign && action === "/events" && request.method === "GET") {
+      const enc = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          const send = (obj: unknown) =>
+            controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+          try {
+            for (let i = 0; i < 25; i++) { // ~50s, then EventSource auto-reconnects
+              const row = (await db.select({ status: campaigns.status })
+                .from(campaigns).where(eq(campaigns.id, cid!)).limit(1))[0];
+              send({ status: row?.status ?? "gone" });
+              if (!row || !["fetching", "sending"].includes(row.status)) break;
+              await new Promise((r) => setTimeout(r, 2000));
+            }
+          } catch { /* client went away */ }
+          try { controller.close(); } catch { /* already closed */ }
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+        },
+      });
+    }
+
     // ── Dispatch: send / dryrun / test ───────────────────────────────────────
     if (campaign && action === "/dispatch" && request.method === "POST") {
       const form = await request.formData();
@@ -324,12 +419,14 @@ export default {
         return back("Check the confirmation box to send", true);
       }
       const cfg = parseConfig(campaign.config_json);
+      const { cardMap } = await loadAssets(db);
       const allRows = await db.select().from(recipients)
         .where(eq(recipients.campaign_id, cid!))
         .orderBy(asc(recipients.unit), asc(recipients.email));
       const eligibleRows = allRows.filter((r) => ELIGIBLE.includes(r.status));
 
-      const errors = validateForDispatch(cfg, campaign.property_name, eligibleRows.length, kind);
+      const errors = validateForDispatch(cfg, campaign.property_name, eligibleRows.length, kind,
+        new Set(Object.keys(cardMap)));
       if (errors.length) return back(errors.join(" "), true);
 
       const limit = kind === "dryrun" ? cfg.dry_run_limit : cfg.max_per_run;
@@ -363,7 +460,7 @@ export default {
           kind,
           config: {
             subjectTemplate: cfg.subject_template,
-            bodyTemplate: composeBodyTemplate(cfg),
+            bodyTemplate: composeBodyTemplate(cfg, cardMap),
             senderName: cfg.sender_display_name,
             replyTo: cfg.reply_to,
             cc: [cfg.manager_email, cfg.cc_extra].filter(Boolean).join(","),
@@ -388,7 +485,7 @@ export default {
         const label = kind === "send" ? `Sending to ${wfRecipients.length} recipients`
           : kind === "dryrun" ? `Creating ${wfRecipients.length} drafts in member.support@`
           : `Test email queued to ${user.email}`;
-        return back(`${label} — refresh for results`);
+        return back(`${label} — results will appear here automatically`);
       } catch (e: any) {
         return back(e?.message ?? String(e), true);
       }
@@ -434,6 +531,88 @@ export default {
       return back("Recipient added");
     }
 
+    // ── /edit — cards & disclaimers management ───────────────────────────────
+    if (url.pathname === "/edit" && request.method === "GET") {
+      const { cards, disclaimers } = await loadAssets(db);
+      return renderPage({
+        page: "edit", user, role,
+        campaigns: [], recipients: [], roleRequests: [], runs: [],
+        cards, disclaimers,
+        flash: url.searchParams.get("flash") ?? undefined,
+        error: url.searchParams.get("error") ?? undefined,
+      });
+    }
+    const editorMatch = url.pathname.match(/^\/edit\/(card|disclaimer)\/(new|[0-9a-f-]{36})$/);
+    if (editorMatch && request.method === "GET") {
+      const [, kind, idOrNew] = editorMatch;
+      const { cards, disclaimers } = await loadAssets(db);
+      const pool = kind === "card" ? cards : disclaimers;
+      const editing = idOrNew === "new" ? undefined : pool.find((a) => a.id === idOrNew);
+      if (idOrNew !== "new" && !editing) {
+        return Response.redirect(new URL("/edit?error=Not+found", request.url).toString(), 303);
+      }
+      // Editor preview: card rendered in its shell / disclaimer as-is, sample tokens.
+      const sample = { ...SAMPLE_TOKENS, today: formatToday("America/Mexico_City") };
+      let editorPreviewHtml = "";
+      if (editing) {
+        editorPreviewHtml = kind === "card"
+          ? renderTokens(renderCard(editing.config as unknown as CardDef), sample, true)
+          : renderTokens(String(editing.config.html ?? ""), sample, true);
+      }
+      return renderPage({
+        page: "editor", user, role,
+        campaigns: [], recipients: [], roleRequests: [], runs: [],
+        cards, disclaimers,
+        editorKind: kind as "card" | "disclaimer",
+        editing, editorPreviewHtml,
+        flash: url.searchParams.get("flash") ?? undefined,
+        error: url.searchParams.get("error") ?? undefined,
+      });
+    }
+    const editApiMatch = url.pathname.match(/^\/api\/edit\/(card|disclaimer)$/);
+    if (editApiMatch && request.method === "POST") {
+      const kind = editApiMatch[1];
+      const form = await request.formData();
+      const id = form.get("id")?.toString() || crypto.randomUUID();
+      const isNew = !form.get("id");
+      const active = form.get("active") === "on" ? 1 : 0;
+      const now = new Date().toISOString();
+      let name = "";
+      let config: Record<string, string> = {};
+      if (kind === "card") {
+        const key = (form.get("key")?.toString() ?? "").trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+        if (!key) return Response.redirect(new URL("/edit?error=Card+key+is+required", request.url).toString(), 303);
+        const { cards } = await loadAssets(db);
+        if (cards.some((c) => String(c.config.key) === key && c.id !== id)) {
+          return Response.redirect(new URL(`/edit?error=Card+key+${key}+already+exists`, request.url).toString(), 303);
+        }
+        name = key;
+        config = {
+          key,
+          label: form.get("label")?.toString().trim() || key,
+          accent: form.get("accent")?.toString().trim() || "#1A61D9",
+          icon: form.get("icon")?.toString().trim() || "",
+          title: form.get("title")?.toString().trim() || key,
+          body_html: form.get("body_html")?.toString() ?? "",
+        };
+      } else {
+        name = form.get("name")?.toString().trim() || "Untitled disclaimer";
+        config = { name, html: form.get("html")?.toString() ?? "" };
+      }
+      if (isNew) {
+        await db.insert(templates).values({
+          id, name, kind, config_json: JSON.stringify(config), active,
+          updated_by: user.email, updated_at: now,
+        });
+      } else {
+        await db.update(templates)
+          .set({ name, config_json: JSON.stringify(config), active, updated_by: user.email, updated_at: now })
+          .where(eq(templates.id, id));
+      }
+      return Response.redirect(
+        new URL(`/edit/${kind}/${id}?flash=Saved`, request.url).toString(), 303);
+    }
+
     // ── Recipient status update / delete (field-level) ───────────────────────
     const recEditMatch = url.pathname.match(/^\/api\/recipients\/([0-9a-f-]{36})$/);
     if (recEditMatch && request.method === "POST") {
@@ -463,6 +642,7 @@ export default {
       const runRows = await db.select().from(runs)
         .where(eq(runs.campaign_id, cid!))
         .orderBy(desc(runs.started_at)).limit(10);
+      const { cards, disclaimers, cardMap } = await loadAssets(db);
 
       // Server-rendered preview against a chosen (or first eligible) recipient.
       const cfg = parseConfig(campaign.config_json);
@@ -476,20 +656,39 @@ export default {
            : { email: "", name: "Resident", unit: "101" },
         cfg.include_unit_line
       );
-      const previewHtml = renderTokens(composeBodyTemplate(cfg), tokens, true);
+      const previewHtml = renderTokens(composeBodyTemplate(cfg, cardMap), tokens, true);
       const previewSubject = renderTokens(cfg.subject_template, tokens, false);
+
+      // Live status watcher: SSE while fetching/sending, reload on transition.
+      const watchScript = ["fetching", "sending"].includes(campaign.status) ? `
+(function(){
+  if (!window.EventSource) return;
+  var initial = ${JSON.stringify(campaign.status)};
+  function watch(){
+    var es = new EventSource(location.pathname.replace(/\\/$/, "") + "/events");
+    es.onmessage = function(ev){
+      try {
+        var d = JSON.parse(ev.data);
+        if (d.status && d.status !== initial) { es.close(); location.reload(); }
+      } catch(e){}
+    };
+    es.onerror = function(){ es.close(); setTimeout(watch, 3000); };
+  }
+  watch();
+})();` : undefined;
 
       return renderPage({
         page: "campaign", user, role,
         campaigns: [campaign as CampaignRow], recipients: recRows as RecipientRow[],
         roleRequests: [], runs: runRows as RunRow[],
+        cards, disclaimers,
         config: cfg,
         previewHtml, previewSubject,
         previewFor: pr ? pr.email : "generic (no recipients)",
         previewRecipientId: pr?.id,
         flash: url.searchParams.get("flash") ?? undefined,
         error: url.searchParams.get("error") ?? undefined,
-      });
+      }, watchScript);
     }
 
     // ── Home: campaign list ──────────────────────────────────────────────────
@@ -507,7 +706,7 @@ export default {
   },
 };
 
-function renderPage(props: AppProps): Response {
+function renderPage(props: AppProps, extraScript?: string): Response {
   const appHtml = renderToString(<App {...props} />);
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -518,7 +717,7 @@ function renderPage(props: AppProps): Response {
   <style>${styles}</style>
 </head>
 <body>
-  <div id="root">${appHtml}</div>
+  <div id="root">${appHtml}</div>${extraScript ? `\n  <script>${extraScript}</script>` : ""}
 </body>
 </html>`;
   return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });

--- a/sandy-mass-notifications/src/index.tsx
+++ b/sandy-mass-notifications/src/index.tsx
@@ -208,6 +208,24 @@ export default {
         .where(eq(workflowRuns.run_id, body.run_id));
 
       const now = new Date().toISOString();
+
+      // Card generation: write the AI HTML into the card row and finish.
+      const cardBody = body as unknown as { kind?: string; card_id?: string; card_body_html?: string };
+      if (cardBody.kind === "card_gen" && cardBody.card_id) {
+        if (body.status === "complete" && cardBody.card_body_html) {
+          const row = (await db.select().from(templates).where(eq(templates.id, cardBody.card_id)).limit(1))[0];
+          if (row) {
+            let cfgJson: Record<string, string> = {};
+            try { cfgJson = JSON.parse(row.config_json); } catch { /* keep empty */ }
+            cfgJson.body_html = cardBody.card_body_html;
+            await db.update(templates)
+              .set({ config_json: JSON.stringify(cfgJson), updated_by: "ai-generate", updated_at: now })
+              .where(eq(templates.id, cardBody.card_id));
+          }
+        }
+        return Response.json({ ok: true });
+      }
+
       const results = body.results ?? [];
       const okCount = results.filter((r) => r.ok).length;
 
@@ -654,16 +672,74 @@ export default {
           ? renderTokens(renderCard(editing.config as unknown as CardDef), sample, true)
           : renderTokens(String(editing.config.html ?? ""), sample, true);
       }
+      // While AI generation runs, poll the card's updated_at and reload when
+      // the workflow callback lands the new body_html.
+      const generating = url.searchParams.get("generating") === "1" && editing && kind === "card";
+      const genScript = generating ? `
+(function(){
+  var initial = ${JSON.stringify(editing!.updated_at ?? "")};
+  var tries = 0;
+  var timer = setInterval(function(){
+    if (++tries > 45) { clearInterval(timer); return; }
+    fetch("/api/edit/card/${editing!.id}/state").then(function(r){ return r.json(); }).then(function(d){
+      if (d.updated_at && d.updated_at !== initial) {
+        clearInterval(timer);
+        location.replace(location.pathname + "?flash=AI+draft+loaded+into+Body+HTML+—+review+and+Save");
+      }
+    }).catch(function(){});
+  }, 2000);
+})();` : undefined;
       return renderPage({
         page: "editor", user, role,
         campaigns: [], recipients: [], roleRequests: [], runs: [],
         cards, disclaimers,
         editorKind: kind as "card" | "disclaimer",
         editing, editorPreviewHtml,
+        generating: !!generating,
         flash: url.searchParams.get("flash") ?? undefined,
         error: url.searchParams.get("error") ?? undefined,
-      });
+      }, genScript);
     }
+    // ── AI card generation: describe → Haiku → body_html on the saved card ───
+    const genMatch = url.pathname.match(/^\/api\/edit\/card\/([0-9a-f-]{36})\/generate$/);
+    if (genMatch && request.method === "POST") {
+      const cardId = genMatch[1];
+      const form = await request.formData();
+      const description = form.get("description")?.toString().trim() ?? "";
+      const row = (await db.select().from(templates).where(eq(templates.id, cardId)).limit(1))[0];
+      if (!row) return Response.redirect(new URL("/edit?error=Card+not+found", request.url).toString(), 303);
+      if (description.length < 10) {
+        return Response.redirect(new URL(`/edit/card/${cardId}?error=Describe+the+card+in+a+sentence+or+two`, request.url).toString(), 303);
+      }
+      let cardCfg: Record<string, string> = {};
+      try { cardCfg = JSON.parse(row.config_json); } catch { /* empty */ }
+      const wfId = (await db.select().from(appConfig).where(eq(appConfig.key, "dispatch_workflow_id")).limit(1))[0]?.value
+        ?? DISPATCH_WORKFLOW_ID;
+      try {
+        const run = await triggerWorkflowWithCallback(wfId, DISPATCH_WORKFLOW_NAME, request, {
+          kind: "card_gen",
+          card_gen: { card_id: cardId, title: cardCfg.title || row.name, description },
+        });
+        await db.insert(workflowRuns).values({
+          run_id: run.id, workflow_name: DISPATCH_WORKFLOW_NAME,
+          status: "pending", created_at: new Date().toISOString(),
+        });
+        return Response.redirect(
+          new URL(`/edit/card/${cardId}?generating=1&flash=Generating+card+HTML+with+AI…`, request.url).toString(), 303);
+      } catch (e: any) {
+        return Response.redirect(
+          new URL(`/edit/card/${cardId}?error=${encodeURIComponent(e?.message ?? String(e))}`, request.url).toString(), 303);
+      }
+    }
+
+    // Poll target for the editor while generation runs.
+    const stateMatch = url.pathname.match(/^\/api\/edit\/card\/([0-9a-f-]{36})\/state$/);
+    if (stateMatch && request.method === "GET") {
+      const row = (await db.select({ updated_at: templates.updated_at, updated_by: templates.updated_by })
+        .from(templates).where(eq(templates.id, stateMatch[1])).limit(1))[0];
+      return Response.json({ ok: true, updated_at: row?.updated_at ?? null, updated_by: row?.updated_by ?? null });
+    }
+
     const editApiMatch = url.pathname.match(/^\/api\/edit\/(card|disclaimer)$/);
     if (editApiMatch && request.method === "POST") {
       const kind = editApiMatch[1];
@@ -821,6 +897,13 @@ const BASE_SCRIPT = `
   var sels = document.querySelectorAll("[data-autosubmit]");
   for (var i = 0; i < sels.length; i++) {
     (function(s){ s.addEventListener("change", function(){ if (s.form) s.form.submit(); }); })(sels[i]);
+  }
+  var swatches = document.querySelectorAll("[data-set-accent]");
+  for (var j = 0; j < swatches.length; j++) {
+    (function(b){ b.addEventListener("click", function(){
+      var input = document.querySelector("input[name=accent]");
+      if (input) input.value = b.getAttribute("data-set-accent");
+    }); })(swatches[j]);
   }
 })();`;
 

--- a/sandy-mass-notifications/src/index.tsx
+++ b/sandy-mass-notifications/src/index.tsx
@@ -18,7 +18,7 @@ import { serveFont } from "./design-system/fonts.js";
 import {
   parseConfig, composeBodyTemplate, buildGlobalTokens, buildRecipientTokens,
   renderTokens, renderCard, applyTemplate, validateForDispatch, CONFIG_DEFAULTS,
-  SEED_CARDS, SEED_DISCLAIMERS, formatToday,
+  SEED_CARDS, SEED_DISCLAIMERS, formatToday, emojiToEntities,
   type CampaignConfig, type CardDef,
 } from "./emailkit.js";
 import type { AssetRow } from "./App.js";
@@ -591,7 +591,8 @@ export default {
           key,
           label: form.get("label")?.toString().trim() || key,
           accent: form.get("accent")?.toString().trim() || "#1A61D9",
-          icon: form.get("icon")?.toString().trim() || "",
+          // Operators paste a plain emoji; store as Gmail-safe hex entities.
+          icon: emojiToEntities(form.get("icon")?.toString() ?? ""),
           title: form.get("title")?.toString().trim() || key,
           body_html: form.get("body_html")?.toString() ?? "",
         };
@@ -706,8 +707,29 @@ export default {
   },
 };
 
+// Injected on every page:
+//  - strips flash/error params after render so banners can't go stale on
+//    refresh or SSE-triggered reloads (keeps other params like ?preview)
+//  - binds data-autosubmit selects (recipient status pills) to save on change
+const BASE_SCRIPT = `
+(function(){
+  try {
+    var u = new URL(location.href);
+    if (u.searchParams.has("flash") || u.searchParams.has("error")) {
+      u.searchParams.delete("flash"); u.searchParams.delete("error");
+      var q = u.searchParams.toString();
+      history.replaceState(null, "", u.pathname + (q ? "?" + q : ""));
+    }
+  } catch(e){}
+  var sels = document.querySelectorAll("select[data-autosubmit]");
+  for (var i = 0; i < sels.length; i++) {
+    (function(s){ s.addEventListener("change", function(){ if (s.form) s.form.submit(); }); })(sels[i]);
+  }
+})();`;
+
 function renderPage(props: AppProps, extraScript?: string): Response {
   const appHtml = renderToString(<App {...props} />);
+  const script = BASE_SCRIPT + (extraScript ? `\n${extraScript}` : "");
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -717,7 +739,8 @@ function renderPage(props: AppProps, extraScript?: string): Response {
   <style>${styles}</style>
 </head>
 <body>
-  <div id="root">${appHtml}</div>${extraScript ? `\n  <script>${extraScript}</script>` : ""}
+  <div id="root">${appHtml}</div>
+  <script>${script}</script>
 </body>
 </html>`;
   return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });

--- a/sandy-mass-notifications/workflows/mass-notify-dispatch.js
+++ b/sandy-mass-notifications/workflows/mass-notify-dispatch.js
@@ -1,53 +1,63 @@
 /**
- * mass-notify-dispatch — Sandy Workflow
+ * mass-notify-dispatch — Sandy Workflow (v0.2: email + SMS companion)
  *
- * Email send pipeline for the mass-notifications app. Receives a composed
- * body/subject template (tokens intact) plus per-recipient token data,
- * renders each message, and dispatches through the GAS mail dispatcher
- * deployed under member.support@hellolanding.com (payload mode, batches of
- * up to 10 messages per call). Reports per-recipient results via callback.
+ * Email send pipeline for the mass-notifications app, plus the P3 SMS
+ * companion (OpsVP): one AI-summarized version of the email body per
+ * campaign, sent to each member via Dialpad SMS from the Member Support
+ * line. Reports per-recipient results via callback.
  *
- * ── Required secrets (per-workflow, already set) ─────────────────────────────
- *   MN_DISPATCH_URL      GAS dispatcher /exec URL
+ * ── Required secrets (per-workflow / org) ────────────────────────────────────
+ *   MN_DISPATCH_URL      GAS dispatcher /exec URL (member.support@)
  *   MN_DISPATCH_SECRET   shared secret (DISPATCH_SECRET script property)
+ *   DIALPAD_API_KEY      Dialpad write key — SMS sends
+ *   AI_GATEWAY_TOKEN     org-level global — Cloudflare AI Gateway
+ *   LANDING_API_GRAPHQL_KEY  org-level global — opt-out lookup (users)
  *
  * ── Trigger payload ──────────────────────────────────────────────────────────
  *   {
- *     campaign_id: string,
- *     app_run_id:  string,             // app D1 runs.id for audit correlation
- *     kind: "send" | "dryrun" | "test",
+ *     campaign_id, app_run_id, callback_url, callback_token,
+ *     kind: "send" | "dryrun" | "test" | "sms_preview" | "sms_test" | "sms_only",
  *     config: {
- *       subjectTemplate: string,       // {{tokens}} intact
- *       bodyTemplate:    string,       // composed HTML, {{tokens}} intact
- *       senderName:      string,
- *       replyTo:         string,
- *       cc:              string,       // manager_email + cc_extra, comma-joined
- *       includeUnitLine: boolean,
- *       globalTokens:    { property_name, event_name, date_range, today,
- *                          manager_email, manager_name },
- *       configAttachmentIds: string[], // campaign-level Drive IDs
+ *       subjectTemplate, bodyTemplate,        // {{tokens}} intact
+ *       senderName, replyTo, cc, includeUnitLine,
+ *       globalTokens, configAttachmentIds,
  *     },
- *     recipients: [ { id, email, name, unit, attachmentIds: string[] } ],
- *     callback_url, callback_token
+ *     recipients: [ { id, email, name, unit, attachmentIds,
+ *                     phone_e164, segment_timezone } ],
+ *     sms: {                                   // required for send(+enabled)/sms_*
+ *       enabled: boolean,
+ *       from_number: "+14159804986",
+ *       quiet_start: 8, quiet_end: 21,         // local hours [start, end)
+ *       test_number: "+1..."                    // sms_test only
+ *     }
  *   }
  *
- *   kind semantics (legacy parity):
- *     send   → GmailApp send to each recipient
- *     dryrun → Gmail DRAFTS in the member.support@ mailbox, subject "[DRAFT] "
- *     test   → real send of ONE rendered sample to the operator (recipients[0]
- *              carries the operator's email), subject "TEST — "
+ *   Kind semantics:
+ *     send        → emails; then, if sms.enabled, SMS phase to the same targets
+ *     dryrun/test → email drafts / operator test (no SMS)
+ *     sms_preview → AI summary only; callback carries sms_text (nothing sent)
+ *     sms_test    → AI summary sent to sms.test_number only
+ *     sms_only    → SMS phase only (post-send retry / standalone)
  *
  * ── Callback body ────────────────────────────────────────────────────────────
  *   { run_id, callback_token, campaign_id, app_run_id, kind,
  *     status: "complete" | "error",
- *     results: [ { id, email, ok, error } ],
- *     quota_remaining: number | null,
- *     error: string | null }
+ *     results: [ { id, email, ok, error } ],            // email phase
+ *     sms_text: string | null,                          // the summary used
+ *     sms_truncated: boolean,                           // hard-truncate flag
+ *     sms_results: [ { id, state, error } ],            // sent|error|skipped_*
+ *     sms_warning: string | null,                       // e.g. opt-out lookup failed
+ *     quota_remaining, error }
  */
 
 import { WorkflowEntrypoint } from "cloudflare:workers";
 
 const BATCH_SIZE = 10; // dispatcher MAX_MESSAGES_PER_CALL
+const SMS_MAX_CHARS = 320;
+const AI_GATEWAY = "https://gateway.ai.cloudflare.com/v1/d094105625bec434114c0b80ecfa7238/sandy-workflows/compat/chat/completions";
+const AI_MODEL = "dynamic/sandy-workflows";
+const DIALPAD_SMS_URL = "https://dialpad.com/api/v2/sms";
+const LANDING_GRAPHQL_URL = "https://api.hellolanding.com/api/v1/graphql";
 
 // ── Token engine — KEEP IN SYNC with src/emailkit.ts (renderTokens etc.) ─────
 
@@ -88,7 +98,7 @@ function buildRecipientTokens(globals, r, includeUnitLine) {
   };
 }
 
-// ── Dispatcher client ────────────────────────────────────────────────────────
+// ── Email dispatcher client ──────────────────────────────────────────────────
 
 async function dispatch(mode, messages, secrets) {
   const url = secrets?.MN_DISPATCH_URL;
@@ -106,7 +116,142 @@ async function dispatch(mode, messages, secrets) {
   if (body.status === "error" && !Array.isArray(body.results)) {
     throw new Error(`Dispatcher error: ${body.message || JSON.stringify(body).slice(0, 300)}`);
   }
-  return body; // { status, quotaRemaining, results: [{to, ok, error?}] }
+  return body;
+}
+
+// ── SMS helpers ──────────────────────────────────────────────────────────────
+
+// Rough HTML → plain text for the summarizer input.
+function htmlToText(html) {
+  return String(html || "")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|tr|li|table)>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&").replace(/&lt;/gi, "<").replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"').replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, h) => { try { return String.fromCodePoint(parseInt(h, 16)); } catch { return ""; } })
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .trim();
+}
+
+async function aiSummarize(subject, bodyText, secrets, retryNote) {
+  const token = secrets?.AI_GATEWAY_TOKEN;
+  if (!token) throw new Error("AI_GATEWAY_TOKEN secret missing");
+  const system =
+    "You write SMS notifications for residents of Landing apartment properties. " +
+    "Summarize the given email into ONE plain-text SMS of AT MOST 300 characters. " +
+    "Rules: include the property name; state the key facts (what, when, what the " +
+    "resident should do); no invented facts; no links unless a URL appears in the " +
+    "email; no emojis; no greeting or sign-off; do not mention that this is a summary.";
+  const user = `Subject: ${subject}\n\nEmail body:\n${bodyText.slice(0, 6000)}` +
+    (retryNote ? `\n\nIMPORTANT: ${retryNote}` : "");
+  const res = await fetch(AI_GATEWAY, {
+    method: "POST",
+    // RAW token in cf-aig-authorization (NO "Bearer") — gateway convention.
+    headers: { "cf-aig-authorization": token, "content-type": "application/json" },
+    body: JSON.stringify({
+      model: AI_MODEL,
+      max_tokens: 300,
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    }),
+    signal: AbortSignal.timeout(120000),
+  });
+  if (!res.ok) throw new Error(`AI Gateway ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json();
+  return (data.choices?.[0]?.message?.content ?? "").trim();
+}
+
+// Summary with length guard: one strict retry, then sentence-boundary truncate.
+async function summarizeForSms(subject, bodyHtml, secrets) {
+  const text = htmlToText(bodyHtml);
+  let out = await aiSummarize(subject, text, secrets, null);
+  let truncated = false;
+  if (out.length > SMS_MAX_CHARS) {
+    out = await aiSummarize(subject, text, secrets,
+      `Your previous answer was ${out.length} characters — too long. Rewrite it under 280 characters.`);
+  }
+  if (out.length > SMS_MAX_CHARS) {
+    const cut = out.slice(0, SMS_MAX_CHARS - 1);
+    const lastStop = Math.max(cut.lastIndexOf(". "), cut.lastIndexOf("! "), cut.lastIndexOf("? "));
+    out = (lastStop > 80 ? cut.slice(0, lastStop + 1) : cut).trim() + "…";
+    truncated = true;
+  }
+  return { text: out, truncated };
+}
+
+// Rails-style tz names (warehouse MS_TIMEZONE) → IANA. Default Central.
+const RAILS_TZ = {
+  "Eastern Time (US & Canada)": "America/New_York",
+  "Central Time (US & Canada)": "America/Chicago",
+  "Mountain Time (US & Canada)": "America/Denver",
+  "Arizona": "America/Phoenix",
+  "Pacific Time (US & Canada)": "America/Los_Angeles",
+  "Alaska": "America/Anchorage",
+  "Hawaii": "Pacific/Honolulu",
+};
+
+function localHour(railsTz) {
+  const iana = RAILS_TZ[String(railsTz || "").trim()] || "America/Chicago";
+  try {
+    return parseInt(new Intl.DateTimeFormat("en-US", {
+      hour: "numeric", hour12: false, timeZone: iana,
+    }).format(new Date()), 10);
+  } catch {
+    return 12; // unknown tz — assume mid-day rather than blocking
+  }
+}
+
+// Opt-out lookup: User.text_notifications_enabled === false → skip.
+// Graceful: on any failure, return empty set + a warning (parity: the manual
+// Hub-Manager SMS process had no opt-out check at all).
+async function fetchOptOuts(emails, secrets) {
+  const key = secrets?.LANDING_API_GRAPHQL_KEY;
+  const optedOut = new Set();
+  if (!key || emails.length === 0) {
+    return { optedOut, warning: key ? null : "opt-out lookup skipped: LANDING_API_GRAPHQL_KEY missing" };
+  }
+  try {
+    for (let i = 0; i < emails.length; i += 100) {
+      const chunk = emails.slice(i, i + 100);
+      const q = `{ users(per_page: 100, filters: [{ field: "email", operator: "in", value: ${JSON.stringify(chunk)} }]) { data { email text_notifications_enabled } } }`;
+      const res = await fetch(LANDING_GRAPHQL_URL, {
+        method: "POST",
+        headers: { "X-API-TOKEN": key, "Content-Type": "application/json" },
+        body: JSON.stringify({ query: q }),
+        signal: AbortSignal.timeout(60000),
+      });
+      if (!res.ok) throw new Error(`GraphQL ${res.status}`);
+      const data = await res.json();
+      if (data.errors) throw new Error(JSON.stringify(data.errors).slice(0, 200));
+      for (const u of data.data?.users?.data ?? []) {
+        if (u.text_notifications_enabled === false) optedOut.add(String(u.email).toLowerCase());
+      }
+      await new Promise((r) => setTimeout(r, 1100)); // 60 req/min limit
+    }
+    return { optedOut, warning: null };
+  } catch (err) {
+    return { optedOut: new Set(), warning: `opt-out lookup failed (SMS proceeded): ${String(err?.message || err).slice(0, 150)}` };
+  }
+}
+
+async function dialpadSms(toNumber, text, fromNumber, secrets) {
+  const key = secrets?.DIALPAD_API_KEY;
+  if (!key) throw new Error("DIALPAD_API_KEY secret missing");
+  const res = await fetch(DIALPAD_SMS_URL, {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ from_number: fromNumber, to_numbers: [toNumber], text }),
+    signal: AbortSignal.timeout(60000),
+  });
+  if (!res.ok) throw new Error(`Dialpad ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return true;
 }
 
 // ── Callback helper (standard Sandy pattern — do not modify) ─────────────────
@@ -134,61 +279,145 @@ async function sendCallback(callbackUrl, payload, sandySecrets) {
 
 // ── Workflow ─────────────────────────────────────────────────────────────────
 
+const KINDS = ["send", "dryrun", "test", "sms_preview", "sms_test", "sms_only"];
+
 export class TenantWorkflow extends WorkflowEntrypoint {
   async run(event, step) {
-    const { campaign_id, app_run_id, kind, config, recipients, callback_url, callback_token } = event.payload || {};
+    const { campaign_id, app_run_id, kind, config, recipients, sms, callback_url, callback_token } = event.payload || {};
     const secrets = event.payload?._sandySecrets || {};
 
     try {
       await step.do("validate-inputs", async () => {
-        if (!secrets.MN_DISPATCH_URL || !secrets.MN_DISPATCH_SECRET) {
+        if (!callback_url) throw new Error("callback_url is required");
+        if (!KINDS.includes(kind)) throw new Error(`bad kind: ${kind}`);
+        if (!config?.subjectTemplate || !config?.bodyTemplate) throw new Error("config templates missing");
+        const isEmailKind = ["send", "dryrun", "test"].includes(kind);
+        if (isEmailKind && (!secrets.MN_DISPATCH_URL || !secrets.MN_DISPATCH_SECRET)) {
           throw new Error("dispatcher secrets missing");
         }
-        if (!callback_url) throw new Error("callback_url is required");
-        if (!config?.subjectTemplate || !config?.bodyTemplate) throw new Error("config templates missing");
-        if (!Array.isArray(recipients) || recipients.length === 0) throw new Error("recipients[] is empty");
-        if (!["send", "dryrun", "test"].includes(kind)) throw new Error(`bad kind: ${kind}`);
-        return { ok: true, count: recipients.length };
+        if (isEmailKind || kind === "sms_only") {
+          if (!Array.isArray(recipients) || recipients.length === 0) throw new Error("recipients[] is empty");
+        }
+        if (kind === "sms_test" && !sms?.test_number) throw new Error("sms.test_number is required");
+        return { ok: true };
       });
 
-      const dispatcherMode = kind === "dryrun" ? "draft" : "send";
-      const subjectPrefix = kind === "dryrun" ? "[DRAFT] " : kind === "test" ? "TEST — " : "";
-
+      // ── Email phase ────────────────────────────────────────────────────────
       const results = [];
       let quotaRemaining = null;
+      if (["send", "dryrun", "test"].includes(kind)) {
+        const dispatcherMode = kind === "dryrun" ? "draft" : "send";
+        const subjectPrefix = kind === "dryrun" ? "[DRAFT] " : kind === "test" ? "TEST — " : "";
+        for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
+          const batch = recipients.slice(i, i + BATCH_SIZE);
+          const batchResult = await step.do(
+            `dispatch-batch-${Math.floor(i / BATCH_SIZE) + 1}`,
+            { retries: { limit: 1, delay: "30 seconds", backoff: "linear" } },
+            async () => {
+              const messages = batch.map((r) => {
+                const tokens = buildRecipientTokens(config.globalTokens || {}, r, !!config.includeUnitLine);
+                const attachmentFileIds = [
+                  ...(config.configAttachmentIds || []),
+                  ...(r.attachmentIds || []),
+                ];
+                return {
+                  to: r.email,
+                  cc: config.cc || "",
+                  replyTo: config.replyTo || "",
+                  senderName: config.senderName || "Landing Notifications",
+                  subject: subjectPrefix + renderTokens(config.subjectTemplate, tokens, false),
+                  htmlBody: renderTokens(config.bodyTemplate, tokens, true),
+                  plainText: "Please view this email in an HTML-capable client.",
+                  ...(attachmentFileIds.length ? { attachmentFileIds } : {}),
+                };
+              });
+              return dispatch(dispatcherMode, messages, secrets);
+            }
+          );
+          quotaRemaining = batchResult.quotaRemaining ?? quotaRemaining;
+          const brs = batchResult.results || [];
+          batch.forEach((r, j) => {
+            const br = brs[j] || { ok: false, error: "no dispatcher result" };
+            results.push({ id: r.id, email: r.email, ok: !!br.ok, error: br.error || null });
+          });
+        }
+      }
 
-      for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
-        const batch = recipients.slice(i, i + BATCH_SIZE);
-        const batchResult = await step.do(
-          `dispatch-batch-${Math.floor(i / BATCH_SIZE) + 1}`,
-          { retries: { limit: 1, delay: "30 seconds", backoff: "linear" } },
+      // ── SMS phase ──────────────────────────────────────────────────────────
+      let smsText = null;
+      let smsTruncated = false;
+      let smsWarning = null;
+      const smsResults = [];
+      const smsWanted =
+        kind === "sms_preview" || kind === "sms_test" || kind === "sms_only" ||
+        (kind === "send" && sms?.enabled);
+
+      if (smsWanted) {
+        const summary = await step.do(
+          "sms-summarize",
+          { retries: { limit: 2, delay: "15 seconds", backoff: "exponential" } },
           async () => {
-            const messages = batch.map((r) => {
-              const tokens = buildRecipientTokens(config.globalTokens || {}, r, !!config.includeUnitLine);
-              const attachmentFileIds = [
-                ...(config.configAttachmentIds || []),
-                ...(r.attachmentIds || []),
-              ];
-              return {
-                to: r.email,
-                cc: config.cc || "",
-                replyTo: config.replyTo || "",
-                senderName: config.senderName || "Landing Notifications",
-                subject: subjectPrefix + renderTokens(config.subjectTemplate, tokens, false),
-                htmlBody: renderTokens(config.bodyTemplate, tokens, true),
-                plainText: "Please view this email in an HTML-capable client.",
-                ...(attachmentFileIds.length ? { attachmentFileIds } : {}),
-              };
-            });
-            return dispatch(dispatcherMode, messages, secrets);
+            // Generic-recipient render: the summary is per-campaign, not per-member.
+            const tokens = buildRecipientTokens(config.globalTokens || {},
+              { email: "", name: "Resident", unit: "" }, false);
+            const subject = renderTokens(config.subjectTemplate, tokens, false);
+            const body = renderTokens(config.bodyTemplate, tokens, true);
+            return summarizeForSms(subject, body, secrets);
           }
         );
-        quotaRemaining = batchResult.quotaRemaining ?? quotaRemaining;
-        const brs = batchResult.results || [];
-        batch.forEach((r, j) => {
-          const br = brs[j] || { ok: false, error: "no dispatcher result" };
-          results.push({ id: r.id, email: r.email, ok: !!br.ok, error: br.error || null });
-        });
+        smsText = summary.text;
+        smsTruncated = summary.truncated;
+
+        if (kind === "sms_test") {
+          await step.do("sms-test-send", async () =>
+            dialpadSms(sms.test_number, `TEST — ${smsText}`, sms.from_number, secrets));
+          smsResults.push({ id: "sms_test", state: "sent", error: null });
+        } else if (kind === "sms_only" || (kind === "send" && sms?.enabled)) {
+          // For 'send', only recipients whose email actually went out get SMS.
+          const okIds = kind === "send" ? new Set(results.filter((r) => r.ok).map((r) => r.id)) : null;
+          const targets = recipients.filter((r) => (okIds ? okIds.has(r.id) : true));
+
+          const optOut = await step.do("sms-optout-lookup", async () =>
+            fetchOptOuts(targets.map((t) => String(t.email).toLowerCase()), secrets));
+          smsWarning = optOut.warning;
+          const optedOut = new Set(optOut.optedOut);
+
+          for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+            const batch = targets.slice(i, i + BATCH_SIZE);
+            const batchOut = await step.do(
+              `sms-batch-${Math.floor(i / BATCH_SIZE) + 1}`,
+              { retries: { limit: 1, delay: "30 seconds", backoff: "linear" } },
+              async () => {
+                const out = [];
+                for (const r of batch) {
+                  if (!r.phone_e164) {
+                    out.push({ id: r.id, state: "skipped_no_phone", error: null });
+                    continue;
+                  }
+                  if (optedOut.has(String(r.email).toLowerCase())) {
+                    out.push({ id: r.id, state: "skipped_optout", error: null });
+                    continue;
+                  }
+                  const h = localHour(r.segment_timezone);
+                  const qs = sms?.quiet_start ?? 8, qe = sms?.quiet_end ?? 21;
+                  if (h < qs || h >= qe) {
+                    out.push({ id: r.id, state: "skipped_quiet_hours", error: null });
+                    continue;
+                  }
+                  try {
+                    await dialpadSms(r.phone_e164, smsText, sms.from_number, secrets);
+                    out.push({ id: r.id, state: "sent", error: null });
+                  } catch (err) {
+                    out.push({ id: r.id, state: "error", error: String(err?.message || err).slice(0, 200) });
+                  }
+                  await new Promise((res) => setTimeout(res, 150)); // pacing
+                }
+                return out;
+              }
+            );
+            smsResults.push(...batchOut);
+          }
+        }
       }
 
       await step.do(
@@ -196,28 +425,30 @@ export class TenantWorkflow extends WorkflowEntrypoint {
         { retries: { limit: 2, delay: "30 seconds", backoff: "linear" } },
         async () => sendCallback(callback_url, {
           run_id: event.instanceId,
-          callback_token,
-          campaign_id,
-          app_run_id,
-          kind,
+          callback_token, campaign_id, app_run_id, kind,
           status: "complete",
           results,
+          sms_text: smsText,
+          sms_truncated: smsTruncated,
+          sms_results: smsResults,
+          sms_warning: smsWarning,
           quota_remaining: quotaRemaining,
           error: null,
         }, secrets)
       );
 
-      return { ok: true, sent: results.filter((r) => r.ok).length, failed: results.filter((r) => !r.ok).length };
+      return {
+        ok: true,
+        emails_ok: results.filter((r) => r.ok).length,
+        sms_sent: smsResults.filter((r) => r.state === "sent").length,
+      };
     } catch (err) {
       if (callback_url) {
         await step.do("send-error-callback", async () => sendCallback(callback_url, {
           run_id: event.instanceId,
-          callback_token,
-          campaign_id,
-          app_run_id,
-          kind,
+          callback_token, campaign_id, app_run_id, kind,
           status: "error",
-          results: [],
+          results: [], sms_text: null, sms_truncated: false, sms_results: [], sms_warning: null,
           quota_remaining: null,
           error: String(err?.message || err),
         }, secrets));

--- a/sandy-mass-notifications/workflows/mass-notify-dispatch.js
+++ b/sandy-mass-notifications/workflows/mass-notify-dispatch.js
@@ -279,17 +279,68 @@ async function sendCallback(callbackUrl, payload, sandySecrets) {
 
 // ── Workflow ─────────────────────────────────────────────────────────────────
 
-const KINDS = ["send", "dryrun", "test", "sms_preview", "sms_test", "sms_only"];
+const KINDS = ["send", "dryrun", "test", "sms_preview", "sms_test", "sms_only", "card_gen"];
+
+// ── Card generation (editor "describe your card" feature) ────────────────────
+// Pinned to Haiku for cheap, fast HTML transforms; falls back to the gateway's
+// dynamic route if the pinned slug is rejected.
+
+const CARD_GEN_MODEL = "anthropic/claude-haiku-4-5-20251001";
+
+async function aiGenerateCardHtml(title, description, secrets) {
+  const token = secrets?.AI_GATEWAY_TOKEN;
+  if (!token) throw new Error("AI_GATEWAY_TOKEN secret missing");
+  const system =
+    "You generate the inner body HTML for a Landing resident notification card " +
+    "(an email component). Output ONLY raw HTML — no markdown fences, no commentary. " +
+    "Constraints: email-safe HTML with ALL styles inline (Gmail strips <style> blocks). " +
+    "Compose 2–4 key/value rows, each following EXACTLY this pattern: " +
+    '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:6px;">' +
+    '<tr><td style="font-size:12px;color:#4A4A4A;text-transform:uppercase;letter-spacing:0.5px;' +
+    'width:38%;vertical-align:top;padding-right:8px;">LABEL</td>' +
+    '<td style="font-size:14px;font-weight:bold;color:#15192D;vertical-align:top;">VALUE</td></tr></table> ' +
+    "Row order: a Property row first with value {{property_name}}; a timing row with " +
+    "{{date_range}} (scheduled windows) or {{today}} (live incidents) when relevant; then " +
+    "1–2 guidance rows telling residents what to expect or do. You may use these tokens, " +
+    "substituted later: {{property_name}}, {{event_name}}, {{date_range}}, {{today}}, " +
+    "{{manager_name}}. Use <strong> for emphasis inside values. Do NOT include the outer " +
+    "card shell (border, colored header) — only the inner rows.";
+  const call = async (model) => {
+    const res = await fetch(AI_GATEWAY, {
+      method: "POST",
+      headers: { "cf-aig-authorization": token, "content-type": "application/json" },
+      body: JSON.stringify({
+        model, max_tokens: 1000, temperature: 0.4,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: `Card title: ${title}\n\nDescribe the card to generate:\n${description}` },
+        ],
+      }),
+      signal: AbortSignal.timeout(120000),
+    });
+    if (!res.ok) throw new Error(`AI Gateway ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    return ((await res.json()).choices?.[0]?.message?.content ?? "").trim();
+  };
+  let out;
+  try { out = await call(CARD_GEN_MODEL); }
+  catch { out = await call(AI_MODEL); } // fallback: dynamic route
+  // Strip markdown fences if the model wrapped its output anyway.
+  return out.replace(/^```(?:html)?\s*/i, "").replace(/\s*```$/, "").trim();
+}
 
 export class TenantWorkflow extends WorkflowEntrypoint {
   async run(event, step) {
-    const { campaign_id, app_run_id, kind, config, recipients, sms, callback_url, callback_token } = event.payload || {};
+    const { campaign_id, app_run_id, kind, config, recipients, sms, card_gen, callback_url, callback_token } = event.payload || {};
     const secrets = event.payload?._sandySecrets || {};
 
     try {
       await step.do("validate-inputs", async () => {
         if (!callback_url) throw new Error("callback_url is required");
         if (!KINDS.includes(kind)) throw new Error(`bad kind: ${kind}`);
+        if (kind === "card_gen") {
+          if (!card_gen?.card_id || !card_gen?.description) throw new Error("card_gen.card_id and description required");
+          return { ok: true };
+        }
         if (!config?.subjectTemplate || !config?.bodyTemplate) throw new Error("config templates missing");
         const isEmailKind = ["send", "dryrun", "test"].includes(kind);
         if (isEmailKind && (!secrets.MN_DISPATCH_URL || !secrets.MN_DISPATCH_SECRET)) {
@@ -301,6 +352,29 @@ export class TenantWorkflow extends WorkflowEntrypoint {
         if (kind === "sms_test" && !sms?.test_number) throw new Error("sms.test_number is required");
         return { ok: true };
       });
+
+      // ── Card generation (standalone kind — no email/SMS phases) ───────────
+      if (kind === "card_gen") {
+        const bodyHtml = await step.do(
+          "generate-card-html",
+          { retries: { limit: 2, delay: "10 seconds", backoff: "exponential" } },
+          async () => aiGenerateCardHtml(card_gen.title || "Notification", card_gen.description, secrets)
+        );
+        await step.do(
+          "send-callback",
+          { retries: { limit: 2, delay: "30 seconds", backoff: "linear" } },
+          async () => sendCallback(callback_url, {
+            run_id: event.instanceId,
+            callback_token, campaign_id: null, app_run_id: null, kind,
+            status: "complete",
+            card_id: card_gen.card_id,
+            card_body_html: bodyHtml,
+            results: [], sms_text: null, sms_truncated: false, sms_results: [], sms_warning: null,
+            quota_remaining: null, error: null,
+          }, secrets)
+        );
+        return { ok: true, generated_chars: bodyHtml.length };
+      }
 
       // ── Email phase ────────────────────────────────────────────────────────
       const results = [];

--- a/sandy-mass-notifications/workflows/mass-notify-dispatch.js
+++ b/sandy-mass-notifications/workflows/mass-notify-dispatch.js
@@ -1,0 +1,228 @@
+/**
+ * mass-notify-dispatch — Sandy Workflow
+ *
+ * Email send pipeline for the mass-notifications app. Receives a composed
+ * body/subject template (tokens intact) plus per-recipient token data,
+ * renders each message, and dispatches through the GAS mail dispatcher
+ * deployed under member.support@hellolanding.com (payload mode, batches of
+ * up to 10 messages per call). Reports per-recipient results via callback.
+ *
+ * ── Required secrets (per-workflow, already set) ─────────────────────────────
+ *   MN_DISPATCH_URL      GAS dispatcher /exec URL
+ *   MN_DISPATCH_SECRET   shared secret (DISPATCH_SECRET script property)
+ *
+ * ── Trigger payload ──────────────────────────────────────────────────────────
+ *   {
+ *     campaign_id: string,
+ *     app_run_id:  string,             // app D1 runs.id for audit correlation
+ *     kind: "send" | "dryrun" | "test",
+ *     config: {
+ *       subjectTemplate: string,       // {{tokens}} intact
+ *       bodyTemplate:    string,       // composed HTML, {{tokens}} intact
+ *       senderName:      string,
+ *       replyTo:         string,
+ *       cc:              string,       // manager_email + cc_extra, comma-joined
+ *       includeUnitLine: boolean,
+ *       globalTokens:    { property_name, event_name, date_range, today,
+ *                          manager_email, manager_name },
+ *       configAttachmentIds: string[], // campaign-level Drive IDs
+ *     },
+ *     recipients: [ { id, email, name, unit, attachmentIds: string[] } ],
+ *     callback_url, callback_token
+ *   }
+ *
+ *   kind semantics (legacy parity):
+ *     send   → GmailApp send to each recipient
+ *     dryrun → Gmail DRAFTS in the member.support@ mailbox, subject "[DRAFT] "
+ *     test   → real send of ONE rendered sample to the operator (recipients[0]
+ *              carries the operator's email), subject "TEST — "
+ *
+ * ── Callback body ────────────────────────────────────────────────────────────
+ *   { run_id, callback_token, campaign_id, app_run_id, kind,
+ *     status: "complete" | "error",
+ *     results: [ { id, email, ok, error } ],
+ *     quota_remaining: number | null,
+ *     error: string | null }
+ */
+
+import { WorkflowEntrypoint } from "cloudflare:workers";
+
+const BATCH_SIZE = 10; // dispatcher MAX_MESSAGES_PER_CALL
+
+// ── Token engine — KEEP IN SYNC with src/emailkit.ts (renderTokens etc.) ─────
+
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderTokens(template, tokens, escapeValues = true) {
+  if (!template) return "";
+  return String(template).replace(
+    /\{\{\s*(html:)?([a-zA-Z0-9_]+)\s*(?:\|\s*([^}]+))?\s*\}\}/g,
+    (_, htmlPrefix, key, fallback) => {
+      const val = tokens[key];
+      const out = (val !== undefined && val !== null && String(val).trim() !== "")
+        ? String(val)
+        : (fallback != null ? String(fallback).trim() : "");
+      return (htmlPrefix || !escapeValues) ? out : escapeHtml(out);
+    }
+  );
+}
+
+function buildRecipientTokens(globals, r, includeUnitLine) {
+  const firstName = r.name ? String(r.name).trim().split(/\s+/)[0] : "";
+  return {
+    ...globals,
+    member_email: r.email || "",
+    member_name: r.name || "",
+    first_name: firstName || "Resident",
+    unit: r.unit || "",
+    unit_line: includeUnitLine && r.unit
+      ? `<p style="margin:0 0 0.8em 0;"><strong>Your unit number is:</strong> ${escapeHtml(r.unit)}</p>`
+      : "",
+  };
+}
+
+// ── Dispatcher client ────────────────────────────────────────────────────────
+
+async function dispatch(mode, messages, secrets) {
+  const url = secrets?.MN_DISPATCH_URL;
+  const secret = secrets?.MN_DISPATCH_SECRET;
+  if (!url || !secret) throw new Error("MN_DISPATCH_URL / MN_DISPATCH_SECRET secret missing");
+  const res = await fetch(url, {
+    method: "POST",
+    redirect: "follow", // GAS 302s /exec to googleusercontent
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret, mode, messages }),
+    signal: AbortSignal.timeout(300000),
+  });
+  if (!res.ok) throw new Error(`Dispatcher HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const body = await res.json();
+  if (body.status === "error" && !Array.isArray(body.results)) {
+    throw new Error(`Dispatcher error: ${body.message || JSON.stringify(body).slice(0, 300)}`);
+  }
+  return body; // { status, quotaRemaining, results: [{to, ok, error?}] }
+}
+
+// ── Callback helper (standard Sandy pattern — do not modify) ─────────────────
+
+async function sendCallback(callbackUrl, payload, sandySecrets) {
+  const secret = sandySecrets?._sandyCallbackSecret;
+  const bodyText = JSON.stringify(payload);
+  const headers = { "Content-Type": "application/json" };
+  if (secret) {
+    const pathname = new URL(callbackUrl).pathname;
+    const key = await crypto.subtle.importKey(
+      "raw", new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+    );
+    const mac = await crypto.subtle.sign(
+      "HMAC", key, new TextEncoder().encode(`POST|${pathname}|${bodyText}`)
+    );
+    headers["X-Sandy-Workflow-Callback"] = Array.from(new Uint8Array(mac))
+      .map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  const res = await fetch(callbackUrl, { method: "POST", headers, body: bodyText, signal: AbortSignal.timeout(30000) });
+  if (!res.ok) throw new Error(`Callback failed: HTTP ${res.status}`);
+  return { delivered: true };
+}
+
+// ── Workflow ─────────────────────────────────────────────────────────────────
+
+export class TenantWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const { campaign_id, app_run_id, kind, config, recipients, callback_url, callback_token } = event.payload || {};
+    const secrets = event.payload?._sandySecrets || {};
+
+    try {
+      await step.do("validate-inputs", async () => {
+        if (!secrets.MN_DISPATCH_URL || !secrets.MN_DISPATCH_SECRET) {
+          throw new Error("dispatcher secrets missing");
+        }
+        if (!callback_url) throw new Error("callback_url is required");
+        if (!config?.subjectTemplate || !config?.bodyTemplate) throw new Error("config templates missing");
+        if (!Array.isArray(recipients) || recipients.length === 0) throw new Error("recipients[] is empty");
+        if (!["send", "dryrun", "test"].includes(kind)) throw new Error(`bad kind: ${kind}`);
+        return { ok: true, count: recipients.length };
+      });
+
+      const dispatcherMode = kind === "dryrun" ? "draft" : "send";
+      const subjectPrefix = kind === "dryrun" ? "[DRAFT] " : kind === "test" ? "TEST — " : "";
+
+      const results = [];
+      let quotaRemaining = null;
+
+      for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
+        const batch = recipients.slice(i, i + BATCH_SIZE);
+        const batchResult = await step.do(
+          `dispatch-batch-${Math.floor(i / BATCH_SIZE) + 1}`,
+          { retries: { limit: 1, delay: "30 seconds", backoff: "linear" } },
+          async () => {
+            const messages = batch.map((r) => {
+              const tokens = buildRecipientTokens(config.globalTokens || {}, r, !!config.includeUnitLine);
+              const attachmentFileIds = [
+                ...(config.configAttachmentIds || []),
+                ...(r.attachmentIds || []),
+              ];
+              return {
+                to: r.email,
+                cc: config.cc || "",
+                replyTo: config.replyTo || "",
+                senderName: config.senderName || "Landing Notifications",
+                subject: subjectPrefix + renderTokens(config.subjectTemplate, tokens, false),
+                htmlBody: renderTokens(config.bodyTemplate, tokens, true),
+                plainText: "Please view this email in an HTML-capable client.",
+                ...(attachmentFileIds.length ? { attachmentFileIds } : {}),
+              };
+            });
+            return dispatch(dispatcherMode, messages, secrets);
+          }
+        );
+        quotaRemaining = batchResult.quotaRemaining ?? quotaRemaining;
+        const brs = batchResult.results || [];
+        batch.forEach((r, j) => {
+          const br = brs[j] || { ok: false, error: "no dispatcher result" };
+          results.push({ id: r.id, email: r.email, ok: !!br.ok, error: br.error || null });
+        });
+      }
+
+      await step.do(
+        "send-callback",
+        { retries: { limit: 2, delay: "30 seconds", backoff: "linear" } },
+        async () => sendCallback(callback_url, {
+          run_id: event.instanceId,
+          callback_token,
+          campaign_id,
+          app_run_id,
+          kind,
+          status: "complete",
+          results,
+          quota_remaining: quotaRemaining,
+          error: null,
+        }, secrets)
+      );
+
+      return { ok: true, sent: results.filter((r) => r.ok).length, failed: results.filter((r) => !r.ok).length };
+    } catch (err) {
+      if (callback_url) {
+        await step.do("send-error-callback", async () => sendCallback(callback_url, {
+          run_id: event.instanceId,
+          callback_token,
+          campaign_id,
+          app_run_id,
+          kind,
+          status: "error",
+          results: [],
+          quota_remaining: null,
+          error: String(err?.message || err),
+        }, secrets));
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #179, which was merged at the v0.4 commit — everything after it
stayed on the branch while the deployed app moved ahead. This PR brings main
up to what is live at mass-notifications.sandy.hellolanding.tech (v0.9):

- **P2 send pipeline (v0.5)** — emailkit (token engine w/ HTML-escape default,
  6 cards + 6 templates, legacy-string parity), Configure/Preview/Send UI,
  `mass-notify-dispatch` workflow (batched GAS dispatcher calls, per-recipient
  results, callback), runs audit + undo, dry-run drafts + test-send.
- **/edit surface (v0.6)** — D1-backed editable cards & disclaimers, instant-
  apply chiclets, SSE live status.
- **Frontend polish (v0.7)** — custom navy chrome (no stock dead links), OG
  #E7EFFB background, stale-flash fix, single auto-saving status pill,
  Templates-vs-Cards explainers, emoji→entity icon field.
- **P3 SMS companion (v0.8)** — per-campaign AI summary (AI Gateway), Dialpad
  sends from +14159804986, quiet hours via segment TZ, opt-out respect, kinds
  sms_preview/sms_test/sms_only; SSE change-signature watcher. Live SMS
  delivery confirmed by the operator.
- **Editor AI (v0.9)** — native color picker + palette swatches; describe-a-card
  → claude-haiku-4-5 drafts row HTML into Body HTML (workflow kind card_gen).

All versions deployed with clean advisory scans; E2E evidence in the commit
messages (Wayland fetch/draft runs, 185-char SMS summary, card generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7cSv4Vy1wFY3DTt8wKvTB